### PR TITLE
Update README and docs for current engine state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
-# Vulkan Game
+# HD-2D Vulkan Game Engine
 
-A Vulkan-based game built with C++23, GLFW, and glm.
+A Vulkan-based HD-2D game engine built with C++23, featuring 3D Gaussian Splatting rendering, an ECS architecture, and a suite of web-based creative tools.
+
+## Features
+
+- **HD-2D rendering** — Sprite-based entities over parallax backgrounds with bloom, depth-of-field, and tone mapping
+- **3D Gaussian Splatting** — GPU compute pipeline for rendering `.ply` point clouds as an alternative to tilemaps
+- **Entity Component System** — Header-only ECS with archetype storage, typed views, and system functions
+- **Async asset streaming** — Background thread loading with budget-limited GPU uploads for open-world support
+- **Particle system** — Configurable emitters with ring-buffer pool (600 particles)
+- **Audio** — 4-layer music + spatial SFX via miniaudio
+- **Scripting** — Wren 0.4.0 VM for NPC behavior and game logic
+- **Day/night cycle** — Ambient color interpolation with weather system
+- **Save system** — JSON-based save/load with game flags
+- **AI debugging** — Unix socket control server for deterministic step-mode testing
+- **Creative tooling** — 7 web-based tools for content authoring (level design, sprite art, particles, audio, maps)
 
 ## Prerequisites
 
@@ -11,18 +25,21 @@ A Vulkan-based game built with C++23, GLFW, and glm.
 
 ### macOS
 
-Install the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) (includes MoltenVK).
+```bash
+brew install vulkan-headers vulkan-loader molten-vk
+```
+
+Or install the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home).
 
 ### Linux
 
 ```bash
+# Ubuntu/Debian
+sudo apt install vulkan-tools libvulkan-dev vulkan-validationlayers-dev spirv-tools glslc
+
 # Fedora
 sudo dnf install vulkan-headers vulkan-loader-devel vulkan-tools \
     vulkan-validation-layers-devel mesa-vulkan-drivers glslc
-
-# Ubuntu/Debian
-sudo apt install vulkan-tools libvulkan-dev vulkan-validationlayers-dev \
-    spirv-tools glslc
 ```
 
 ### Windows
@@ -32,7 +49,7 @@ Install the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home).
 ## Building
 
 ```bash
-# Configure (automatically selects platform preset)
+# Configure
 cmake --preset <platform>-debug    # linux-debug, macos-debug, windows-debug
 cmake --preset <platform>-release  # linux-release, macos-release, windows-release
 
@@ -41,43 +58,112 @@ cmake --build --preset <platform>-debug
 cmake --build --preset <platform>-release
 ```
 
-The executable is output to `build/<preset>/vulkan_game`.
+Two demo executables are produced:
 
-## Dev Container (Podman + krunkit)
+| Executable | Description |
+|---|---|
+| `vulkan_game_demo` | Full engine demo with gameplay, NPCs, dialog, particles |
+| `vulkan_game_gs_demo` | 3D Gaussian Splatting viewer with visual effects and streaming |
 
-For M-series Macs with GPU remoting via krunkit:
+## Architecture
 
