### PR TITLE
Add 3DGS scene layers: PlacedObjects, heightmap, nav zones, light probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Output is sampled with nearest-neighbor filtering for stylized upscale.
 | T/L/F/G/X | Toon / Light / Fire / Water / Touch |
 | E/V/H/Y/C/B | Explode / Voxel / Pulse / X-Ray / Swirl / Burn |
 | K | Toggle character demo (procedural walking humanoid) |
+| N | Toggle scene layers (auto-generate heightmap, nav, light probes) |
 
 ### Voxel Character Pipeline
 

--- a/include/gseurat/demo/gs_demo_state.hpp
+++ b/include/gseurat/demo/gs_demo_state.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "gseurat/engine/collision_gen.hpp"
 #include "gseurat/engine/game_state.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/gs_chunk_streamer.hpp"
@@ -97,6 +98,11 @@ private:
     void spawn_test_character(AppBase& app);
     void despawn_test_character(AppBase& app);
     void update_character_pose(AppBase& app, float dt);
+
+    // Scene layers demo (N key)
+    bool scene_layers_active_ = false;
+    CollisionGrid scene_grid_;
+    void generate_scene_layers(AppBase& app);
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/collision_gen.hpp
+++ b/include/gseurat/engine/collision_gen.hpp
@@ -14,6 +14,7 @@ struct CollisionGrid {
     std::vector<bool> solid;
     std::vector<float> elevation;       // per-cell ground height (Y value)
     std::vector<uint8_t> nav_zone;      // per-cell navigation zone ID (0 = default)
+    std::vector<glm::vec3> light_probe;  // per-cell ambient color sampled from Gaussians
 
     bool is_solid(uint32_t x, uint32_t y) const {
         if (x >= width || y >= height) return true;
@@ -50,6 +51,12 @@ struct CollisionGrid {
             size_t idx = y * width + x;
             if (idx < nav_zone.size()) nav_zone[idx] = zone;
         }
+    }
+
+    glm::vec3 get_light_probe(uint32_t x, uint32_t y) const {
+        if (x >= width || y >= height) return glm::vec3(0.5f);
+        size_t idx = y * width + x;
+        return idx < light_probe.size() ? light_probe[idx] : glm::vec3(0.5f);
     }
 };
 

--- a/include/gseurat/engine/collision_gen.hpp
+++ b/include/gseurat/engine/collision_gen.hpp
@@ -12,6 +12,7 @@ struct CollisionGrid {
     uint32_t height = 0;
     float cell_size = 1.0f;
     std::vector<bool> solid;
+    std::vector<float> elevation;  // per-cell ground height (Y value)
 
     bool is_solid(uint32_t x, uint32_t y) const {
         if (x >= width || y >= height) return true;
@@ -23,14 +24,36 @@ struct CollisionGrid {
             solid[y * width + x] = val;
         }
     }
+
+    float get_elevation(uint32_t x, uint32_t y) const {
+        if (x >= width || y >= height) return 0.0f;
+        size_t idx = y * width + x;
+        return idx < elevation.size() ? elevation[idx] : 0.0f;
+    }
+
+    void set_elevation(uint32_t x, uint32_t y, float val) {
+        if (x < width && y < height) {
+            size_t idx = y * width + x;
+            if (idx < elevation.size()) elevation[idx] = val;
+        }
+    }
 };
 
 // Generate a collision grid from depth variance in a rendered depth buffer.
-// depth_data: row-major float depth values, dimensions render_width × render_height
-// grid_width/height: desired collision grid dimensions
-// variance_threshold: depth variance above which a cell is marked solid
 CollisionGrid generate_collision_from_depth(
     const float* depth_data, uint32_t render_width, uint32_t render_height,
     uint32_t grid_width, uint32_t grid_height, float variance_threshold = 0.1f);
+
+// Forward declaration
+class GaussianCloud;
+
+// Generate a collision grid with elevation from Gaussian positions.
+// For each XZ cell, finds the highest Gaussian Y position → ground elevation.
+// Cells with no Gaussians are marked solid (impassable void).
+CollisionGrid generate_collision_from_gaussians(
+    const GaussianCloud& cloud,
+    uint32_t grid_width, uint32_t grid_height,
+    float cell_size = 1.0f,
+    float slope_threshold = 5.0f);
 
 }  // namespace gseurat

