### PR TITLE
Scene layers follow-up: collision grid upgrade, test data scripts, full demo

### DIFF
--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -117,13 +117,16 @@ export function exportSceneJson(state: SceneStoreState): object {
     }));
   }
 
-  if (state.collisionGrid.size > 0) {
-    const cells: { x: number; z: number }[] = [];
-    for (const key of state.collisionGrid) {
-      const [x, z] = key.split(',').map(Number);
-      cells.push({ x, z });
-    }
-    scene.collision = { cells };
+  if (state.collisionGridData) {
+    const g = state.collisionGridData;
+    scene.collision = {
+      width: g.width,
+      height: g.height,
+      cell_size: g.cell_size,
+      solid: g.solid,
+      elevation: g.elevation,
+      nav_zone: g.nav_zone,
+    };
   }
 
   return scene;

--- a/tools/apps/bricklayer/src/panels/GaussianTab.tsx
+++ b/tools/apps/bricklayer/src/panels/GaussianTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 
 const styles: Record<string, React.CSSProperties> = {
@@ -9,11 +9,26 @@ const styles: Record<string, React.CSSProperties> = {
     flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
     borderRadius: 4, color: '#ddd', fontSize: 13,
   },
+  btn: {
+    padding: '4px 10px', background: '#3a3a6a', border: '1px solid #555',
+    borderRadius: 4, color: '#ddd', fontSize: 12, cursor: 'pointer',
+  },
+  info: { fontSize: 11, color: '#aaa' },
 };
 
 export function GaussianTab() {
   const gs = useSceneStore((s) => s.gaussianSplat);
   const setGs = useSceneStore((s) => s.setGaussianSplat);
+  const collisionGridData = useSceneStore((s) => s.collisionGridData);
+  const initCollisionGrid = useSceneStore((s) => s.initCollisionGrid);
+  const navZoneNames = useSceneStore((s) => s.navZoneNames);
+  const addNavZoneName = useSceneStore((s) => s.addNavZoneName);
+  const removeNavZoneName = useSceneStore((s) => s.removeNavZoneName);
+
+  const [gridW, setGridW] = useState(32);
+  const [gridH, setGridH] = useState(32);
+  const [cellSize, setCellSize] = useState(1.0);
+  const [newZoneName, setNewZoneName] = useState('');
 
   return (
     <div>
@@ -159,6 +174,68 @@ export function GaussianTab() {
           />
         </div>
       </div>
+
+      {/* ── Collision Grid ── */}
+      <div style={styles.section}>
+        <span style={styles.label}>Collision Grid</span>
+        {!collisionGridData ? (
+          <>
+            <div style={styles.row}>
+              <span style={{ fontSize: 12, minWidth: 50 }}>Width</span>
+              <input type="number" value={gridW} min={1}
+                onChange={(e) => setGridW(Math.max(1, Number(e.target.value)))}
+                style={{ ...styles.input, maxWidth: 60 }} />
+              <span style={{ fontSize: 12, minWidth: 50 }}>Height</span>
+              <input type="number" value={gridH} min={1}
+                onChange={(e) => setGridH(Math.max(1, Number(e.target.value)))}
+                style={{ ...styles.input, maxWidth: 60 }} />
+            </div>
+            <div style={styles.row}>
+              <span style={{ fontSize: 12, minWidth: 50 }}>Cell</span>
+              <input type="number" value={cellSize} step={0.1} min={0.1}
+                onChange={(e) => setCellSize(Math.max(0.1, Number(e.target.value)))}
+                style={{ ...styles.input, maxWidth: 60 }} />
+            </div>
+            <button style={styles.btn} onClick={() => initCollisionGrid(gridW, gridH, cellSize)}>
+              Init Grid
+            </button>
+          </>
+        ) : (
+          <>
+            <span style={styles.info}>
+              {collisionGridData.width} x {collisionGridData.height} (cell {collisionGridData.cell_size}) &mdash;{' '}
+              {collisionGridData.solid.filter(Boolean).length} solid /{' '}
+              {collisionGridData.solid.length - collisionGridData.solid.filter(Boolean).length} walkable
+            </span>
+            <span style={styles.info}>
+              Enable &quot;Collision&quot; overlay in viewport to paint cells.
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* ── Nav Zones ── */}
+      {collisionGridData && (
+        <div style={styles.section}>
+          <span style={styles.label}>Nav Zones</span>
+          {navZoneNames.map((name, i) => (
+            <div key={i} style={styles.row}>
+              <span style={{ fontSize: 12, flex: 1 }}>#{i + 1}: {name}</span>
+              <button style={{ ...styles.btn, padding: '2px 6px' }}
+                onClick={() => removeNavZoneName(i)}>x</button>
+            </div>
+          ))}
+          <div style={styles.row}>
+            <input type="text" value={newZoneName} placeholder="zone name"
+              onChange={(e) => setNewZoneName(e.target.value)}
+              style={styles.input} />
+            <button style={styles.btn}
+              onClick={() => { if (newZoneName.trim()) { addNavZoneName(newZoneName.trim()); setNewZoneName(''); } }}>
+              Add
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/panels/Inspector.tsx
+++ b/tools/apps/bricklayer/src/panels/Inspector.tsx
@@ -9,6 +9,7 @@ import { EntitiesTab } from './EntitiesTab.js';
 import { BackgroundTab } from './BackgroundTab.js';
 import { GaussianTab } from './GaussianTab.js';
 import { ObjectsTab } from './ObjectsTab.js';
+import { NavZoneTab } from './NavZoneTab.js';
 
 const tabs: { id: InspectorTab; label: string }[] = [
   { id: 'scene', label: 'Scene' },
@@ -19,6 +20,7 @@ const tabs: { id: InspectorTab; label: string }[] = [
   { id: 'objects', label: 'Objects' },
   { id: 'backgrounds', label: 'BG' },
   { id: 'gaussian', label: 'GS' },
+  { id: 'nav_zone', label: 'Nav' },
 ];
 
 const styles: Record<string, React.CSSProperties> = {
@@ -83,6 +85,7 @@ export function Inspector() {
         {inspectorTab === 'objects' && <ObjectsTab />}
         {inspectorTab === 'backgrounds' && <BackgroundTab />}
         {inspectorTab === 'gaussian' && <GaussianTab />}
+        {inspectorTab === 'nav_zone' && <NavZoneTab />}
       </div>
     </div>
   );

--- a/tools/apps/bricklayer/src/panels/NavZoneTab.tsx
+++ b/tools/apps/bricklayer/src/panels/NavZoneTab.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { useSceneStore } from '../store/useSceneStore.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+  input: {
+    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 13,
+  },
+  btn: {
+    padding: '4px 10px', background: '#3a3a6a', border: '1px solid #555',
+    borderRadius: 4, color: '#ddd', fontSize: 12, cursor: 'pointer',
+  },
+  info: { fontSize: 11, color: '#aaa', lineHeight: 1.5 },
+};
+
+export function NavZoneTab() {
+  const navZoneNames = useSceneStore((s) => s.navZoneNames);
+  const addNavZoneName = useSceneStore((s) => s.addNavZoneName);
+  const removeNavZoneName = useSceneStore((s) => s.removeNavZoneName);
+  const collisionGridData = useSceneStore((s) => s.collisionGridData);
+
+  const [newName, setNewName] = useState('');
+
+  if (!collisionGridData) {
+    return (
+      <div style={styles.section}>
+        <span style={styles.info}>
+          Initialize a collision grid in the GS tab first to manage navigation zones.
+        </span>
+      </div>
+    );
+  }
+
+  // Count cells per zone
+  const zoneCounts: Record<number, number> = {};
+  for (const z of collisionGridData.nav_zone) {
+    zoneCounts[z] = (zoneCounts[z] ?? 0) + 1;
+  }
+
+  return (
+    <div>
+      <div style={styles.section}>
+        <span style={styles.label}>Zone Names</span>
+        <div style={styles.row}>
+          <span style={{ fontSize: 12, color: '#aaa' }}>#0: default ({zoneCounts[0] ?? 0} cells)</span>
+        </div>
+        {navZoneNames.map((name, i) => (
+          <div key={i} style={styles.row}>
+            <span style={{ fontSize: 12, flex: 1 }}>
+              #{i + 1}: {name} ({zoneCounts[i + 1] ?? 0} cells)
+            </span>
+            <button style={{ ...styles.btn, padding: '2px 6px' }}
+              onClick={() => removeNavZoneName(i)}>x</button>
+          </div>
+        ))}
+        <div style={styles.row}>
+          <input type="text" value={newName} placeholder="new zone name"
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && newName.trim()) {
+                addNavZoneName(newName.trim());
+                setNewName('');
+              }
+            }}
+            style={styles.input} />
+          <button style={styles.btn}
+            onClick={() => { if (newName.trim()) { addNavZoneName(newName.trim()); setNewName(''); } }}>
+            Add
+          </button>
+        </div>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Instructions</span>
+        <span style={styles.info}>
+          Click cells in the viewport while the Collision overlay is visible to paint zones.
+          Use the GS tab to set the active zone before painting.
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/panels/SceneTab.tsx
+++ b/tools/apps/bricklayer/src/panels/SceneTab.tsx
@@ -36,7 +36,7 @@ export function SceneTab() {
   const voxels = useSceneStore((s) => s.voxels);
   const dayNight = useSceneStore((s) => s.dayNight);
   const setDayNight = useSceneStore((s) => s.setDayNight);
-  const autoGenerateCollision = useSceneStore((s) => s.autoGenerateCollision);
+  const collisionGridData = useSceneStore((s) => s.collisionGridData);
 
   return (
     <div>
@@ -105,9 +105,11 @@ export function SceneTab() {
 
       <div style={styles.section}>
         <span style={styles.label}>Collision</span>
-        <button style={styles.btn} onClick={autoGenerateCollision}>
-          Auto-Generate from Voxels
-        </button>
+        <span style={{ fontSize: 12, color: '#aaa' }}>
+          {collisionGridData
+            ? `${collisionGridData.width}x${collisionGridData.height} grid (${collisionGridData.solid.filter(Boolean).length} solid)`
+            : 'No grid — init in GS tab'}
+        </span>
       </div>
     </div>
   );

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -143,7 +143,8 @@ export type InspectorTab =
   | 'entities'
   | 'objects'
   | 'backgrounds'
-  | 'gaussian';
+  | 'gaussian'
+  | 'nav_zone';
 
 export interface PlacedObjectData {
   id: string;
@@ -155,6 +156,15 @@ export interface PlacedObjectData {
   character_manifest: string;
 }
 
+export interface CollisionGridData {
+  width: number;
+  height: number;
+  cell_size: number;
+  solid: boolean[];         // row-major walkability
+  elevation: number[];      // per-cell ground height
+  nav_zone: number[];       // per-cell zone ID (0=default)
+}
+
 export interface SelectedEntity {
   type: string;
   id: string;
@@ -162,7 +172,7 @@ export interface SelectedEntity {
 
 export interface Snapshot {
   voxels: [VoxelKey, Voxel][];
-  collisionGrid: string[];
+  collisionGridData: CollisionGridData | null;
 }
 
 export interface BricklayerFile {
@@ -170,7 +180,9 @@ export interface BricklayerFile {
   gridWidth: number;
   gridDepth: number;
   voxels: { x: number; y: number; z: number; r: number; g: number; b: number; a: number }[];
-  collision: string[];
+  collision: string[];  // legacy format
+  collisionGridData?: CollisionGridData;
+  nav_zone_names?: string[];
   scene: {
     ambientColor: [number, number, number, number];
     staticLights: StaticLight[];

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -17,6 +17,7 @@ import type {
   SelectedEntity,
   Snapshot,
   BricklayerFile,
+  CollisionGridData,
 } from './types.js';
 import { voxelKey, parseKey, floodFill3D, brushPositions } from '../lib/voxelUtils.js';
 
@@ -92,17 +93,29 @@ function defaultPlayer(): PlayerData {
   };
 }
 
-function makeSnapshot(voxels: Map<VoxelKey, Voxel>, collisionGrid: Set<string>): Snapshot {
+function cloneCollisionGrid(g: CollisionGridData | null): CollisionGridData | null {
+  if (!g) return null;
   return {
-    voxels: Array.from(voxels.entries()),
-    collisionGrid: Array.from(collisionGrid),
+    width: g.width,
+    height: g.height,
+    cell_size: g.cell_size,
+    solid: [...g.solid],
+    elevation: [...g.elevation],
+    nav_zone: [...g.nav_zone],
   };
 }
 
-function restoreSnapshot(snapshot: Snapshot): { voxels: Map<VoxelKey, Voxel>; collisionGrid: Set<string> } {
+function makeSnapshot(voxels: Map<VoxelKey, Voxel>, collisionGridData: CollisionGridData | null): Snapshot {
+  return {
+    voxels: Array.from(voxels.entries()),
+    collisionGridData: cloneCollisionGrid(collisionGridData),
+  };
+}
+
+function restoreSnapshot(snapshot: Snapshot): { voxels: Map<VoxelKey, Voxel>; collisionGridData: CollisionGridData | null } {
   return {
     voxels: new Map(snapshot.voxels),
-    collisionGrid: new Set(snapshot.collisionGrid),
+    collisionGridData: cloneCollisionGrid(snapshot.collisionGridData),
   };
 }
 
@@ -138,7 +151,8 @@ export interface SceneStoreState {
   weather: WeatherData;
   dayNight: DayNightData;
   gaussianSplat: GaussianSplatConfig;
-  collisionGrid: Set<string>;
+  collisionGridData: CollisionGridData | null;
+  navZoneNames: string[];
 
   // Editor state
   selectedEntity: SelectedEntity | null;
@@ -195,8 +209,12 @@ export interface SceneStoreState {
   setWeather: (w: Partial<WeatherData>) => void;
   setDayNight: (d: Partial<DayNightData>) => void;
   setGaussianSplat: (g: Partial<GaussianSplatConfig>) => void;
-  toggleCollision: (x: number, z: number) => void;
-  autoGenerateCollision: () => void;
+  initCollisionGrid: (width: number, height: number, cellSize: number) => void;
+  toggleCellSolid: (x: number, z: number) => void;
+  setCellElevation: (x: number, z: number, value: number) => void;
+  setCellNavZone: (x: number, z: number, zone: number) => void;
+  addNavZoneName: (name: string) => void;
+  removeNavZoneName: (index: number) => void;
 
   // Actions – editor
   setSelectedEntity: (e: SelectedEntity | null) => void;
@@ -240,7 +258,8 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   weather: defaultWeather(),
   dayNight: defaultDayNight(),
   gaussianSplat: defaultGaussianSplat(),
-  collisionGrid: new Set(),
+  collisionGridData: null,
+  navZoneNames: [],
 
   selectedEntity: null,
   inspectorTab: 'scene',
@@ -253,15 +272,15 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
 
   // ── Undo ──
   pushUndo: () => {
-    const { voxels, collisionGrid, undoStack } = get();
-    const snap = makeSnapshot(voxels, collisionGrid);
+    const { voxels, collisionGridData, undoStack } = get();
+    const snap = makeSnapshot(voxels, collisionGridData);
     set({ undoStack: [...undoStack.slice(-49), snap], redoStack: [] });
   },
 
   undo: () => {
-    const { undoStack, voxels, collisionGrid } = get();
+    const { undoStack, voxels, collisionGridData } = get();
     if (undoStack.length === 0) return;
-    const current = makeSnapshot(voxels, collisionGrid);
+    const current = makeSnapshot(voxels, collisionGridData);
     const prev = undoStack[undoStack.length - 1];
     const restored = restoreSnapshot(prev);
     set({
@@ -272,9 +291,9 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   },
 
   redo: () => {
-    const { redoStack, voxels, collisionGrid } = get();
+    const { redoStack, voxels, collisionGridData } = get();
     if (redoStack.length === 0) return;
-    const current = makeSnapshot(voxels, collisionGrid);
+    const current = makeSnapshot(voxels, collisionGridData);
     const next = redoStack[redoStack.length - 1];
     const restored = restoreSnapshot(next);
     set({
@@ -498,26 +517,56 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   setDayNight: (d) => set({ dayNight: { ...get().dayNight, ...d } }),
   setGaussianSplat: (g) => set({ gaussianSplat: { ...get().gaussianSplat, ...g } }),
 
-  toggleCollision: (x, z) => {
-    const { collisionGrid } = get();
-    const next = new Set(collisionGrid);
-    const key = `${x},${z}`;
-    if (next.has(key)) {
-      next.delete(key);
-    } else {
-      next.add(key);
-    }
-    set({ collisionGrid: next });
+  initCollisionGrid: (width, height, cellSize) => {
+    const count = width * height;
+    set({
+      collisionGridData: {
+        width,
+        height,
+        cell_size: cellSize,
+        solid: new Array(count).fill(false),
+        elevation: new Array(count).fill(0),
+        nav_zone: new Array(count).fill(0),
+      },
+    });
   },
 
-  autoGenerateCollision: () => {
-    const { voxels } = get();
-    const occupied = new Set<string>();
-    for (const key of voxels.keys()) {
-      const [x, , z] = parseKey(key);
-      occupied.add(`${x},${z}`);
-    }
-    set({ collisionGrid: occupied });
+  toggleCellSolid: (x, z) => {
+    const { collisionGridData } = get();
+    if (!collisionGridData) return;
+    const idx = z * collisionGridData.width + x;
+    if (idx < 0 || idx >= collisionGridData.solid.length) return;
+    const solid = [...collisionGridData.solid];
+    solid[idx] = !solid[idx];
+    set({ collisionGridData: { ...collisionGridData, solid } });
+  },
+
+  setCellElevation: (x, z, value) => {
+    const { collisionGridData } = get();
+    if (!collisionGridData) return;
+    const idx = z * collisionGridData.width + x;
+    if (idx < 0 || idx >= collisionGridData.elevation.length) return;
+    const elevation = [...collisionGridData.elevation];
+    elevation[idx] = value;
+    set({ collisionGridData: { ...collisionGridData, elevation } });
+  },
+
+  setCellNavZone: (x, z, zone) => {
+    const { collisionGridData } = get();
+    if (!collisionGridData) return;
+    const idx = z * collisionGridData.width + x;
+    if (idx < 0 || idx >= collisionGridData.nav_zone.length) return;
+    const nav_zone = [...collisionGridData.nav_zone];
+    nav_zone[idx] = zone;
+    set({ collisionGridData: { ...collisionGridData, nav_zone } });
+  },
+
+  addNavZoneName: (name) => {
+    set({ navZoneNames: [...get().navZoneNames, name] });
+  },
+
+  removeNavZoneName: (index) => {
+    set({ navZoneNames: get().navZoneNames.filter((_, i) => i !== index) });
   },
 
   // ── Editor actions ──
@@ -532,7 +581,8 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     voxels: new Map(),
     gridWidth: width,
     gridDepth: depth,
-    collisionGrid: new Set(),
+    collisionGridData: null,
+    navZoneNames: [],
     staticLights: [],
     npcs: [],
     portals: [],
@@ -632,7 +682,9 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       gridWidth: s.gridWidth,
       gridDepth: s.gridDepth,
       voxels: voxelArr,
-      collision: Array.from(s.collisionGrid),
+      collision: [],
+      collisionGridData: s.collisionGridData ?? undefined,
+      nav_zone_names: s.navZoneNames.length > 0 ? s.navZoneNames : undefined,
       scene: {
         ambientColor: s.ambientColor,
         staticLights: s.staticLights,
@@ -661,7 +713,8 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       voxels,
       gridWidth: data.gridWidth,
       gridDepth: data.gridDepth,
-      collisionGrid: new Set(data.collision),
+      collisionGridData: data.collisionGridData ?? null,
+      navZoneNames: data.nav_zone_names ?? [],
       ambientColor: data.scene.ambientColor,
       staticLights: data.scene.staticLights,
       npcs: data.scene.npcs,

--- a/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
+++ b/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
@@ -1,27 +1,109 @@
 import React, { useMemo } from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 
+// HSL hue per nav zone (golden angle spacing for good contrast)
+function zoneColor(zone: number): string {
+  if (zone <= 0) return '#ff1744';
+  const hue = (zone * 137.508) % 360;
+  return `hsl(${hue}, 70%, 50%)`;
+}
+
+function elevationColor(elev: number, minElev: number, maxElev: number): string {
+  if (maxElev <= minElev) return '#ff1744';
+  const t = (elev - minElev) / (maxElev - minElev);
+  // blue (low) -> red (high)
+  const r = Math.round(t * 255);
+  const b = Math.round((1 - t) * 255);
+  return `rgb(${r}, 40, ${b})`;
+}
+
+interface CellProps {
+  x: number;
+  z: number;
+  cellSize: number;
+  elevation: number;
+  color: string;
+  opacity: number;
+}
+
+function Cell({ x, z, cellSize, elevation, color, opacity }: CellProps) {
+  return (
+    <mesh position={[x * cellSize, elevation + 0.01, z * cellSize]} rotation={[-Math.PI / 2, 0, 0]}>
+      <planeGeometry args={[cellSize, cellSize]} />
+      <meshBasicMaterial color={color} transparent opacity={opacity} depthWrite={false} />
+    </mesh>
+  );
+}
+
 export function CollisionOverlay() {
-  const collisionGrid = useSceneStore((s) => s.collisionGrid);
+  const collisionGridData = useSceneStore((s) => s.collisionGridData);
   const showCollision = useSceneStore((s) => s.showCollision);
 
   const cells = useMemo(() => {
-    if (!showCollision) return [];
-    return Array.from(collisionGrid).map((key) => {
-      const [x, z] = key.split(',').map(Number);
-      return { x, z, key };
-    });
-  }, [collisionGrid, showCollision]);
+    if (!showCollision || !collisionGridData) return [];
 
-  if (!showCollision) return null;
+    const g = collisionGridData;
+    const result: { x: number; z: number; elevation: number; color: string; opacity: number; key: string }[] = [];
+
+    // Determine if elevation varies
+    let minElev = Infinity;
+    let maxElev = -Infinity;
+    for (let i = 0; i < g.solid.length; i++) {
+      if (g.solid[i]) {
+        minElev = Math.min(minElev, g.elevation[i]);
+        maxElev = Math.max(maxElev, g.elevation[i]);
+      }
+    }
+    const elevVaries = minElev < maxElev;
+
+    // Check if any non-zero nav zones exist
+    let hasZones = false;
+    for (let i = 0; i < g.nav_zone.length; i++) {
+      if (g.nav_zone[i] > 0) { hasZones = true; break; }
+    }
+
+    for (let z = 0; z < g.height; z++) {
+      for (let x = 0; x < g.width; x++) {
+        const idx = z * g.width + x;
+        if (!g.solid[idx]) continue;
+
+        let color: string;
+        if (hasZones && g.nav_zone[idx] > 0) {
+          color = zoneColor(g.nav_zone[idx]);
+        } else if (elevVaries) {
+          color = elevationColor(g.elevation[idx], minElev, maxElev);
+        } else {
+          color = '#ff1744';
+        }
+
+        result.push({
+          x,
+          z,
+          elevation: g.elevation[idx],
+          color,
+          opacity: 0.35,
+          key: `${x},${z}`,
+        });
+      }
+    }
+
+    return result;
+  }, [collisionGridData, showCollision]);
+
+  if (!showCollision || !collisionGridData) return null;
 
   return (
     <group>
-      {cells.map(({ x, z, key }) => (
-        <mesh key={key} position={[x, 0.01, z]} rotation={[-Math.PI / 2, 0, 0]}>
-          <planeGeometry args={[1, 1]} />
-          <meshBasicMaterial color="#ff1744" transparent opacity={0.35} depthWrite={false} />
-        </mesh>
+      {cells.map((c) => (
+        <Cell
+          key={c.key}
+          x={c.x}
+          z={c.z}
+          cellSize={collisionGridData.cell_size}
+          elevation={c.elevation}
+          color={c.color}
+          opacity={c.opacity}
+        />
       ))}
     </group>
   );


### PR DESCRIPTION
## Summary

### Bricklayer Collision Grid Upgrade
- `CollisionGridData` type with solid/elevation/nav_zone arrays (replaces `Set<string>`)
- Init Grid controls in GS tab (width/height/cell_size)
- Collision overlay with color coding (solid=red, elevation gradient, zone hues)
- NavZone tab for managing named navigation zones
- Full collision data round-trips through save/load and scene export

### Test Data Generation Scripts
Reusable Python scripts (no external dependencies):
- `scripts/ply_utils.py` — shared PLY binary writer
- `scripts/generate_test_terrain.py` — 64x64 rolling hills terrain (sine waves, height-colored)
- `scripts/generate_test_props.py` — tree, rock, house procedural props
- `scripts/generate_test_scene.py` — complete scene with placed objects, collision grid, nav zones

### Full Scene Layers Demo (N key)
- `Pathfinder::find_path_grid()` — A* pathfinding on CollisionGrid (for GS scenes)
- 5 markers placed at elevation-correct Y, tinted by light probe color
- A* path visualization (71 waypoints as yellow dots following terrain)
- HUD shows grid stats, elevation range, walkable count, probe sample, marker/path info
- Run: `./gseurat_demo --scene assets/scenes/gs_layers_demo.json`

### Documentation
- Scene Composition section (PlacedObjects workflow)
- Scene Layers table (elevation/nav_zone/light_probe)
- Updated scene format example
- Test Data Generation usage examples

## Test plan
- [x] `cmake --build --preset macos-debug` passes
- [x] `cmake --build --preset macos-release` passes
- [x] `pnpm --filter @gseurat/bricklayer build` passes
- [x] 10/10 C++ tests pass
- [x] Demo loads gs_layers_demo.json with merged props at 74.8 FPS
- [x] N key shows markers at elevation + A* path with 71 waypoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)