-```bash
-# Build the container
-podman build -t vulkan-dev -f .devcontainer/Dockerfile .
+### Renderer Flow
 
-# Run with GPU access
-podman run --rm -it \
-    --device /dev/dri \
-    -v "$PWD":/workspace:Z \
-    --workdir /workspace \
-    vulkan-dev bash
+```
+Offscreen HDR (RGBA16F) → Bloom → DoF → Composite (tone mapping + vignette)
+```
 
-# Inside the container
-cmake --preset linux-debug
-cmake --build --preset linux-debug
+Draw order: GS compute → GS blit → backgrounds → tilemap → reflections → shadows → outlines → entities → particles → overlay. UI is rendered in the composite pass (unprocessed).
+
+### ECS
+
+Header-only (`include/vulkan_game/engine/ecs/`): archetype-based storage with typed views.
+
+**Components:** Transform, Sprite, PlayerTag, Facing, Animation, NpcPatrol, NpcWaypoints, DialogRef, DynamicLight, ParticleEmitterRef, FootstepEmitterRef, ScriptRef
+
+**Systems:** player_movement, player_collision, npc_patrol, npc_pathfind, animation_update, lighting_rebuild, particle_sync, sprite_collect, shadow_collect, reflection_collect, outline_collect
+
+### Async Asset Streaming
+
+Background asset loading for open-world support:
+
+```
+Main Thread                     Worker Thread (std::thread)
+─────────────                   ────────────────────────────
+submit request ──► request_queue_ ──► disk I/O + CPU parsing
+poll_results() ◄── completed_    ◄── push result
+flush() ──► GPU upload (budget-limited, 4MB/frame)
+```
+
+| Component | Description |
+|---|---|
+| `AsyncLoader` | Thread-safe work queue with single worker thread |
+| `StagingUploader` | Double-buffered, budget-limited per-frame GPU texture uploads |
+| `GsChunkStreamer` | Distance-based GS chunk streaming with hysteresis and memory budget |
+
+All disk I/O and CPU parsing runs on the worker thread. All Vulkan API calls stay on the main thread.
+
+### 3D Gaussian Splatting
+
+```
+PLY file → GaussianCloud → GsRenderer (compute) → Storage Image → Fullscreen Blit
+```
+
+Three compute passes before the main render pass:
+
+1. **Preprocess** — project 3D Gaussians to 2D, frustum cull, compute 2D covariance
+2. **Bitonic Sort** — depth-sort projected splats front-to-back
+3. **Tile Rasterizer** — 16x16 tile-based splatting into a 320x240 HDR storage image
+
+Output is sampled with nearest-neighbor filtering for pixel-art upscale.
+
+**Performance optimizations:**
+- Render early termination on first culled Gaussian (sorted order)
+- Visible count via atomic counter (preprocess SSBO)
+- Spatial chunk grid (`GsChunkGrid`) with frustum culling
+- CPU-side LOD decimation with adaptive budget (converge-and-lock targeting 30 FPS)
+- Hybrid re-render: full compute every Nth frame, cached blit with 2D offset between
+- Async chunk streaming (`GsChunkStreamer`) for open-world scale maps
+
+**GS Demo controls:**
+
+| Key | Action |
+|---|---|
+| Mouse drag | Orbit camera |
+| Scroll | Zoom |
+| WASD | Pan |
+| M | Toggle streaming mode |
+| P | Toggle shadow box (parallax) mode |
+| T/L/F/G/X | Toon / Light / Fire / Water / Touch |
+| E/V/H/Y/C/B | Explode / Voxel / Pulse / X-Ray / Swirl / Burn |
+
+### Scene Format
+
+```json
+{
+  "gaussian_splat": {
+    "ply_file": "maps/map.ply",
+    "camera": { "position": [0, 5, 10], "target": [0, 0, 0], "fov": 60 },
+    "render_width": 320,
+    "render_height": 240,
+    "parallax": { "azimuth_range": 0.15, "parallax_strength": 1.0 }
+  },
+  "collision": { "width": 16, "height": 16, "cell_size": 1.0, "solid": [0,1,...] },
+  "ambient_color": [0.25, 0.28, 0.45, 1.0],
+  "player_position": [3.0, 2.0, 0.0],
+  "npcs": [{ "name": "guard", "position": [5, 3, 0], "dialog": {...} }],
+  "portals": [{ "position": [0, 7], "target_scene": "dungeon.json" }]
+}
 ```
 
 ## AI Debugging via Control Server
 
-The game exposes a Unix domain socket at `/tmp/vulkan_game.sock` for external control. AI agents (Claude Code, etc.) can send commands, step the game deterministically, and capture screenshots to visually inspect rendering — all without human interaction.
-
-### Quick Start
+The engine exposes a Unix domain socket at `/tmp/vulkan_game.sock` for external control. AI agents can send commands, step deterministically, and capture screenshots.
 
 ```bash