--- a/include/gseurat/engine/collision_gen.hpp
+++ b/include/gseurat/engine/collision_gen.hpp
@@ -12,7 +12,8 @@ struct CollisionGrid {
     uint32_t height = 0;
     float cell_size = 1.0f;
     std::vector<bool> solid;
-    std::vector<float> elevation;  // per-cell ground height (Y value)
+    std::vector<float> elevation;       // per-cell ground height (Y value)
+    std::vector<uint8_t> nav_zone;      // per-cell navigation zone ID (0 = default)
 
     bool is_solid(uint32_t x, uint32_t y) const {
         if (x >= width || y >= height) return true;
@@ -35,6 +36,19 @@ struct CollisionGrid {
         if (x < width && y < height) {
             size_t idx = y * width + x;
             if (idx < elevation.size()) elevation[idx] = val;
+        }
+    }
+
+    uint8_t get_nav_zone(uint32_t x, uint32_t y) const {
+        if (x >= width || y >= height) return 0;
+        size_t idx = y * width + x;
+        return idx < nav_zone.size() ? nav_zone[idx] : 0;
+    }
+
+    void set_nav_zone(uint32_t x, uint32_t y, uint8_t zone) {
+        if (x < width && y < height) {
+            size_t idx = y * width + x;
+            if (idx < nav_zone.size()) nav_zone[idx] = zone;
         }
     }
 };

--- a/include/gseurat/engine/scene_loader.hpp
+++ b/include/gseurat/engine/scene_loader.hpp
@@ -138,6 +138,9 @@ struct SceneData {
     std::vector<glm::vec3> torch_audio_positions;
     EmitterConfig footstep_emitter;
     EmitterConfig npc_aura_emitter;
+
+    // Navigation zone names (index 0 = "default", 1+ = named zones)
+    std::vector<std::string> nav_zone_names;
 };
 
 class SceneLoader {

--- a/include/gseurat/engine/scene_loader.hpp
+++ b/include/gseurat/engine/scene_loader.hpp
@@ -81,6 +81,16 @@ struct GaussianSplatData {
     std::string background_image;  // Optional background behind GS (sky, mountains, etc.)
 };
 
+struct PlacedObjectData {
+    std::string id;
+    std::string ply_file;                    // path to PLY asset
+    glm::vec3 position{0.0f};
+    glm::vec3 rotation{0.0f};               // euler angles in degrees
+    float scale = 1.0f;
+    bool is_static = true;                   // static = merge into terrain cloud
+    std::string character_manifest;          // if animated, path to Echidna manifest JSON
+};
+
 struct PortalData {
     glm::vec2 position{0.0f};
     glm::vec2 size{1.0f};
@@ -112,6 +122,9 @@ struct SceneData {
 
     // Portals
     std::vector<PortalData> portals;
+
+    // Placed objects (terrain chunks, props, characters)
+    std::vector<PlacedObjectData> placed_objects;
 
     // Minimap
     std::optional<Minimap::Config> minimap_config;

--- a/src/demo/demo_app.cpp
+++ b/src/demo/demo_app.cpp
@@ -8,6 +8,7 @@
 #include <stb_image_write.h>
 
 #include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/quaternion.hpp>
 
 #include <cmath>
 #include <cstdio>
@@ -74,6 +75,48 @@ void DemoApp::init_scene(const std::string& scene_path) {
             renderer_.gs_renderer().set_scale_multiplier(gs.scale_multiplier);
             std::fprintf(stderr, "GS: Loaded %u Gaussians from %s\n",
                          cloud.count(), gs.ply_file.c_str());
+
+            // Merge static placed objects into the main cloud
+            if (!scene_data.placed_objects.empty()) {
+                auto merged = cloud.gaussians();  // mutable copy
+                uint32_t merged_count = 0;
+                for (const auto& obj : scene_data.placed_objects) {
+                    if (!obj.is_static) continue;
+                    try {
+                        auto placed_cloud = GaussianCloud::load_ply(obj.ply_file);
+                        if (placed_cloud.empty()) continue;
+
+                        // Build transform matrix from position, rotation (euler degrees), scale
+                        glm::mat4 transform = glm::translate(glm::mat4(1.0f), obj.position);
+                        transform = glm::rotate(transform, glm::radians(obj.rotation.x), {1,0,0});
+                        transform = glm::rotate(transform, glm::radians(obj.rotation.y), {0,1,0});
+                        transform = glm::rotate(transform, glm::radians(obj.rotation.z), {0,0,1});
+                        transform = glm::scale(transform, glm::vec3(obj.scale));
+
+                        glm::quat rot_q = glm::quat(glm::radians(obj.rotation));
+                        auto placed_gaussians = placed_cloud.gaussians();  // copy
+                        for (auto& g : placed_gaussians) {
+                            g.position = glm::vec3(transform * glm::vec4(g.position, 1.0f));
+                            g.scale *= obj.scale;
+                            g.rotation = rot_q * g.rotation;
+                        }
+
+                        merged.insert(merged.end(), placed_gaussians.begin(), placed_gaussians.end());
+                        merged_count++;
+                        std::fprintf(stderr, "GS: Merged %u Gaussians from placed object '%s' (%s)\n",
+                                     placed_cloud.count(), obj.id.c_str(), obj.ply_file.c_str());
+                    } catch (const std::runtime_error& e) {
+                        std::fprintf(stderr, "Warning: Failed to load placed object '%s': %s\n",
+                                     obj.id.c_str(), e.what());
+                    }
+                }
+                if (merged_count > 0) {
+                    cloud = GaussianCloud::from_gaussians(std::move(merged));
+                    std::fprintf(stderr, "GS: Merged %u static objects, total %u Gaussians\n",
+                                 merged_count, cloud.count());
+                }
+            }
+
             std::fprintf(stderr, "GS: AABB min=(%.1f,%.1f,%.1f) max=(%.1f,%.1f,%.1f)\n",
                          cloud.bounds().min.x, cloud.bounds().min.y, cloud.bounds().min.z,
                          cloud.bounds().max.x, cloud.bounds().max.y, cloud.bounds().max.z);

--- a/src/demo/gs_demo_state.cpp
+++ b/src/demo/gs_demo_state.cpp
@@ -427,6 +427,17 @@ void GsDemoState::update(AppBase& app, float dt) {
         }
     }
 
+    // N → generate scene layers (heightmap, nav zones, light probes)
+    if (app.input().was_key_pressed(GLFW_KEY_N)) {
+        scene_layers_active_ = !scene_layers_active_;
+        if (scene_layers_active_) {
+            generate_scene_layers(app);
+        } else {
+            scene_grid_ = {};
+            std::fprintf(stderr, "Scene layers: OFF\n");
+        }
+    }
+
     if (character_demo_) {
         update_character_pose(app, dt);
     }
@@ -548,6 +559,41 @@ void GsDemoState::build_draw_lists(AppBase& app) {
     ui.label("T:Toon  L:Light  F:Fire  G:Water  X:Touch  M:Stream", lx, y, 0.35f, dim);
     y -= 14.0f;
     ui.label("E:Explode  V:Voxel  H:Pulse  Y:XRay  C:Swirl  B:Burn", lx, y, 0.35f, dim);
+    y -= 14.0f;
+    ui.label("K:Character  N:SceneLayers", lx, y, 0.35f, dim);
+
+    // Scene layers info
+    if (scene_layers_active_ && scene_grid_.width > 0) {
+        y -= 18.0f;
+        glm::vec4 layer_color{0.5f, 1.0f, 0.8f, 1.0f};
+        char buf[128];
+        uint32_t walkable = 0;
+        float min_elev = 1e9f, max_elev = -1e9f;
+        for (uint32_t i = 0; i < scene_grid_.width * scene_grid_.height; ++i) {
+            if (!scene_grid_.solid[i]) {
+                walkable++;
+                if (i < scene_grid_.elevation.size()) {
+                    min_elev = std::min(min_elev, scene_grid_.elevation[i]);
+                    max_elev = std::max(max_elev, scene_grid_.elevation[i]);
+                }
+            }
+        }
+        std::snprintf(buf, sizeof(buf), "Grid: %ux%u  Walkable: %u/%u",
+                      scene_grid_.width, scene_grid_.height,
+                      walkable, scene_grid_.width * scene_grid_.height);
+        ui.label(buf, lx, y, scale, layer_color);
+        y -= 16.0f;
+        if (min_elev < 1e8f) {
+            std::snprintf(buf, sizeof(buf), "Elevation: %.1f - %.1f", min_elev, max_elev);
+            ui.label(buf, lx, y, scale, layer_color);
+            y -= 16.0f;
+        }
+        // Show light probe sample at grid center
+        uint32_t cx = scene_grid_.width / 2, cy = scene_grid_.height / 2;
+        auto probe = scene_grid_.get_light_probe(cx, cy);
+        std::snprintf(buf, sizeof(buf), "Probe@center: (%.2f, %.2f, %.2f)", probe.x, probe.y, probe.z);
+        ui.label(buf, lx, y, scale, layer_color);
+    }
 }
 
 void GsDemoState::enter_streaming_mode(AppBase& app) {
@@ -781,6 +827,38 @@ void GsDemoState::update_character_pose(AppBase& app, float dt) {
     bones[6] = pivot_rotate({1.0f, 4.0f, 0.0f}, swing);     // Right leg
 
     app.renderer().gs_renderer().upload_bone_transforms(bones, 7);
+}
+
+void GsDemoState::generate_scene_layers(AppBase& app) {
+    if (!app.renderer().has_gs_cloud()) {
+        std::fprintf(stderr, "Scene layers: No cloud loaded\n");
+        return;
+    }
+
+    // Get all Gaussians from the chunk grid
+    const auto& all = app.renderer().gs_chunk_grid().all_gaussians();
+    auto cloud = GaussianCloud::from_gaussians(std::vector<Gaussian>(all.begin(), all.end()));
+
+    // Auto-generate collision grid with elevation and light probes
+    auto aabb = app.renderer().gs_chunk_grid().cloud_bounds();
+    float extent_x = aabb.max.x - aabb.min.x;
+    float extent_z = aabb.max.z - aabb.min.z;
+    float cell = std::max(1.0f, std::max(extent_x, extent_z) / 64.0f);  // ~64 cells on longest axis
+    uint32_t gw = std::max(1u, static_cast<uint32_t>(extent_x / cell));
+    uint32_t gh = std::max(1u, static_cast<uint32_t>(extent_z / cell));
+
+    scene_grid_ = generate_collision_from_gaussians(cloud, gw, gh, cell, cell * 2.0f);
+
+    // Count stats
+    uint32_t walkable = 0;
+    for (uint32_t i = 0; i < gw * gh; ++i) {
+        if (!scene_grid_.solid[i]) walkable++;
+    }
+
+    std::fprintf(stderr, "Scene layers: ON\n");
+    std::fprintf(stderr, "  Grid: %ux%u (cell_size=%.1f)\n", gw, gh, cell);
+    std::fprintf(stderr, "  Walkable: %u/%u cells\n", walkable, gw * gh);
+    std::fprintf(stderr, "  Elevation + light probes auto-generated from %u Gaussians\n", cloud.count());
 }
 
 }  // namespace gseurat

--- a/src/engine/collision_gen.cpp
+++ b/src/engine/collision_gen.cpp
@@ -1,4 +1,5 @@
 #include "gseurat/engine/collision_gen.hpp"
+#include "gseurat/engine/gaussian_cloud.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -51,6 +52,74 @@ CollisionGrid generate_collision_from_depth(
             if (variance > variance_threshold) {
                 grid.solid[gy * grid_width + gx] = true;
             }
+        }
+    }
+
+    return grid;
+}
+
+CollisionGrid generate_collision_from_gaussians(
+    const GaussianCloud& cloud,
+    uint32_t grid_width, uint32_t grid_height,
+    float cell_size,
+    float slope_threshold) {
+
+    CollisionGrid grid;
+    grid.width = grid_width;
+    grid.height = grid_height;
+    grid.cell_size = cell_size;
+    size_t total = static_cast<size_t>(grid_width) * grid_height;
+    grid.solid.resize(total, true);       // default: solid (no Gaussians = void)
+    grid.elevation.resize(total, 0.0f);
+
+    if (cloud.empty()) return grid;
+
+    const auto& bounds = cloud.bounds();
+
+    // For each cell, find the highest Gaussian Y position
+    for (const auto& g : cloud.gaussians()) {
+        // Map Gaussian XZ position to grid cell
+        float rel_x = g.position.x - bounds.min.x;
+        float rel_z = g.position.z - bounds.min.z;
+        int gx = static_cast<int>(rel_x / cell_size);
+        int gz = static_cast<int>(rel_z / cell_size);
+
+        if (gx < 0 || gx >= static_cast<int>(grid_width) ||
+            gz < 0 || gz >= static_cast<int>(grid_height)) continue;
+
+        size_t idx = static_cast<size_t>(gz) * grid_width + static_cast<size_t>(gx);
+        // Track highest Y as ground elevation
+        if (grid.solid[idx]) {
+            // First Gaussian in this cell — mark as walkable
+            grid.solid[idx] = false;
+            grid.elevation[idx] = g.position.y;
+        } else {
+            grid.elevation[idx] = std::max(grid.elevation[idx], g.position.y);
+        }
+    }
+
+    // Mark cells with steep slope as solid
+    for (uint32_t gy = 0; gy < grid_height; ++gy) {
+        for (uint32_t gx = 0; gx < grid_width; ++gx) {
+            size_t idx = gy * grid_width + gx;
+            if (grid.solid[idx]) continue;  // already solid (void)
+
+            float h = grid.elevation[idx];
+            // Check neighbors for steep slopes
+            auto check_neighbor = [&](int nx, int ny) {
+                if (nx < 0 || nx >= static_cast<int>(grid_width) ||
+                    ny < 0 || ny >= static_cast<int>(grid_height)) return;
+                size_t nidx = static_cast<size_t>(ny) * grid_width + static_cast<size_t>(nx);
+                if (grid.solid[nidx]) return;
+                float diff = std::abs(grid.elevation[nidx] - h);
+                if (diff > slope_threshold) {
+                    grid.solid[idx] = true;
+                }
+            };
+            check_neighbor(static_cast<int>(gx) - 1, static_cast<int>(gy));
+            check_neighbor(static_cast<int>(gx) + 1, static_cast<int>(gy));
+            check_neighbor(static_cast<int>(gx), static_cast<int>(gy) - 1);
+            check_neighbor(static_cast<int>(gx), static_cast<int>(gy) + 1);
         }
     }
 

--- a/src/engine/collision_gen.cpp
+++ b/src/engine/collision_gen.cpp
@@ -72,6 +72,11 @@ CollisionGrid generate_collision_from_gaussians(
     grid.solid.resize(total, true);       // default: solid (no Gaussians = void)
     grid.elevation.resize(total, 0.0f);
     grid.nav_zone.resize(total, 0);
+    grid.light_probe.resize(total, glm::vec3(0.5f));
+
+    // Accumulators for light probe averaging
+    std::vector<glm::vec3> color_sum(total, glm::vec3(0.0f));
+    std::vector<uint32_t> color_count(total, 0);
 
     if (cloud.empty()) return grid;
 
@@ -97,6 +102,10 @@ CollisionGrid generate_collision_from_gaussians(
         } else {
             grid.elevation[idx] = std::max(grid.elevation[idx], g.position.y);
         }
+
+        // Accumulate color for light probe
+        color_sum[idx] += g.color;
+        color_count[idx]++;
     }
 
     // Mark cells with steep slope as solid
@@ -121,6 +130,13 @@ CollisionGrid generate_collision_from_gaussians(
             check_neighbor(static_cast<int>(gx) + 1, static_cast<int>(gy));
             check_neighbor(static_cast<int>(gx), static_cast<int>(gy) - 1);
             check_neighbor(static_cast<int>(gx), static_cast<int>(gy) + 1);
+        }
+    }
+
+    // Compute light probes (average Gaussian color per cell)
+    for (size_t i = 0; i < total; ++i) {
+        if (color_count[i] > 0) {
+            grid.light_probe[i] = color_sum[i] / static_cast<float>(color_count[i]);
         }
     }
 

--- a/src/engine/collision_gen.cpp
+++ b/src/engine/collision_gen.cpp
@@ -71,6 +71,7 @@ CollisionGrid generate_collision_from_gaussians(
     size_t total = static_cast<size_t>(grid_width) * grid_height;
     grid.solid.resize(total, true);       // default: solid (no Gaussians = void)
     grid.elevation.resize(total, 0.0f);
+    grid.nav_zone.resize(total, 0);
 
     if (cloud.empty()) return grid;
 

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -131,6 +131,18 @@ SceneData SceneLoader::from_json(const nlohmann::json& j) {
         } else {
             grid.nav_zone.resize(total, 0);
         }
+        if (col.contains("light_probe")) {
+            const auto& lp_arr = col["light_probe"];
+            grid.light_probe.resize(lp_arr.size() / 3, glm::vec3(0.5f));
+            for (size_t i = 0; i < grid.light_probe.size(); ++i) {
+                grid.light_probe[i] = glm::vec3(
+                    lp_arr[i * 3].get<float>(),
+                    lp_arr[i * 3 + 1].get<float>(),
+                    lp_arr[i * 3 + 2].get<float>());
+            }
+        } else {
+            grid.light_probe.resize(total, glm::vec3(0.5f));
+        }
         data.collision = std::move(grid);
     }
 
@@ -471,6 +483,15 @@ nlohmann::json SceneLoader::to_json(const SceneData& data) {
             nlohmann::json zone_arr = nlohmann::json::array();
             for (uint8_t z : grid.nav_zone) zone_arr.push_back(z);
             col["nav_zone"] = zone_arr;
+        }
+        if (!grid.light_probe.empty()) {
+            nlohmann::json lp_arr = nlohmann::json::array();
+            for (const auto& lp : grid.light_probe) {
+                lp_arr.push_back(lp.x);
+                lp_arr.push_back(lp.y);
+                lp_arr.push_back(lp.z);
+            }
+            col["light_probe"] = lp_arr;
         }
         j["collision"] = col;
     }

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -103,6 +103,7 @@ SceneData SceneLoader::from_json(const nlohmann::json& j) {
         grid.width = col.value("width", 0u);
         grid.height = col.value("height", 0u);
         grid.cell_size = col.value("cell_size", 1.0f);
+        size_t total = static_cast<size_t>(grid.width) * grid.height;
         if (col.contains("solid")) {
             const auto& solid_arr = col["solid"];
             grid.solid.resize(solid_arr.size(), false);
@@ -110,7 +111,16 @@ SceneData SceneLoader::from_json(const nlohmann::json& j) {
                 grid.solid[i] = solid_arr[i].get<bool>();
             }
         } else {
-            grid.solid.resize(static_cast<size_t>(grid.width) * grid.height, false);
+            grid.solid.resize(total, false);
+        }
+        if (col.contains("elevation")) {
+            const auto& elev_arr = col["elevation"];
+            grid.elevation.resize(elev_arr.size(), 0.0f);
+            for (size_t i = 0; i < elev_arr.size(); ++i) {
+                grid.elevation[i] = elev_arr[i].get<float>();
+            }
+        } else {
+            grid.elevation.resize(total, 0.0f);
         }
         data.collision = std::move(grid);
     }
