### PR TITLE
Bricklayer UI overhaul: 3-panel mode-based layout

### DIFF
--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -1,11 +1,139 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Viewport } from './viewport/Viewport.js';
 import { MenuBar } from './panels/MenuBar.js';
-import { ToolBar } from './panels/ToolBar.js';
-import { Inspector } from './panels/Inspector.js';
 import { ImportDialog } from './panels/ImportDialog.js';
+import { TerrainLeftPanel } from './panels/TerrainLeftPanel.js';
+import { TerrainRightPanel } from './panels/TerrainRightPanel.js';
+import { SceneTreePanel } from './panels/SceneTreePanel.js';
+import { ScenePropertiesPanel } from './panels/ScenePropertiesPanel.js';
+import { SettingsLeftPanel } from './panels/SettingsLeftPanel.js';
+import { SettingsRightPanel } from './panels/SettingsRightPanel.js';
 import { useSceneStore } from './store/useSceneStore.js';
-import type { ToolType } from './store/types.js';
+import type { BricklayerMode, ToolType } from './store/types.js';
+
+// ── ResizeHandle ──
+
+function ResizeHandle({
+  side,
+  onDrag,
+}: {
+  side: 'left' | 'right';
+  onDrag: (delta: number) => void;
+}) {
+  const [hovering, setHovering] = useState(false);
+  const dragging = useRef(false);
+  const lastX = useRef(0);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      dragging.current = true;
+      lastX.current = e.clientX;
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    [],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragging.current) return;
+      const dx = e.clientX - lastX.current;
+      lastX.current = e.clientX;
+      onDrag(side === 'left' ? dx : -dx);
+    },
+    [onDrag, side],
+  );
+
+  const onPointerUp = useCallback(() => {
+    dragging.current = false;
+  }, []);
+
+  return (
+    <div
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerEnter={() => setHovering(true)}
+      onPointerLeave={() => { setHovering(false); dragging.current = false; }}
+      style={{
+        width: 5,
+        cursor: 'col-resize',
+        background: hovering || dragging.current ? '#77f' : '#333',
+        flexShrink: 0,
+        transition: 'background 0.15s',
+      }}
+    />
+  );
+}
+
+// ── Mode tabs ──
+
+const modeItems: { id: BricklayerMode; label: string }[] = [
+  { id: 'terrain', label: 'TERRAIN' },
+  { id: 'scene', label: 'SCENE' },
+  { id: 'settings', label: 'SETTINGS' },
+];
+
+function ModeTabs() {
+  const mode = useSceneStore((s) => s.mode);
+  const setMode = useSceneStore((s) => s.setMode);
+
+  return (
+    <div style={modeTabsStyles.bar}>
+      {modeItems.map((m) => (
+        <button
+          key={m.id}
+          onClick={() => setMode(m.id)}
+          style={{
+            ...modeTabsStyles.tab,
+            ...(mode === m.id ? modeTabsStyles.tabActive : {}),
+          }}
+        >
+          {m.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+const modeTabsStyles: Record<string, React.CSSProperties> = {
+  bar: {
+    display: 'flex',
+    borderBottom: '1px solid #333',
+    flexShrink: 0,
+  },
+  tab: {
+    flex: 1,
+    padding: '8px 4px',
+    border: 'none',
+    background: 'transparent',
+    color: '#888',
+    cursor: 'pointer',
+    fontSize: 11,
+    fontWeight: 600,
+    textAlign: 'center',
+    letterSpacing: 1,
+  },
+  tabActive: {
+    color: '#fff',
+    borderBottom: '2px solid #77f',
+    background: '#2a2a4a',
+  },
+};
+
+// ── Keyboard shortcuts ──
+
+const toolKeys: Record<string, ToolType> = {
+  v: 'place',
+  b: 'paint',
+  e: 'erase',
+  g: 'fill',
+  x: 'extrude',
+  i: 'eyedropper',
+  s: 'select',
+};
+
+// ── App styles ──
 
 const styles: Record<string, React.CSSProperties> = {
   root: {
@@ -19,24 +147,53 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     overflow: 'hidden',
   },
+  leftPanel: {
+    background: '#1e1e3a',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    flexShrink: 0,
+  },
+  leftContent: {
+    flex: 1,
+    overflowY: 'auto',
+    padding: 12,
+  },
   viewport: {
     flex: 1,
     position: 'relative',
+    minWidth: 100,
+  },
+  rightPanel: {
+    background: '#1e1e3a',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    flexShrink: 0,
+  },
+  rightContent: {
+    flex: 1,
+    overflowY: 'auto',
+    padding: 12,
   },
 };
 
-const toolKeys: Record<string, ToolType> = {
-  v: 'place',
-  b: 'paint',
-  e: 'erase',
-  g: 'fill',
-  x: 'extrude',
-  i: 'eyedropper',
-  s: 'select',
-};
+// ── App ──
 
 export function App() {
   const [showImport, setShowImport] = useState(false);
+  const [leftWidth, setLeftWidth] = useState(220);
+  const [rightWidth, setRightWidth] = useState(320);
+
+  const mode = useSceneStore((s) => s.mode);
+
+  const handleLeftDrag = useCallback((delta: number) => {
+    setLeftWidth((w) => Math.max(160, Math.min(500, w + delta)));
+  }, []);
+
+  const handleRightDrag = useCallback((delta: number) => {
+    setRightWidth((w) => Math.max(200, Math.min(600, w + delta)));
+  }, []);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -78,11 +235,33 @@ export function App() {
     <div style={styles.root}>
       <MenuBar onImport={() => setShowImport(true)} />
       <div style={styles.body}>
-        <ToolBar />
+        {/* Left panel */}
+        <div style={{ ...styles.leftPanel, width: leftWidth }}>
+          <ModeTabs />
+          <div style={styles.leftContent}>
+            {mode === 'terrain' && <TerrainLeftPanel />}
+            {mode === 'scene' && <SceneTreePanel />}
+            {mode === 'settings' && <SettingsLeftPanel />}
+          </div>
+        </div>
+
+        <ResizeHandle side="left" onDrag={handleLeftDrag} />
+
+        {/* Center viewport */}
         <div style={styles.viewport}>
           <Viewport />
         </div>
-        <Inspector />
+
+        <ResizeHandle side="right" onDrag={handleRightDrag} />
+
+        {/* Right panel */}
+        <div style={{ ...styles.rightPanel, width: rightWidth }}>
+          <div style={styles.rightContent}>
+            {mode === 'terrain' && <TerrainRightPanel />}
+            {mode === 'scene' && <ScenePropertiesPanel />}
+            {mode === 'settings' && <SettingsRightPanel />}
+          </div>
+        </div>
       </div>
       {showImport && <ImportDialog onClose={() => setShowImport(false)} />}
     </div>

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 import { exportPly } from '../lib/plyExport.js';
 import { exportSceneJson } from '../lib/sceneExport.js';
@@ -11,10 +11,12 @@ const styles: Record<string, React.CSSProperties> = {
     borderBottom: '1px solid #333',
     display: 'flex',
     alignItems: 'center',
-    padding: '0 12px',
-    gap: 4,
+    padding: '0 4px',
+    gap: 0,
+    position: 'relative',
+    zIndex: 50,
   },
-  btn: {
+  menuBtn: {
     padding: '4px 12px',
     background: 'transparent',
     border: '1px solid transparent',
@@ -22,11 +24,45 @@ const styles: Record<string, React.CSSProperties> = {
     color: '#ccc',
     cursor: 'pointer',
     fontSize: 13,
+    position: 'relative',
+  },
+  menuBtnOpen: {
+    background: '#2a2a4a',
+    borderColor: '#444',
+  },
+  dropdown: {
+    position: 'absolute',
+    top: '100%',
+    left: 0,
+    background: '#1e1e3a',
+    border: '1px solid #444',
+    borderRadius: 4,
+    minWidth: 180,
+    padding: '4px 0',
+    zIndex: 100,
+    boxShadow: '0 4px 12px rgba(0,0,0,0.5)',
+  },
+  menuItem: {
+    display: 'block',
+    width: '100%',
+    padding: '6px 16px',
+    background: 'transparent',
+    border: 'none',
+    color: '#ccc',
+    cursor: 'pointer',
+    fontSize: 13,
+    textAlign: 'left',
+  },
+  separator: {
+    height: 1,
+    background: '#333',
+    margin: '4px 0',
   },
   title: {
     marginLeft: 'auto',
     fontSize: 12,
     color: '#666',
+    paddingRight: 8,
   },
 };
 
@@ -39,8 +75,83 @@ function download(blob: Blob, name: string) {
   URL.revokeObjectURL(url);
 }
 
+interface MenuItem {
+  label: string;
+  action: () => void;
+  separator?: boolean;
+}
+
+function DropdownMenu({
+  label,
+  items,
+  isOpen,
+  onToggle,
+  onClose,
+}: {
+  label: string;
+  items: MenuItem[];
+  isOpen: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [isOpen, onClose]);
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        style={{ ...styles.menuBtn, ...(isOpen ? styles.menuBtnOpen : {}) }}
+        onClick={onToggle}
+      >
+        {label}
+      </button>
+      {isOpen && (
+        <div style={styles.dropdown}>
+          {items.map((item, i) => (
+            <React.Fragment key={i}>
+              {item.separator && <div style={styles.separator} />}
+              <button
+                style={styles.menuItem}
+                onClick={() => {
+                  item.action();
+                  onClose();
+                }}
+                onMouseEnter={(e) => {
+                  (e.target as HTMLElement).style.background = '#3a3a6a';
+                }}
+                onMouseLeave={(e) => {
+                  (e.target as HTMLElement).style.background = 'transparent';
+                }}
+              >
+                {item.label}
+              </button>
+            </React.Fragment>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function MenuBar({ onImport }: { onImport: () => void }) {
   const fileRef = useRef<HTMLInputElement>(null);
+  const [openMenu, setOpenMenu] = useState<string | null>(null);
+
+  const closeMenu = useCallback(() => setOpenMenu(null), []);
+  const toggleMenu = useCallback(
+    (id: string) => setOpenMenu((prev) => (prev === id ? null : id)),
+    [],
+  );
 
   const handleNew = () => {
     if (!confirm('Create new scene? Unsaved changes will be lost.')) return;
@@ -82,15 +193,74 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
     download(new Blob([json], { type: 'application/json' }), 'scene.json');
   };
 
+  const fileItems: MenuItem[] = [
+    { label: 'New', action: handleNew },
+    { label: 'Save', action: handleSave },
+    { label: 'Load', action: handleLoad },
+    { label: 'Import Image...', action: onImport, separator: true },
+    { label: 'Export PLY...', action: handleExportPly, separator: true },
+    { label: 'Export Scene...', action: handleExportScene },
+  ];
+
+  const editItems: MenuItem[] = [
+    { label: 'Undo', action: () => useSceneStore.getState().undo() },
+    { label: 'Redo', action: () => useSceneStore.getState().redo() },
+  ];
+
+  const viewItems: MenuItem[] = [
+    {
+      label: `${useSceneStore.getState().showGrid ? '\u2713 ' : ''}Grid`,
+      action: () => {
+        const s = useSceneStore.getState();
+        s.setShowGrid(!s.showGrid);
+      },
+    },
+    {
+      label: `${useSceneStore.getState().showCollision ? '\u2713 ' : ''}Collision`,
+      action: () => {
+        const s = useSceneStore.getState();
+        s.setShowCollision(!s.showCollision);
+      },
+    },
+    {
+      label: `${useSceneStore.getState().showGizmos ? '\u2713 ' : ''}Gizmos`,
+      action: () => {
+        const s = useSceneStore.getState();
+        s.setShowGizmos(!s.showGizmos);
+      },
+    },
+  ];
+
   return (
     <div style={styles.bar}>
-      <button style={styles.btn} onClick={handleNew}>New</button>
-      <button style={styles.btn} onClick={handleSave}>Save</button>
-      <button style={styles.btn} onClick={handleLoad}>Load</button>
-      <button style={styles.btn} onClick={onImport}>Import Image</button>
-      <button style={styles.btn} onClick={handleExportPly}>Export PLY</button>
-      <button style={styles.btn} onClick={handleExportScene}>Export Scene</button>
-      <input ref={fileRef} type="file" accept=".bricklayer,.json" style={{ display: 'none' }} onChange={handleFileChange} />
+      <DropdownMenu
+        label="File"
+        items={fileItems}
+        isOpen={openMenu === 'file'}
+        onToggle={() => toggleMenu('file')}
+        onClose={closeMenu}
+      />
+      <DropdownMenu
+        label="Edit"
+        items={editItems}
+        isOpen={openMenu === 'edit'}
+        onToggle={() => toggleMenu('edit')}
+        onClose={closeMenu}
+      />
+      <DropdownMenu
+        label="View"
+        items={viewItems}
+        isOpen={openMenu === 'view'}
+        onToggle={() => toggleMenu('view')}
+        onClose={closeMenu}
+      />
+      <input
+        ref={fileRef}
+        type="file"
+        accept=".bricklayer,.json"
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
       <span style={styles.title}>Bricklayer</span>
     </div>
   );

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -1,0 +1,488 @@
+import React from 'react';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type {
+  StaticLight,
+  NpcData,
+  PortalData,
+  PlacedObjectData,
+  PlayerData,
+} from '../store/types.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+  input: {
+    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 13,
+  },
+  select: {
+    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 13,
+  },
+  btnDanger: {
+    padding: '4px 10px', border: '1px solid #c33', borderRadius: 4,
+    background: '#4a2020', color: '#faa', cursor: 'pointer', fontSize: 12,
+  },
+  empty: { fontSize: 12, color: '#666', textAlign: 'center' as const, paddingTop: 40 },
+  checkbox: { marginRight: 4 },
+};
+
+const facings = ['up', 'down', 'left', 'right'];
+
+function Vec3Input({
+  value,
+  onChange,
+  step,
+}: {
+  value: [number, number, number];
+  onChange: (v: [number, number, number]) => void;
+  step?: number;
+}) {
+  return (
+    <div style={styles.row}>
+      {['X', 'Y', 'Z'].map((axis, i) => (
+        <React.Fragment key={axis}>
+          <span style={{ fontSize: 11, color: '#888' }}>{axis}</span>
+          <input
+            type="number"
+            step={step ?? 0.1}
+            value={value[i]}
+            onChange={(e) => {
+              const next = [...value] as [number, number, number];
+              next[i] = Number(e.target.value);
+              onChange(next);
+            }}
+            style={{ ...styles.input, maxWidth: 55 }}
+          />
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+
+// ── Per-entity property editors ──
+
+function ObjectProperties({ obj }: { obj: PlacedObjectData }) {
+  const update = useSceneStore((s) => s.updatePlacedObject);
+  const remove = useSceneStore((s) => s.removePlacedObject);
+
+  return (
+    <div>
+      <div style={{ ...styles.row, marginBottom: 12 }}>
+        <span style={{ ...styles.label, flex: 1 }}>Placed Object</span>
+        <button style={styles.btnDanger} onClick={() => remove(obj.id)}>Remove</button>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>PLY File</span>
+        <input
+          type="text"
+          value={obj.ply_file}
+          onChange={(e) => update(obj.id, { ply_file: e.target.value })}
+          style={styles.input}
+          placeholder="path/to/model.ply"
+        />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Position</span>
+        <Vec3Input value={obj.position} onChange={(v) => update(obj.id, { position: v })} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Rotation (deg)</span>
+        <Vec3Input value={obj.rotation} onChange={(v) => update(obj.id, { rotation: v })} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Scale</span>
+        <input
+          type="number"
+          step={0.1}
+          value={obj.scale}
+          onChange={(e) => update(obj.id, { scale: Number(e.target.value) })}
+          style={{ ...styles.input, maxWidth: 80 }}
+        />
+      </div>
+
+      <div style={styles.section}>
+        <label style={{ fontSize: 12, color: '#ddd', display: 'flex', alignItems: 'center' }}>
+          <input
+            type="checkbox"
+            checked={obj.is_static}
+            onChange={(e) => update(obj.id, { is_static: e.target.checked })}
+            style={styles.checkbox}
+          />
+          Static (merge into terrain)
+        </label>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Character Manifest</span>
+        <input
+          type="text"
+          value={obj.character_manifest}
+          onChange={(e) => update(obj.id, { character_manifest: e.target.value })}
+          style={styles.input}
+          placeholder="character manifest JSON"
+        />
+      </div>
+    </div>
+  );
+}
+
+function LightProperties({ light }: { light: StaticLight }) {
+  const update = useSceneStore((s) => s.updateLight);
+  const remove = useSceneStore((s) => s.removeLight);
+
+  return (
+    <div>
+      <div style={{ ...styles.row, marginBottom: 12 }}>
+        <span style={{ ...styles.label, flex: 1 }}>Light</span>
+        <button style={styles.btnDanger} onClick={() => remove(light.id)}>Remove</button>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Position</span>
+        <div style={styles.row}>
+          <span style={{ fontSize: 12, minWidth: 20 }}>X</span>
+          <input
+            type="number"
+            value={light.position[0]}
+            onChange={(e) => update(light.id, { position: [Number(e.target.value), light.position[1]] })}
+            style={styles.input}
+          />
+          <span style={{ fontSize: 12, minWidth: 20 }}>Z</span>
+          <input
+            type="number"
+            value={light.position[1]}
+            onChange={(e) => update(light.id, { position: [light.position[0], Number(e.target.value)] })}
+            style={styles.input}
+          />
+        </div>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Radius</span>
+        <input
+          type="number"
+          step={0.5}
+          value={light.radius}
+          onChange={(e) => update(light.id, { radius: Number(e.target.value) })}
+          style={styles.input}
+        />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Height</span>
+        <input
+          type="number"
+          step={0.5}
+          value={light.height}
+          onChange={(e) => update(light.id, { height: Number(e.target.value) })}
+          style={styles.input}
+        />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Color</span>
+        <input
+          type="color"
+          value={'#' + light.color.map((c) => Math.round(c * 255).toString(16).padStart(2, '0')).join('')}
+          onChange={(e) => {
+            const hex = e.target.value;
+            update(light.id, {
+              color: [
+                parseInt(hex.slice(1, 3), 16) / 255,
+                parseInt(hex.slice(3, 5), 16) / 255,
+                parseInt(hex.slice(5, 7), 16) / 255,
+              ],
+            });
+          }}
+          style={{ width: 40, height: 24, border: 'none', cursor: 'pointer' }}
+        />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Intensity</span>
+        <input
+          type="number"
+          step={0.1}
+          value={light.intensity}
+          onChange={(e) => update(light.id, { intensity: Number(e.target.value) })}
+          style={styles.input}
+        />
+      </div>
+    </div>
+  );
+}
+
+function NpcProperties({ npc }: { npc: NpcData }) {
+  const update = useSceneStore((s) => s.updateNpc);
+  const remove = useSceneStore((s) => s.removeNpc);
+
+  return (
+    <div>
+      <div style={{ ...styles.row, marginBottom: 12 }}>
+        <span style={{ ...styles.label, flex: 1 }}>NPC</span>
+        <button style={styles.btnDanger} onClick={() => remove(npc.id)}>Remove</button>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Name</span>
+        <input
+          type="text"
+          value={npc.name}
+          onChange={(e) => update(npc.id, { name: e.target.value })}
+          style={styles.input}
+        />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Position</span>
+        <Vec3Input value={npc.position} onChange={(v) => update(npc.id, { position: v })} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Facing</span>
+        <select
+          style={styles.select}
+          value={npc.facing}
+          onChange={(e) => update(npc.id, { facing: e.target.value })}
+        >
+          {facings.map((f) => <option key={f} value={f}>{f}</option>)}
+        </select>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Character ID</span>
+        <input
+          type="text"
+          value={npc.character_id}
+          onChange={(e) => update(npc.id, { character_id: e.target.value })}
+          style={styles.input}
+        />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Patrol</span>
+        <div style={styles.row}>
+          <span style={{ fontSize: 12, minWidth: 50 }}>Interval</span>
+          <input
+            type="number"
+            step={0.1}
+            value={npc.patrol_interval}
+            onChange={(e) => update(npc.id, { patrol_interval: Number(e.target.value) })}
+            style={styles.input}
+          />
+        </div>
+        <div style={styles.row}>
+          <span style={{ fontSize: 12, minWidth: 50 }}>Speed</span>
+          <input
+            type="number"
+            step={0.1}
+            value={npc.patrol_speed}
+            onChange={(e) => update(npc.id, { patrol_speed: Number(e.target.value) })}
+            style={styles.input}
+          />
+        </div>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Dialog ({npc.dialog.length} entries)</span>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Waypoints ({npc.waypoints.length})</span>
+      </div>
+    </div>
+  );
+}
+
+function PortalProperties({ portal }: { portal: PortalData }) {
+  const update = useSceneStore((s) => s.updatePortal);
+  const remove = useSceneStore((s) => s.removePortal);
+
+  return (
+    <div>
+      <div style={{ ...styles.row, marginBottom: 12 }}>
+        <span style={{ ...styles.label, flex: 1 }}>Portal</span>
+        <button style={styles.btnDanger} onClick={() => remove(portal.id)}>Remove</button>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Position</span>
+        <div style={styles.row}>
+          <span style={{ fontSize: 12, minWidth: 20 }}>X</span>
+          <input
+            type="number"
+            value={portal.position[0]}
+            onChange={(e) => update(portal.id, { position: [Number(e.target.value), portal.position[1]] })}
+            style={styles.input}
+          />
+          <span style={{ fontSize: 12, minWidth: 20 }}>Z</span>
+          <input
+            type="number"
+            value={portal.position[1]}
+            onChange={(e) => update(portal.id, { position: [portal.position[0], Number(e.target.value)] })}
+            style={styles.input}
+          />
+        </div>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Size</span>
+        <div style={styles.row}>
+          <span style={{ fontSize: 12, minWidth: 20 }}>W</span>
+          <input
+            type="number"
+            value={portal.size[0]}
+            onChange={(e) => update(portal.id, { size: [Number(e.target.value), portal.size[1]] })}
+            style={styles.input}
+          />
+          <span style={{ fontSize: 12, minWidth: 20 }}>H</span>
+          <input
+            type="number"
+            value={portal.size[1]}
+            onChange={(e) => update(portal.id, { size: [portal.size[0], Number(e.target.value)] })}
+            style={styles.input}
+          />
+        </div>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Target Scene</span>
+        <input
+          type="text"
+          value={portal.target_scene}
+          onChange={(e) => update(portal.id, { target_scene: e.target.value })}
+          style={styles.input}
+          placeholder="scene name"
+        />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Spawn Position</span>
+        <Vec3Input
+          value={portal.spawn_position}
+          onChange={(v) => update(portal.id, { spawn_position: v })}
+        />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Spawn Facing</span>
+        <select
+          style={styles.select}
+          value={portal.spawn_facing}
+          onChange={(e) => update(portal.id, { spawn_facing: e.target.value })}
+        >
+          {facings.map((f) => <option key={f} value={f}>{f}</option>)}
+        </select>
+      </div>
+    </div>
+  );
+}
+
+function PlayerProperties({ player }: { player: PlayerData }) {
+  const update = useSceneStore((s) => s.updatePlayer);
+
+  return (
+    <div>
+      <div style={{ marginBottom: 12 }}>
+        <span style={styles.label}>Player Spawn</span>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Position</span>
+        <Vec3Input value={player.position} onChange={(v) => update({ position: v })} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Facing</span>
+        <select
+          style={styles.select}
+          value={player.facing}
+          onChange={(e) => update({ facing: e.target.value })}
+        >
+          {facings.map((f) => <option key={f} value={f}>{f}</option>)}
+        </select>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Character ID</span>
+        <input
+          type="text"
+          value={player.character_id}
+          onChange={(e) => update({ character_id: e.target.value })}
+          style={styles.input}
+        />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Tint</span>
+        <input
+          type="color"
+          value={'#' + player.tint.slice(0, 3).map((c) => Math.round(c * 255).toString(16).padStart(2, '0')).join('')}
+          onChange={(e) => {
+            const hex = e.target.value;
+            update({
+              tint: [
+                parseInt(hex.slice(1, 3), 16) / 255,
+                parseInt(hex.slice(3, 5), 16) / 255,
+                parseInt(hex.slice(5, 7), 16) / 255,
+                player.tint[3],
+              ],
+            });
+          }}
+          style={{ width: 40, height: 24, border: 'none', cursor: 'pointer' }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ──
+
+export function ScenePropertiesPanel() {
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const placedObjects = useSceneStore((s) => s.placedObjects);
+  const staticLights = useSceneStore((s) => s.staticLights);
+  const npcs = useSceneStore((s) => s.npcs);
+  const portals = useSceneStore((s) => s.portals);
+  const player = useSceneStore((s) => s.player);
+
+  if (!selectedEntity) {
+    return <div style={styles.empty}>Select an entity in the scene tree</div>;
+  }
+
+  if (selectedEntity.type === 'object') {
+    const obj = placedObjects.find((o) => o.id === selectedEntity.id);
+    if (!obj) return <div style={styles.empty}>Object not found</div>;
+    return <ObjectProperties obj={obj} />;
+  }
+
+  if (selectedEntity.type === 'light') {
+    const light = staticLights.find((l) => l.id === selectedEntity.id);
+    if (!light) return <div style={styles.empty}>Light not found</div>;
+    return <LightProperties light={light} />;
+  }
+
+  if (selectedEntity.type === 'npc') {
+    const npc = npcs.find((n) => n.id === selectedEntity.id);
+    if (!npc) return <div style={styles.empty}>NPC not found</div>;
+    return <NpcProperties npc={npc} />;
+  }
+
+  if (selectedEntity.type === 'portal') {
+    const portal = portals.find((p) => p.id === selectedEntity.id);
+    if (!portal) return <div style={styles.empty}>Portal not found</div>;
+    return <PortalProperties portal={portal} />;
+  }
+
+  if (selectedEntity.type === 'player') {
+    return <PlayerProperties player={player} />;
+  }
+
+  return <div style={styles.empty}>Unknown entity type</div>;
+}

--- a/tools/apps/bricklayer/src/panels/SceneTreePanel.tsx
+++ b/tools/apps/bricklayer/src/panels/SceneTreePanel.tsx
@@ -1,0 +1,265 @@
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { useSceneStore } from '../store/useSceneStore.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  section: {
+    marginBottom: 4,
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    padding: '4px 0',
+    cursor: 'pointer',
+    fontSize: 13,
+    color: '#ccc',
+    userSelect: 'none',
+  },
+  arrow: {
+    fontSize: 10,
+    width: 12,
+    textAlign: 'center' as const,
+    color: '#888',
+  },
+  count: {
+    fontSize: 11,
+    color: '#666',
+    marginLeft: 4,
+  },
+  item: {
+    padding: '3px 8px 3px 24px',
+    fontSize: 12,
+    color: '#aaa',
+    cursor: 'pointer',
+    borderRadius: 3,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as const,
+  },
+  itemSelected: {
+    background: '#3a3a6a',
+    color: '#fff',
+  },
+  addRow: {
+    display: 'flex',
+    gap: 4,
+    marginBottom: 12,
+  },
+  btn: {
+    padding: '4px 10px',
+    border: '1px solid #555',
+    borderRadius: 4,
+    background: '#3a3a6a',
+    color: '#ddd',
+    cursor: 'pointer',
+    fontSize: 12,
+    position: 'relative' as const,
+  },
+  dropdown: {
+    position: 'absolute' as const,
+    top: '100%',
+    left: 0,
+    background: '#1e1e3a',
+    border: '1px solid #444',
+    borderRadius: 4,
+    minWidth: 120,
+    padding: '4px 0',
+    zIndex: 100,
+    boxShadow: '0 4px 12px rgba(0,0,0,0.5)',
+  },
+  dropdownItem: {
+    display: 'block',
+    width: '100%',
+    padding: '6px 12px',
+    background: 'transparent',
+    border: 'none',
+    color: '#ccc',
+    cursor: 'pointer',
+    fontSize: 12,
+    textAlign: 'left' as const,
+  },
+};
+
+function CollapsibleSection({
+  title,
+  count,
+  defaultOpen,
+  children,
+}: {
+  title: string;
+  count: number;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen ?? true);
+
+  return (
+    <div style={styles.section}>
+      <div style={styles.header} onClick={() => setOpen(!open)}>
+        <span style={styles.arrow}>{open ? '\u25BE' : '\u25B8'}</span>
+        <span>{title}</span>
+        <span style={styles.count}>({count})</span>
+      </div>
+      {open && children}
+    </div>
+  );
+}
+
+function TreeItem({
+  label,
+  selected,
+  onClick,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <div
+      style={{ ...styles.item, ...(selected ? styles.itemSelected : {}) }}
+      onClick={onClick}
+    >
+      {label}
+    </div>
+  );
+}
+
+export function SceneTreePanel() {
+  const placedObjects = useSceneStore((s) => s.placedObjects);
+  const staticLights = useSceneStore((s) => s.staticLights);
+  const npcs = useSceneStore((s) => s.npcs);
+  const portals = useSceneStore((s) => s.portals);
+  const player = useSceneStore((s) => s.player);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
+  const addPlacedObject = useSceneStore((s) => s.addPlacedObject);
+  const addLight = useSceneStore((s) => s.addLight);
+  const addNpc = useSceneStore((s) => s.addNpc);
+  const addPortal = useSceneStore((s) => s.addPortal);
+
+  const [showAdd, setShowAdd] = useState(false);
+  const addRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!showAdd) return;
+    const handler = (e: MouseEvent) => {
+      if (addRef.current && !addRef.current.contains(e.target as Node)) {
+        setShowAdd(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showAdd]);
+
+  const handleAddObject = () => {
+    const plyFile = window.prompt('PLY file path:', '');
+    if (plyFile) addPlacedObject(plyFile);
+    setShowAdd(false);
+  };
+
+  return (
+    <div>
+      {/* Add button */}
+      <div style={styles.addRow}>
+        <div ref={addRef} style={{ position: 'relative' }}>
+          <button style={styles.btn} onClick={() => setShowAdd(!showAdd)}>
+            + Add
+          </button>
+          {showAdd && (
+            <div style={styles.dropdown}>
+              <button
+                style={styles.dropdownItem}
+                onClick={handleAddObject}
+                onMouseEnter={(e) => { (e.target as HTMLElement).style.background = '#3a3a6a'; }}
+                onMouseLeave={(e) => { (e.target as HTMLElement).style.background = 'transparent'; }}
+              >
+                Object
+              </button>
+              <button
+                style={styles.dropdownItem}
+                onClick={() => { addLight(); setShowAdd(false); }}
+                onMouseEnter={(e) => { (e.target as HTMLElement).style.background = '#3a3a6a'; }}
+                onMouseLeave={(e) => { (e.target as HTMLElement).style.background = 'transparent'; }}
+              >
+                Light
+              </button>
+              <button
+                style={styles.dropdownItem}
+                onClick={() => { addNpc(); setShowAdd(false); }}
+                onMouseEnter={(e) => { (e.target as HTMLElement).style.background = '#3a3a6a'; }}
+                onMouseLeave={(e) => { (e.target as HTMLElement).style.background = 'transparent'; }}
+              >
+                NPC
+              </button>
+              <button
+                style={styles.dropdownItem}
+                onClick={() => { addPortal(); setShowAdd(false); }}
+                onMouseEnter={(e) => { (e.target as HTMLElement).style.background = '#3a3a6a'; }}
+                onMouseLeave={(e) => { (e.target as HTMLElement).style.background = 'transparent'; }}
+              >
+                Portal
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Placed Objects */}
+      <CollapsibleSection title="Placed Objects" count={placedObjects.length}>
+        {placedObjects.map((obj) => (
+          <TreeItem
+            key={obj.id}
+            label={obj.ply_file || obj.id.slice(0, 16)}
+            selected={selectedEntity?.type === 'object' && selectedEntity.id === obj.id}
+            onClick={() => setSelectedEntity({ type: 'object', id: obj.id })}
+          />
+        ))}
+      </CollapsibleSection>
+
+      {/* Lights */}
+      <CollapsibleSection title="Lights" count={staticLights.length}>
+        {staticLights.map((l) => (
+          <TreeItem
+            key={l.id}
+            label={l.id.slice(0, 16)}
+            selected={selectedEntity?.type === 'light' && selectedEntity.id === l.id}
+            onClick={() => setSelectedEntity({ type: 'light', id: l.id })}
+          />
+        ))}
+      </CollapsibleSection>
+
+      {/* NPCs */}
+      <CollapsibleSection title="NPCs" count={npcs.length}>
+        {npcs.map((n) => (
+          <TreeItem
+            key={n.id}
+            label={n.name || n.id.slice(0, 16)}
+            selected={selectedEntity?.type === 'npc' && selectedEntity.id === n.id}
+            onClick={() => setSelectedEntity({ type: 'npc', id: n.id })}
+          />
+        ))}
+      </CollapsibleSection>
+
+      {/* Portals */}
+      <CollapsibleSection title="Portals" count={portals.length}>
+        {portals.map((p) => (
+          <TreeItem
+            key={p.id}
+            label={p.target_scene || p.id.slice(0, 16)}
+            selected={selectedEntity?.type === 'portal' && selectedEntity.id === p.id}
+            onClick={() => setSelectedEntity({ type: 'portal', id: p.id })}
+          />
+        ))}
+      </CollapsibleSection>
+
+      {/* Player */}
+      <CollapsibleSection title="Player" count={1} defaultOpen>
+        <TreeItem
+          label={`Player (${player.facing})`}
+          selected={selectedEntity?.type === 'player'}
+          onClick={() => setSelectedEntity({ type: 'player', id: 'player' })}
+        />
+      </CollapsibleSection>
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/panels/SettingsLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/SettingsLeftPanel.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { SettingsCategory } from '../store/types.js';
+
+const categories: { id: SettingsCategory; label: string }[] = [
+  { id: 'gs_camera', label: 'GS Camera & Render' },
+  { id: 'ambient', label: 'Ambient & Lighting' },
+  { id: 'weather', label: 'Weather' },
+  { id: 'day_night', label: 'Day/Night Cycle' },
+  { id: 'vfx', label: 'Particles (VFX)' },
+  { id: 'backgrounds', label: 'Backgrounds' },
+];
+
+const styles: Record<string, React.CSSProperties> = {
+  item: {
+    display: 'block',
+    width: '100%',
+    padding: '8px 12px',
+    border: 'none',
+    borderRadius: 4,
+    background: 'transparent',
+    color: '#aaa',
+    cursor: 'pointer',
+    fontSize: 13,
+    textAlign: 'left' as const,
+    marginBottom: 2,
+  },
+  itemActive: {
+    background: '#3a3a6a',
+    color: '#fff',
+  },
+};
+
+export function SettingsLeftPanel() {
+  const selected = useSceneStore((s) => s.selectedSettingsCategory);
+  const setSelected = useSceneStore((s) => s.setSelectedSettingsCategory);
+
+  return (
+    <div>
+      {categories.map((cat) => (
+        <button
+          key={cat.id}
+          style={{
+            ...styles.item,
+            ...(selected === cat.id ? styles.itemActive : {}),
+          }}
+          onClick={() => setSelected(cat.id)}
+        >
+          {cat.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/panels/SettingsRightPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/SettingsRightPanel.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { useSceneStore } from '../store/useSceneStore.js';
+import { GaussianTab } from './GaussianTab.js';
+import { SceneTab } from './SceneTab.js';
+import { WeatherTab } from './WeatherTab.js';
+import { VfxTab } from './VfxTab.js';
+import { BackgroundTab } from './BackgroundTab.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  heading: {
+    fontSize: 11,
+    color: '#888',
+    textTransform: 'uppercase' as const,
+    letterSpacing: 1,
+    marginBottom: 12,
+    paddingBottom: 8,
+    borderBottom: '1px solid #333',
+  },
+};
+
+export function SettingsRightPanel() {
+  const category = useSceneStore((s) => s.selectedSettingsCategory);
+
+  return (
+    <div>
+      {category === 'gs_camera' && (
+        <>
+          <div style={styles.heading}>GS Camera & Render</div>
+          <GaussianTab />
+        </>
+      )}
+
+      {category === 'ambient' && (
+        <>
+          <div style={styles.heading}>Ambient & Lighting</div>
+          <SceneTab />
+        </>
+      )}
+
+      {category === 'weather' && (
+        <>
+          <div style={styles.heading}>Weather</div>
+          <WeatherTab />
+        </>
+      )}
+
+      {category === 'day_night' && (
+        <>
+          <div style={styles.heading}>Day/Night Cycle</div>
+          <DayNightSettings />
+        </>
+      )}
+
+      {category === 'vfx' && (
+        <>
+          <div style={styles.heading}>Particles (VFX)</div>
+          <VfxTab />
+        </>
+      )}
+
+      {category === 'backgrounds' && (
+        <>
+          <div style={styles.heading}>Backgrounds</div>
+          <BackgroundTab />
+        </>
+      )}
+    </div>
+  );
+}
+
+// Extracted day/night section from SceneTab for standalone use
+function DayNightSettings() {
+  const dayNight = useSceneStore((s) => s.dayNight);
+  const setDayNight = useSceneStore((s) => s.setDayNight);
+
+  const inputStyle: React.CSSProperties = {
+    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 13,
+  };
+  const row: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8 };
+  const section: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 };
+
+  return (
+    <div style={section}>
+      <label style={{ ...row, fontSize: 13, cursor: 'pointer' }}>
+        <input
+          type="checkbox"
+          checked={dayNight.enabled}
+          onChange={(e) => setDayNight({ enabled: e.target.checked })}
+        />
+        Enabled
+      </label>
+      {dayNight.enabled && (
+        <>
+          <div style={row}>
+            <span style={{ fontSize: 12, minWidth: 80 }}>Speed</span>
+            <input
+              type="number"
+              step={0.1}
+              value={dayNight.cycle_speed}
+              onChange={(e) => setDayNight({ cycle_speed: Number(e.target.value) })}
+              style={inputStyle}
+            />
+          </div>
+          <div style={row}>
+            <span style={{ fontSize: 12, minWidth: 80 }}>Initial Time</span>
+            <input
+              type="number"
+              step={0.05}
+              min={0}
+              max={1}
+              value={dayNight.initial_time}
+              onChange={(e) => setDayNight({ initial_time: Number(e.target.value) })}
+              style={inputStyle}
+            />
+          </div>
+          <span style={{ fontSize: 11, color: '#666' }}>
+            {dayNight.keyframes.length} keyframes
+          </span>
+        </>
+      )}
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
@@ -1,0 +1,380 @@
+import React, { useState } from 'react';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { ToolType, CollisionLayer } from '../store/types.js';
+
+const tools: { id: ToolType; label: string; key: string }[] = [
+  { id: 'place', label: 'Place', key: 'V' },
+  { id: 'paint', label: 'Paint', key: 'B' },
+  { id: 'erase', label: 'Erase', key: 'E' },
+  { id: 'fill', label: 'Fill', key: 'G' },
+  { id: 'extrude', label: 'Extrude', key: 'X' },
+  { id: 'eyedropper', label: 'Eyedrop', key: 'I' },
+  { id: 'select', label: 'Select', key: 'S' },
+];
+
+const presetColors: [number, number, number, number][] = [
+  [34, 139, 34, 255],
+  [139, 90, 43, 255],
+  [100, 100, 100, 255],
+  [200, 200, 200, 255],
+  [60, 60, 180, 255],
+  [180, 60, 60, 255],
+  [180, 180, 60, 255],
+  [60, 180, 180, 255],
+  [220, 160, 80, 255],
+  [80, 40, 20, 255],
+  [160, 80, 160, 255],
+  [20, 20, 20, 255],
+];
+
+const collisionLayers: { id: CollisionLayer; label: string }[] = [
+  { id: 'solid', label: 'Solid' },
+  { id: 'elevation', label: 'Elevation' },
+  { id: 'nav_zone', label: 'NavZone' },
+];
+
+const styles: Record<string, React.CSSProperties> = {
+  section: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 11,
+    color: '#888',
+    textTransform: 'uppercase' as const,
+    letterSpacing: 1,
+    marginBottom: 2,
+  },
+  toolBtn: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '6px 10px',
+    border: '1px solid #444',
+    borderRadius: 4,
+    background: '#2a2a4a',
+    color: '#ddd',
+    cursor: 'pointer',
+    fontSize: 13,
+  },
+  toolBtnActive: {
+    background: '#4a4a8a',
+    borderColor: '#77f',
+  },
+  shortcut: {
+    fontSize: 11,
+    color: '#777',
+  },
+  colorGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(4, 1fr)',
+    gap: 4,
+  },
+  colorSwatch: {
+    width: '100%',
+    aspectRatio: '1',
+    border: '2px solid transparent',
+    borderRadius: 4,
+    cursor: 'pointer',
+  },
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+  },
+  input: {
+    width: 60,
+    padding: '4px 6px',
+    background: '#2a2a4a',
+    border: '1px solid #444',
+    borderRadius: 4,
+    color: '#ddd',
+    fontSize: 13,
+  },
+  inputFlex: {
+    flex: 1,
+    padding: '4px 6px',
+    background: '#2a2a4a',
+    border: '1px solid #444',
+    borderRadius: 4,
+    color: '#ddd',
+    fontSize: 13,
+  },
+  btn: {
+    padding: '4px 10px',
+    border: '1px solid #555',
+    borderRadius: 4,
+    background: '#3a3a6a',
+    color: '#ddd',
+    cursor: 'pointer',
+    fontSize: 12,
+  },
+  layerBtn: {
+    flex: 1,
+    padding: '4px 6px',
+    border: '1px solid #444',
+    borderRadius: 4,
+    background: '#2a2a4a',
+    color: '#ddd',
+    cursor: 'pointer',
+    fontSize: 12,
+    textAlign: 'center' as const,
+  },
+  layerBtnActive: {
+    background: '#4a4a8a',
+    borderColor: '#77f',
+    color: '#fff',
+  },
+};
+
+export function TerrainLeftPanel() {
+  const activeTool = useSceneStore((s) => s.activeTool);
+  const activeColor = useSceneStore((s) => s.activeColor);
+  const brushSize = useSceneStore((s) => s.brushSize);
+  const yLevelLock = useSceneStore((s) => s.yLevelLock);
+  const setTool = useSceneStore((s) => s.setTool);
+  const setActiveColor = useSceneStore((s) => s.setActiveColor);
+  const setBrushSize = useSceneStore((s) => s.setBrushSize);
+  const setYLevelLock = useSceneStore((s) => s.setYLevelLock);
+  const showCollision = useSceneStore((s) => s.showCollision);
+  const collisionGridData = useSceneStore((s) => s.collisionGridData);
+  const collisionLayer = useSceneStore((s) => s.collisionLayer);
+  const setCollisionLayer = useSceneStore((s) => s.setCollisionLayer);
+  const collisionHeight = useSceneStore((s) => s.collisionHeight);
+  const setCollisionHeight = useSceneStore((s) => s.setCollisionHeight);
+  const activeNavZone = useSceneStore((s) => s.activeNavZone);
+  const setActiveNavZone = useSceneStore((s) => s.setActiveNavZone);
+  const navZoneNames = useSceneStore((s) => s.navZoneNames);
+  const addNavZoneName = useSceneStore((s) => s.addNavZoneName);
+  const initCollisionGrid = useSceneStore((s) => s.initCollisionGrid);
+
+  const [gridW, setGridW] = useState(32);
+  const [gridH, setGridH] = useState(32);
+  const [cellSize, setCellSize] = useState(1.0);
+  const [newZoneName, setNewZoneName] = useState('');
+
+  const hexColor = `#${activeColor.slice(0, 3).map((c) => c.toString(16).padStart(2, '0')).join('')}`;
+
+  return (
+    <div>
+      {/* Tools */}
+      <div style={styles.section}>
+        <span style={styles.label}>Tools</span>
+        {tools.map((t) => (
+          <button
+            key={t.id}
+            style={{
+              ...styles.toolBtn,
+              ...(activeTool === t.id ? styles.toolBtnActive : {}),
+            }}
+            onClick={() => setTool(t.id)}
+          >
+            {t.label}
+            <span style={styles.shortcut}>{t.key}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Color */}
+      <div style={styles.section}>
+        <span style={styles.label}>Color</span>
+        <div style={styles.row}>
+          <input
+            type="color"
+            value={hexColor}
+            onChange={(e) => {
+              const hex = e.target.value;
+              const r = parseInt(hex.slice(1, 3), 16);
+              const g = parseInt(hex.slice(3, 5), 16);
+              const b = parseInt(hex.slice(5, 7), 16);
+              setActiveColor([r, g, b, activeColor[3]]);
+            }}
+            style={{ width: 40, height: 30, border: 'none', cursor: 'pointer' }}
+          />
+          <div
+            style={{
+              width: 30,
+              height: 30,
+              borderRadius: 4,
+              background: `rgba(${activeColor.join(',')})`,
+              border: '1px solid #666',
+            }}
+          />
+        </div>
+        <div style={styles.colorGrid}>
+          {presetColors.map((c, i) => (
+            <div
+              key={i}
+              style={{
+                ...styles.colorSwatch,
+                background: `rgba(${c.join(',')})`,
+                borderColor:
+                  c[0] === activeColor[0] && c[1] === activeColor[1] && c[2] === activeColor[2]
+                    ? '#fff'
+                    : 'transparent',
+              }}
+              onClick={() => setActiveColor(c)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Brush Size */}
+      <div style={styles.section}>
+        <span style={styles.label}>Brush Size</span>
+        <div style={styles.row}>
+          <input
+            type="range"
+            min={1}
+            max={8}
+            value={brushSize}
+            onChange={(e) => setBrushSize(Number(e.target.value))}
+            style={{ flex: 1 }}
+          />
+          <span style={{ fontSize: 13 }}>{brushSize}</span>
+        </div>
+      </div>
+
+      {/* Y Level Lock */}
+      <div style={styles.section}>
+        <span style={styles.label}>Y Level Lock</span>
+        <div style={styles.row}>
+          <input
+            type="checkbox"
+            checked={yLevelLock !== null}
+            onChange={(e) => setYLevelLock(e.target.checked ? 0 : null)}
+          />
+          {yLevelLock !== null && (
+            <input
+              type="number"
+              value={yLevelLock}
+              onChange={(e) => setYLevelLock(Number(e.target.value))}
+              style={styles.input}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Collision section — only shown when collision overlay is active */}
+      {showCollision && (
+        <div style={styles.section}>
+          <span style={styles.label}>Collision</span>
+          {!collisionGridData ? (
+            <>
+              <div style={styles.row}>
+                <span style={{ fontSize: 12, minWidth: 40 }}>W</span>
+                <input
+                  type="number"
+                  value={gridW}
+                  min={1}
+                  onChange={(e) => setGridW(Math.max(1, Number(e.target.value)))}
+                  style={{ ...styles.inputFlex, maxWidth: 60 }}
+                />
+                <span style={{ fontSize: 12, minWidth: 20 }}>H</span>
+                <input
+                  type="number"
+                  value={gridH}
+                  min={1}
+                  onChange={(e) => setGridH(Math.max(1, Number(e.target.value)))}
+                  style={{ ...styles.inputFlex, maxWidth: 60 }}
+                />
+              </div>
+              <div style={styles.row}>
+                <span style={{ fontSize: 12, minWidth: 40 }}>Cell</span>
+                <input
+                  type="number"
+                  value={cellSize}
+                  step={0.1}
+                  min={0.1}
+                  onChange={(e) => setCellSize(Math.max(0.1, Number(e.target.value)))}
+                  style={{ ...styles.inputFlex, maxWidth: 60 }}
+                />
+              </div>
+              <button style={styles.btn} onClick={() => initCollisionGrid(gridW, gridH, cellSize)}>
+                Init Grid
+              </button>
+            </>
+          ) : (
+            <>
+              <div style={styles.row}>
+                {collisionLayers.map((cl) => (
+                  <button
+                    key={cl.id}
+                    style={{
+                      ...styles.layerBtn,
+                      ...(collisionLayer === cl.id ? styles.layerBtnActive : {}),
+                    }}
+                    onClick={() => setCollisionLayer(cl.id)}
+                  >
+                    {cl.label}
+                  </button>
+                ))}
+              </div>
+
+              {collisionLayer === 'elevation' && (
+                <div style={styles.row}>
+                  <span style={{ fontSize: 12, minWidth: 50 }}>Height</span>
+                  <input
+                    type="number"
+                    step={0.5}
+                    value={collisionHeight}
+                    onChange={(e) => setCollisionHeight(Number(e.target.value))}
+                    style={styles.inputFlex}
+                  />
+                </div>
+              )}
+
+              {collisionLayer === 'nav_zone' && (
+                <>
+                  <div style={styles.row}>
+                    <span style={{ fontSize: 12, minWidth: 50 }}>Zone</span>
+                    <select
+                      value={activeNavZone}
+                      onChange={(e) => setActiveNavZone(Number(e.target.value))}
+                      style={styles.inputFlex}
+                    >
+                      <option value={0}>0: default</option>
+                      {navZoneNames.map((name, i) => (
+                        <option key={i + 1} value={i + 1}>
+                          {i + 1}: {name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div style={styles.row}>
+                    <input
+                      type="text"
+                      value={newZoneName}
+                      placeholder="new zone name"
+                      onChange={(e) => setNewZoneName(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && newZoneName.trim()) {
+                          addNavZoneName(newZoneName.trim());
+                          setNewZoneName('');
+                        }
+                      }}
+                      style={styles.inputFlex}
+                    />
+                    <button
+                      style={styles.btn}
+                      onClick={() => {
+                        if (newZoneName.trim()) {
+                          addNavZoneName(newZoneName.trim());
+                          setNewZoneName('');
+                        }
+                      }}
+                    >
+                      +
+                    </button>
+                  </div>
+                </>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
@@ -158,7 +158,7 @@ export function TerrainLeftPanel() {
   const hexColor = `#${activeColor.slice(0, 3).map((c) => c.toString(16).padStart(2, '0')).join('')}`;
 
   return (
-    <div>
+    <div style={{ flex: 1, overflowY: 'auto', padding: 0 }}>
       {/* Tools */}
       <div style={styles.section}>
         <span style={styles.label}>Tools</span>
@@ -257,11 +257,18 @@ export function TerrainLeftPanel() {
         </div>
       </div>
 
-      {/* Collision section — only shown when collision overlay is active */}
-      {showCollision && (
-        <div style={styles.section}>
-          <span style={styles.label}>Collision</span>
-          {!collisionGridData ? (
+      {/* Collision section — always shown in TERRAIN mode */}
+      <div style={styles.section}>
+        <span style={styles.label}>Collision Grid</span>
+        {!showCollision && (
+          <button
+            style={{ ...styles.btn, marginBottom: 8 }}
+            onClick={() => useSceneStore.getState().setShowCollision(true)}
+          >
+            Show Overlay
+          </button>
+        )}
+        {!collisionGridData ? (
             <>
               <div style={styles.row}>
                 <span style={{ fontSize: 12, minWidth: 40 }}>W</span>
@@ -374,7 +381,6 @@ export function TerrainLeftPanel() {
             </>
           )}
         </div>
-      )}
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/panels/TerrainRightPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/TerrainRightPanel.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useSceneStore } from '../store/useSceneStore.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
+  info: { fontSize: 12, color: '#aaa' },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+};
+
+export function TerrainRightPanel() {
+  const voxels = useSceneStore((s) => s.voxels);
+  const gridWidth = useSceneStore((s) => s.gridWidth);
+  const gridDepth = useSceneStore((s) => s.gridDepth);
+  const showCollision = useSceneStore((s) => s.showCollision);
+  const collisionGridData = useSceneStore((s) => s.collisionGridData);
+  const collisionLayer = useSceneStore((s) => s.collisionLayer);
+
+  return (
+    <div>
+      <div style={styles.section}>
+        <span style={styles.label}>Terrain Info</span>
+        <span style={styles.info}>
+          Grid: {gridWidth} x {gridDepth}
+        </span>
+        <span style={styles.info}>
+          Voxels: {voxels.size.toLocaleString()}
+        </span>
+      </div>
+
+      {showCollision && collisionGridData && (
+        <div style={styles.section}>
+          <span style={styles.label}>Collision Grid</span>
+          <span style={styles.info}>
+            {collisionGridData.width} x {collisionGridData.height} (cell {collisionGridData.cell_size})
+          </span>
+          <span style={styles.info}>
+            {collisionGridData.solid.filter(Boolean).length} solid / {collisionGridData.solid.length - collisionGridData.solid.filter(Boolean).length} walkable
+          </span>
+          <span style={styles.info}>
+            Active layer: {collisionLayer}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -126,6 +126,8 @@ export interface PlayerData {
   character_id: string;
 }
 
+export type BricklayerMode = 'terrain' | 'scene' | 'settings';
+
 export type ToolType =
   | 'place'
   | 'paint'
@@ -145,6 +147,16 @@ export type InspectorTab =
   | 'backgrounds'
   | 'gaussian'
   | 'nav_zone';
+
+export type CollisionLayer = 'solid' | 'elevation' | 'nav_zone';
+
+export type SettingsCategory =
+  | 'gs_camera'
+  | 'ambient'
+  | 'weather'
+  | 'day_night'
+  | 'vfx'
+  | 'backgrounds';
 
 export interface PlacedObjectData {
   id: string;

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -14,6 +14,9 @@ import type {
   PlayerData,
   ToolType,
   InspectorTab,
+  BricklayerMode,
+  CollisionLayer,
+  SettingsCategory,
   SelectedEntity,
   Snapshot,
   BricklayerFile,
@@ -155,11 +158,16 @@ export interface SceneStoreState {
   navZoneNames: string[];
 
   // Editor state
+  mode: BricklayerMode;
   selectedEntity: SelectedEntity | null;
   inspectorTab: InspectorTab;
   showGrid: boolean;
   showCollision: boolean;
   showGizmos: boolean;
+  collisionLayer: CollisionLayer;
+  collisionHeight: number;
+  activeNavZone: number;
+  selectedSettingsCategory: SettingsCategory;
 
   // Undo/redo
   undoStack: Snapshot[];
@@ -217,11 +225,16 @@ export interface SceneStoreState {
   removeNavZoneName: (index: number) => void;
 
   // Actions – editor
+  setMode: (mode: BricklayerMode) => void;
   setSelectedEntity: (e: SelectedEntity | null) => void;
   setInspectorTab: (tab: InspectorTab) => void;
   setShowGrid: (v: boolean) => void;
   setShowCollision: (v: boolean) => void;
   setShowGizmos: (v: boolean) => void;
+  setCollisionLayer: (layer: CollisionLayer) => void;
+  setCollisionHeight: (h: number) => void;
+  setActiveNavZone: (zone: number) => void;
+  setSelectedSettingsCategory: (cat: SettingsCategory) => void;
 
   // Actions – undo/redo
   undo: () => void;
@@ -261,11 +274,16 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   collisionGridData: null,
   navZoneNames: [],
 
+  mode: 'terrain',
   selectedEntity: null,
   inspectorTab: 'scene',
   showGrid: true,
   showCollision: false,
   showGizmos: true,
+  collisionLayer: 'solid',
+  collisionHeight: 0,
+  activeNavZone: 0,
+  selectedSettingsCategory: 'gs_camera',
 
   undoStack: [],
   redoStack: [],
@@ -570,11 +588,16 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   },
 
   // ── Editor actions ──
+  setMode: (mode) => set({ mode }),
   setSelectedEntity: (e) => set({ selectedEntity: e }),
   setInspectorTab: (tab) => set({ inspectorTab: tab }),
   setShowGrid: (v) => set({ showGrid: v }),
   setShowCollision: (v) => set({ showCollision: v }),
   setShowGizmos: (v) => set({ showGizmos: v }),
+  setCollisionLayer: (layer) => set({ collisionLayer: layer }),
+  setCollisionHeight: (h) => set({ collisionHeight: h }),
+  setActiveNavZone: (zone) => set({ activeNavZone: zone }),
+  setSelectedSettingsCategory: (cat) => set({ selectedSettingsCategory: cat }),
 
   // ── File actions ──
   newScene: (width, depth) => set({

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -546,6 +546,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
         elevation: new Array(count).fill(0),
         nav_zone: new Array(count).fill(0),
       },
+      showCollision: true,
     });
   },
 

--- a/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
+++ b/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
+import { ThreeEvent } from '@react-three/fiber';
 
 // HSL hue per nav zone (golden angle spacing for good contrast)
 function zoneColor(zone: number): string {
@@ -38,6 +39,34 @@ function Cell({ x, z, cellSize, elevation, color, opacity }: CellProps) {
 export function CollisionOverlay() {
   const collisionGridData = useSceneStore((s) => s.collisionGridData);
   const showCollision = useSceneStore((s) => s.showCollision);
+
+  const handleClick = useCallback((e: ThreeEvent<MouseEvent>) => {
+    e.stopPropagation();
+    const store = useSceneStore.getState();
+    const grid = store.collisionGridData;
+    if (!grid) return;
+
+    // Raycast hit point on the click plane
+    const point = e.point;
+    const cellX = Math.round(point.x / grid.cell_size);
+    const cellZ = Math.round(point.z / grid.cell_size);
+
+    if (cellX < 0 || cellX >= grid.width || cellZ < 0 || cellZ >= grid.height) return;
+
+    store.pushUndo();
+
+    switch (store.collisionLayer) {
+      case 'solid':
+        store.toggleCellSolid(cellX, cellZ);
+        break;
+      case 'elevation':
+        store.setCellElevation(cellX, cellZ, store.collisionHeight);
+        break;
+      case 'nav_zone':
+        store.setCellNavZone(cellX, cellZ, store.activeNavZone);
+        break;
+    }
+  }, []);
 
   const cells = useMemo(() => {
     if (!showCollision || !collisionGridData) return [];
@@ -94,6 +123,23 @@ export function CollisionOverlay() {
 
   return (
     <group>
+      {/* Invisible click plane covering the full grid */}
+      <mesh
+        position={[
+          (collisionGridData.width * collisionGridData.cell_size) / 2 - collisionGridData.cell_size / 2,
+          0,
+          (collisionGridData.height * collisionGridData.cell_size) / 2 - collisionGridData.cell_size / 2,
+        ]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        onClick={handleClick}
+      >
+        <planeGeometry args={[
+          collisionGridData.width * collisionGridData.cell_size,
+          collisionGridData.height * collisionGridData.cell_size,
+        ]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+
       {cells.map((c) => (
         <Cell
           key={c.key}

--- a/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
+++ b/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
@@ -77,8 +77,8 @@ export function CollisionOverlay() {
     // Determine if elevation varies
     let minElev = Infinity;
     let maxElev = -Infinity;
-    for (let i = 0; i < g.solid.length; i++) {
-      if (g.solid[i]) {
+    for (let i = 0; i < g.elevation.length; i++) {
+      if (g.elevation[i] !== 0) {
         minElev = Math.min(minElev, g.elevation[i]);
         maxElev = Math.max(maxElev, g.elevation[i]);
       }
@@ -94,15 +94,33 @@ export function CollisionOverlay() {
     for (let z = 0; z < g.height; z++) {
       for (let x = 0; x < g.width; x++) {
         const idx = z * g.width + x;
-        if (!g.solid[idx]) continue;
+        const isSolid = g.solid[idx];
 
         let color: string;
-        if (hasZones && g.nav_zone[idx] > 0) {
+        let opacity: number;
+
+        if (isSolid) {
+          // Solid cells: red, or colored by zone/elevation
+          if (hasZones && g.nav_zone[idx] > 0) {
+            color = zoneColor(g.nav_zone[idx]);
+          } else if (elevVaries) {
+            color = elevationColor(g.elevation[idx], minElev, maxElev);
+          } else {
+            color = '#ff1744';
+          }
+          opacity = 0.4;
+        } else if (hasZones && g.nav_zone[idx] > 0) {
+          // Walkable with zone
           color = zoneColor(g.nav_zone[idx]);
-        } else if (elevVaries) {
-          color = elevationColor(g.elevation[idx], minElev, maxElev);
+          opacity = 0.2;
+        } else if (g.elevation[idx] !== 0) {
+          // Walkable with elevation
+          color = elevationColor(g.elevation[idx], minElev || -10, maxElev || 10);
+          opacity = 0.15;
         } else {
-          color = '#ff1744';
+          // Walkable default — subtle green grid
+          color = '#44aa44';
+          opacity = 0.08;
         }
 
         result.push({
@@ -110,7 +128,7 @@ export function CollisionOverlay() {
           z,
           elevation: g.elevation[idx],
           color,
-          opacity: 0.35,
+          opacity,
           key: `${x},${z}`,
         });
       }

--- a/tools/tests/package.json
+++ b/tools/tests/package.json
@@ -20,7 +20,8 @@
     "test:remote-commands": "node --import tsx/esm --conditions source src/remote-commands.test.ts",
     "test:normal-map": "node --import tsx/esm --conditions source src/normal-map.test.ts",
     "test:pose-templates": "node --import tsx/esm --conditions source src/pose-templates.test.ts",
-    "test:echidna-ply-export": "node --import tsx/esm --conditions source src/echidna-ply-export.test.ts"
+    "test:echidna-ply-export": "node --import tsx/esm --conditions source src/echidna-ply-export.test.ts",
+    "test:bricklayer-store": "node --import tsx/esm --conditions source src/bricklayer-store.test.ts"
   },
   "dependencies": {
     "@gseurat/test-harness": "workspace:*",

--- a/tools/tests/src/bricklayer-store.test.ts
+++ b/tools/tests/src/bricklayer-store.test.ts
@@ -1,0 +1,618 @@
+/**
+ * Unit tests for Bricklayer store logic.
+ *
+ * Run: pnpm test:bricklayer-store
+ */
+
+// Re-implement minimal types and pure functions inline to avoid
+// importing from the app (which has React/Three.js dependencies).
+
+// ── Types ──
+
+interface CollisionGridData {
+  width: number;
+  height: number;
+  cell_size: number;
+  solid: boolean[];
+  elevation: number[];
+  nav_zone: number[];
+}
+
+interface PlacedObjectData {
+  id: string;
+  ply_file: string;
+  position: [number, number, number];
+  rotation: [number, number, number];
+  scale: number;
+  is_static: boolean;
+}
+
+interface StaticLight {
+  position: [number, number];
+  radius: number;
+  height: number;
+  color: [number, number, number];
+  intensity: number;
+}
+
+interface NpcEntry {
+  name: string;
+  position: [number, number, number];
+  facing: string;
+}
+
+interface PortalEntry {
+  position: [number, number];
+  size: [number, number];
+  target_scene: string;
+  spawn_position: [number, number, number];
+}
+
+interface GaussianSplatConfig {
+  camera: { position: [number, number, number]; target: [number, number, number]; fov: number };
+  render_width: number;
+  render_height: number;
+}
+
+// ── Collision grid operations (mirrors store logic) ──
+
+function initCollisionGrid(width: number, height: number, cellSize: number): CollisionGridData {
+  const count = width * height;
+  return {
+    width,
+    height,
+    cell_size: cellSize,
+    solid: new Array(count).fill(false),
+    elevation: new Array(count).fill(0),
+    nav_zone: new Array(count).fill(0),
+  };
+}
+
+function toggleCellSolid(grid: CollisionGridData, x: number, z: number): CollisionGridData {
+  const idx = z * grid.width + x;
+  if (idx < 0 || idx >= grid.solid.length) return grid;
+  const solid = [...grid.solid];
+  solid[idx] = !solid[idx];
+  return { ...grid, solid };
+}
+
+function setCellElevation(grid: CollisionGridData, x: number, z: number, value: number): CollisionGridData {
+  const idx = z * grid.width + x;
+  if (idx < 0 || idx >= grid.elevation.length) return grid;
+  const elevation = [...grid.elevation];
+  elevation[idx] = value;
+  return { ...grid, elevation };
+}
+
+function setCellNavZone(grid: CollisionGridData, x: number, z: number, zone: number): CollisionGridData {
+  const idx = z * grid.width + x;
+  if (idx < 0 || idx >= grid.nav_zone.length) return grid;
+  const nav_zone = [...grid.nav_zone];
+  nav_zone[idx] = zone;
+  return { ...grid, nav_zone };
+}
+
+// ── Scene export (mirrors lib/sceneExport.ts logic) ──
+
+interface ExportInput {
+  ambientColor: [number, number, number, number];
+  collisionGridData: CollisionGridData | null;
+  placedObjects: PlacedObjectData[];
+  staticLights: StaticLight[];
+  npcs: NpcEntry[];
+  portals: PortalEntry[];
+  gaussianSplat: GaussianSplatConfig | null;
+}
+
+function exportScene(input: ExportInput): Record<string, unknown> {
+  const scene: Record<string, unknown> = {
+    ambient_color: input.ambientColor,
+  };
+
+  if (input.collisionGridData) {
+    const g = input.collisionGridData;
+    scene.collision = {
+      width: g.width,
+      height: g.height,
+      cell_size: g.cell_size,
+      solid: g.solid,
+      elevation: g.elevation,
+      nav_zone: g.nav_zone,
+    };
+  }
+
+  if (input.placedObjects.length > 0) {
+    scene.placed_objects = input.placedObjects.map((obj) => ({
+      id: obj.id,
+      ply_file: obj.ply_file,
+      position: obj.position,
+      rotation: obj.rotation,
+      scale: obj.scale,
+      is_static: obj.is_static,
+    }));
+  }
+
+  if (input.staticLights.length > 0) {
+    scene.static_lights = input.staticLights.map((l) => ({
+      position: l.position,
+      radius: l.radius,
+      color: l.color,
+      intensity: l.intensity,
+    }));
+  }
+
+  if (input.npcs.length > 0) {
+    scene.npcs = input.npcs.map((n) => ({
+      name: n.name,
+      position: n.position,
+      facing: n.facing,
+    }));
+  }
+
+  if (input.portals.length > 0) {
+    scene.portals = input.portals.map((p) => ({
+      position: p.position,
+      size: p.size,
+      target_scene: p.target_scene,
+      spawn_position: p.spawn_position,
+    }));
+  }
+
+  if (input.gaussianSplat) {
+    scene.gaussian_splat = {
+      camera: input.gaussianSplat.camera,
+      render_width: input.gaussianSplat.render_width,
+      render_height: input.gaussianSplat.render_height,
+    };
+  }
+
+  return scene;
+}
+
+// ── Nav zone name operations ──
+
+function addNavZoneName(names: string[], name: string): string[] {
+  return [...names, name];
+}
+
+function removeNavZoneName(names: string[], index: number): string[] {
+  return names.filter((_, i) => i !== index);
+}
+
+// ── File save/load (mirrors store saveProject/loadProject) ──
+
+type VoxelKey = `${number},${number},${number}`;
+
+function voxelKey(x: number, y: number, z: number): VoxelKey {
+  return `${x},${y},${z}`;
+}
+
+interface Voxel {
+  color: [number, number, number, number];
+}
+
+interface BricklayerFile {
+  version: number;
+  gridWidth: number;
+  gridDepth: number;
+  voxels: { x: number; y: number; z: number; r: number; g: number; b: number; a: number }[];
+  collision: string[];
+  collisionGridData?: CollisionGridData;
+  nav_zone_names?: string[];
+  placedObjects?: PlacedObjectData[];
+}
+
+function saveProject(
+  voxels: Map<VoxelKey, Voxel>,
+  gridWidth: number,
+  gridDepth: number,
+  collisionGridData: CollisionGridData | null,
+  navZoneNames: string[],
+  placedObjects: PlacedObjectData[],
+): BricklayerFile {
+  const voxelArr: BricklayerFile['voxels'] = [];
+  for (const [key, vox] of voxels) {
+    const parts = key.split(',');
+    voxelArr.push({
+      x: Number(parts[0]), y: Number(parts[1]), z: Number(parts[2]),
+      r: vox.color[0], g: vox.color[1], b: vox.color[2], a: vox.color[3],
+    });
+  }
+  return {
+    version: 1,
+    gridWidth,
+    gridDepth,
+    voxels: voxelArr,
+    collision: [],
+    collisionGridData: collisionGridData ?? undefined,
+    nav_zone_names: navZoneNames.length > 0 ? navZoneNames : undefined,
+    placedObjects: placedObjects.length > 0 ? placedObjects : undefined,
+  };
+}
+
+function loadProject(data: BricklayerFile): {
+  voxels: Map<VoxelKey, Voxel>;
+  gridWidth: number;
+  gridDepth: number;
+  collisionGridData: CollisionGridData | null;
+  navZoneNames: string[];
+  placedObjects: PlacedObjectData[];
+} {
+  const voxels = new Map<VoxelKey, Voxel>();
+  for (const v of data.voxels) {
+    voxels.set(voxelKey(v.x, v.y, v.z), { color: [v.r, v.g, v.b, v.a] });
+  }
+  return {
+    voxels,
+    gridWidth: data.gridWidth,
+    gridDepth: data.gridDepth,
+    collisionGridData: data.collisionGridData ?? null,
+    navZoneNames: data.nav_zone_names ?? [],
+    placedObjects: data.placedObjects ?? [],
+  };
+}
+
+// ---------- Test helpers ----------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, message: string) {
+  if (!condition) {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  } else {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  }
+}
+
+// ---------- Tests ----------
+
+console.log('\n=== Bricklayer Store Tests ===\n');
+
+// ═══════════════════════════════════════════════════════════════
+// 1. CollisionGridData operations (8 tests)
+// ═══════════════════════════════════════════════════════════════
+
+console.log('--- CollisionGridData operations ---\n');
+
+{
+  console.log('Test 1.1: Init solid array length');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  assert(grid.solid.length === 16, `solid array length is 16 (got ${grid.solid.length})`);
+  assert(grid.solid.every((v) => v === false), 'all solid values are false');
+}
+
+{
+  console.log('Test 1.2: Init elevation array length');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  assert(grid.elevation.length === 16, `elevation array length is 16 (got ${grid.elevation.length})`);
+  assert(grid.elevation.every((v) => v === 0), 'all elevation values are 0');
+}
+
+{
+  console.log('Test 1.3: Init nav_zone array length');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  assert(grid.nav_zone.length === 16, `nav_zone array length is 16 (got ${grid.nav_zone.length})`);
+  assert(grid.nav_zone.every((v) => v === 0), 'all nav_zone values are 0');
+}
+
+{
+  console.log('Test 1.4: Toggle solid at (1,2)');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const updated = toggleCellSolid(grid, 1, 2);
+  const idx = 2 * 4 + 1;
+  assert(updated.solid[idx] === true, `solid[${idx}] is true after toggle (got ${updated.solid[idx]})`);
+}
+
+{
+  console.log('Test 1.5: Set elevation at (1,2) to 5.5');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const updated = setCellElevation(grid, 1, 2, 5.5);
+  const idx = 2 * 4 + 1;
+  assert(updated.elevation[idx] === 5.5, `elevation[${idx}] is 5.5 (got ${updated.elevation[idx]})`);
+}
+
+{
+  console.log('Test 1.6: Set nav zone at (1,2) to 2');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const updated = setCellNavZone(grid, 1, 2, 2);
+  const idx = 2 * 4 + 1;
+  assert(updated.nav_zone[idx] === 2, `nav_zone[${idx}] is 2 (got ${updated.nav_zone[idx]})`);
+}
+
+{
+  console.log('Test 1.7: Out-of-bounds toggle (99,99) does not crash');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  let crashed = false;
+  try {
+    const updated = toggleCellSolid(grid, 99, 99);
+    // Should return the grid unchanged
+    assert(updated.solid.length === 16, 'solid array unchanged after OOB toggle');
+    assert(updated.solid.every((v) => v === false), 'all solid values still false');
+  } catch {
+    crashed = true;
+  }
+  assert(!crashed, 'no crash on out-of-bounds toggle');
+}
+
+{
+  console.log('Test 1.8: Toggle solid twice returns to false');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const once = toggleCellSolid(grid, 1, 2);
+  const twice = toggleCellSolid(once, 1, 2);
+  const idx = 2 * 4 + 1;
+  assert(twice.solid[idx] === false, `solid[${idx}] is false after double toggle (got ${twice.solid[idx]})`);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 2. Scene export format (10 tests)
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- Scene export format ---\n');
+
+function baseInput(): ExportInput {
+  return {
+    ambientColor: [0.25, 0.28, 0.45, 1],
+    collisionGridData: null,
+    placedObjects: [],
+    staticLights: [],
+    npcs: [],
+    portals: [],
+    gaussianSplat: null,
+  };
+}
+
+{
+  console.log('Test 2.1: No collision grid -> no collision key');
+  const result = exportScene(baseInput());
+  assert(!('collision' in result), 'no collision key in export');
+}
+
+{
+  console.log('Test 2.2: With collision grid -> has width/height/cell_size/solid');
+  const input = baseInput();
+  input.collisionGridData = initCollisionGrid(4, 4, 1.0);
+  const result = exportScene(input);
+  assert('collision' in result, 'has collision key');
+  const coll = result.collision as Record<string, unknown>;
+  assert(coll.width === 4, `collision.width is 4 (got ${coll.width})`);
+  assert(coll.height === 4, `collision.height is 4 (got ${coll.height})`);
+  assert(coll.cell_size === 1.0, `collision.cell_size is 1.0 (got ${coll.cell_size})`);
+  assert(Array.isArray(coll.solid), 'collision.solid is an array');
+}
+
+{
+  console.log('Test 2.3: With elevation data -> has elevation array');
+  const input = baseInput();
+  const grid = initCollisionGrid(2, 2, 1.0);
+  grid.elevation[0] = 3.0;
+  input.collisionGridData = grid;
+  const result = exportScene(input);
+  const coll = result.collision as Record<string, unknown>;
+  assert(Array.isArray(coll.elevation), 'collision has elevation array');
+  assert((coll.elevation as number[])[0] === 3.0, 'elevation[0] is 3.0');
+}
+
+{
+  console.log('Test 2.4: With nav_zone data -> has nav_zone array');
+  const input = baseInput();
+  const grid = initCollisionGrid(2, 2, 1.0);
+  grid.nav_zone[1] = 5;
+  input.collisionGridData = grid;
+  const result = exportScene(input);
+  const coll = result.collision as Record<string, unknown>;
+  assert(Array.isArray(coll.nav_zone), 'collision has nav_zone array');
+  assert((coll.nav_zone as number[])[1] === 5, 'nav_zone[1] is 5');
+}
+
+{
+  console.log('Test 2.5: With placed objects -> has placed_objects array');
+  const input = baseInput();
+  input.placedObjects = [{
+    id: 'obj1',
+    ply_file: 'tree.ply',
+    position: [1, 2, 3],
+    rotation: [0, 45, 0],
+    scale: 1.5,
+    is_static: true,
+  }];
+  const result = exportScene(input);
+  assert('placed_objects' in result, 'has placed_objects key');
+  const objs = result.placed_objects as Record<string, unknown>[];
+  assert(objs.length === 1, 'placed_objects has 1 entry');
+  assert(objs[0].id === 'obj1', 'object id matches');
+  assert(objs[0].ply_file === 'tree.ply', 'object ply_file matches');
+  assert(objs[0].is_static === true, 'object is_static matches');
+}
+
+{
+  console.log('Test 2.6: No placed objects -> no placed_objects key');
+  const result = exportScene(baseInput());
+  assert(!('placed_objects' in result), 'no placed_objects key');
+}
+
+{
+  console.log('Test 2.7: With static light -> has static_lights');
+  const input = baseInput();
+  input.staticLights = [{
+    position: [5, 10],
+    radius: 8,
+    height: 2,
+    color: [1, 0.9, 0.7],
+    intensity: 1.2,
+  }];
+  const result = exportScene(input);
+  assert('static_lights' in result, 'has static_lights key');
+  const lights = result.static_lights as Record<string, unknown>[];
+  assert(lights.length === 1, 'static_lights has 1 entry');
+  assert(lights[0].radius === 8, 'light radius matches');
+  assert(lights[0].intensity === 1.2, 'light intensity matches');
+}
+
+{
+  console.log('Test 2.8: With NPC -> has npcs with name/position/facing');
+  const input = baseInput();
+  input.npcs = [{ name: 'Guard', position: [3, 0, 5], facing: 'left' }];
+  const result = exportScene(input);
+  assert('npcs' in result, 'has npcs key');
+  const npcs = result.npcs as Record<string, unknown>[];
+  assert(npcs.length === 1, 'npcs has 1 entry');
+  assert(npcs[0].name === 'Guard', 'npc name matches');
+  assert(npcs[0].facing === 'left', 'npc facing matches');
+}
+
+{
+  console.log('Test 2.9: With portal -> has portals with position/size/target_scene/spawn_position');
+  const input = baseInput();
+  input.portals = [{
+    position: [10, 20],
+    size: [2, 3],
+    target_scene: 'dungeon',
+    spawn_position: [1, 0, 1],
+  }];
+  const result = exportScene(input);
+  assert('portals' in result, 'has portals key');
+  const portals = result.portals as Record<string, unknown>[];
+  assert(portals.length === 1, 'portals has 1 entry');
+  assert(portals[0].target_scene === 'dungeon', 'portal target_scene matches');
+}
+
+{
+  console.log('Test 2.10: Gaussian splat config -> has camera/render_width/render_height');
+  const input = baseInput();
+  input.gaussianSplat = {
+    camera: { position: [0, 5, 10], target: [0, 0, 0], fov: 45 },
+    render_width: 320,
+    render_height: 240,
+  };
+  const result = exportScene(input);
+  assert('gaussian_splat' in result, 'has gaussian_splat key');
+  const gs = result.gaussian_splat as Record<string, unknown>;
+  assert(gs.render_width === 320, 'render_width is 320');
+  assert(gs.render_height === 240, 'render_height is 240');
+  const cam = gs.camera as Record<string, unknown>;
+  assert(cam.fov === 45, 'camera fov is 45');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 3. Nav zone names (5 tests)
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- Nav zone names ---\n');
+
+{
+  console.log('Test 3.1: Add zone name -> array grows');
+  const names = addNavZoneName([], 'safe');
+  assert(names.length === 1, `length is 1 (got ${names.length})`);
+  assert(names[0] === 'safe', `first name is 'safe' (got '${names[0]}')`);
+}
+
+{
+  console.log('Test 3.2: Remove by index -> array shrinks');
+  const names = addNavZoneName(addNavZoneName([], 'safe'), 'danger');
+  const after = removeNavZoneName(names, 0);
+  assert(after.length === 1, `length is 1 (got ${after.length})`);
+  assert(after[0] === 'danger', `remaining name is 'danger' (got '${after[0]}')`);
+}
+
+{
+  console.log('Test 3.3: Multiple zones -> correct count');
+  let names: string[] = [];
+  names = addNavZoneName(names, 'zone_a');
+  names = addNavZoneName(names, 'zone_b');
+  names = addNavZoneName(names, 'zone_c');
+  assert(names.length === 3, `length is 3 (got ${names.length})`);
+}
+
+{
+  console.log('Test 3.4: Empty zones -> length 0');
+  const names: string[] = [];
+  assert(names.length === 0, `length is 0 (got ${names.length})`);
+}
+
+{
+  console.log('Test 3.5: Zone name roundtrip (add, serialize, deserialize, compare)');
+  let names: string[] = [];
+  names = addNavZoneName(names, 'forest');
+  names = addNavZoneName(names, 'river');
+  const serialized = JSON.stringify(names);
+  const deserialized: string[] = JSON.parse(serialized);
+  assert(deserialized.length === names.length, 'deserialized length matches');
+  assert(deserialized[0] === 'forest', 'deserialized[0] matches');
+  assert(deserialized[1] === 'river', 'deserialized[1] matches');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 4. File roundtrip (5 tests)
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- File roundtrip ---\n');
+
+{
+  console.log('Test 4.1: Save empty -> load -> save again -> identical JSON');
+  const voxels = new Map<VoxelKey, Voxel>();
+  const file1 = saveProject(voxels, 128, 96, null, [], []);
+  const json1 = JSON.stringify(file1);
+  const loaded = loadProject(JSON.parse(json1));
+  const file2 = saveProject(loaded.voxels, loaded.gridWidth, loaded.gridDepth, loaded.collisionGridData, loaded.navZoneNames, loaded.placedObjects);
+  const json2 = JSON.stringify(file2);
+  assert(json1 === json2, 'save -> load -> save produces identical JSON');
+}
+
+{
+  console.log('Test 4.2: Save with 3 voxels -> load -> voxel count = 3');
+  const voxels = new Map<VoxelKey, Voxel>();
+  voxels.set(voxelKey(0, 0, 0), { color: [255, 0, 0, 255] });
+  voxels.set(voxelKey(1, 0, 0), { color: [0, 255, 0, 255] });
+  voxels.set(voxelKey(2, 0, 0), { color: [0, 0, 255, 255] });
+  const file = saveProject(voxels, 32, 32, null, [], []);
+  const loaded = loadProject(JSON.parse(JSON.stringify(file)));
+  assert(loaded.voxels.size === 3, `voxel count is 3 (got ${loaded.voxels.size})`);
+}
+
+{
+  console.log('Test 4.3: Save with collision grid -> load -> dimensions match');
+  const grid = initCollisionGrid(8, 6, 2.0);
+  grid.solid[5] = true;
+  grid.elevation[3] = 1.5;
+  const file = saveProject(new Map(), 64, 48, grid, [], []);
+  const loaded = loadProject(JSON.parse(JSON.stringify(file)));
+  assert(loaded.collisionGridData !== null, 'collision grid loaded');
+  assert(loaded.collisionGridData!.width === 8, `width is 8 (got ${loaded.collisionGridData!.width})`);
+  assert(loaded.collisionGridData!.height === 6, `height is 6 (got ${loaded.collisionGridData!.height})`);
+  assert(loaded.collisionGridData!.cell_size === 2.0, `cell_size is 2.0 (got ${loaded.collisionGridData!.cell_size})`);
+  assert(loaded.collisionGridData!.solid[5] === true, 'solid[5] preserved');
+  assert(loaded.collisionGridData!.elevation[3] === 1.5, 'elevation[3] preserved');
+}
+
+{
+  console.log('Test 4.4: Save with 2 placed objects -> load -> count = 2');
+  const objs: PlacedObjectData[] = [
+    { id: 'a', ply_file: 'tree.ply', position: [1, 2, 3], rotation: [0, 0, 0], scale: 1, is_static: true },
+    { id: 'b', ply_file: 'rock.ply', position: [4, 5, 6], rotation: [0, 90, 0], scale: 2, is_static: false },
+  ];
+  const file = saveProject(new Map(), 32, 32, null, [], objs);
+  const loaded = loadProject(JSON.parse(JSON.stringify(file)));
+  assert(loaded.placedObjects.length === 2, `placed object count is 2 (got ${loaded.placedObjects.length})`);
+  assert(loaded.placedObjects[0].ply_file === 'tree.ply', 'first object ply_file matches');
+  assert(loaded.placedObjects[1].ply_file === 'rock.ply', 'second object ply_file matches');
+}
+
+{
+  console.log('Test 4.5: Save with nav zone names -> load -> names match');
+  const names = ['forest', 'river', 'mountain'];
+  const file = saveProject(new Map(), 32, 32, null, names, []);
+  const loaded = loadProject(JSON.parse(JSON.stringify(file)));
+  assert(loaded.navZoneNames.length === 3, `nav zone name count is 3 (got ${loaded.navZoneNames.length})`);
+  assert(loaded.navZoneNames[0] === 'forest', 'first name matches');
+  assert(loaded.navZoneNames[1] === 'river', 'second name matches');
+  assert(loaded.navZoneNames[2] === 'mountain', 'third name matches');
+}
+
+// --- Summary ---
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ${passed} passed, ${failed} failed`);
+console.log('='.repeat(40));
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
Major UI restructure from 9 inspector tabs to 3 modes (TERRAIN / SCENE / SETTINGS) with resizable panels, dropdown menus, and interactive collision editing.

### Phase 0 — Tests (68 assertions)
- Collision grid operations: init, toggle solid, set elevation/zone
- Scene export format: all data types verified
- Nav zone names: add/remove/roundtrip
- File roundtrip: save-load identity

### Phase 1 — Core Layout
- 3-panel resizable layout (left 220px / center / right 320px)
- Mode tabs at top of left panel: TERRAIN | SCENE | SETTINGS
- Dropdown menus: File (Save/Load/Import/Export), Edit (Undo/Redo), View (toggles)
- ResizeHandle with drag-to-resize and hover highlight

### Phase 2 — TERRAIN Mode
- Brush tools (Place/Paint/Erase/Fill/Extrude/Eyedrop) in left panel
- Color picker + presets, brush size, Y-lock
- Collision grid editing: layer selector (Solid/Elevation/NavZone)
- **Interactive collision overlay**: click cells to toggle solid/paint elevation/assign zones
- Right panel: voxel stats, collision grid info

### Phase 3 — SCENE Mode
- Hierarchical scene tree (Placed Objects, Lights, NPCs, Portals, Player)
- Collapsible sections with item counts
- "+ Add" dropdown for creating new elements
- Context-sensitive properties panel for selected entity
- Full property editors for each entity type

### Phase 4 — SETTINGS Mode
- Settings category list (GS Camera, Ambient, Weather, Day/Night, VFX, Backgrounds)
- Properties panel for selected category
- Reuses existing tab components as sub-panels

## Test plan
- [x] 68 store unit tests pass (`pnpm --filter @gseurat/tests test:bricklayer-store`)
- [x] 37 Echidna PLY export tests still pass
- [x] `pnpm --filter @gseurat/bricklayer build` passes
- [ ] TERRAIN mode: paint voxels, click collision overlay
- [ ] SCENE mode: scene tree, select elements, edit properties
- [ ] SETTINGS mode: all categories accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)