### PR TITLE
Bricklayer: project format, tree navigator, collision/grab/palette improvements

### DIFF
--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -186,6 +186,7 @@ export function App() {
   const [rightWidth, setRightWidth] = useState(320);
 
   const mode = useSceneStore((s) => s.mode);
+  const grabMode = useSceneStore((s) => s.grabMode);
 
   const handleLeftDrag = useCallback((delta: number) => {
     setLeftWidth((w) => Math.max(160, Math.min(500, w + delta)));
@@ -214,8 +215,36 @@ export function App() {
         return;
       }
 
+      // Escape: cancel grab mode
+      if (e.key === 'Escape' && store.grabMode) {
+        // Revert to original position
+        const orig = store.grabOriginalPosition;
+        const sel = store.selectedEntity;
+        if (orig && sel) {
+          if (sel.type === 'object' && orig.length === 3) {
+            store.updatePlacedObject(sel.id, { position: orig as [number, number, number] });
+          } else if (sel.type === 'npc' && orig.length === 3) {
+            store.updateNpc(sel.id, { position: orig as [number, number, number] });
+          } else if (sel.type === 'portal' && orig.length === 2) {
+            store.updatePortal(sel.id, { position: orig as [number, number] });
+          } else if (sel.type === 'light' && orig.length === 2) {
+            store.updateLight(sel.id, { position: orig as [number, number] });
+          } else if (sel.type === 'player' && orig.length === 3) {
+            store.updatePlayer({ position: orig as [number, number, number] });
+          }
+        }
+        store.setGrabMode(false);
+        return;
+      }
+
+      // G key: grab mode (Blender style) — only in scene mode with selected entity
+      if (e.key.toLowerCase() === 'g' && !meta && store.mode === 'scene' && store.selectedEntity && !store.grabMode) {
+        store.setGrabMode(true);
+        return;
+      }
+
       const tool = toolKeys[e.key.toLowerCase()];
-      if (tool) {
+      if (tool && !store.grabMode) {
         store.setTool(tool);
         return;
       }
@@ -296,6 +325,24 @@ export function App() {
         {/* Center viewport */}
         <div style={styles.viewport}>
           <Viewport />
+          {grabMode && (
+            <div style={{
+              position: 'absolute',
+              top: 8,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              background: 'rgba(0,0,0,0.8)',
+              color: '#ffcc00',
+              padding: '4px 12px',
+              borderRadius: 4,
+              fontSize: 12,
+              fontWeight: 600,
+              zIndex: 10,
+              pointerEvents: 'none',
+            }}>
+              GRAB MODE — Click to confirm, Escape to cancel
+            </div>
+          )}
         </div>
 
         <ResizeHandle side="right" onDrag={handleRightDrag} />

--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -1,0 +1,205 @@
+/**
+ * File System Access API integration for Bricklayer project directories.
+ *
+ * The File System Access API (showDirectoryPicker) is only available in
+ * Chromium-based browsers (Chrome, Edge). A feature check + fallback
+ * message is provided for unsupported browsers.
+ */
+
+import type {
+  ProjectManifest,
+  TerrainEntry,
+  AssetEntry,
+  VoxelKey,
+  Voxel,
+  CollisionGridData,
+} from '../store/types.js';
+
+// ── Feature detection ──
+
+export function hasFileSystemAccess(): boolean {
+  return typeof window !== 'undefined' && 'showDirectoryPicker' in window;
+}
+
+// ── Open directory ──
+
+export async function openProjectDirectory(): Promise<FileSystemDirectoryHandle | null> {
+  if (!hasFileSystemAccess()) return null;
+  try {
+    return await (window as unknown as { showDirectoryPicker: () => Promise<FileSystemDirectoryHandle> }).showDirectoryPicker();
+  } catch {
+    // User cancelled or permission denied
+    return null;
+  }
+}
+
+// ── Helpers ──
+
+async function getOrCreateSubDir(
+  parent: FileSystemDirectoryHandle,
+  name: string,
+): Promise<FileSystemDirectoryHandle> {
+  return parent.getDirectoryHandle(name, { create: true });
+}
+
+async function writeTextFile(
+  dir: FileSystemDirectoryHandle,
+  name: string,
+  content: string,
+): Promise<void> {
+  const fileHandle = await dir.getFileHandle(name, { create: true });
+  const writable = await fileHandle.createWritable();
+  await writable.write(content);
+  await writable.close();
+}
+
+async function readTextFile(
+  dir: FileSystemDirectoryHandle,
+  name: string,
+): Promise<string | null> {
+  try {
+    const fileHandle = await dir.getFileHandle(name);
+    const file = await fileHandle.getFile();
+    return await file.text();
+  } catch {
+    return null;
+  }
+}
+
+// ── Voxel data serialization ──
+
+interface SerializedVoxel {
+  x: number;
+  y: number;
+  z: number;
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+function serializeVoxels(entries: [VoxelKey, Voxel][]): SerializedVoxel[] {
+  return entries.map(([key, vox]) => {
+    const parts = key.split(',');
+    return {
+      x: Number(parts[0]),
+      y: Number(parts[1]),
+      z: Number(parts[2]),
+      r: vox.color[0],
+      g: vox.color[1],
+      b: vox.color[2],
+      a: vox.color[3],
+    };
+  });
+}
+
+function deserializeVoxels(arr: SerializedVoxel[]): [VoxelKey, Voxel][] {
+  return arr.map((v) => [
+    `${v.x},${v.y},${v.z}` as VoxelKey,
+    { color: [v.r, v.g, v.b, v.a] },
+  ]);
+}
+
+// ── Save project ──
+
+export async function saveProject(
+  handle: FileSystemDirectoryHandle,
+  manifest: ProjectManifest,
+  voxelDataMap: Map<string, [VoxelKey, Voxel][]>,
+): Promise<void> {
+  // Write project.json
+  await writeTextFile(handle, 'project.json', JSON.stringify(manifest, null, 2));
+
+  // Ensure terrains/ directory exists
+  const terrainsDir = await getOrCreateSubDir(handle, 'terrains');
+
+  // Write per-terrain voxel data files
+  for (const terrain of manifest.terrains) {
+    const voxelData = voxelDataMap.get(terrain.id);
+    if (!voxelData) continue;
+
+    // terrain.voxelFile is e.g. "terrains/terrain_123.bricklayer"
+    const filename = terrain.voxelFile.replace(/^terrains\//, '');
+    const serialized = serializeVoxels(voxelData);
+    await writeTextFile(terrainsDir, filename, JSON.stringify(serialized));
+  }
+
+  // Ensure assets/ directory exists
+  await getOrCreateSubDir(handle, 'assets');
+}
+
+// ── Load project ──
+
+export async function loadProject(
+  handle: FileSystemDirectoryHandle,
+): Promise<{
+  manifest: ProjectManifest;
+  voxelDataMap: Map<string, [VoxelKey, Voxel][]>;
+} | null> {
+  const manifestJson = await readTextFile(handle, 'project.json');
+  if (!manifestJson) return null;
+
+  let manifest: ProjectManifest;
+  try {
+    manifest = JSON.parse(manifestJson) as ProjectManifest;
+  } catch {
+    return null;
+  }
+
+  const voxelDataMap = new Map<string, [VoxelKey, Voxel][]>();
+
+  // Load each terrain's voxel data
+  let terrainsDir: FileSystemDirectoryHandle | null = null;
+  try {
+    terrainsDir = await handle.getDirectoryHandle('terrains');
+  } catch {
+    // No terrains directory yet
+  }
+
+  if (terrainsDir) {
+    for (const terrain of manifest.terrains) {
+      const filename = terrain.voxelFile.replace(/^terrains\//, '');
+      const data = await readTextFile(terrainsDir, filename);
+      if (data) {
+        try {
+          const arr = JSON.parse(data) as SerializedVoxel[];
+          voxelDataMap.set(terrain.id, deserializeVoxels(arr));
+        } catch {
+          // Skip corrupt terrain data
+        }
+      }
+    }
+  }
+
+  return { manifest, voxelDataMap };
+}
+
+// ── Import asset ──
+
+export async function importAssetToProject(
+  handle: FileSystemDirectoryHandle,
+  file: File,
+  subdir?: string,
+): Promise<string> {
+  const assetsDir = await getOrCreateSubDir(handle, 'assets');
+  const targetDir = subdir
+    ? await getOrCreateSubDir(assetsDir, subdir)
+    : assetsDir;
+
+  const fileHandle = await targetDir.getFileHandle(file.name, { create: true });
+  const writable = await fileHandle.createWritable();
+  await writable.write(file);
+  await writable.close();
+
+  const relativePath = subdir ? `assets/${subdir}/${file.name}` : `assets/${file.name}`;
+  return relativePath;
+}
+
+// ── Export scene.json ──
+
+export async function exportSceneJson(
+  handle: FileSystemDirectoryHandle,
+  scene: object,
+): Promise<void> {
+  await writeTextFile(handle, 'scene.json', JSON.stringify(scene, null, 2));
+}

--- a/tools/apps/bricklayer/src/panels/ImportDialog.tsx
+++ b/tools/apps/bricklayer/src/panels/ImportDialog.tsx
@@ -128,6 +128,9 @@ export function ImportDialog({ onClose }: { onClose: () => void }) {
       const store = useSceneStore.getState();
       store.pushUndo();
 
+      // Extract palette colors from the image
+      store.extractColorsFromImage(imageData, file.name);
+
       if (mode === 'depth') {
         setLoading(true);
         setProgress(0);

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -1,8 +1,16 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 import { exportPly } from '../lib/plyExport.js';
-import { exportSceneJson } from '../lib/sceneExport.js';
-import type { BricklayerFile } from '../store/types.js';
+import { exportSceneJson as buildSceneJson } from '../lib/sceneExport.js';
+import type { BricklayerFile, ProjectManifest } from '../store/types.js';
+import {
+  hasFileSystemAccess,
+  openProjectDirectory,
+  saveProject as saveProjectDir,
+  loadProject as loadProjectDir,
+  importAssetToProject,
+  exportSceneJson as writeSceneJson,
+} from '../lib/projectIO.js';
 
 const styles: Record<string, React.CSSProperties> = {
   bar: {
@@ -65,6 +73,33 @@ const styles: Record<string, React.CSSProperties> = {
     paddingRight: 8,
   },
 };
+
+function buildProjectManifest(store: ReturnType<typeof useSceneStore.getState>): ProjectManifest {
+  return {
+    name: store.projectName,
+    version: 1,
+    terrains: store.terrains,
+    assets: store.assets,
+    globalSettings: {
+      ambientColor: store.ambientColor,
+      gaussianSplat: store.gaussianSplat,
+      weather: store.weather,
+      dayNight: store.dayNight,
+      backgroundLayers: store.backgroundLayers,
+      torchEmitter: store.torchEmitter,
+      torchPositions: store.torchPositions,
+      footstepEmitter: store.footstepEmitter,
+      npcAuraEmitter: store.npcAuraEmitter,
+    },
+    scene: {
+      placedObjects: store.placedObjects,
+      staticLights: store.staticLights,
+      npcs: store.npcs,
+      portals: store.portals,
+      player: store.player,
+    },
+  };
+}
 
 function download(blob: Blob, name: string) {
   const url = URL.createObjectURL(blob);
@@ -145,6 +180,7 @@ function DropdownMenu({
 
 export function MenuBar({ onImport }: { onImport: () => void }) {
   const fileRef = useRef<HTMLInputElement>(null);
+  const assetRef = useRef<HTMLInputElement>(null);
   const [openMenu, setOpenMenu] = useState<string | null>(null);
 
   const closeMenu = useCallback(() => setOpenMenu(null), []);
@@ -188,18 +224,173 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
 
   const handleExportScene = () => {
     const s = useSceneStore.getState();
-    const scene = exportSceneJson(s);
+    const scene = buildSceneJson(s);
     const json = JSON.stringify(scene, null, 2);
     download(new Blob([json], { type: 'application/json' }), 'scene.json');
   };
 
+  // ── Project directory operations ──
+
+  const handleNewProject = async () => {
+    if (!hasFileSystemAccess()) {
+      alert('Project directories require Chrome or Edge (File System Access API not available in this browser).');
+      return;
+    }
+    if (!confirm('Create new project? Unsaved changes will be lost.')) return;
+    const handle = await openProjectDirectory();
+    if (!handle) return;
+    const store = useSceneStore.getState();
+    store.newScene(128, 96);
+    store.setProjectHandle(handle);
+    store.setProjectName(handle.name || 'Untitled');
+  };
+
+  const handleOpenProject = async () => {
+    if (!hasFileSystemAccess()) {
+      alert('Project directories require Chrome or Edge (File System Access API not available in this browser).');
+      return;
+    }
+    const handle = await openProjectDirectory();
+    if (!handle) return;
+    const result = await loadProjectDir(handle);
+    if (!result) {
+      alert('No valid project.json found in the selected directory.');
+      return;
+    }
+    const store = useSceneStore.getState();
+    store.setProjectHandle(handle);
+    store.setProjectName(result.manifest.name);
+
+    // Restore terrains and assets from manifest
+    // For now, load first terrain's voxel data into the editor
+    const state: Record<string, unknown> = {
+      terrains: result.manifest.terrains,
+      assets: result.manifest.assets,
+      currentTerrainId: result.manifest.terrains.length > 0 ? result.manifest.terrains[0].id : null,
+      ambientColor: result.manifest.globalSettings.ambientColor,
+      gaussianSplat: result.manifest.globalSettings.gaussianSplat,
+      weather: result.manifest.globalSettings.weather,
+      dayNight: result.manifest.globalSettings.dayNight,
+      backgroundLayers: result.manifest.globalSettings.backgroundLayers,
+      torchEmitter: result.manifest.globalSettings.torchEmitter,
+      torchPositions: result.manifest.globalSettings.torchPositions,
+      footstepEmitter: result.manifest.globalSettings.footstepEmitter,
+      npcAuraEmitter: result.manifest.globalSettings.npcAuraEmitter,
+      placedObjects: result.manifest.scene.placedObjects,
+      staticLights: result.manifest.scene.staticLights,
+      npcs: result.manifest.scene.npcs,
+      portals: result.manifest.scene.portals,
+      player: result.manifest.scene.player,
+    };
+
+    // Load voxels for the first terrain
+    if (result.manifest.terrains.length > 0) {
+      const firstId = result.manifest.terrains[0].id;
+      const voxelEntries = result.voxelDataMap.get(firstId);
+      if (voxelEntries) {
+        (state as Record<string, unknown>).voxels = new Map(voxelEntries);
+      }
+      const firstTerrain = result.manifest.terrains[0];
+      if (firstTerrain.collision) {
+        (state as Record<string, unknown>).collisionGridData = firstTerrain.collision;
+      }
+      (state as Record<string, unknown>).navZoneNames = firstTerrain.navZoneNames;
+    }
+
+    useSceneStore.setState(state as Partial<typeof store>);
+  };
+
+  const handleSaveProject = async () => {
+    const store = useSceneStore.getState();
+    let handle = store.projectHandle;
+    if (!handle) {
+      if (!hasFileSystemAccess()) {
+        alert('Project directories require Chrome or Edge (File System Access API not available in this browser).');
+        return;
+      }
+      handle = await openProjectDirectory();
+      if (!handle) return;
+      store.setProjectHandle(handle);
+      store.setProjectName(handle.name || store.projectName);
+    }
+
+    const manifest = buildProjectManifest(store);
+    const voxelDataMap = new Map<string, [import('../store/types.js').VoxelKey, import('../store/types.js').Voxel][]>();
+
+    // Save current terrain voxel data
+    if (store.currentTerrainId) {
+      voxelDataMap.set(store.currentTerrainId, Array.from(store.voxels.entries()));
+    } else if (manifest.terrains.length === 0) {
+      // Auto-create a default terrain for existing voxels
+      const id = `terrain_${Date.now()}`;
+      const terrain = {
+        id,
+        name: 'Default Terrain',
+        voxelFile: `terrains/${id}.bricklayer`,
+        collision: store.collisionGridData,
+        navZoneNames: store.navZoneNames,
+      };
+      manifest.terrains.push(terrain);
+      voxelDataMap.set(id, Array.from(store.voxels.entries()));
+    }
+
+    await saveProjectDir(handle, manifest, voxelDataMap);
+  };
+
+  const handleImportAsset = () => {
+    if (!useSceneStore.getState().projectHandle) {
+      alert('Open or create a project first before importing assets.');
+      return;
+    }
+    assetRef.current?.click();
+  };
+
+  const handleAssetFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const handle = useSceneStore.getState().projectHandle;
+    if (!handle) return;
+
+    const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+    const subdir = ext === 'ply' ? 'ply' : undefined;
+    const relativePath = await importAssetToProject(handle, file, subdir);
+
+    const assetType: 'ply' | 'image' | 'other' =
+      ext === 'ply' ? 'ply' :
+      ['png', 'jpg', 'jpeg', 'bmp', 'gif', 'webp'].includes(ext) ? 'image' :
+      'other';
+
+    useSceneStore.getState().addAsset({
+      id: `asset_${Date.now()}`,
+      path: relativePath,
+      type: assetType,
+    });
+
+    e.target.value = '';
+  };
+
+  const handleExportProjectScene = async () => {
+    const store = useSceneStore.getState();
+    const handle = store.projectHandle;
+    if (!handle) {
+      alert('Open or create a project first before exporting scene.');
+      return;
+    }
+    const scene = buildSceneJson(store);
+    await writeSceneJson(handle, scene);
+  };
+
   const fileItems: MenuItem[] = [
-    { label: 'New', action: handleNew },
-    { label: 'Save', action: handleSave },
-    { label: 'Load', action: handleLoad },
+    { label: 'New Project', action: handleNewProject },
+    { label: 'Open Project...', action: handleOpenProject },
+    { label: 'Save Project', action: handleSaveProject },
+    { label: 'Import Asset...', action: handleImportAsset },
+    { label: 'Export Scene', action: handleExportProjectScene },
+    { label: 'Save File...', action: handleSave, separator: true },
+    { label: 'Open File...', action: handleLoad },
     { label: 'Import Image...', action: onImport, separator: true },
     { label: 'Export PLY...', action: handleExportPly, separator: true },
-    { label: 'Export Scene...', action: handleExportScene },
+    { label: 'Export Scene (Download)...', action: handleExportScene },
   ];
 
   const editItems: MenuItem[] = [
@@ -261,7 +452,16 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
         style={{ display: 'none' }}
         onChange={handleFileChange}
       />
-      <span style={styles.title}>Bricklayer</span>
+      <input
+        ref={assetRef}
+        type="file"
+        accept=".ply,.png,.jpg,.jpeg,.bmp,.gif,.webp"
+        style={{ display: 'none' }}
+        onChange={handleAssetFileChange}
+      />
+      <span style={styles.title}>
+        Bricklayer — {useSceneStore.getState().projectName}
+      </span>
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/panels/ObjectsTab.tsx
+++ b/tools/apps/bricklayer/src/panels/ObjectsTab.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { NumberInput } from '../components/NumberInput.js';
 import { useSceneStore } from '../store/useSceneStore.js';
 import type { PlacedObjectData } from '../store/types.js';
+import { hasFileSystemAccess, importAssetToProject } from '../lib/projectIO.js';
 
 const styles: Record<string, React.CSSProperties> = {
   section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
@@ -134,16 +135,47 @@ function ObjectEditor({ obj }: { obj: PlacedObjectData }) {
 export function ObjectsTab() {
   const placedObjects = useSceneStore((s) => s.placedObjects);
   const addPlacedObject = useSceneStore((s) => s.addPlacedObject);
+  const plyInputRef = useRef<HTMLInputElement>(null);
 
   const handleAdd = () => {
-    const plyFile = window.prompt('PLY file path:', '');
-    if (plyFile) {
-      addPlacedObject(plyFile);
+    // Use file picker for PLY selection
+    plyInputRef.current?.click();
+  };
+
+  const handlePlyFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const store = useSceneStore.getState();
+    const handle = store.projectHandle;
+
+    if (handle && hasFileSystemAccess()) {
+      // Copy PLY into project assets/ and use relative path
+      const relativePath = await importAssetToProject(handle, file, 'ply');
+      addPlacedObject(relativePath);
+
+      store.addAsset({
+        id: `asset_${Date.now()}`,
+        path: relativePath,
+        type: 'ply',
+      });
+    } else {
+      // No project directory: use filename as-is
+      addPlacedObject(file.name);
     }
+
+    e.target.value = '';
   };
 
   return (
     <div>
+      <input
+        ref={plyInputRef}
+        type="file"
+        accept=".ply"
+        style={{ display: 'none' }}
+        onChange={handlePlyFileChange}
+      />
       <div style={{ ...styles.row, marginBottom: 8 }}>
         <span style={{ ...styles.label, flex: 1 }}>Placed Objects ({placedObjects.length})</span>
         <button style={styles.btn} onClick={handleAdd}>+ Add</button>

--- a/tools/apps/bricklayer/src/panels/SceneTreePanel.tsx
+++ b/tools/apps/bricklayer/src/panels/SceneTreePanel.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
+import { hasFileSystemAccess, importAssetToProject } from '../lib/projectIO.js';
 
 const styles: Record<string, React.CSSProperties> = {
   section: {
@@ -139,6 +140,7 @@ export function SceneTreePanel() {
 
   const [showAdd, setShowAdd] = useState(false);
   const addRef = useRef<HTMLDivElement>(null);
+  const plyInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!showAdd) return;
@@ -152,13 +154,41 @@ export function SceneTreePanel() {
   }, [showAdd]);
 
   const handleAddObject = () => {
-    const plyFile = window.prompt('PLY file path:', '');
-    if (plyFile) addPlacedObject(plyFile);
+    plyInputRef.current?.click();
     setShowAdd(false);
+  };
+
+  const handlePlyFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const store = useSceneStore.getState();
+    const handle = store.projectHandle;
+
+    if (handle && hasFileSystemAccess()) {
+      const relativePath = await importAssetToProject(handle, file, 'ply');
+      addPlacedObject(relativePath);
+      store.addAsset({
+        id: `asset_${Date.now()}`,
+        path: relativePath,
+        type: 'ply',
+      });
+    } else {
+      addPlacedObject(file.name);
+    }
+
+    e.target.value = '';
   };
 
   return (
     <div>
+      <input
+        ref={plyInputRef}
+        type="file"
+        accept=".ply"
+        style={{ display: 'none' }}
+        onChange={handlePlyFileChange}
+      />
       {/* Add button */}
       <div style={styles.addRow}>
         <div ref={addRef} style={{ position: 'relative' }}>

--- a/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
@@ -3,12 +3,15 @@ import { NumberInput } from '../components/NumberInput.js';
 import { useSceneStore } from '../store/useSceneStore.js';
 import type { ToolType, CollisionLayer } from '../store/types.js';
 
-const tools: { id: ToolType; label: string; key: string }[] = [
+const drawTools: { id: ToolType; label: string; key: string }[] = [
   { id: 'place', label: 'Place', key: 'V' },
   { id: 'paint', label: 'Paint', key: 'B' },
   { id: 'erase', label: 'Erase', key: 'E' },
   { id: 'fill', label: 'Fill', key: 'G' },
   { id: 'extrude', label: 'Extrude', key: 'X' },
+];
+
+const utilityTools: { id: ToolType; label: string; key: string }[] = [
   { id: 'eyedropper', label: 'Eyedrop', key: 'I' },
   { id: 'select', label: 'Select', key: 'S' },
 ];
@@ -70,14 +73,14 @@ const styles: Record<string, React.CSSProperties> = {
   },
   colorGrid: {
     display: 'grid',
-    gridTemplateColumns: 'repeat(4, 1fr)',
-    gap: 4,
+    gridTemplateColumns: 'repeat(8, 1fr)',
+    gap: 3,
   },
   colorSwatch: {
-    width: '100%',
-    aspectRatio: '1',
+    width: 24,
+    height: 24,
     border: '2px solid transparent',
-    borderRadius: 4,
+    borderRadius: 3,
     cursor: 'pointer',
   },
   row: {
@@ -128,7 +131,38 @@ const styles: Record<string, React.CSSProperties> = {
     borderColor: '#77f',
     color: '#fff',
   },
+  separator: {
+    height: 1,
+    background: '#444',
+    margin: '6px 0',
+  },
 };
+
+function ToolGroup({ tools, activeTool, setTool, label }: {
+  tools: { id: ToolType; label: string; key: string }[];
+  activeTool: ToolType;
+  setTool: (t: ToolType) => void;
+  label: string;
+}) {
+  return (
+    <>
+      <span style={{ fontSize: 10, color: '#666', letterSpacing: 1, textTransform: 'uppercase' as const }}>{label}</span>
+      {tools.map((t) => (
+        <button
+          key={t.id}
+          style={{
+            ...styles.toolBtn,
+            ...(activeTool === t.id ? styles.toolBtnActive : {}),
+          }}
+          onClick={() => setTool(t.id)}
+        >
+          {t.label}
+          <span style={styles.shortcut}>{t.key}</span>
+        </button>
+      ))}
+    </>
+  );
+}
 
 export function TerrainLeftPanel() {
   const activeTool = useSceneStore((s) => s.activeTool);
@@ -150,32 +184,35 @@ export function TerrainLeftPanel() {
   const navZoneNames = useSceneStore((s) => s.navZoneNames);
   const addNavZoneName = useSceneStore((s) => s.addNavZoneName);
   const initCollisionGrid = useSceneStore((s) => s.initCollisionGrid);
+  const collisionBoxFill = useSceneStore((s) => s.collisionBoxFill);
+  const setCollisionBoxFill = useSceneStore((s) => s.setCollisionBoxFill);
+  const autoGenerateCollision = useSceneStore((s) => s.autoGenerateCollision);
+  const colorPalettes = useSceneStore((s) => s.colorPalettes);
+  const activePaletteIndex = useSceneStore((s) => s.activePaletteIndex);
+  const addPalette = useSceneStore((s) => s.addPalette);
+  const removePalette = useSceneStore((s) => s.removePalette);
+  const setActivePalette = useSceneStore((s) => s.setActivePalette);
+  const addColorToPalette = useSceneStore((s) => s.addColorToPalette);
 
   const [gridW, setGridW] = useState(32);
   const [gridH, setGridH] = useState(32);
   const [cellSize, setCellSize] = useState(1.0);
   const [newZoneName, setNewZoneName] = useState('');
+  const [slopeThreshold, setSlopeThreshold] = useState(5.0);
 
   const hexColor = `#${activeColor.slice(0, 3).map((c) => c.toString(16).padStart(2, '0')).join('')}`;
 
+  // Active palette colors (preset if -1, or custom palette)
+  const displayColors = activePaletteIndex < 0 ? presetColors : (colorPalettes[activePaletteIndex] ?? []);
+
   return (
     <div style={{ flex: 1, overflowY: 'auto', padding: 0 }}>
-      {/* Tools */}
+      {/* Tools — split into draw + utility */}
       <div style={styles.section}>
         <span style={styles.label}>Tools</span>
-        {tools.map((t) => (
-          <button
-            key={t.id}
-            style={{
-              ...styles.toolBtn,
-              ...(activeTool === t.id ? styles.toolBtnActive : {}),
-            }}
-            onClick={() => setTool(t.id)}
-          >
-            {t.label}
-            <span style={styles.shortcut}>{t.key}</span>
-          </button>
-        ))}
+        <ToolGroup tools={drawTools} activeTool={activeTool} setTool={setTool} label="Draw" />
+        <div style={styles.separator} />
+        <ToolGroup tools={utilityTools} activeTool={activeTool} setTool={setTool} label="Utility" />
       </div>
 
       {/* Color */}
@@ -203,9 +240,38 @@ export function TerrainLeftPanel() {
               border: '1px solid #666',
             }}
           />
+          {/* Add current color to active palette */}
+          {activePaletteIndex >= 0 && (
+            <button
+              style={styles.btn}
+              title="Add color to palette"
+              onClick={() => addColorToPalette(activePaletteIndex, [...activeColor])}
+            >
+              +
+            </button>
+          )}
         </div>
+
+        {/* Palette selector */}
+        <div style={{ ...styles.row, marginTop: 4 }}>
+          <select
+            value={activePaletteIndex}
+            onChange={(e) => setActivePalette(Number(e.target.value))}
+            style={{ ...styles.inputFlex, fontSize: 12 }}
+          >
+            <option value={-1}>Default</option>
+            {colorPalettes.map((_, i) => (
+              <option key={i} value={i}>Palette {i + 1} ({colorPalettes[i].length})</option>
+            ))}
+          </select>
+          <button style={styles.btn} onClick={addPalette} title="New Palette">New</button>
+          {activePaletteIndex >= 0 && (
+            <button style={styles.btn} onClick={() => removePalette(activePaletteIndex)} title="Delete Palette">Del</button>
+          )}
+        </div>
+
         <div style={styles.colorGrid}>
-          {presetColors.map((c, i) => (
+          {displayColors.map((c, i) => (
             <div
               key={i}
               style={{
@@ -257,7 +323,7 @@ export function TerrainLeftPanel() {
         </div>
       </div>
 
-      {/* Collision section — always shown in TERRAIN mode */}
+      {/* Collision section */}
       <div style={styles.section}>
         <span style={styles.label}>Collision Grid</span>
         {!showCollision && (
@@ -317,6 +383,16 @@ export function TerrainLeftPanel() {
                 ))}
               </div>
 
+              {/* Box Fill toggle */}
+              <div style={styles.row}>
+                <input
+                  type="checkbox"
+                  checked={collisionBoxFill}
+                  onChange={(e) => setCollisionBoxFill(e.target.checked)}
+                />
+                <span style={{ fontSize: 12 }}>Box Fill</span>
+              </div>
+
               {collisionLayer === 'elevation' && (
                 <div style={styles.row}>
                   <span style={{ fontSize: 12, minWidth: 50 }}>Height</span>
@@ -374,6 +450,31 @@ export function TerrainLeftPanel() {
                   </div>
                 </>
               )}
+
+              {/* Auto-generate from terrain */}
+              <div style={styles.separator} />
+              <div style={styles.row}>
+                <span style={{ fontSize: 12, minWidth: 50 }}>Slope</span>
+                <input
+                  type="range"
+                  min={0.5}
+                  max={20}
+                  step={0.5}
+                  value={slopeThreshold}
+                  onChange={(e) => setSlopeThreshold(Number(e.target.value))}
+                  style={{ flex: 1 }}
+                />
+                <span style={{ fontSize: 11, minWidth: 30 }}>{slopeThreshold}</span>
+              </div>
+              <button
+                style={styles.btn}
+                onClick={() => {
+                  useSceneStore.getState().pushUndo();
+                  autoGenerateCollision(slopeThreshold);
+                }}
+              >
+                Auto-generate
+              </button>
             </>
           )}
         </div>

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -177,6 +177,45 @@ export interface CollisionGridData {
   nav_zone: number[];       // per-cell zone ID (0=default)
 }
 
+export interface ProjectManifest {
+  name: string;
+  version: number;
+  terrains: TerrainEntry[];
+  assets: AssetEntry[];
+  globalSettings: {
+    ambientColor: [number, number, number, number];
+    gaussianSplat: GaussianSplatConfig;
+    weather: WeatherData;
+    dayNight: DayNightData;
+    backgroundLayers: BackgroundLayer[];
+    torchEmitter: EmitterConfig;
+    torchPositions: [number, number][];
+    footstepEmitter: EmitterConfig;
+    npcAuraEmitter: EmitterConfig;
+  };
+  scene: {
+    placedObjects: PlacedObjectData[];
+    staticLights: StaticLight[];
+    npcs: NpcData[];
+    portals: PortalData[];
+    player: PlayerData;
+  };
+}
+
+export interface TerrainEntry {
+  id: string;
+  name: string;
+  voxelFile: string;     // relative path to .bricklayer voxel data file
+  collision: CollisionGridData | null;
+  navZoneNames: string[];
+}
+
+export interface AssetEntry {
+  id: string;
+  path: string;          // relative path within project assets/
+  type: 'ply' | 'image' | 'other';
+}
+
 export interface SelectedEntity {
   type: string;
   id: string;

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -216,6 +216,16 @@ export interface AssetEntry {
   type: 'ply' | 'image' | 'other';
 }
 
+export type NavigationNode =
+  | { type: 'terrain'; terrainId: string }
+  | { type: 'collision'; terrainId: string }
+  | { type: 'scene' }
+  | { type: 'scene_category'; category: 'objects' | 'lights' | 'npcs' | 'portals' }
+  | { type: 'scene_item'; entityType: string; entityId: string }
+  | { type: 'player' }
+  | { type: 'settings' }
+  | { type: 'settings_category'; category: SettingsCategory };
+
 export interface SelectedEntity {
   type: string;
   id: string;

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -21,6 +21,9 @@ import type {
   Snapshot,
   BricklayerFile,
   CollisionGridData,
+  TerrainEntry,
+  AssetEntry,
+  NavigationNode,
 } from './types.js';
 import { voxelKey, parseKey, floodFill3D, brushPositions } from '../lib/voxelUtils.js';
 
@@ -177,6 +180,14 @@ export interface SceneStoreState {
   colorPalettes: [number, number, number, number][][];
   activePaletteIndex: number;
 
+  // Project
+  projectName: string;
+  projectHandle: FileSystemDirectoryHandle | null;
+  terrains: TerrainEntry[];
+  currentTerrainId: string | null;
+  assets: AssetEntry[];
+  activeNode: NavigationNode | null;
+
   // Undo/redo
   undoStack: Snapshot[];
   redoStack: Snapshot[];
@@ -258,6 +269,16 @@ export interface SceneStoreState {
   addColorToPalette: (paletteIdx: number, color: [number, number, number, number]) => void;
   extractColorsFromImage: (imageData: ImageData, filename: string) => void;
 
+  // Actions – project
+  setProjectName: (name: string) => void;
+  setProjectHandle: (handle: FileSystemDirectoryHandle | null) => void;
+  addTerrain: (name: string) => void;
+  removeTerrain: (id: string) => void;
+  switchTerrain: (id: string) => void;
+  addAsset: (entry: AssetEntry) => void;
+  removeAsset: (id: string) => void;
+  setActiveNode: (node: NavigationNode | null) => void;
+
   // Actions – undo/redo
   undo: () => void;
   redo: () => void;
@@ -306,6 +327,13 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   collisionHeight: 0,
   activeNavZone: 0,
   selectedSettingsCategory: 'gs_camera',
+  projectName: 'Untitled',
+  projectHandle: null,
+  terrains: [],
+  currentTerrainId: null,
+  assets: [],
+  activeNode: null,
+
   collisionBoxFill: false,
   collisionBoxStart: null,
   grabMode: false,
@@ -786,6 +814,26 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     const newPalettes = [...colorPalettes, topColors];
     set({ colorPalettes: newPalettes, activePaletteIndex: newPalettes.length - 1 });
   },
+
+  // ── Project actions ──
+  setProjectName: (name) => set({ projectName: name }),
+  setProjectHandle: (handle) => set({ projectHandle: handle }),
+  addTerrain: (name) => {
+    const id = `terrain_${Date.now()}`;
+    const entry: TerrainEntry = { id, name, voxelFile: '', collision: null, navZoneNames: [] };
+    set({ terrains: [...get().terrains, entry], currentTerrainId: id });
+  },
+  removeTerrain: (id) => {
+    const filtered = get().terrains.filter((t) => t.id !== id);
+    const nextId = get().currentTerrainId === id ? (filtered[0]?.id ?? null) : get().currentTerrainId;
+    set({ terrains: filtered, currentTerrainId: nextId });
+  },
+  switchTerrain: (id) => {
+    if (get().terrains.some((t) => t.id === id)) set({ currentTerrainId: id });
+  },
+  addAsset: (entry) => set({ assets: [...get().assets, entry] }),
+  removeAsset: (id) => set({ assets: get().assets.filter((a) => a.id !== id) }),
+  setActiveNode: (node) => set({ activeNode: node }),
 
   // ── File actions ──
   newScene: (width, depth) => set({

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -168,6 +168,14 @@ export interface SceneStoreState {
   collisionHeight: number;
   activeNavZone: number;
   selectedSettingsCategory: SettingsCategory;
+  collisionBoxFill: boolean;
+  collisionBoxStart: [number, number] | null;
+  grabMode: boolean;
+  grabOriginalPosition: [number, number, number] | [number, number] | null;
+
+  // Palettes
+  colorPalettes: [number, number, number, number][][];
+  activePaletteIndex: number;
 
   // Undo/redo
   undoStack: Snapshot[];
@@ -219,10 +227,12 @@ export interface SceneStoreState {
   setGaussianSplat: (g: Partial<GaussianSplatConfig>) => void;
   initCollisionGrid: (width: number, height: number, cellSize: number) => void;
   toggleCellSolid: (x: number, z: number) => void;
+  setCellSolid: (x: number, z: number, solid: boolean) => void;
   setCellElevation: (x: number, z: number, value: number) => void;
   setCellNavZone: (x: number, z: number, zone: number) => void;
   addNavZoneName: (name: string) => void;
   removeNavZoneName: (index: number) => void;
+  autoGenerateCollision: (slopeThreshold: number) => void;
 
   // Actions – editor
   setMode: (mode: BricklayerMode) => void;
@@ -235,6 +245,18 @@ export interface SceneStoreState {
   setCollisionHeight: (h: number) => void;
   setActiveNavZone: (zone: number) => void;
   setSelectedSettingsCategory: (cat: SettingsCategory) => void;
+  setCollisionBoxFill: (on: boolean) => void;
+  setCollisionBoxStart: (start: [number, number] | null) => void;
+  setGrabMode: (on: boolean) => void;
+  setGrabOriginalPosition: (pos: [number, number, number] | [number, number] | null) => void;
+
+  // Actions – palettes
+  addPalette: () => void;
+  removePalette: (index: number) => void;
+  setActivePalette: (index: number) => void;
+  setPaletteColor: (paletteIdx: number, colorIdx: number, color: [number, number, number, number]) => void;
+  addColorToPalette: (paletteIdx: number, color: [number, number, number, number]) => void;
+  extractColorsFromImage: (imageData: ImageData, filename: string) => void;
 
   // Actions – undo/redo
   undo: () => void;
@@ -284,6 +306,13 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   collisionHeight: 0,
   activeNavZone: 0,
   selectedSettingsCategory: 'gs_camera',
+  collisionBoxFill: false,
+  collisionBoxStart: null,
+  grabMode: false,
+  grabOriginalPosition: null,
+
+  colorPalettes: [],
+  activePaletteIndex: -1,
 
   undoStack: [],
   redoStack: [],
@@ -560,6 +589,16 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     set({ collisionGridData: { ...collisionGridData, solid } });
   },
 
+  setCellSolid: (x, z, value) => {
+    const { collisionGridData } = get();
+    if (!collisionGridData) return;
+    const idx = z * collisionGridData.width + x;
+    if (idx < 0 || idx >= collisionGridData.solid.length) return;
+    const solid = [...collisionGridData.solid];
+    solid[idx] = value;
+    set({ collisionGridData: { ...collisionGridData, solid } });
+  },
+
   setCellElevation: (x, z, value) => {
     const { collisionGridData } = get();
     if (!collisionGridData) return;
@@ -588,6 +627,56 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     set({ navZoneNames: get().navZoneNames.filter((_, i) => i !== index) });
   },
 
+  autoGenerateCollision: (slopeThreshold) => {
+    const { voxels, collisionGridData } = get();
+    if (!collisionGridData) return;
+    const g = collisionGridData;
+
+    // Find highest Y per XZ cell
+    const highestY = new Map<string, number>();
+    for (const key of voxels.keys()) {
+      const [x, y, z] = parseKey(key);
+      const cellX = Math.round(x / g.cell_size);
+      const cellZ = Math.round(z / g.cell_size);
+      if (cellX < 0 || cellX >= g.width || cellZ < 0 || cellZ >= g.height) continue;
+      const ck = `${cellX},${cellZ}`;
+      const prev = highestY.get(ck);
+      if (prev === undefined || y > prev) highestY.set(ck, y);
+    }
+
+    const solid = [...g.solid];
+    const elevation = [...g.elevation];
+
+    for (let z = 0; z < g.height; z++) {
+      for (let x = 0; x < g.width; x++) {
+        const idx = z * g.width + x;
+        const ck = `${x},${z}`;
+        const h = highestY.get(ck);
+        if (h === undefined) {
+          // No voxels -> solid (unwalkable)
+          solid[idx] = true;
+          elevation[idx] = 0;
+        } else {
+          elevation[idx] = h;
+          // Check slope: compare to neighbors
+          let maxSlope = 0;
+          for (const [dx, dz] of [[1, 0], [-1, 0], [0, 1], [0, -1]] as [number, number][]) {
+            const nx = x + dx;
+            const nz = z + dz;
+            if (nx < 0 || nx >= g.width || nz < 0 || nz >= g.height) continue;
+            const nh = highestY.get(`${nx},${nz}`);
+            if (nh !== undefined) {
+              maxSlope = Math.max(maxSlope, Math.abs(h - nh));
+            }
+          }
+          solid[idx] = maxSlope > slopeThreshold;
+        }
+      }
+    }
+
+    set({ collisionGridData: { ...g, solid, elevation } });
+  },
+
   // ── Editor actions ──
   setMode: (mode) => set({ mode }),
   setSelectedEntity: (e) => set({ selectedEntity: e }),
@@ -599,6 +688,104 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   setCollisionHeight: (h) => set({ collisionHeight: h }),
   setActiveNavZone: (zone) => set({ activeNavZone: zone }),
   setSelectedSettingsCategory: (cat) => set({ selectedSettingsCategory: cat }),
+  setCollisionBoxFill: (on) => set({ collisionBoxFill: on, collisionBoxStart: null }),
+  setCollisionBoxStart: (start) => set({ collisionBoxStart: start }),
+  setGrabMode: (on) => {
+    if (on) {
+      // Store original position for cancel
+      const { selectedEntity, placedObjects, npcs, portals, staticLights, player } = get();
+      let pos: [number, number, number] | [number, number] | null = null;
+      if (selectedEntity) {
+        if (selectedEntity.type === 'object') {
+          const obj = placedObjects.find((o) => o.id === selectedEntity.id);
+          if (obj) pos = [...obj.position];
+        } else if (selectedEntity.type === 'npc') {
+          const npc = npcs.find((n) => n.id === selectedEntity.id);
+          if (npc) pos = [...npc.position];
+        } else if (selectedEntity.type === 'portal') {
+          const portal = portals.find((p) => p.id === selectedEntity.id);
+          if (portal) pos = [...portal.position];
+        } else if (selectedEntity.type === 'light') {
+          const light = staticLights.find((l) => l.id === selectedEntity.id);
+          if (light) pos = [...light.position];
+        } else if (selectedEntity.type === 'player') {
+          pos = [...player.position];
+        }
+      }
+      set({ grabMode: true, grabOriginalPosition: pos });
+    } else {
+      set({ grabMode: false, grabOriginalPosition: null });
+    }
+  },
+  setGrabOriginalPosition: (pos) => set({ grabOriginalPosition: pos }),
+
+  // ── Palette actions ──
+  addPalette: () => {
+    const { colorPalettes } = get();
+    set({ colorPalettes: [...colorPalettes, []], activePaletteIndex: colorPalettes.length });
+  },
+  removePalette: (index) => {
+    const { colorPalettes, activePaletteIndex } = get();
+    const next = colorPalettes.filter((_, i) => i !== index);
+    const nextActive = activePaletteIndex >= next.length
+      ? next.length - 1
+      : (activePaletteIndex > index ? activePaletteIndex - 1 : activePaletteIndex);
+    set({ colorPalettes: next, activePaletteIndex: nextActive });
+  },
+  setActivePalette: (index) => set({ activePaletteIndex: index }),
+  setPaletteColor: (paletteIdx, colorIdx, color) => {
+    const palettes = [...get().colorPalettes];
+    if (!palettes[paletteIdx]) return;
+    const palette = [...palettes[paletteIdx]];
+    palette[colorIdx] = color;
+    palettes[paletteIdx] = palette;
+    set({ colorPalettes: palettes });
+  },
+  addColorToPalette: (paletteIdx, color) => {
+    const palettes = [...get().colorPalettes];
+    if (!palettes[paletteIdx]) return;
+    palettes[paletteIdx] = [...palettes[paletteIdx], color];
+    set({ colorPalettes: palettes });
+  },
+  extractColorsFromImage: (imageData, filename) => {
+    // Bucket RGB into 4-bit per channel (4096 buckets)
+    const buckets = new Map<number, { count: number; r: number; g: number; b: number }>();
+    const data = imageData.data;
+    for (let i = 0; i < data.length; i += 4) {
+      const a = data[i + 3];
+      if (a < 10) continue;
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+      const rq = (r >> 4) & 0xf;
+      const gq = (g >> 4) & 0xf;
+      const bq = (b >> 4) & 0xf;
+      const key = (rq << 8) | (gq << 4) | bq;
+      const existing = buckets.get(key);
+      if (existing) {
+        existing.count++;
+        // Accumulate for averaging
+        existing.r += r;
+        existing.g += g;
+        existing.b += b;
+      } else {
+        buckets.set(key, { count: 1, r, g, b });
+      }
+    }
+
+    // Sort by frequency, pick top 20
+    const sorted = Array.from(buckets.values()).sort((a, b) => b.count - a.count);
+    const topColors: [number, number, number, number][] = sorted.slice(0, 20).map((b) => [
+      Math.round(b.r / b.count),
+      Math.round(b.g / b.count),
+      Math.round(b.b / b.count),
+      255,
+    ]);
+
+    const { colorPalettes } = get();
+    const newPalettes = [...colorPalettes, topColors];
+    set({ colorPalettes: newPalettes, activePaletteIndex: newPalettes.length - 1 });
+  },
 
   // ── File actions ──
   newScene: (width, depth) => set({

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -21,6 +21,8 @@ import type {
   Snapshot,
   BricklayerFile,
   CollisionGridData,
+  TerrainEntry,
+  AssetEntry,
 } from './types.js';
 import { voxelKey, parseKey, floodFill3D, brushPositions } from '../lib/voxelUtils.js';
 
@@ -128,6 +130,13 @@ function genId(prefix: string): string {
 }
 
 export interface SceneStoreState {
+  // Project
+  projectName: string;
+  projectHandle: FileSystemDirectoryHandle | null;
+  terrains: TerrainEntry[];
+  currentTerrainId: string | null;
+  assets: AssetEntry[];
+
   // Voxels
   voxels: Map<VoxelKey, Voxel>;
   gridWidth: number;
@@ -240,6 +249,15 @@ export interface SceneStoreState {
   undo: () => void;
   redo: () => void;
 
+  // Actions – project
+  setProjectName: (name: string) => void;
+  setProjectHandle: (handle: FileSystemDirectoryHandle | null) => void;
+  addTerrain: (name: string) => void;
+  removeTerrain: (id: string) => void;
+  switchTerrain: (id: string) => void;
+  addAsset: (entry: AssetEntry) => void;
+  removeAsset: (id: string) => void;
+
   // Actions – file
   newScene: (width: number, depth: number) => void;
   importImage: (imageData: ImageData, mode: 'flat' | 'luminance' | 'depth', maxHeight: number, depthMap?: Float32Array, budget?: number) => void;
@@ -248,6 +266,12 @@ export interface SceneStoreState {
 }
 
 export const useSceneStore = create<SceneStoreState>((set, get) => ({
+  projectName: 'Untitled',
+  projectHandle: null,
+  terrains: [],
+  currentTerrainId: null,
+  assets: [],
+
   voxels: new Map(),
   gridWidth: 128,
   gridDepth: 96,
@@ -586,6 +610,44 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
 
   removeNavZoneName: (index) => {
     set({ navZoneNames: get().navZoneNames.filter((_, i) => i !== index) });
+  },
+
+  // ── Project actions ──
+  setProjectName: (name) => set({ projectName: name }),
+  setProjectHandle: (handle) => set({ projectHandle: handle }),
+
+  addTerrain: (name) => {
+    const id = genId('terrain');
+    const entry: TerrainEntry = {
+      id,
+      name,
+      voxelFile: `terrains/${id}.bricklayer`,
+      collision: null,
+      navZoneNames: [],
+    };
+    set({ terrains: [...get().terrains, entry], currentTerrainId: id });
+  },
+
+  removeTerrain: (id) => {
+    const { terrains, currentTerrainId } = get();
+    const filtered = terrains.filter((t) => t.id !== id);
+    const nextId = currentTerrainId === id
+      ? (filtered.length > 0 ? filtered[0].id : null)
+      : currentTerrainId;
+    set({ terrains: filtered, currentTerrainId: nextId });
+  },
+
+  switchTerrain: (id) => {
+    const terrain = get().terrains.find((t) => t.id === id);
+    if (terrain) set({ currentTerrainId: id });
+  },
+
+  addAsset: (entry) => {
+    set({ assets: [...get().assets, entry] });
+  },
+
+  removeAsset: (id) => {
+    set({ assets: get().assets.filter((a) => a.id !== id) });
   },
 
   // ── Editor actions ──

--- a/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
+++ b/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 import { ThreeEvent } from '@react-three/fiber';
+import * as THREE from 'three';
 
 // HSL hue per nav zone (golden angle spacing for good contrast)
 function zoneColor(zone: number): string {
@@ -39,6 +40,20 @@ function Cell({ x, z, cellSize, elevation, color, opacity }: CellProps) {
 export function CollisionOverlay() {
   const collisionGridData = useSceneStore((s) => s.collisionGridData);
   const showCollision = useSceneStore((s) => s.showCollision);
+  const collisionBoxFill = useSceneStore((s) => s.collisionBoxFill);
+  const collisionBoxStart = useSceneStore((s) => s.collisionBoxStart);
+  const [hoverCell, setHoverCell] = useState<[number, number] | null>(null);
+
+  const handlePointerMove = useCallback((e: ThreeEvent<PointerEvent>) => {
+    const store = useSceneStore.getState();
+    const grid = store.collisionGridData;
+    if (!grid || !store.collisionBoxFill || !store.collisionBoxStart) return;
+    const point = e.point;
+    const cellX = Math.round(point.x / grid.cell_size);
+    const cellZ = Math.round(point.z / grid.cell_size);
+    if (cellX < 0 || cellX >= grid.width || cellZ < 0 || cellZ >= grid.height) return;
+    setHoverCell([cellX, cellZ]);
+  }, []);
 
   const handleClick = useCallback((e: ThreeEvent<MouseEvent>) => {
     e.stopPropagation();
@@ -54,6 +69,38 @@ export function CollisionOverlay() {
     const cellZ = Math.round(point.z / grid.cell_size);
 
     if (cellX < 0 || cellX >= grid.width || cellZ < 0 || cellZ >= grid.height) return;
+
+    // Box fill mode
+    if (store.collisionBoxFill) {
+      if (store.collisionBoxStart) {
+        const [sx, sz] = store.collisionBoxStart;
+        store.pushUndo();
+        const minX = Math.min(sx, cellX);
+        const maxX = Math.max(sx, cellX);
+        const minZ = Math.min(sz, cellZ);
+        const maxZ = Math.max(sz, cellZ);
+        for (let x = minX; x <= maxX; x++) {
+          for (let z = minZ; z <= maxZ; z++) {
+            switch (store.collisionLayer) {
+              case 'solid':
+                store.setCellSolid(x, z, true);
+                break;
+              case 'elevation':
+                store.setCellElevation(x, z, store.collisionHeight);
+                break;
+              case 'nav_zone':
+                store.setCellNavZone(x, z, store.activeNavZone);
+                break;
+            }
+          }
+        }
+        store.setCollisionBoxStart(null);
+        setHoverCell(null);
+      } else {
+        store.setCollisionBoxStart([cellX, cellZ]);
+      }
+      return;
+    }
 
     store.pushUndo();
 
@@ -139,6 +186,31 @@ export function CollisionOverlay() {
     return result;
   }, [collisionGridData, showCollision]);
 
+  // Box fill preview rectangle
+  const boxPreview = useMemo(() => {
+    if (!collisionBoxFill || !collisionBoxStart || !hoverCell || !collisionGridData) return null;
+    const [sx, sz] = collisionBoxStart;
+    const [hx, hz] = hoverCell;
+    const cs = collisionGridData.cell_size;
+    const minX = Math.min(sx, hx);
+    const maxX = Math.max(sx, hx);
+    const minZ = Math.min(sz, hz);
+    const maxZ = Math.max(sz, hz);
+    const w = (maxX - minX + 1) * cs;
+    const d = (maxZ - minZ + 1) * cs;
+    const cx = (minX + maxX) / 2 * cs;
+    const cz = (minZ + maxZ) / 2 * cs;
+    return { cx, cz, w, d };
+  }, [collisionBoxFill, collisionBoxStart, hoverCell, collisionGridData]);
+
+  // Start marker
+  const startMarker = useMemo(() => {
+    if (!collisionBoxFill || !collisionBoxStart || !collisionGridData) return null;
+    const [sx, sz] = collisionBoxStart;
+    const cs = collisionGridData.cell_size;
+    return { x: sx * cs, z: sz * cs };
+  }, [collisionBoxFill, collisionBoxStart, collisionGridData]);
+
   if (!showCollision || !collisionGridData) return null;
 
   return (
@@ -152,6 +224,7 @@ export function CollisionOverlay() {
         ]}
         rotation={[-Math.PI / 2, 0, 0]}
         onClick={handleClick}
+        onPointerMove={handlePointerMove}
       >
         <planeGeometry args={[
           collisionGridData.width * collisionGridData.cell_size,
@@ -171,6 +244,22 @@ export function CollisionOverlay() {
           opacity={c.opacity}
         />
       ))}
+
+      {/* Box fill start marker */}
+      {startMarker && (
+        <mesh position={[startMarker.x, 0.05, startMarker.z]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[collisionGridData.cell_size, collisionGridData.cell_size]} />
+          <meshBasicMaterial color="#ffcc00" transparent opacity={0.6} depthWrite={false} />
+        </mesh>
+      )}
+
+      {/* Box fill preview rectangle */}
+      {boxPreview && (
+        <mesh position={[boxPreview.cx, 0.03, boxPreview.cz]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[boxPreview.w, boxPreview.d]} />
+          <meshBasicMaterial color="#ffcc00" transparent opacity={0.25} depthWrite={false} />
+        </mesh>
+      )}
     </group>
   );
 }

--- a/tools/apps/bricklayer/src/viewport/GrabOverlay.tsx
+++ b/tools/apps/bricklayer/src/viewport/GrabOverlay.tsx
@@ -1,0 +1,95 @@
+import React, { useCallback, useRef } from 'react';
+import { useThree, useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { useSceneStore } from '../store/useSceneStore.js';
+
+const _plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+const _raycaster = new THREE.Raycaster();
+const _intersection = new THREE.Vector3();
+const _pointer = new THREE.Vector2();
+
+export function GrabOverlay() {
+  const grabMode = useSceneStore((s) => s.grabMode);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const { camera, gl } = useThree();
+  const tracking = useRef(false);
+
+  // Start tracking on mount when grabMode is active
+  useFrame(() => {
+    if (!grabMode || !selectedEntity) return;
+
+    if (!tracking.current) {
+      tracking.current = true;
+
+      // Determine the Y height for the grab plane
+      const store = useSceneStore.getState();
+      let y = 0;
+      if (selectedEntity.type === 'object') {
+        const obj = store.placedObjects.find((o) => o.id === selectedEntity.id);
+        if (obj) y = obj.position[1];
+      } else if (selectedEntity.type === 'npc') {
+        const npc = store.npcs.find((n) => n.id === selectedEntity.id);
+        if (npc) y = npc.position[1];
+      } else if (selectedEntity.type === 'light') {
+        const light = store.staticLights.find((l) => l.id === selectedEntity.id);
+        if (light) y = light.height;
+      } else if (selectedEntity.type === 'player') {
+        y = store.player.position[1];
+      }
+      _plane.set(new THREE.Vector3(0, 1, 0), -y);
+
+      const el = gl.domElement;
+
+      const onMove = (ev: PointerEvent) => {
+        const rect = el.getBoundingClientRect();
+        _pointer.set(
+          ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+          -((ev.clientY - rect.top) / rect.height) * 2 + 1,
+        );
+        _raycaster.setFromCamera(_pointer, camera);
+        if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
+          const sx = Math.round(_intersection.x * 10) / 10;
+          const sz = Math.round(_intersection.z * 10) / 10;
+          const store = useSceneStore.getState();
+          const sel = store.selectedEntity;
+          if (!sel) return;
+
+          if (sel.type === 'object') {
+            store.updatePlacedObject(sel.id, { position: [sx, y, sz] });
+          } else if (sel.type === 'npc') {
+            store.updateNpc(sel.id, { position: [sx, y, sz] });
+          } else if (sel.type === 'portal') {
+            store.updatePortal(sel.id, { position: [sx, sz] });
+          } else if (sel.type === 'light') {
+            store.updateLight(sel.id, { position: [sx, sz] });
+          } else if (sel.type === 'player') {
+            store.updatePlayer({ position: [sx, y, sz] });
+          }
+        }
+      };
+
+      const onClick = () => {
+        // Confirm position, exit grab mode
+        el.removeEventListener('pointermove', onMove);
+        el.removeEventListener('click', onClick);
+        tracking.current = false;
+        useSceneStore.getState().setGrabMode(false);
+      };
+
+      el.addEventListener('pointermove', onMove);
+      el.addEventListener('click', onClick);
+    }
+  });
+
+  // Clean up if grab mode is turned off externally (e.g., Escape)
+  useFrame(() => {
+    if (!grabMode && tracking.current) {
+      tracking.current = false;
+    }
+  });
+
+  if (!grabMode || !selectedEntity) return null;
+
+  // Render nothing visible — we just need the useFrame hooks above
+  return null;
+}

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -11,6 +11,7 @@ import { PortalMarkers } from './PortalMarkers.js';
 import { ObjectMarkers } from './ObjectMarkers.js';
 import { PlayerMarker } from './PlayerMarker.js';
 import { CollisionOverlay } from './CollisionOverlay.js';
+import { GrabOverlay } from './GrabOverlay.js';
 import { useSceneStore } from '../store/useSceneStore.js';
 
 // Module-level ref so App.tsx can access the orbit controls for F/Home keys
@@ -68,6 +69,7 @@ function SceneContent() {
   const gridWidth = useSceneStore((s) => s.gridWidth);
   const gridDepth = useSceneStore((s) => s.gridDepth);
   const showGrid = useSceneStore((s) => s.showGrid);
+  const grabMode = useSceneStore((s) => s.grabMode);
   const controlsRef = useRef<OrbitControlsRef | null>(null);
 
   return (
@@ -100,6 +102,7 @@ function SceneContent() {
       <ObjectMarkers />
       <PlayerMarker />
       <CollisionOverlay />
+      <GrabOverlay />
       <TeleportPlane />
 
       <OrbitControls
@@ -107,6 +110,7 @@ function SceneContent() {
           controlsRef.current = r;
           orbitControlsRef = r;
         }}
+        enabled={!grabMode}
         target={[gridWidth / 2, 0, gridDepth / 2]}
         makeDefault
         screenSpacePanning

--- a/tools/apps/bricklayer/src/viewport/VoxelMesh.tsx
+++ b/tools/apps/bricklayer/src/viewport/VoxelMesh.tsx
@@ -23,6 +23,9 @@ const NEIGHBORS: [number, number, number][] = [
 export function VoxelMesh() {
   const meshRef = useRef<THREE.InstancedMesh>(null!);
   const voxels = useSceneStore((s) => s.voxels);
+  const showCollision = useSceneStore((s) => s.showCollision);
+  const collisionLayer = useSceneStore((s) => s.collisionLayer);
+  const isCollisionMode = showCollision;
 
   // Filter to surface-only voxels (at least one exposed face)
   const surfaceEntries = useMemo(() => {
@@ -179,7 +182,7 @@ export function VoxelMesh() {
       frustumCulled={false}
     >
       <boxGeometry args={[1, 1, 1]} />
-      <meshLambertMaterial />
+      <meshLambertMaterial transparent={isCollisionMode} opacity={isCollisionMode ? 0.3 : 1.0} />
     </instancedMesh>
   );
 }

--- a/tools/tests/package.json
+++ b/tools/tests/package.json
@@ -21,7 +21,8 @@
     "test:normal-map": "node --import tsx/esm --conditions source src/normal-map.test.ts",
     "test:pose-templates": "node --import tsx/esm --conditions source src/pose-templates.test.ts",
     "test:echidna-ply-export": "node --import tsx/esm --conditions source src/echidna-ply-export.test.ts",
-    "test:bricklayer-store": "node --import tsx/esm --conditions source src/bricklayer-store.test.ts"
+    "test:bricklayer-store": "node --import tsx/esm --conditions source src/bricklayer-store.test.ts",
+    "test:bricklayer-project": "node --import tsx/esm --conditions source src/bricklayer-project.test.ts"
   },
   "dependencies": {
     "@gseurat/test-harness": "workspace:*",

--- a/tools/tests/src/bricklayer-project.test.ts
+++ b/tools/tests/src/bricklayer-project.test.ts
@@ -1,0 +1,731 @@
+/**
+ * Unit tests for Bricklayer project manifest and directory format.
+ *
+ * Run: pnpm test:bricklayer-project
+ */
+
+// Re-implement minimal types and pure functions inline to avoid
+// importing from the app (which has React/Three.js dependencies).
+
+// ── Types ──
+
+interface CollisionGridData {
+  width: number;
+  height: number;
+  cell_size: number;
+  solid: boolean[];
+  elevation: number[];
+  nav_zone: number[];
+}
+
+interface TerrainEntry {
+  id: string;
+  name: string;
+  voxelFile: string;
+  collision: CollisionGridData | null;
+  navZoneNames: string[];
+}
+
+interface AssetEntry {
+  id: string;
+  path: string;
+  type: 'ply' | 'image' | 'other';
+}
+
+interface EmitterConfig {
+  spawn_rate: number;
+  particle_lifetime_min: number;
+  particle_lifetime_max: number;
+  velocity_min: [number, number];
+  velocity_max: [number, number];
+  acceleration: [number, number];
+  size_min: number;
+  size_max: number;
+  size_end_scale: number;
+  color_start: [number, number, number, number];
+  color_end: [number, number, number, number];
+  tile: string;
+  z: number;
+  spawn_offset_min: [number, number];
+  spawn_offset_max: [number, number];
+}
+
+interface BackgroundLayer {
+  id: string;
+  texture: string;
+  z: number;
+  parallax_factor: number;
+  quad_width: number;
+  quad_height: number;
+  uv_repeat_x: number;
+  uv_repeat_y: number;
+  tint: [number, number, number, number];
+  wall: boolean;
+  wall_y_offset: number;
+}
+
+interface WeatherData {
+  enabled: boolean;
+  type: string;
+  emitter: EmitterConfig;
+  ambient_override: [number, number, number, number];
+  fog_density: number;
+  fog_color: [number, number, number];
+  transition_speed: number;
+}
+
+interface DayNightData {
+  enabled: boolean;
+  cycle_speed: number;
+  initial_time: number;
+  keyframes: { time: number; ambient: [number, number, number, number]; torch_intensity: number }[];
+}
+
+interface GaussianSplatConfig {
+  camera: { position: [number, number, number]; target: [number, number, number]; fov: number };
+  render_width: number;
+  render_height: number;
+  scale_multiplier: number;
+  background_image: string;
+  parallax: {
+    azimuth_range: number;
+    elevation_min: number;
+    elevation_max: number;
+    distance_range: number;
+    parallax_strength: number;
+  };
+}
+
+interface PlacedObjectData {
+  id: string;
+  ply_file: string;
+  position: [number, number, number];
+  rotation: [number, number, number];
+  scale: number;
+  is_static: boolean;
+  character_manifest: string;
+}
+
+interface StaticLight {
+  id: string;
+  position: [number, number];
+  radius: number;
+  height: number;
+  color: [number, number, number];
+  intensity: number;
+}
+
+interface NpcData {
+  id: string;
+  name: string;
+  position: [number, number, number];
+  tint: [number, number, number, number];
+  facing: string;
+  reverse_facing: string;
+  patrol_interval: number;
+  patrol_speed: number;
+  waypoints: [number, number][];
+  waypoint_pause: number;
+  dialog: { speaker_key: string; text_key: string }[];
+  light_color: [number, number, number, number];
+  light_radius: number;
+  aura_color_start: [number, number, number, number];
+  aura_color_end: [number, number, number, number];
+  character_id: string;
+  script_module: string;
+  script_class: string;
+}
+
+interface PortalData {
+  id: string;
+  position: [number, number];
+  size: [number, number];
+  target_scene: string;
+  spawn_position: [number, number, number];
+  spawn_facing: string;
+}
+
+interface PlayerData {
+  position: [number, number, number];
+  tint: [number, number, number, number];
+  facing: string;
+  character_id: string;
+}
+
+interface ProjectManifest {
+  name: string;
+  version: number;
+  terrains: TerrainEntry[];
+  assets: AssetEntry[];
+  globalSettings: {
+    ambientColor: [number, number, number, number];
+    gaussianSplat: GaussianSplatConfig;
+    weather: WeatherData;
+    dayNight: DayNightData;
+    backgroundLayers: BackgroundLayer[];
+    torchEmitter: EmitterConfig;
+    torchPositions: [number, number][];
+    footstepEmitter: EmitterConfig;
+    npcAuraEmitter: EmitterConfig;
+  };
+  scene: {
+    placedObjects: PlacedObjectData[];
+    staticLights: StaticLight[];
+    npcs: NpcData[];
+    portals: PortalData[];
+    player: PlayerData;
+  };
+}
+
+// ── Helpers ──
+
+function defaultEmitter(): EmitterConfig {
+  return {
+    spawn_rate: 10,
+    particle_lifetime_min: 0.5,
+    particle_lifetime_max: 1.5,
+    velocity_min: [-0.5, -0.5],
+    velocity_max: [0.5, 0.5],
+    acceleration: [0, 0],
+    size_min: 1,
+    size_max: 2,
+    size_end_scale: 0.5,
+    color_start: [1, 1, 1, 1],
+    color_end: [1, 1, 1, 0],
+    tile: '',
+    z: 0,
+    spawn_offset_min: [0, 0],
+    spawn_offset_max: [0, 0],
+  };
+}
+
+function defaultGaussianSplat(): GaussianSplatConfig {
+  return {
+    camera: { position: [0, 5, 10], target: [0, 0, 0], fov: 45 },
+    render_width: 320,
+    render_height: 240,
+    scale_multiplier: 1,
+    background_image: '',
+    parallax: {
+      azimuth_range: 15,
+      elevation_min: -5,
+      elevation_max: 5,
+      distance_range: 2,
+      parallax_strength: 1,
+    },
+  };
+}
+
+function defaultWeather(): WeatherData {
+  return {
+    enabled: false,
+    type: 'rain',
+    emitter: defaultEmitter(),
+    ambient_override: [0.3, 0.3, 0.4, 1],
+    fog_density: 0,
+    fog_color: [0.5, 0.5, 0.6],
+    transition_speed: 1,
+  };
+}
+
+function defaultDayNight(): DayNightData {
+  return {
+    enabled: false,
+    cycle_speed: 1,
+    initial_time: 0.25,
+    keyframes: [
+      { time: 0, ambient: [0.05, 0.05, 0.15, 1], torch_intensity: 1 },
+      { time: 0.25, ambient: [0.8, 0.7, 0.5, 1], torch_intensity: 0 },
+    ],
+  };
+}
+
+function defaultPlayer(): PlayerData {
+  return {
+    position: [0, 0, 0],
+    tint: [1, 1, 1, 1],
+    facing: 'down',
+    character_id: '',
+  };
+}
+
+let idCounter = 0;
+function genId(prefix: string): string {
+  return `${prefix}_${++idCounter}`;
+}
+
+function createManifest(name: string): ProjectManifest {
+  return {
+    name,
+    version: 1,
+    terrains: [],
+    assets: [],
+    globalSettings: {
+      ambientColor: [0.25, 0.28, 0.45, 1],
+      gaussianSplat: defaultGaussianSplat(),
+      weather: defaultWeather(),
+      dayNight: defaultDayNight(),
+      backgroundLayers: [],
+      torchEmitter: defaultEmitter(),
+      torchPositions: [],
+      footstepEmitter: defaultEmitter(),
+      npcAuraEmitter: defaultEmitter(),
+    },
+    scene: {
+      placedObjects: [],
+      staticLights: [],
+      npcs: [],
+      portals: [],
+      player: defaultPlayer(),
+    },
+  };
+}
+
+function addTerrain(manifest: ProjectManifest, name: string): TerrainEntry {
+  const id = genId('terrain');
+  const entry: TerrainEntry = {
+    id,
+    name,
+    voxelFile: `terrains/${id}.bricklayer`,
+    collision: null,
+    navZoneNames: [],
+  };
+  manifest.terrains.push(entry);
+  return entry;
+}
+
+function removeTerrain(manifest: ProjectManifest, id: string): void {
+  manifest.terrains = manifest.terrains.filter((t) => t.id !== id);
+}
+
+function addAsset(manifest: ProjectManifest, entry: AssetEntry): void {
+  manifest.assets.push(entry);
+}
+
+function removeAsset(manifest: ProjectManifest, id: string): void {
+  manifest.assets = manifest.assets.filter((a) => a.id !== id);
+}
+
+// Export scene from project manifest (simplified version of sceneExport.ts logic)
+function exportSceneFromProject(manifest: ProjectManifest): Record<string, unknown> {
+  const scene: Record<string, unknown> = {
+    ambient_color: manifest.globalSettings.ambientColor,
+  };
+
+  if (manifest.scene.staticLights.length > 0) {
+    scene.static_lights = manifest.scene.staticLights.map((l) => ({
+      position: l.position,
+      radius: l.radius,
+      height: l.height,
+      color: l.color,
+      intensity: l.intensity,
+    }));
+  }
+
+  if (manifest.scene.npcs.length > 0) {
+    scene.npcs = manifest.scene.npcs.map((n) => ({
+      name: n.name,
+      position: n.position,
+      facing: n.facing,
+    }));
+  }
+
+  if (manifest.scene.portals.length > 0) {
+    scene.portals = manifest.scene.portals.map((p) => ({
+      position: p.position,
+      size: p.size,
+      target_scene: p.target_scene,
+      spawn_position: p.spawn_position,
+    }));
+  }
+
+  scene.player_position = manifest.scene.player.position;
+  scene.player_facing = manifest.scene.player.facing;
+
+  scene.gaussian_splat = {
+    camera: manifest.globalSettings.gaussianSplat.camera,
+    render_width: manifest.globalSettings.gaussianSplat.render_width,
+    render_height: manifest.globalSettings.gaussianSplat.render_height,
+  };
+
+  if (manifest.scene.placedObjects.length > 0) {
+    scene.placed_objects = manifest.scene.placedObjects.map((obj) => ({
+      id: obj.id,
+      ply_file: obj.ply_file,
+      position: obj.position,
+      rotation: obj.rotation,
+      scale: obj.scale,
+      is_static: obj.is_static,
+    }));
+  }
+
+  // Add collision from first terrain
+  if (manifest.terrains.length > 0 && manifest.terrains[0].collision) {
+    const g = manifest.terrains[0].collision;
+    scene.collision = {
+      width: g.width,
+      height: g.height,
+      cell_size: g.cell_size,
+      solid: g.solid,
+      elevation: g.elevation,
+      nav_zone: g.nav_zone,
+    };
+  }
+
+  return scene;
+}
+
+// ---------- Test helpers ----------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, message: string) {
+  if (!condition) {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  } else {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  }
+}
+
+// ---------- Tests ----------
+
+console.log('\n=== Bricklayer Project Tests ===\n');
+
+// ===============================================================
+// 1. Project manifest structure (6 tests)
+// ===============================================================
+
+console.log('--- Project manifest structure ---\n');
+
+{
+  console.log('Test 1.1: Create manifest -> has required fields');
+  const m = createManifest('My Project');
+  assert(m.name === 'My Project', `name is 'My Project' (got '${m.name}')`);
+  assert(m.version === 1, `version is 1 (got ${m.version})`);
+  assert(Array.isArray(m.terrains), 'terrains is an array');
+  assert(m.terrains.length === 0, 'terrains starts empty');
+  assert(Array.isArray(m.assets), 'assets is an array');
+  assert(m.assets.length === 0, 'assets starts empty');
+}
+
+{
+  console.log('Test 1.2: Create manifest -> globalSettings has all fields');
+  const m = createManifest('Test');
+  assert(Array.isArray(m.globalSettings.ambientColor), 'has ambientColor');
+  assert(m.globalSettings.gaussianSplat != null, 'has gaussianSplat');
+  assert(m.globalSettings.weather != null, 'has weather');
+  assert(m.globalSettings.dayNight != null, 'has dayNight');
+  assert(Array.isArray(m.globalSettings.backgroundLayers), 'has backgroundLayers');
+  assert(m.globalSettings.torchEmitter != null, 'has torchEmitter');
+  assert(Array.isArray(m.globalSettings.torchPositions), 'has torchPositions');
+  assert(m.globalSettings.footstepEmitter != null, 'has footstepEmitter');
+  assert(m.globalSettings.npcAuraEmitter != null, 'has npcAuraEmitter');
+}
+
+{
+  console.log('Test 1.3: Create manifest -> scene has all fields');
+  const m = createManifest('Test');
+  assert(Array.isArray(m.scene.placedObjects), 'has placedObjects');
+  assert(Array.isArray(m.scene.staticLights), 'has staticLights');
+  assert(Array.isArray(m.scene.npcs), 'has npcs');
+  assert(Array.isArray(m.scene.portals), 'has portals');
+  assert(m.scene.player != null, 'has player');
+  assert(m.scene.player.facing === 'down', `player facing is 'down' (got '${m.scene.player.facing}')`);
+}
+
+// ===============================================================
+// 2. Terrain operations (6 tests)
+// ===============================================================
+
+console.log('\n--- Terrain operations ---\n');
+
+{
+  console.log('Test 2.1: Add terrain -> terrain count increases');
+  const m = createManifest('Test');
+  addTerrain(m, 'Forest');
+  assert(m.terrains.length === 1, `terrain count is 1 (got ${m.terrains.length})`);
+  assert(m.terrains[0].name === 'Forest', `terrain name is 'Forest' (got '${m.terrains[0].name}')`);
+}
+
+{
+  console.log('Test 2.2: Add terrain -> has valid voxelFile path');
+  const m = createManifest('Test');
+  const t = addTerrain(m, 'Cave');
+  assert(t.voxelFile.startsWith('terrains/'), `voxelFile starts with terrains/ (got '${t.voxelFile}')`);
+  assert(t.voxelFile.endsWith('.bricklayer'), `voxelFile ends with .bricklayer (got '${t.voxelFile}')`);
+}
+
+{
+  console.log('Test 2.3: Add terrain -> collision is null, navZoneNames is empty');
+  const m = createManifest('Test');
+  const t = addTerrain(m, 'Plains');
+  assert(t.collision === null, 'collision is null');
+  assert(t.navZoneNames.length === 0, `navZoneNames is empty (got ${t.navZoneNames.length})`);
+}
+
+{
+  console.log('Test 2.4: Remove terrain -> terrain count decreases');
+  const m = createManifest('Test');
+  const t1 = addTerrain(m, 'Forest');
+  addTerrain(m, 'Cave');
+  assert(m.terrains.length === 2, `terrain count is 2 before removal (got ${m.terrains.length})`);
+  removeTerrain(m, t1.id);
+  assert(m.terrains.length === 1, `terrain count is 1 after removal (got ${m.terrains.length})`);
+  assert(m.terrains[0].name === 'Cave', `remaining terrain is 'Cave' (got '${m.terrains[0].name}')`);
+}
+
+{
+  console.log('Test 2.5: Remove non-existent terrain -> no change');
+  const m = createManifest('Test');
+  addTerrain(m, 'Forest');
+  removeTerrain(m, 'nonexistent');
+  assert(m.terrains.length === 1, `terrain count unchanged (got ${m.terrains.length})`);
+}
+
+{
+  console.log('Test 2.6: Add multiple terrains -> unique IDs');
+  const m = createManifest('Test');
+  const t1 = addTerrain(m, 'A');
+  const t2 = addTerrain(m, 'B');
+  const t3 = addTerrain(m, 'C');
+  assert(t1.id !== t2.id, 'terrain 1 and 2 have different IDs');
+  assert(t2.id !== t3.id, 'terrain 2 and 3 have different IDs');
+  assert(t1.id !== t3.id, 'terrain 1 and 3 have different IDs');
+}
+
+// ===============================================================
+// 3. Asset operations (5 tests)
+// ===============================================================
+
+console.log('\n--- Asset operations ---\n');
+
+{
+  console.log('Test 3.1: Add asset -> asset list grows');
+  const m = createManifest('Test');
+  addAsset(m, { id: 'a1', path: 'assets/tree.ply', type: 'ply' });
+  assert(m.assets.length === 1, `asset count is 1 (got ${m.assets.length})`);
+  assert(m.assets[0].path === 'assets/tree.ply', `path is correct (got '${m.assets[0].path}')`);
+  assert(m.assets[0].type === 'ply', `type is 'ply' (got '${m.assets[0].type}')`);
+}
+
+{
+  console.log('Test 3.2: Add image asset -> correct type');
+  const m = createManifest('Test');
+  addAsset(m, { id: 'a2', path: 'assets/bg.png', type: 'image' });
+  assert(m.assets[0].type === 'image', `type is 'image' (got '${m.assets[0].type}')`);
+}
+
+{
+  console.log('Test 3.3: Remove asset -> asset list shrinks');
+  const m = createManifest('Test');
+  addAsset(m, { id: 'a1', path: 'assets/tree.ply', type: 'ply' });
+  addAsset(m, { id: 'a2', path: 'assets/rock.ply', type: 'ply' });
+  assert(m.assets.length === 2, `asset count is 2 before removal (got ${m.assets.length})`);
+  removeAsset(m, 'a1');
+  assert(m.assets.length === 1, `asset count is 1 after removal (got ${m.assets.length})`);
+  assert(m.assets[0].id === 'a2', `remaining asset is a2 (got '${m.assets[0].id}')`);
+}
+
+{
+  console.log('Test 3.4: Remove non-existent asset -> no change');
+  const m = createManifest('Test');
+  addAsset(m, { id: 'a1', path: 'assets/tree.ply', type: 'ply' });
+  removeAsset(m, 'nonexistent');
+  assert(m.assets.length === 1, `asset count unchanged (got ${m.assets.length})`);
+}
+
+{
+  console.log('Test 3.5: Multiple asset types');
+  const m = createManifest('Test');
+  addAsset(m, { id: 'a1', path: 'assets/tree.ply', type: 'ply' });
+  addAsset(m, { id: 'a2', path: 'assets/bg.png', type: 'image' });
+  addAsset(m, { id: 'a3', path: 'assets/data.bin', type: 'other' });
+  assert(m.assets.length === 3, `asset count is 3 (got ${m.assets.length})`);
+  const types = m.assets.map((a) => a.type);
+  assert(types.includes('ply'), 'has ply type');
+  assert(types.includes('image'), 'has image type');
+  assert(types.includes('other'), 'has other type');
+}
+
+// ===============================================================
+// 4. Export scene from project (6 tests)
+// ===============================================================
+
+console.log('\n--- Export scene from project ---\n');
+
+{
+  console.log('Test 4.1: Export empty project -> valid scene JSON');
+  const m = createManifest('Test');
+  const scene = exportSceneFromProject(m);
+  assert('ambient_color' in scene, 'has ambient_color');
+  assert('player_position' in scene, 'has player_position');
+  assert('player_facing' in scene, 'has player_facing');
+  assert('gaussian_splat' in scene, 'has gaussian_splat');
+}
+
+{
+  console.log('Test 4.2: Export with placed objects -> has placed_objects');
+  const m = createManifest('Test');
+  m.scene.placedObjects.push({
+    id: 'obj1',
+    ply_file: 'assets/ply/tree.ply',
+    position: [1, 2, 3],
+    rotation: [0, 45, 0],
+    scale: 1.5,
+    is_static: true,
+    character_manifest: '',
+  });
+  const scene = exportSceneFromProject(m);
+  assert('placed_objects' in scene, 'has placed_objects');
+  const objs = scene.placed_objects as Record<string, unknown>[];
+  assert(objs.length === 1, `placed_objects count is 1 (got ${objs.length})`);
+  assert(objs[0].ply_file === 'assets/ply/tree.ply', 'ply_file matches');
+}
+
+{
+  console.log('Test 4.3: Export with collision terrain -> has collision');
+  const m = createManifest('Test');
+  const t = addTerrain(m, 'Terrain');
+  t.collision = {
+    width: 4,
+    height: 4,
+    cell_size: 1,
+    solid: new Array(16).fill(false),
+    elevation: new Array(16).fill(0),
+    nav_zone: new Array(16).fill(0),
+  };
+  const scene = exportSceneFromProject(m);
+  assert('collision' in scene, 'has collision');
+  const coll = scene.collision as Record<string, unknown>;
+  assert(coll.width === 4, `collision width is 4 (got ${coll.width})`);
+}
+
+{
+  console.log('Test 4.4: Export with NPCs -> has npcs');
+  const m = createManifest('Test');
+  m.scene.npcs.push({
+    id: 'npc1', name: 'Guard', position: [3, 0, 5], tint: [1, 1, 1, 1],
+    facing: 'left', reverse_facing: 'right', patrol_interval: 0,
+    patrol_speed: 1, waypoints: [], waypoint_pause: 1, dialog: [],
+    light_color: [0, 0, 0, 0], light_radius: 0,
+    aura_color_start: [0, 0, 0, 0], aura_color_end: [0, 0, 0, 0],
+    character_id: '', script_module: '', script_class: '',
+  });
+  const scene = exportSceneFromProject(m);
+  assert('npcs' in scene, 'has npcs');
+  const npcs = scene.npcs as Record<string, unknown>[];
+  assert(npcs[0].name === 'Guard', 'npc name matches');
+}
+
+{
+  console.log('Test 4.5: Export with portals -> has portals');
+  const m = createManifest('Test');
+  m.scene.portals.push({
+    id: 'p1', position: [10, 20], size: [2, 3],
+    target_scene: 'dungeon', spawn_position: [1, 0, 1],
+    spawn_facing: 'down',
+  });
+  const scene = exportSceneFromProject(m);
+  assert('portals' in scene, 'has portals');
+  const portals = scene.portals as Record<string, unknown>[];
+  assert(portals[0].target_scene === 'dungeon', 'portal target_scene matches');
+}
+
+{
+  console.log('Test 4.6: Export gaussian_splat -> has camera/render_width/render_height');
+  const m = createManifest('Test');
+  const scene = exportSceneFromProject(m);
+  const gs = scene.gaussian_splat as Record<string, unknown>;
+  assert(gs.render_width === 320, `render_width is 320 (got ${gs.render_width})`);
+  assert(gs.render_height === 240, `render_height is 240 (got ${gs.render_height})`);
+  const cam = gs.camera as Record<string, unknown>;
+  assert(cam.fov === 45, `camera fov is 45 (got ${cam.fov})`);
+}
+
+// ===============================================================
+// 5. Manifest roundtrip (4 tests)
+// ===============================================================
+
+console.log('\n--- Manifest roundtrip ---\n');
+
+{
+  console.log('Test 5.1: Empty manifest roundtrip');
+  const m = createManifest('RoundtripTest');
+  const json = JSON.stringify(m);
+  const parsed = JSON.parse(json) as ProjectManifest;
+  assert(parsed.name === m.name, 'name preserved');
+  assert(parsed.version === m.version, 'version preserved');
+  assert(parsed.terrains.length === m.terrains.length, 'terrains length preserved');
+  assert(parsed.assets.length === m.assets.length, 'assets length preserved');
+}
+
+{
+  console.log('Test 5.2: Manifest with terrains roundtrip');
+  const m = createManifest('RoundtripTest');
+  addTerrain(m, 'Forest');
+  addTerrain(m, 'Cave');
+  const json = JSON.stringify(m);
+  const parsed = JSON.parse(json) as ProjectManifest;
+  assert(parsed.terrains.length === 2, `terrains length is 2 (got ${parsed.terrains.length})`);
+  assert(parsed.terrains[0].name === 'Forest', 'first terrain name preserved');
+  assert(parsed.terrains[1].name === 'Cave', 'second terrain name preserved');
+  assert(parsed.terrains[0].voxelFile === m.terrains[0].voxelFile, 'voxelFile preserved');
+}
+
+{
+  console.log('Test 5.3: Manifest with assets roundtrip');
+  const m = createManifest('RoundtripTest');
+  addAsset(m, { id: 'a1', path: 'assets/tree.ply', type: 'ply' });
+  addAsset(m, { id: 'a2', path: 'assets/bg.png', type: 'image' });
+  const json = JSON.stringify(m);
+  const parsed = JSON.parse(json) as ProjectManifest;
+  assert(parsed.assets.length === 2, `assets length is 2 (got ${parsed.assets.length})`);
+  assert(parsed.assets[0].path === 'assets/tree.ply', 'first asset path preserved');
+  assert(parsed.assets[1].type === 'image', 'second asset type preserved');
+}
+
+{
+  console.log('Test 5.4: Full manifest roundtrip (terrains + assets + scene data)');
+  const m = createManifest('FullTest');
+  const t = addTerrain(m, 'Main');
+  t.collision = {
+    width: 8, height: 6, cell_size: 2,
+    solid: new Array(48).fill(false),
+    elevation: new Array(48).fill(0),
+    nav_zone: new Array(48).fill(0),
+  };
+  t.navZoneNames = ['safe', 'danger'];
+  addAsset(m, { id: 'a1', path: 'assets/tree.ply', type: 'ply' });
+  m.scene.placedObjects.push({
+    id: 'obj1', ply_file: 'assets/tree.ply', position: [1, 2, 3],
+    rotation: [0, 0, 0], scale: 1, is_static: true, character_manifest: '',
+  });
+  m.scene.staticLights.push({
+    id: 'l1', position: [5, 10], radius: 8, height: 2,
+    color: [1, 0.9, 0.7], intensity: 1,
+  });
+  m.globalSettings.ambientColor = [0.5, 0.5, 0.5, 1];
+
+  const json = JSON.stringify(m);
+  const parsed = JSON.parse(json) as ProjectManifest;
+
+  assert(parsed.name === 'FullTest', 'name preserved');
+  assert(parsed.terrains.length === 1, 'terrains length preserved');
+  assert(parsed.terrains[0].collision !== null, 'terrain collision preserved');
+  assert(parsed.terrains[0].collision!.width === 8, 'collision width preserved');
+  assert(parsed.terrains[0].navZoneNames.length === 2, 'navZoneNames length preserved');
+  assert(parsed.terrains[0].navZoneNames[0] === 'safe', 'first nav zone name preserved');
+  assert(parsed.assets.length === 1, 'assets length preserved');
+  assert(parsed.scene.placedObjects.length === 1, 'placedObjects length preserved');
+  assert(parsed.scene.staticLights.length === 1, 'staticLights length preserved');
+  assert(parsed.globalSettings.ambientColor[0] === 0.5, 'ambientColor preserved');
+}
+
+// --- Summary ---
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ${passed} passed, ${failed} failed`);
+console.log('='.repeat(40));
+process.exit(failed > 0 ? 1 : 0);

--- a/tools/tests/src/bricklayer-store.test.ts
+++ b/tools/tests/src/bricklayer-store.test.ts
@@ -611,6 +611,300 @@ console.log('\n--- File roundtrip ---\n');
   assert(loaded.navZoneNames[2] === 'mountain', 'third name matches');
 }
 
+// ═══════════════════════════════════════════════════════════════
+// 5. Box fill collision (4 tests)
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- Box fill collision ---\n');
+
+function setCellSolid(grid: CollisionGridData, x: number, z: number, value: boolean): CollisionGridData {
+  const idx = z * grid.width + x;
+  if (idx < 0 || idx >= grid.solid.length) return grid;
+  const solid = [...grid.solid];
+  solid[idx] = value;
+  return { ...grid, solid };
+}
+
+function boxFillSolid(grid: CollisionGridData, sx: number, sz: number, ex: number, ez: number): CollisionGridData {
+  let result = grid;
+  const minX = Math.min(sx, ex);
+  const maxX = Math.max(sx, ex);
+  const minZ = Math.min(sz, ez);
+  const maxZ = Math.max(sz, ez);
+  for (let x = minX; x <= maxX; x++) {
+    for (let z = minZ; z <= maxZ; z++) {
+      result = setCellSolid(result, x, z, true);
+    }
+  }
+  return result;
+}
+
+{
+  console.log('Test 5.1: Box fill 2x2 -> 4 cells solid');
+  const grid = initCollisionGrid(8, 8, 1.0);
+  const filled = boxFillSolid(grid, 1, 1, 2, 2);
+  let solidCount = 0;
+  for (let i = 0; i < filled.solid.length; i++) {
+    if (filled.solid[i]) solidCount++;
+  }
+  assert(solidCount === 4, `solid count is 4 (got ${solidCount})`);
+}
+
+{
+  console.log('Test 5.2: Box fill single cell -> 1 cell solid');
+  const grid = initCollisionGrid(8, 8, 1.0);
+  const filled = boxFillSolid(grid, 3, 3, 3, 3);
+  let solidCount = 0;
+  for (let i = 0; i < filled.solid.length; i++) {
+    if (filled.solid[i]) solidCount++;
+  }
+  assert(solidCount === 1, `solid count is 1 (got ${solidCount})`);
+}
+
+{
+  console.log('Test 5.3: Box fill reversed coords -> same result');
+  const grid = initCollisionGrid(8, 8, 1.0);
+  const filled1 = boxFillSolid(grid, 0, 0, 3, 3);
+  const filled2 = boxFillSolid(grid, 3, 3, 0, 0);
+  let count1 = 0, count2 = 0;
+  for (let i = 0; i < filled1.solid.length; i++) {
+    if (filled1.solid[i]) count1++;
+    if (filled2.solid[i]) count2++;
+  }
+  assert(count1 === count2, `forward and reverse fill same count (${count1} vs ${count2})`);
+  assert(count1 === 16, `solid count is 16 (got ${count1})`);
+}
+
+{
+  console.log('Test 5.4: setCellSolid explicit -> sets value');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const updated = setCellSolid(grid, 2, 3, true);
+  const idx = 3 * 4 + 2;
+  assert(updated.solid[idx] === true, `solid[${idx}] is true (got ${updated.solid[idx]})`);
+  const reverted = setCellSolid(updated, 2, 3, false);
+  assert(reverted.solid[idx] === false, `solid[${idx}] is false after revert (got ${reverted.solid[idx]})`);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 6. Auto-generate collision from voxels (4 tests)
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- Auto-generate collision ---\n');
+
+function autoGenerateCollision(
+  voxelEntries: [number, number, number][],
+  grid: CollisionGridData,
+  slopeThreshold: number,
+): CollisionGridData {
+  // Find highest Y per XZ cell
+  const highestY = new Map<string, number>();
+  for (const [x, y, z] of voxelEntries) {
+    const cellX = Math.round(x / grid.cell_size);
+    const cellZ = Math.round(z / grid.cell_size);
+    if (cellX < 0 || cellX >= grid.width || cellZ < 0 || cellZ >= grid.height) continue;
+    const ck = `${cellX},${cellZ}`;
+    const prev = highestY.get(ck);
+    if (prev === undefined || y > prev) highestY.set(ck, y);
+  }
+
+  const solid = [...grid.solid];
+  const elevation = [...grid.elevation];
+
+  for (let z = 0; z < grid.height; z++) {
+    for (let x = 0; x < grid.width; x++) {
+      const idx = z * grid.width + x;
+      const ck = `${x},${z}`;
+      const h = highestY.get(ck);
+      if (h === undefined) {
+        solid[idx] = true;
+        elevation[idx] = 0;
+      } else {
+        elevation[idx] = h;
+        let maxSlope = 0;
+        for (const [dx, dz] of [[1, 0], [-1, 0], [0, 1], [0, -1]] as [number, number][]) {
+          const nx = x + dx;
+          const nz = z + dz;
+          if (nx < 0 || nx >= grid.width || nz < 0 || nz >= grid.height) continue;
+          const nh = highestY.get(`${nx},${nz}`);
+          if (nh !== undefined) {
+            maxSlope = Math.max(maxSlope, Math.abs(h - nh));
+          }
+        }
+        solid[idx] = maxSlope > slopeThreshold;
+      }
+    }
+  }
+
+  return { ...grid, solid, elevation };
+}
+
+{
+  console.log('Test 6.1: Empty voxels -> all solid');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const result = autoGenerateCollision([], grid, 5.0);
+  assert(result.solid.every((v) => v === true), 'all cells solid when no voxels');
+}
+
+{
+  console.log('Test 6.2: Flat voxels -> no solid (flat = no slope)');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const voxels: [number, number, number][] = [];
+  for (let x = 0; x < 4; x++) {
+    for (let z = 0; z < 4; z++) {
+      voxels.push([x, 0, z]);
+    }
+  }
+  const result = autoGenerateCollision(voxels, grid, 5.0);
+  assert(result.solid.every((v) => v === false), 'no cells solid for flat terrain');
+  assert(result.elevation.every((v) => v === 0), 'all elevations are 0');
+}
+
+{
+  console.log('Test 6.3: Steep slope -> solid');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const voxels: [number, number, number][] = [
+    [0, 0, 0], [1, 10, 0], [2, 0, 0], [3, 0, 0],
+    [0, 0, 1], [1, 0, 1], [2, 0, 1], [3, 0, 1],
+    [0, 0, 2], [1, 0, 2], [2, 0, 2], [3, 0, 2],
+    [0, 0, 3], [1, 0, 3], [2, 0, 3], [3, 0, 3],
+  ];
+  const result = autoGenerateCollision(voxels, grid, 5.0);
+  // Cell (1,0) has height 10, neighbors have 0 -> slope = 10 > 5 -> solid
+  const idx10 = 0 * 4 + 1;
+  assert(result.solid[idx10] === true, `cell (1,0) is solid due to steep slope (got ${result.solid[idx10]})`);
+  // Cell (0,0) neighbors cell (1,0) with slope 10 > 5 -> also solid
+  const idx00 = 0 * 4 + 0;
+  assert(result.solid[idx00] === true, `cell (0,0) is solid due to neighbor slope (got ${result.solid[idx00]})`);
+}
+
+{
+  console.log('Test 6.4: Elevation set correctly from highest voxel');
+  const grid = initCollisionGrid(2, 2, 1.0);
+  const voxels: [number, number, number][] = [
+    [0, 0, 0], [0, 3, 0], [0, 5, 0], // Multiple Y at same XZ -> highest is 5
+    [1, 2, 0],
+    [0, 1, 1],
+    [1, 4, 1],
+  ];
+  const result = autoGenerateCollision(voxels, grid, 100); // high threshold = no solid from slope
+  assert(result.elevation[0] === 5, `elevation at (0,0) is 5 (got ${result.elevation[0]})`);
+  assert(result.elevation[1] === 2, `elevation at (1,0) is 2 (got ${result.elevation[1]})`);
+  assert(result.elevation[2] === 1, `elevation at (0,1) is 1 (got ${result.elevation[2]})`);
+  assert(result.elevation[3] === 4, `elevation at (1,1) is 4 (got ${result.elevation[3]})`);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 7. Palette operations (5 tests)
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- Palette operations ---\n');
+
+type RGBA = [number, number, number, number];
+
+{
+  console.log('Test 7.1: Add palette -> palette count increases');
+  const palettes: RGBA[][] = [];
+  const next = [...palettes, []];
+  assert(next.length === 1, `palette count is 1 (got ${next.length})`);
+}
+
+{
+  console.log('Test 7.2: Add color to palette');
+  const palettes: RGBA[][] = [[]];
+  const color: RGBA = [255, 0, 0, 255];
+  palettes[0] = [...palettes[0], color];
+  assert(palettes[0].length === 1, `palette has 1 color (got ${palettes[0].length})`);
+  assert(palettes[0][0][0] === 255, `red is 255 (got ${palettes[0][0][0]})`);
+}
+
+{
+  console.log('Test 7.3: Remove palette -> palette count decreases');
+  const palettes: RGBA[][] = [[], [[10, 20, 30, 255]]];
+  const filtered = palettes.filter((_, i) => i !== 0);
+  assert(filtered.length === 1, `palette count is 1 (got ${filtered.length})`);
+  assert(filtered[0].length === 1, `remaining palette has 1 color`);
+}
+
+{
+  console.log('Test 7.4: Extract colors from histogram');
+  // Simulate color extraction
+  function extractColors(pixels: [number, number, number][]): RGBA[] {
+    const buckets = new Map<number, { count: number; r: number; g: number; b: number }>();
+    for (const [r, g, b] of pixels) {
+      const rq = (r >> 4) & 0xf;
+      const gq = (g >> 4) & 0xf;
+      const bq = (b >> 4) & 0xf;
+      const key = (rq << 8) | (gq << 4) | bq;
+      const existing = buckets.get(key);
+      if (existing) {
+        existing.count++;
+        existing.r += r;
+        existing.g += g;
+        existing.b += b;
+      } else {
+        buckets.set(key, { count: 1, r, g, b });
+      }
+    }
+    const sorted = Array.from(buckets.values()).sort((a, b) => b.count - a.count);
+    return sorted.slice(0, 20).map((b) => [
+      Math.round(b.r / b.count),
+      Math.round(b.g / b.count),
+      Math.round(b.b / b.count),
+      255,
+    ]);
+  }
+
+  const pixels: [number, number, number][] = [];
+  for (let i = 0; i < 100; i++) pixels.push([255, 0, 0]);
+  for (let i = 0; i < 50; i++) pixels.push([0, 255, 0]);
+  for (let i = 0; i < 25; i++) pixels.push([0, 0, 255]);
+
+  const colors = extractColors(pixels);
+  assert(colors.length === 3, `extracted 3 colors (got ${colors.length})`);
+  assert(colors[0][0] === 255 && colors[0][1] === 0, 'most frequent color is red');
+  assert(colors[1][1] === 255 && colors[1][0] === 0, 'second most frequent is green');
+}
+
+{
+  console.log('Test 7.5: Extract colors limits to 20');
+  function extractColors(pixels: [number, number, number][]): RGBA[] {
+    const buckets = new Map<number, { count: number; r: number; g: number; b: number }>();
+    for (const [r, g, b] of pixels) {
+      const rq = (r >> 4) & 0xf;
+      const gq = (g >> 4) & 0xf;
+      const bq = (b >> 4) & 0xf;
+      const key = (rq << 8) | (gq << 4) | bq;
+      const existing = buckets.get(key);
+      if (existing) {
+        existing.count++;
+        existing.r += r;
+        existing.g += g;
+        existing.b += b;
+      } else {
+        buckets.set(key, { count: 1, r, g, b });
+      }
+    }
+    const sorted = Array.from(buckets.values()).sort((a, b) => b.count - a.count);
+    return sorted.slice(0, 20).map((b) => [
+      Math.round(b.r / b.count),
+      Math.round(b.g / b.count),
+      Math.round(b.b / b.count),
+      255,
+    ]);
+  }
+
+  // Generate 30 distinct 4-bit-quantized colors
+  const pixels: [number, number, number][] = [];
+  for (let i = 0; i < 30; i++) {
+    const r = (i * 17) % 256;
+    const g = (i * 37) % 256;
+    const b = (i * 53) % 256;
+    pixels.push([r, g, b]);
+  }
+  const colors = extractColors(pixels);
+  assert(colors.length <= 20, `extracted at most 20 colors (got ${colors.length})`);
+}
+
 // --- Summary ---
 console.log(`\n${'='.repeat(40)}`);
 console.log(`  ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## Summary

### Phase 1 — Project Directory Format
- `ProjectManifest` type with terrains, assets, global settings, scene data
- File System Access API integration (`showDirectoryPicker`)
- Save/Load project directories with manifest + per-terrain voxel files
- Import PLY assets via file picker → copies to project `assets/`
- Legacy single-file save/load preserved for backwards compatibility

### Phase 2 — Tree-based Project Navigator
- Hierarchical project tree replaces mode tabs (TERRAIN/SCENE/SETTINGS)
- Click terrain → terrain editing tools, click collision → collision mode
- Scene tree: Placed Objects, Lights, NPCs, Portals, Player with "+" add buttons
- Settings categories: GS Camera, Ambient, Weather, Day/Night, VFX, Backgrounds
- Active node drives right panel content and viewport behavior

### Phase 3 — Collision Mode Improvements
- Terrain becomes semi-transparent (0.3 opacity) when editing collision
- Box fill tool: click two corners to fill a rectangle of cells
- Auto-generate collision from voxel terrain (highest Y → elevation, slope detection)
- Slope threshold slider (0.5-20, default 5.0)

### Phase 4 — G-key Grab Mode (Blender style)
- Select entity → press G → mouse moves entity on XZ plane
- Click to confirm, Escape to cancel (reverts position)
- OrbitControls disabled during grab — no conflict
- GrabOverlay component handles all entity types

### Phase 5 — Terrain UX Improvements
- Tool categories: Draw (Place/Paint/Erase/Fill/Extrude) vs Utility (Eyedrop/Select)
- 8-column color palette (smaller tiles, more visible)
- Multiple palettes with selector dropdown, New/Delete buttons
- Auto-extract colors from imported images (histogram-based)

## Test plan
- [x] 92 store tests pass (including 13 new for collision/palette)
- [x] `pnpm --filter @gseurat/bricklayer build` passes
- [ ] Project tree navigation works
- [ ] Collision box fill and auto-generate from terrain
- [ ] G-key grab mode: select object → G → move → click to confirm
- [ ] Multiple color palettes with image color extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)