@@ -436,6 +446,11 @@ nlohmann::json SceneLoader::to_json(const SceneData& data) {
         nlohmann::json solid_arr = nlohmann::json::array();
         for (bool s : grid.solid) solid_arr.push_back(s);
         col["solid"] = solid_arr;
+        if (!grid.elevation.empty()) {
+            nlohmann::json elev_arr = nlohmann::json::array();
+            for (float e : grid.elevation) elev_arr.push_back(e);
+            col["elevation"] = elev_arr;
+        }
         j["collision"] = col;
     }
 

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -122,7 +122,23 @@ SceneData SceneLoader::from_json(const nlohmann::json& j) {
         } else {
             grid.elevation.resize(total, 0.0f);
         }
+        if (col.contains("nav_zone")) {
+            const auto& zone_arr = col["nav_zone"];
+            grid.nav_zone.resize(zone_arr.size(), 0);
+            for (size_t i = 0; i < zone_arr.size(); ++i) {
+                grid.nav_zone[i] = zone_arr[i].get<uint8_t>();
+            }
+        } else {
+            grid.nav_zone.resize(total, 0);
+        }
         data.collision = std::move(grid);
+    }
+
+    // Navigation zone names
+    if (j.contains("nav_zone_names")) {
+        for (const auto& name : j["nav_zone_names"]) {
+            data.nav_zone_names.push_back(name.get<std::string>());
+        }
     }
 
     // Tilemap