-# 1. Build and launch the game
-cmake --build --preset macos-debug
-cd build/macos-debug && ./vulkan_game &
-
-# 2. Connect and send commands (Python example)
+# Connect and control
 python3 -c "
 import socket, json
-
 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 s.connect('/tmp/vulkan_game.sock')
 
@@ -85,109 +171,48 @@ def send(cmd):
     s.sendall(json.dumps(cmd).encode() + b'\n')
     return json.loads(s.recv(4096).decode())
 
-# Switch to deterministic step mode
-print(send({'cmd': 'set_mode', 'mode': 'step'}))
-
-# Move player right for 30 frames (~0.5s)
+send({'cmd': 'set_mode', 'mode': 'step'})
 send({'cmd': 'move', 'direction': 'right'})
-print(send({'cmd': 'step', 'frames': 30}))
-
-# Stop and capture a screenshot
-send({'cmd': 'stop'})
-send({'cmd': 'step', 'frames': 1})
-print(send({'cmd': 'screenshot', 'path': '/tmp/debug.png'}))
-
+send({'cmd': 'step', 'frames': 30})
+send({'cmd': 'screenshot', 'path': '/tmp/debug.png'})
 s.close()
 "
 ```
 
-### Protocol
-
-All communication uses JSON Lines (one JSON object per line) over the Unix socket.
-
-#### Commands
+<details>
+<summary>Full command reference</summary>
 
 | Command | Payload | Description |
 |---------|---------|-------------|
-| `get_state` | — | Returns player/NPC positions, facing, animation, dialog state, tick count |
-| `get_map` | — | Returns tilemap data (dimensions, tiles, solid flags) |
-| `move` | `direction`: `"up"/"down"/"left"/"right"`, `sprint`: bool | Inject movement input |
+| `get_state` | — | Player/NPC positions, animation, tick count |
+| `get_map` | — | Tilemap dimensions, tiles, solid flags |
+| `move` | `direction`, `sprint` | Inject movement input |
 | `stop` | — | Clear all injected inputs |
-| `interact` | — | Press the interact key (E) for one frame |
-| `set_mode` | `mode`: `"step"/"realtime"` | Switch between deterministic and real-time modes |
-| `step` | `frames`: int (1-600) | Advance N frames at fixed 1/60s dt (step mode only) |
-| `screenshot` | `path`: string | Capture current frame to PNG file |
-| `get_scene` | — | Returns full scene JSON (tilemap, NPCs, lights, portals, etc.) |
-| `get_tilemap` | — | Returns tilemap tiles and solid arrays |
-| `reload_scene` | — | Re-initializes current scene from disk |
-| `set_tile` | `col`, `row`, `tile_id`, `solid` | Modify a single tile |
-| `set_tiles` | `tiles`: array of `{col, row, tile_id, solid}` | Batch tile modification |
-| `resize_tilemap` | `width`, `height`, `fill_tile` | Resize tilemap with fill |
-| `set_player_position` | `position`: `[x,y,z]` | Teleport the player |
-| `update_npc` | `index`, `position?`, `tint?`, `facing?` | Modify NPC properties |
-| `set_ambient` | `color`: `[r,g,b,a]` | Change ambient lighting color |
-| `add_light` | `position`, `radius`, `color`, `intensity`, `height` | Add a point light |
-| `remove_light` | `index` | Remove a point light |
-| `update_light` | `index`, field overrides | Modify a point light |
-| `add_portal` | `portal`: `{position, size, target_scene, ...}` | Add a scene portal |
-| `remove_portal` | `index` | Remove a portal |
-| `set_weather` | `type`, `fog_density?`, `fog_color?` | Change weather state |
-| `set_day_night` | `enabled`, `cycle_speed?`, `time?` | Configure day/night cycle |
-| `set_emitter_config` | `emitter_index`, `config` | Modify particle emitter |
-| `add_emitter` | `config`, `position` | Add a particle emitter |
-| `remove_emitter` | `index` | Remove a particle emitter |
-| `list_emitters` | — | List all particle emitters |
-| `get_features` | — | List feature flags and states |
-| `set_feature` | `name`, `enabled` | Toggle a feature flag |
-| `set_camera` | `position?`, `zoom?` | Override camera position/zoom |
-| `subscribe` | `events`: string array | Filter which events are sent |
-| `unsubscribe` | — | Receive all events (default) |
+| `interact` | — | Press interact key for one frame |
+| `set_mode` | `mode`: `"step"/"realtime"` | Switch modes |
+| `step` | `frames`: 1-600 | Advance N frames at fixed 1/60s dt |
+| `screenshot` | `path` | Capture frame to PNG |
+| `get_scene` | — | Full scene JSON |
+| `reload_scene` | — | Re-initialize scene from disk |
+| `set_tile` | `col`, `row`, `tile_id`, `solid` | Modify a tile |
+| `set_tiles` | `tiles` array | Batch tile modification |
+| `resize_tilemap` | `width`, `height`, `fill_tile` | Resize tilemap |
+| `set_player_position` | `position` | Teleport player |
+| `update_npc` | `index`, field overrides | Modify NPC |
+| `set_ambient` | `color` | Change ambient lighting |
+| `add_light` / `remove_light` / `update_light` | light params | Manage point lights |
+| `add_portal` / `remove_portal` | portal params | Manage portals |
+| `set_weather` | `type`, `fog_density`, `fog_color` | Change weather |
+| `set_day_night` | `enabled`, `cycle_speed`, `time` | Day/night cycle |
+| `set_emitter_config` / `add_emitter` / `remove_emitter` / `list_emitters` | emitter params | Manage particles |
+| `get_features` / `set_feature` | `name`, `enabled` | Toggle feature flags |
+| `set_camera` | `position`, `zoom` | Override camera |
 
-#### Responses
+</details>
 
-```jsonc
-// State (from get_state or after step)
-{"type": "state", "tick": 42, "game_mode": "explore",
- "player": {"x": 3.5, "y": 2.0, "direction": "down", "animation": "idle_down"},
- "npcs": [{"index": 0, "x": 5.0, "y": 3.0, "direction": "left"}]}
+## Creative Tooling
 