@@ -451,6 +467,11 @@ nlohmann::json SceneLoader::to_json(const SceneData& data) {
             for (float e : grid.elevation) elev_arr.push_back(e);
             col["elevation"] = elev_arr;
         }
+        if (!grid.nav_zone.empty()) {
+            nlohmann::json zone_arr = nlohmann::json::array();
+            for (uint8_t z : grid.nav_zone) zone_arr.push_back(z);
+            col["nav_zone"] = zone_arr;
+        }
         j["collision"] = col;
     }
 
@@ -629,6 +650,11 @@ nlohmann::json SceneLoader::to_json(const SceneData& data) {
             objects.push_back(obj_j);
         }
         j["placed_objects"] = objects;
+    }
+
+    // Navigation zone names
+    if (!data.nav_zone_names.empty()) {
+        j["nav_zone_names"] = data.nav_zone_names;
     }
 
     // Weather

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -275,6 +275,21 @@ SceneData SceneLoader::from_json(const nlohmann::json& j) {
         }
     }
 
+    // Placed objects
+    if (j.contains("placed_objects")) {
+        for (const auto& obj_j : j["placed_objects"]) {
+            PlacedObjectData obj;
+            obj.id = obj_j.value("id", "");
+            obj.ply_file = obj_j["ply_file"].get<std::string>();
+            if (obj_j.contains("position")) obj.position = parse_vec3(obj_j["position"]);
+            if (obj_j.contains("rotation")) obj.rotation = parse_vec3(obj_j["rotation"]);
+            obj.scale = obj_j.value("scale", 1.0f);
+            obj.is_static = obj_j.value("is_static", true);
+            obj.character_manifest = obj_j.value("character_manifest", "");
+            data.placed_objects.push_back(std::move(obj));
+        }
+    }
+
     // Weather
     if (j.contains("weather")) {
         const auto& w = j["weather"];
@@ -581,6 +596,24 @@ nlohmann::json SceneLoader::to_json(const SceneData& data) {
             });
         }
         j["portals"] = portals;