-// Screenshot
-{"type": "screenshot", "path": "/tmp/debug.png", "width": 2560, "height": 1440}
-
-// Events (emitted automatically)
-{"type": "dialog_started", "speaker_key": "npc_guard", "text_key": "guard_greeting"}
-{"type": "dialog_advanced", "line": 1}
-{"type": "dialog_ended"}
-
-// Errors
-{"type": "error", "message": "not in step mode"}
-```
-
-### Debugging Workflow for AI Agents
-
-The recommended loop for AI-driven visual debugging:
-
-1. **Launch** the game in the background
-2. **Connect** to `/tmp/vulkan_game.sock`
-3. **Switch to step mode** — game pauses, frames advance only on `step` commands
-4. **Send commands** (move, interact, step) to reproduce the issue
-5. **Capture screenshot** — read the PNG to visually inspect rendering
-6. **Inspect state** via `get_state` / `get_map` for numerical verification
-7. **Iterate** — make code changes, rebuild, relaunch, repeat
-
-Step mode ensures deterministic reproduction: the same sequence of commands always produces the same game state, regardless of wall-clock timing.
-
-### Notes
-
-- The socket auto-cleans stale files on startup
-- Only one client connection at a time
-- Client disconnect automatically reverts to real-time mode
-- Screenshot dimensions reflect the actual framebuffer (e.g., 2560x1440 on Retina, 1280x720 otherwise)
-- Screenshots capture the final composited frame including post-processing (bloom, DoF, vignette, fog)
-
-## Creative Tooling Ecosystem
-
-The `tools/` directory contains a suite of web-based creative tools for authoring game content. Each tool connects to the running engine via a WebSocket bridge proxy for live preview.
+The `tools/` directory contains web-based creative tools connected to the engine via a WebSocket bridge proxy.
 
 ```
 Engine (Vulkan) ←→ Unix Socket ←→ Bridge Proxy (ws://localhost:9100) ←→ Web Tools
@@ -196,82 +221,79 @@ Engine (Vulkan) ←→ Unix Socket ←→ Bridge Proxy (ws://localhost:9100) ←
 | Tool | Port | Description |
 |------|------|-------------|
 | **Bridge Proxy** | 9100/9101 | Node.js relay between Unix socket and WebSocket clients |
-| **Seurat** | 5179 | Sprite art pipeline: concept → chibi → pixel → animation frames (includes pixel painter & keyframe animator). Two-pass IP-Adapter pipeline (Concept→Pose→Chibi→Pixel) for consistent sprite animation with OpenPose control. |
+| **Seurat** | 5179 | Sprite art pipeline: concept → chibi → pixel → animation frames |
 | **Level Designer** | 5173 | Tile painting, NPC/light/portal placement, AI level generation |
 | **Particle Designer** | 5176 | Visual EmitterConfig editor with live engine preview |
 | **Audio Composer** | 5177 | 4-layer interactive music editor with MusicGen AI |
 | **SFX Designer** | 5178 | Waveform editor, procedural synthesis, AI SFX generation |
-
-### Quick Start
+| **Bricklayer** | 5180 | 3D voxel map editor with depth estimation and PLY export |
 
 ```bash
 # Prerequisites: Node.js 18+, pnpm
-# From the project root:
 cd tools && pnpm install
 
-# Start the bridge (requires running game; build first)
+# Start the bridge (requires running engine)
 cd tools/apps/bridge && pnpm build && pnpm start
 
-# Start a tool (e.g., level designer — no build needed)
+# Start a tool
 cd tools/apps/level-designer && pnpm dev
 ```
 
-See [tools/README.md](tools/README.md) for full documentation.
+## Testing
 
-## 3D Gaussian Splatting
+Tests use `assert`-based validation (no framework). Each test file includes build instructions as comments.
 
-The engine supports 3D Gaussian Splatting (3DGS) as an alternative to traditional tilemaps for rendering environments. A scene can use a `.ply` file containing Gaussians instead of (or alongside) a tilemap.
-
-### Pipeline
-
-```
-PLY file → GaussianCloud → GsRenderer (compute) → Storage Image → Fullscreen Blit
+```bash
+# Build and run all tests
+c++ -std=c++23 -I include tests/test_async_loader.cpp src/engine/async_loader.cpp -o build/test_async_loader
+./build/test_async_loader
 ```
 
-The GS compute pipeline runs three passes before the main render pass:
+| Test Suite | Tests | What it covers |
+|---|---|---|
+| `test_async_loader` | 10 | Queue semantics, ordering, cancel, shutdown, reuse |
+| `test_staging_uploader` | 6 | Budget enforcement, double-buffer, callbacks |
+| `test_gs_chunk_streamer` | 7 | Manifest parsing, state transitions, hysteresis, memory budget |
+| `test_gs_chunk_grid` | 9 | Spatial partitioning, frustum culling, LOD decimation |
+| `test_feature_flags` | 8 | Flag defaults, GS viewer profile, categories |
+| `test_tilemap` | 12 | Tile animation, collision resolution, draw info generation |
+| `test_gaussian_cloud` | 9 | PLY loading, scene format parsing, collision generation |
+| `test_gs_parallax_camera` | 6 | Camera configuration, Y-flip, smoothing convergence |
+| `test_screenshot` | 5 | State machine, BGRA→RGBA swizzle |
+| `test_character_data` | 12 | Character animation JSON loading |
 
-1. **Preprocess** — project 3D Gaussians to 2D screen space, frustum cull, compute 2D covariance
-2. **Bitonic Sort** — depth-sort projected splats front-to-back
-3. **Tile Rasterizer** — 16x16 tile-based splatting into a 320x240 HDR storage image
-
-The output is sampled with nearest-neighbor filtering for pixel-art upscale and composited as a fullscreen quad.
-
-### Performance Optimization
-
-For large maps (open-world scale), the renderer uses a multi-layered optimization strategy:
-
-- **Render early termination** — the render shader `break`s on the first culled Gaussian instead of skipping one-by-one, since bitonic sort places all culled entries at the end
-- **Visible count via atomic counter** — the preprocess shader atomically counts non-culled Gaussians; the render shader uses this count as its loop bound instead of the total Gaussian count
-- **Spatial chunk grid** (`GsChunkGrid`) — partitions the cloud into a 2D grid on the XZ ground plane (default 32-unit chunks). Each frame, the CPU determines which chunks intersect the camera frustum and uploads only those Gaussians. A dirty-check skips re-upload when the visible chunk set hasn't changed
-
-This caps GPU work to approximately one screen's worth of Gaussians (~57K) regardless of total map size.
-
-### Scene Format
-
-```json
-{
-  "gaussian_splat": {
-    "ply_file": "maps/map.ply",
-    "camera": { "position": [0, 5, 10], "target": [0, 0, 0] },
-    "render_width": 320,
-    "render_height": 240
-  }
-}
-```
-
-### Map Painter
-
-The **Map Painter** tool (port 5180) provides a browser-based editor for creating 3DGS maps: paint a 2D pixel canvas with height brush, then export as voxel-to-Gaussian PLY.
+See [tests/README.md](tests/README.md) for detailed build commands and test descriptions.
 
 ## Project Structure
 
 ```
-src/            C++ source files
-include/        Public headers
-shaders/        GLSL shaders (compiled to SPIR-V at build time)
-assets/         Game assets (copied to build directory)
-tools/          Web-based creative tooling ecosystem (TypeScript/React)
-  packages/     Shared libraries (engine-client, asset-types, ai-providers, ui-kit)
-  apps/         Tool applications (bridge, level-designer, pixel-painter, etc.)
-.devcontainer/  Container development environment
+src/
+  engine/         Engine core (renderer, ECS, audio, particles, streaming, etc.)
+  game/           Game-specific states and systems
+  demo/           Demo applications (gameplay demo, GS viewer)
+include/
+  vulkan_game/
+    engine/       Engine headers
+    game/         Game state headers
+    demo/         Demo app headers
+shaders/          GLSL shaders (compiled to SPIR-V at build time)
+assets/           Game assets (scenes, textures, maps)
+tests/            C++ integration tests (assert-based)
+tools/            Web-based creative tooling ecosystem (TypeScript/React)
+  packages/       Shared libraries (engine-client, asset-types, ai-providers, ui-kit)
+  apps/           Tool applications (bridge, level-designer, seurat, bricklayer, etc.)
+docs/             Performance reports and tool documentation
+.devcontainer/    Container development environment
+```
+
+## Dev Container (Podman + krunkit)
+
+For M-series Macs with GPU remoting via krunkit:
+
+```bash
+podman build -t vulkan-dev -f .devcontainer/Dockerfile .
+podman run --rm -it --device /dev/dri -v "$PWD":/workspace:Z --workdir /workspace vulkan-dev bash
+
+# Inside the container
+cmake --preset linux-debug && cmake --build --preset linux-debug
 ```

--- a/docs/gs-performance-report.md
+++ b/docs/gs-performance-report.md
@@ -279,6 +279,48 @@ The stride-based sampling preserves scene structure even at extreme decimation
 | `renderer.hpp` | Adaptive budget state (`gs_gaussian_budget_`, `gs_budget_locked_`, etc.) |
 | `renderer.cpp` | Adaptive budget feedback loop; `gather_lod()` call; auto-enable for large clouds |
 
+## Async Chunk Streaming
+
+**Date:** 2026-03-22
+
+For open-world scale maps where the full PLY exceeds memory, the engine supports
+distance-based chunk streaming via `GsChunkStreamer`.
+
+### Architecture
+
+```
+AsyncLoader (worker thread)  →  disk I/O + PLY parsing
+GsChunkStreamer              →  distance-based load/unload state machine
+StagingUploader              →  budget-limited GPU uploads (4MB/frame)
+```
+
+### Key design decisions
+
+1. **Single worker thread** — disk I/O serializes naturally; a thread pool adds
+   complexity without clear benefit for this workload.
+
+2. **Hysteresis** — load radius < unload radius prevents chunk thrashing at
+   boundaries (default: load at 40% of map extent, unload at 60%).
+
+3. **Memory budget** — tracks loaded chunk memory, evicts furthest chunks when
+   exceeded (default: 512 MB).
+
+4. **Frame-fence sync** — replaced `vkDeviceWaitIdle()` in GS prepass with
+   per-frame fence waiting, eliminating full GPU pipeline stalls.
+
+5. **LOD integration** — assembled active buffer uses stride-based decimation
+   from `gather_lod()`, combining streaming with distance-based LOD.
+
+### GS Demo streaming mode
+
+Press **M** in the GS demo to enter streaming mode. The loaded PLY is split
+into per-chunk PLY files and streamed via `GsChunkStreamer`. HUD displays:
+- Loaded / loading / total chunks
+- Stream memory usage
+- Load/unload radii
+
+Move the camera to observe chunks loading and unloading in real-time.
+
 ## Recommendation
 
 For production use, always run the release build (`cmake --build --preset

--- a/tests/README.md
+++ b/tests/README.md
@@ -200,9 +200,100 @@ c++ -std=c++23 -I include \
 | 5 | Smoothing converges | Many `update()` calls converge to target |
 | 6 | Aspect ratio | Configure 320×240, verify proj encodes 4:3 |
 
+### test_async_loader
+
+Tests AsyncLoader: thread-safe work queue with single worker thread.
+
+**Build:**
+```bash
+c++ -std=c++23 -I include \
+    tests/test_async_loader.cpp src/engine/async_loader.cpp \
+    -o build/test_async_loader
+```
+
+**Run:**
+```bash
+./build/test_async_loader
+```
+
+**Tests (10):**
+| # | Test | What it verifies |
+|---|------|------------------|
+| 1 | Submit and poll | Submit a job, poll_results returns it |
+| 2 | Multiple requests all processed | 10 requests all complete with correct IDs |
+| 3 | poll_results empty when idle | Returns empty when nothing is complete |
+| 4 | Cancel prevents result | Cancelled job's result does not appear |
+| 5 | Shutdown with pending requests | Shutdown completes promptly, doesn't process all |
+| 6 | Job exception reported as error | Throwing job sets `success=false` with error message |
+| 7 | Monotonic request IDs | IDs are sequential and increasing |
+| 8 | pending_count tracking | Tracks queued + in-flight, reaches 0 after completion |
+| 9 | Double init/shutdown safe | Redundant init/shutdown calls are no-ops |
+| 10 | Reuse after shutdown | Can init → use → shutdown → init → use again |
+
+### test_staging_uploader
+
+Tests StagingUploader: budget-limited per-frame GPU texture uploads.
+
+**Build:**
+```bash
+c++ -std=c++23 -I include \
+    -I build/macos-debug/_deps/glm-src \
+    -I build/macos-debug/_deps/stb-src \
+    -I build/macos-debug/_deps/vma-src/include \
+    $(pkg-config --cflags vulkan 2>/dev/null || echo "-I$VULKAN_SDK/include") \
+    tests/test_staging_uploader.cpp src/engine/staging_uploader.cpp \
+    -o build/test_staging_uploader
+```
+
+**Run:**
+```bash
+./build/test_staging_uploader
+```
+
+**Tests (6):**
+| # | Test | What it verifies |
+|---|------|------------------|
+| 1 | Enqueue tracking | `pending_count()` and `pending_bytes()` update correctly |
+| 2 | Flush processes all within budget | Large budget processes all textures |
+| 3 | Flush respects budget | Partial processing when budget is exceeded |
+| 4 | Empty flush no-op | No GPU submits when nothing is pending |
+| 5 | Callback receives correct keys | Cache keys delivered in order via callback |
+| 6 | byte_size calculation | `width * height * 4` computed correctly |
+
+### test_gs_chunk_streamer
+
+Tests GsChunkStreamer: distance-based chunk streaming with hysteresis and memory budget.
+
+**Build:**
+```bash
+c++ -std=c++23 -I include \
+    -I build/macos-debug/_deps/glm-src \
+    -I build/macos-debug/_deps/stb-src \
+    -I build/macos-debug/_deps/json-src/include \
+    tests/test_gs_chunk_streamer.cpp src/engine/gs_chunk_streamer.cpp \
+    src/engine/async_loader.cpp src/engine/gaussian_cloud.cpp \
+    -o build/test_gs_chunk_streamer
+```
+
+**Run:**
+```bash
+./build/test_gs_chunk_streamer
+```
+
+**Tests (7):**
+| # | Test | What it verifies |
+|---|------|------------------|
+| 1 | Manifest from JSON | Parses chunk_size, grid dimensions, per-chunk metadata |
+| 2 | Chunks within load_radius → Loading | Nearby chunks transition to Loading state |
+| 3 | Chunks beyond unload_radius → Unloaded | Far chunks are released |
+| 4 | Hysteresis zone preserves state | Chunks between load/unload radii stay in current state |
+| 5 | Memory budget enforcement | Evicts furthest chunks when budget exceeded |
+| 6 | active_set_dirty flag | Set on load, cleared by assemble_active() |
+| 7 | Assemble with frustum culling | Narrow VP returns fewer Gaussians than wide VP |
+
 ### test_character_data
 
-Tests character animation JSON loading (pre-existing).
+Tests character animation JSON loading.
 
 **Build:**
 ```bash
@@ -220,43 +311,17 @@ c++ -std=c++23 -I include \
 
 All tool tests run via the QA test runner which uses headless Chrome + WebSocket to manipulate Zustand stores.
 
-### Map Painter Tests
+### Bricklayer Tests
 
 **Prerequisites:** Start the dev server first:
 ```bash
-cd tools/apps/map-painter && pnpm dev
+cd tools/apps/bricklayer && pnpm dev
 ```
 
 **Run all tests (unit + scenario):**
 ```bash
-cd tools/tests && pnpm test:map-painter
+cd tools/tests && pnpm test:bricklayer
 ```
-
-**Run scenarios only:**
-```bash
-cd tools/tests && pnpm test:map-painter:scenario
-```
-
-**Unit Tests (19):**
-- Store accessibility and default dimensions
-- Pixel set/erase on ground layer
-- Height brush updates
-- Tool, layer, color selection
-- Zoom clamping (min=1, max=64)
-- Collision toggle and auto-generation from heights
-- Undo/redo for pixel operations
-- Map resize with data preservation
-- Flood fill across connected region
-- Preview camera updates
-- Layer independence (ground vs walls vs decorations)
-
-**Scenario Tests (3):**
-
-| Scenario | Steps | What it verifies |
-|----------|-------|------------------|
-| Village map | Init → grass fill → wall border → heights → auto-collision → water feature → camera → undo/redo | Full creative workflow with multi-layer painting |
-| Cross-layer undo/redo | Paint across 3 layers + height → undo all → redo all | State isolation between operations |
-| Collision refinement | Set all heights → auto-gen (all solid) → manually clear path → verify mixed state | Manual override of auto-generated collision |
 
 ### Other Tool Tests
 
@@ -275,4 +340,4 @@ pnpm test --scenario         # Scenarios only
 | particle-designer | 5176 | 6176 |
 | audio-composer | 5177 | 6177 |
 | sfx-designer | 5178 | 6178 |
-| map-painter | 5180 | 6180 |
+| bricklayer | 5180 | 6180 |


### PR DESCRIPTION
## Summary
- **README.md**: Complete rewrite covering all engine features — ECS, async streaming, GS pipeline, 10 test suites, 7 creative tools, architecture diagrams, demo controls. Fixed outdated executable references and Map Painter → Bricklayer rename.
- **tests/README.md**: Added documentation for `test_async_loader` (10 tests), `test_staging_uploader` (6 tests), `test_gs_chunk_streamer` (7 tests)
- **docs/gs-performance-report.md**: Added async chunk streaming section with architecture, design decisions, and streaming demo instructions

## Test plan
- [x] No code changes — documentation only
- [x] Verify all referenced files/paths exist in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)