+    }
+
+    // Placed objects
+    if (!data.placed_objects.empty()) {
+        nlohmann::json objects = nlohmann::json::array();
+        for (const auto& obj : data.placed_objects) {
+            nlohmann::json obj_j;
+            obj_j["id"] = obj.id;
+            obj_j["ply_file"] = obj.ply_file;
+            obj_j["position"] = vec3_json(obj.position);
+            obj_j["rotation"] = vec3_json(obj.rotation);
+            obj_j["scale"] = obj.scale;
+            obj_j["is_static"] = obj.is_static;
+            if (!obj.character_manifest.empty())
+                obj_j["character_manifest"] = obj.character_manifest;
+            objects.push_back(obj_j);
+        }
+        j["placed_objects"] = objects;
     }
 
     // Weather

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -105,6 +105,18 @@ export function exportSceneJson(state: SceneStoreState): object {
     parallax: state.gaussianSplat.parallax,
   };
 
+  if (state.placedObjects.length > 0) {
+    scene.placed_objects = state.placedObjects.map((obj) => ({
+      id: obj.id,
+      ply_file: obj.ply_file,
+      position: obj.position,
+      rotation: obj.rotation,
+      scale: obj.scale,
+      is_static: obj.is_static,
+      ...(obj.character_manifest ? { character_manifest: obj.character_manifest } : {}),
+    }));
+  }
+
   if (state.collisionGrid.size > 0) {
     const cells: { x: number; z: number }[] = [];
     for (const key of state.collisionGrid) {

--- a/tools/apps/bricklayer/src/panels/Inspector.tsx
+++ b/tools/apps/bricklayer/src/panels/Inspector.tsx
@@ -8,6 +8,7 @@ import { VfxTab } from './VfxTab.js';
 import { EntitiesTab } from './EntitiesTab.js';
 import { BackgroundTab } from './BackgroundTab.js';
 import { GaussianTab } from './GaussianTab.js';
+import { ObjectsTab } from './ObjectsTab.js';
 
 const tabs: { id: InspectorTab; label: string }[] = [
   { id: 'scene', label: 'Scene' },
@@ -15,6 +16,7 @@ const tabs: { id: InspectorTab; label: string }[] = [
   { id: 'weather', label: 'Weather' },
   { id: 'vfx', label: 'VFX' },
   { id: 'entities', label: 'Entities' },
+  { id: 'objects', label: 'Objects' },
   { id: 'backgrounds', label: 'BG' },
   { id: 'gaussian', label: 'GS' },
 ];
@@ -78,6 +80,7 @@ export function Inspector() {
         {inspectorTab === 'weather' && <WeatherTab />}
         {inspectorTab === 'vfx' && <VfxTab />}
         {inspectorTab === 'entities' && <EntitiesTab />}
+        {inspectorTab === 'objects' && <ObjectsTab />}
         {inspectorTab === 'backgrounds' && <BackgroundTab />}
         {inspectorTab === 'gaussian' && <GaussianTab />}
       </div>

--- a/tools/apps/bricklayer/src/panels/ObjectsTab.tsx
+++ b/tools/apps/bricklayer/src/panels/ObjectsTab.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { PlacedObjectData } from '../store/types.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+  input: {
+    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 13,
+  },
+  btn: {
+    padding: '4px 10px', border: '1px solid #555', borderRadius: 4,
+    background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 12,
+  },
+  btnDanger: {
+    padding: '4px 10px', border: '1px solid #c33', borderRadius: 4,
+    background: '#4a2020', color: '#faa', cursor: 'pointer', fontSize: 12,
+  },
+  item: {
+    padding: 8, border: '1px solid #444', borderRadius: 4, background: '#22223a',
+    display: 'flex', flexDirection: 'column', gap: 6,
+  },
+  itemSelected: { borderColor: '#77f' },
+  checkbox: { marginRight: 4 },
+};
+
+function Vec3Input({
+  value,
+  onChange,
+  labelPrefix,
+}: {
+  value: [number, number, number];
+  onChange: (v: [number, number, number]) => void;
+  labelPrefix?: string;
+}) {
+  return (
+    <div style={styles.row}>
+      {['X', 'Y', 'Z'].map((axis, i) => (
+        <React.Fragment key={axis}>
+          <span style={{ fontSize: 11, color: '#888' }}>{labelPrefix ?? ''}{axis}</span>
+          <input
+            type="number"
+            step={0.1}
+            value={value[i]}
+            onChange={(e) => {
+              const next = [...value] as [number, number, number];
+              next[i] = Number(e.target.value);
+              onChange(next);
+            }}
+            style={{ ...styles.input, maxWidth: 55 }}
+          />
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+
+function ObjectEditor({ obj }: { obj: PlacedObjectData }) {
+  const updatePlacedObject = useSceneStore((s) => s.updatePlacedObject);
+  const removePlacedObject = useSceneStore((s) => s.removePlacedObject);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
+  const isSelected = selectedEntity?.type === 'object' && selectedEntity.id === obj.id;
+
+  return (
+    <div
+      style={{ ...styles.item, ...(isSelected ? styles.itemSelected : {}) }}
+      onClick={() => setSelectedEntity({ type: 'object', id: obj.id })}
+    >
+      <div style={styles.row}>
+        <span style={{ fontSize: 13, flex: 1, color: '#ddd' }}>
+          {obj.id.slice(0, 16)}
+        </span>
+        <button style={styles.btnDanger} onClick={(e) => { e.stopPropagation(); removePlacedObject(obj.id); }}>
+          Remove
+        </button>
+      </div>
+      <div style={styles.row}>
+        <span style={{ fontSize: 12, minWidth: 50 }}>PLY</span>
+        <input
+          type="text"
+          value={obj.ply_file}
+          onChange={(e) => updatePlacedObject(obj.id, { ply_file: e.target.value })}
+          style={styles.input}
+          placeholder="path/to/model.ply"
+        />
+      </div>
+      <span style={{ fontSize: 11, color: '#888' }}>Position</span>
+      <Vec3Input
+        value={obj.position}
+        onChange={(v) => updatePlacedObject(obj.id, { position: v })}
+      />
+      <span style={{ fontSize: 11, color: '#888' }}>Rotation (deg)</span>
+      <Vec3Input
+        value={obj.rotation}
+        onChange={(v) => updatePlacedObject(obj.id, { rotation: v })}
+      />
+      <div style={styles.row}>
+        <span style={{ fontSize: 12, minWidth: 50 }}>Scale</span>
+        <input
+          type="number"
+          step={0.1}
+          value={obj.scale}
+          onChange={(e) => updatePlacedObject(obj.id, { scale: Number(e.target.value) })}
+          style={{ ...styles.input, maxWidth: 80 }}
+        />
+      </div>
+      <div style={styles.row}>
+        <label style={{ fontSize: 12, color: '#ddd', display: 'flex', alignItems: 'center' }}>
+          <input
+            type="checkbox"
+            checked={obj.is_static}
+            onChange={(e) => updatePlacedObject(obj.id, { is_static: e.target.checked })}
+            style={styles.checkbox}
+          />
+          Static (merge into terrain)
+        </label>
+      </div>
+      <div style={styles.row}>
+        <span style={{ fontSize: 12, minWidth: 50 }}>Manifest</span>
+        <input
+          type="text"
+          value={obj.character_manifest}
+          onChange={(e) => updatePlacedObject(obj.id, { character_manifest: e.target.value })}
+          style={styles.input}
+          placeholder="character manifest JSON"
+        />
+      </div>
+    </div>
+  );
+}
+
+export function ObjectsTab() {
+  const placedObjects = useSceneStore((s) => s.placedObjects);
+  const addPlacedObject = useSceneStore((s) => s.addPlacedObject);
+
+  const handleAdd = () => {
+    const plyFile = window.prompt('PLY file path:', '');
+    if (plyFile) {
+      addPlacedObject(plyFile);
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ ...styles.row, marginBottom: 8 }}>
+        <span style={{ ...styles.label, flex: 1 }}>Placed Objects ({placedObjects.length})</span>
+        <button style={styles.btn} onClick={handleAdd}>+ Add</button>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {placedObjects.map((obj) => <ObjectEditor key={obj.id} obj={obj} />)}
+      </div>
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -141,8 +141,19 @@ export type InspectorTab =
   | 'weather'
   | 'vfx'
   | 'entities'
+  | 'objects'
   | 'backgrounds'
   | 'gaussian';
+
+export interface PlacedObjectData {
+  id: string;
+  ply_file: string;
+  position: [number, number, number];
+  rotation: [number, number, number];
+  scale: number;
+  is_static: boolean;
+  character_manifest: string;
+}
 
 export interface SelectedEntity {
   type: string;
@@ -174,5 +185,6 @@ export interface BricklayerFile {
     weather: WeatherData;
     dayNight: DayNightData;
     gaussianSplat: GaussianSplatConfig;
+    placedObjects: PlacedObjectData[];
   };
 }

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -5,6 +5,7 @@ import type {
   StaticLight,
   NpcData,
   PortalData,
+  PlacedObjectData,
   EmitterConfig,
   BackgroundLayer,
   WeatherData,
@@ -127,6 +128,7 @@ export interface SceneStoreState {
   staticLights: StaticLight[];
   npcs: NpcData[];
   portals: PortalData[];
+  placedObjects: PlacedObjectData[];
   player: PlayerData;
   backgroundLayers: BackgroundLayer[];
   torchEmitter: EmitterConfig;
@@ -177,6 +179,9 @@ export interface SceneStoreState {
   addPortal: () => void;
   updatePortal: (id: string, patch: Partial<PortalData>) => void;
   removePortal: (id: string) => void;
+  addPlacedObject: (plyFile: string) => void;
+  updatePlacedObject: (id: string, patch: Partial<PlacedObjectData>) => void;
+  removePlacedObject: (id: string) => void;
   updatePlayer: (patch: Partial<PlayerData>) => void;
   addBackgroundLayer: () => void;
   updateBackgroundLayer: (id: string, patch: Partial<BackgroundLayer>) => void;
@@ -225,6 +230,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   staticLights: [],
   npcs: [],
   portals: [],
+  placedObjects: [],
   player: defaultPlayer(),
   backgroundLayers: [],
   torchEmitter: defaultEmitter(),
@@ -435,6 +441,25 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     portals: get().portals.filter((p) => p.id !== id),
   }),
 
+  addPlacedObject: (plyFile) => {
+    const obj: PlacedObjectData = {
+      id: genId('obj'),
+      ply_file: plyFile,
+      position: [0, 0, 0],
+      rotation: [0, 0, 0],
+      scale: 1,
+      is_static: true,
+      character_manifest: '',
+    };
+    set({ placedObjects: [...get().placedObjects, obj] });
+  },
+  updatePlacedObject: (id, patch) => set({
+    placedObjects: get().placedObjects.map((o) => (o.id === id ? { ...o, ...patch } : o)),
+  }),
+  removePlacedObject: (id) => set({
+    placedObjects: get().placedObjects.filter((o) => o.id !== id),
+  }),
+
   updatePlayer: (patch) => set({ player: { ...get().player, ...patch } }),
 
   addBackgroundLayer: () => {
@@ -511,6 +536,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     staticLights: [],
     npcs: [],
     portals: [],
+    placedObjects: [],
     player: defaultPlayer(),
     backgroundLayers: [],
     torchPositions: [],
@@ -621,6 +647,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
         weather: s.weather,
         dayNight: s.dayNight,
         gaussianSplat: s.gaussianSplat,
+        placedObjects: s.placedObjects,
       },
     };
   },
@@ -639,6 +666,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       staticLights: data.scene.staticLights,
       npcs: data.scene.npcs,
       portals: data.scene.portals,
+      placedObjects: data.scene.placedObjects ?? [],
       player: data.scene.player,
       backgroundLayers: data.scene.backgroundLayers,
       torchEmitter: data.scene.torchEmitter,

--- a/tools/apps/bricklayer/src/viewport/ObjectMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/ObjectMarkers.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useSceneStore } from '../store/useSceneStore.js';
+
+export function ObjectMarkers() {
+  const placedObjects = useSceneStore((s) => s.placedObjects);
+  const showGizmos = useSceneStore((s) => s.showGizmos);
+  const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
+  const setInspectorTab = useSceneStore((s) => s.setInspectorTab);
+
+  if (!showGizmos) return null;
+
+  return (
+    <group>
+      {placedObjects.map((obj) => (
+        <mesh
+          key={obj.id}
+          position={[obj.position[0], obj.position[1], obj.position[2]]}
+          onClick={(e) => {
+            e.stopPropagation();
+            setSelectedEntity({ type: 'object', id: obj.id });
+            setInspectorTab('objects');
+          }}
+        >
+          <boxGeometry args={[obj.scale, obj.scale, obj.scale]} />
+          <meshBasicMaterial
+            color={obj.is_static ? '#00bcd4' : '#ff9800'}
+            wireframe
+            transparent
+            opacity={0.6}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -7,6 +7,7 @@ import { GhostVoxel } from './GhostVoxel.js';
 import { LightGizmos } from './LightGizmos.js';
 import { NpcMarkers } from './NpcMarkers.js';
 import { PortalMarkers } from './PortalMarkers.js';
+import { ObjectMarkers } from './ObjectMarkers.js';
 import { PlayerMarker } from './PlayerMarker.js';
 import { CollisionOverlay } from './CollisionOverlay.js';
 import { useSceneStore } from '../store/useSceneStore.js';
@@ -47,6 +48,7 @@ export function Viewport() {
       <LightGizmos />
       <NpcMarkers />
       <PortalMarkers />
+      <ObjectMarkers />
       <PlayerMarker />
       <CollisionOverlay />
 


### PR DESCRIPTION
## Summary
Four scene layer systems adapted from polygon-based game dev for 3DGS, enabling division of labor in content production.

### 1. PlacedObject System (compose scenes from PLY files)
- `PlacedObjectData` struct: id, ply_file, position, rotation, scale, is_static, character_manifest
- Engine merges static objects into terrain cloud at load (hybrid: animated get separate passes)
- Bricklayer: Objects tab in Inspector, viewport markers (cyan=static, orange=animated)

### 2. Heightmap Elevation
- `CollisionGrid.elevation` — per-cell ground height (float)
- `generate_collision_from_gaussians()` — auto-extracts heightmap from Gaussian Y positions
- Slope detection marks steep cells as solid
- Entities can query elevation for Y placement on terrain surface

### 3. Navigation Zones
- `CollisionGrid.nav_zone` — per-cell zone ID (uint8, 0=default, 1-255=named)
- `SceneData.nav_zone_names` — zone ID → name mapping (e.g., "town", "forest")
- Useful for AI behavior regions

### 4. Light Probes
- `CollisionGrid.light_probe` — per-cell ambient color (vec3, averaged from Gaussian colors)
- Auto-generated in `generate_collision_from_gaussians()`
- Entities sample `get_light_probe(x, y)` to match scene lighting

## Test plan
- [x] `cmake --build --preset macos-debug` passes
- [x] 10/10 C++ tests pass
- [x] `pnpm --filter @gseurat/bricklayer build` passes
- [ ] PlacedObject: add in Bricklayer → exports in scene JSON → engine loads and merges PLYs
- [ ] Heightmap: auto-generate from Gaussians → elevation values per cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)