### PR TITLE
Bricklayer: complete improvements (project tree, collision tools, grab mode, palettes)

### DIFF
--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -4,6 +4,7 @@ import { MenuBar } from './panels/MenuBar.js';
 import { ImportDialog } from './panels/ImportDialog.js';
 import { ProjectTree } from './panels/ProjectTree.js';
 import { TerrainLeftPanel } from './panels/TerrainLeftPanel.js';
+import { CollisionLeftPanel } from './panels/CollisionLeftPanel.js';
 import { TerrainRightPanel } from './panels/TerrainRightPanel.js';
 import { SceneTreePanel } from './panels/SceneTreePanel.js';
 import { ScenePropertiesPanel } from './panels/ScenePropertiesPanel.js';
@@ -343,14 +344,17 @@ export function App() {
   }, []);
 
   // Determine which contextual panel to show in left below ProjectTree
-  const showTerrainTools = mode === 'terrain' || (activeNode?.kind === 'terrain') || (activeNode?.kind === 'collision');
-  const showSceneTree = mode === 'scene' && !showTerrainTools;
-  const showSettingsList = mode === 'settings' && !showTerrainTools;
+  const isCollisionMode = activeNode?.kind === 'collision';
+  const showTerrainTools = !isCollisionMode && (mode === 'terrain' || (activeNode?.kind === 'terrain'));
+  const showCollisionTools = isCollisionMode;
+  const showSceneTree = mode === 'scene' && !showTerrainTools && !showCollisionTools;
+  const showSettingsList = mode === 'settings' && !showTerrainTools && !showCollisionTools;
 
   // Determine right panel content
   const rightContent = (() => {
     if (activeNode?.kind === 'settings_category' || mode === 'settings') return <SettingsRightPanel />;
     if (activeNode?.kind === 'scene_item' || activeNode?.kind === 'player' || (mode === 'scene')) return <ScenePropertiesPanel />;
+    if (activeNode?.kind === 'collision') return <TerrainRightPanel />;
     return <TerrainRightPanel />;
   })();
 
@@ -367,6 +371,7 @@ export function App() {
           {/* Contextual tools below */}
           <div style={styles.leftContent}>
             {showTerrainTools && <TerrainLeftPanel />}
+            {showCollisionTools && <CollisionLeftPanel />}
             {showSceneTree && <SceneTreePanel />}
             {showSettingsList && <SettingsLeftPanel />}
           </div>

--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Viewport, getOrbitControls } from './viewport/Viewport.js';
 import { MenuBar } from './panels/MenuBar.js';
 import { ImportDialog } from './panels/ImportDialog.js';
+import { ProjectTree } from './panels/ProjectTree.js';
 import { TerrainLeftPanel } from './panels/TerrainLeftPanel.js';
 import { TerrainRightPanel } from './panels/TerrainRightPanel.js';
 import { SceneTreePanel } from './panels/SceneTreePanel.js';
@@ -9,7 +10,7 @@ import { ScenePropertiesPanel } from './panels/ScenePropertiesPanel.js';
 import { SettingsLeftPanel } from './panels/SettingsLeftPanel.js';
 import { SettingsRightPanel } from './panels/SettingsRightPanel.js';
 import { useSceneStore } from './store/useSceneStore.js';
-import type { BricklayerMode, ToolType } from './store/types.js';
+import type { ToolType } from './store/types.js';
 
 // ── ResizeHandle ──
 
@@ -68,34 +69,6 @@ function ResizeHandle({
 
 // ── Mode tabs ──
 
-const modeItems: { id: BricklayerMode; label: string }[] = [
-  { id: 'terrain', label: 'TERRAIN' },
-  { id: 'scene', label: 'SCENE' },
-  { id: 'settings', label: 'SETTINGS' },
-];
-
-function ModeTabs() {
-  const mode = useSceneStore((s) => s.mode);
-  const setMode = useSceneStore((s) => s.setMode);
-
-  return (
-    <div style={modeTabsStyles.bar}>
-      {modeItems.map((m) => (
-        <button
-          key={m.id}
-          onClick={() => setMode(m.id)}
-          style={{
-            ...modeTabsStyles.tab,
-            ...(mode === m.id ? modeTabsStyles.tabActive : {}),
-          }}
-        >
-          {m.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 const modeTabsStyles: Record<string, React.CSSProperties> = {
   bar: {
     display: 'flex',
@@ -127,11 +100,46 @@ const toolKeys: Record<string, ToolType> = {
   v: 'place',
   b: 'paint',
   e: 'erase',
-  g: 'fill',
+  // G is now grab in scene mode, fill in terrain mode
   x: 'extrude',
   i: 'eyedropper',
   s: 'select',
 };
+
+// ── GrabOverlay ──
+
+function GrabOverlay() {
+  const grabMode = useSceneStore((s) => s.grabMode);
+  if (!grabMode) return null;
+
+  return (
+    <div style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      zIndex: 10,
+      cursor: 'move',
+      display: 'flex',
+      alignItems: 'flex-end',
+      justifyContent: 'center',
+      paddingBottom: 12,
+      pointerEvents: 'none',
+    }}>
+      <div style={{
+        background: 'rgba(0,0,0,0.7)',
+        color: '#ffcc00',
+        padding: '4px 12px',
+        borderRadius: 4,
+        fontSize: 12,
+        pointerEvents: 'none',
+      }}>
+        GRAB: Click to confirm, Esc to cancel
+      </div>
+    </div>
+  );
+}
 
 // ── App styles ──
 
@@ -153,6 +161,12 @@ const styles: Record<string, React.CSSProperties> = {
     flexDirection: 'column',
     overflow: 'hidden',
     flexShrink: 0,
+  },
+  leftTop: {
+    overflowY: 'auto',
+    padding: 8,
+    borderBottom: '1px solid #333',
+    maxHeight: '40%',
   },
   leftContent: {
     flex: 1,
@@ -182,10 +196,11 @@ const styles: Record<string, React.CSSProperties> = {
 
 export function App() {
   const [showImport, setShowImport] = useState(false);
-  const [leftWidth, setLeftWidth] = useState(220);
+  const [leftWidth, setLeftWidth] = useState(240);
   const [rightWidth, setRightWidth] = useState(320);
 
   const mode = useSceneStore((s) => s.mode);
+  const activeNode = useSceneStore((s) => s.activeNode);
 
   const handleLeftDrag = useCallback((delta: number) => {
     setLeftWidth((w) => Math.max(160, Math.min(500, w + delta)));
@@ -211,6 +226,56 @@ export function App() {
       if (meta && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
         e.preventDefault();
         store.redo();
+        return;
+      }
+
+      // Escape: cancel grab mode
+      if (e.key === 'Escape' && store.grabMode) {
+        // Restore original position
+        if (store.grabOriginalPosition && store.selectedEntity) {
+          const pos = store.grabOriginalPosition;
+          const sel = store.selectedEntity;
+          if (sel.type === 'object') store.updatePlacedObject(sel.id, { position: pos });
+          else if (sel.type === 'npc') store.updateNpc(sel.id, { position: pos });
+          else if (sel.type === 'light') store.updateLight(sel.id, { position: [pos[0], pos[2]] });
+          else if (sel.type === 'portal') store.updatePortal(sel.id, { position: [pos[0], pos[2]] });
+          else if (sel.type === 'player') store.updatePlayer({ position: pos });
+        }
+        store.setGrabMode(false);
+        store.setGrabOriginalPosition(null);
+        return;
+      }
+
+      // G key: grab in scene mode, fill in terrain mode
+      if (e.key.toLowerCase() === 'g' && !meta) {
+        if (store.mode === 'scene' && store.selectedEntity) {
+          e.preventDefault();
+          // Start grab mode
+          const sel = store.selectedEntity;
+          let pos: [number, number, number] | null = null;
+          if (sel.type === 'object') {
+            const obj = store.placedObjects.find((o) => o.id === sel.id);
+            if (obj) pos = [...obj.position];
+          } else if (sel.type === 'npc') {
+            const npc = store.npcs.find((n) => n.id === sel.id);
+            if (npc) pos = [...npc.position];
+          } else if (sel.type === 'light') {
+            const light = store.staticLights.find((l) => l.id === sel.id);
+            if (light) pos = [light.position[0], light.height, light.position[1]];
+          } else if (sel.type === 'portal') {
+            const portal = store.portals.find((p) => p.id === sel.id);
+            if (portal) pos = [portal.position[0], 0, portal.position[1]];
+          } else if (sel.type === 'player') {
+            pos = [...store.player.position];
+          }
+          if (pos) {
+            store.setGrabOriginalPosition(pos);
+            store.setGrabMode(true);
+          }
+          return;
+        }
+        // Fall through to tool shortcut for terrain mode
+        store.setTool('fill');
         return;
       }
 
@@ -277,17 +342,33 @@ export function App() {
     return () => window.removeEventListener('keydown', handler);
   }, []);
 
+  // Determine which contextual panel to show in left below ProjectTree
+  const showTerrainTools = mode === 'terrain' || (activeNode?.kind === 'terrain') || (activeNode?.kind === 'collision');
+  const showSceneTree = mode === 'scene' && !showTerrainTools;
+  const showSettingsList = mode === 'settings' && !showTerrainTools;
+
+  // Determine right panel content
+  const rightContent = (() => {
+    if (activeNode?.kind === 'settings_category' || mode === 'settings') return <SettingsRightPanel />;
+    if (activeNode?.kind === 'scene_item' || activeNode?.kind === 'player' || (mode === 'scene')) return <ScenePropertiesPanel />;
+    return <TerrainRightPanel />;
+  })();
+
   return (
     <div style={styles.root}>
       <MenuBar onImport={() => setShowImport(true)} />
       <div style={styles.body}>
         {/* Left panel */}
         <div style={{ ...styles.leftPanel, width: leftWidth }}>
-          <ModeTabs />
+          {/* Project tree at top */}
+          <div style={styles.leftTop}>
+            <ProjectTree />
+          </div>
+          {/* Contextual tools below */}
           <div style={styles.leftContent}>
-            {mode === 'terrain' && <TerrainLeftPanel />}
-            {mode === 'scene' && <SceneTreePanel />}
-            {mode === 'settings' && <SettingsLeftPanel />}
+            {showTerrainTools && <TerrainLeftPanel />}
+            {showSceneTree && <SceneTreePanel />}
+            {showSettingsList && <SettingsLeftPanel />}
           </div>
         </div>
 
@@ -296,6 +377,7 @@ export function App() {
         {/* Center viewport */}
         <div style={styles.viewport}>
           <Viewport />
+          <GrabOverlay />
         </div>
 
         <ResizeHandle side="right" onDrag={handleRightDrag} />
@@ -303,9 +385,7 @@ export function App() {
         {/* Right panel */}
         <div style={{ ...styles.rightPanel, width: rightWidth }}>
           <div style={styles.rightContent}>
-            {mode === 'terrain' && <TerrainRightPanel />}
-            {mode === 'scene' && <ScenePropertiesPanel />}
-            {mode === 'settings' && <SettingsRightPanel />}
+            {rightContent}
           </div>
         </div>
       </div>

--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -1,0 +1,78 @@
+import { useSceneStore } from '../store/useSceneStore.js';
+import { exportSceneJson } from './sceneExport.js';
+import type { BricklayerFile } from '../store/types.js';
+
+/**
+ * Check if the File System Access API is available.
+ */
+export function hasFileSystemAccess(): boolean {
+  return typeof window !== 'undefined' && 'showDirectoryPicker' in window;
+}
+
+/**
+ * Open a project directory and set it as the project handle.
+ */
+export async function openProjectDirectory(): Promise<FileSystemDirectoryHandle | null> {
+  if (!hasFileSystemAccess()) return null;
+  try {
+    const handle = await (window as any).showDirectoryPicker({ mode: 'readwrite' });
+    return handle;
+  } catch {
+    return null; // user cancelled
+  }
+}
+
+/**
+ * Save the current project to the project directory.
+ */
+export async function saveProject(handle: FileSystemDirectoryHandle): Promise<void> {
+  const store = useSceneStore.getState();
+  const data = store.saveProject();
+  const json = JSON.stringify(data, null, 2);
+
+  const fileHandle = await handle.getFileHandle('scene.bricklayer', { create: true });
+  const writable = await fileHandle.createWritable();
+  await writable.write(json);
+  await writable.close();
+}
+
+/**
+ * Load a project from the project directory.
+ */
+export async function loadProject(handle: FileSystemDirectoryHandle): Promise<boolean> {
+  try {
+    const fileHandle = await handle.getFileHandle('scene.bricklayer');
+    const file = await fileHandle.getFile();
+    const text = await file.text();
+    const data = JSON.parse(text) as BricklayerFile;
+    useSceneStore.getState().loadProject(data);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Import an asset file into the project directory.
+ */
+export async function importAssetToProject(
+  handle: FileSystemDirectoryHandle,
+  file: File,
+): Promise<string> {
+  const assetsDir = await handle.getDirectoryHandle('assets', { create: true });
+  const fileHandle = await assetsDir.getFileHandle(file.name, { create: true });
+  const writable = await fileHandle.createWritable();
+  await writable.write(file);
+  await writable.close();
+  return `assets/${file.name}`;
+}
+
+/**
+ * Export the scene JSON to the project directory or download it.
+ */
+export function exportSceneJsonBlob(): Blob {
+  const state = useSceneStore.getState();
+  const scene = exportSceneJson(state);
+  const json = JSON.stringify(scene, null, 2);
+  return new Blob([json], { type: 'application/json' });
+}

--- a/tools/apps/bricklayer/src/panels/CollisionLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/CollisionLeftPanel.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from 'react';
+import { NumberInput } from '../components/NumberInput.js';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { CollisionLayer } from '../store/types.js';
+
+const collisionLayers: { id: CollisionLayer; label: string }[] = [
+  { id: 'solid', label: 'Solid' },
+  { id: 'elevation', label: 'Elevation' },
+  { id: 'nav_zone', label: 'NavZone' },
+];
+
+const styles: Record<string, React.CSSProperties> = {
+  container: { flex: 1, overflowY: 'auto', padding: 12 },
+  section: { marginBottom: 16 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1, marginBottom: 8, display: 'block' },
+  row: { display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 },
+  btn: {
+    padding: '6px 12px', border: '1px solid #555', borderRadius: 4,
+    background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 12, width: '100%',
+  },
+  btnActive: { background: '#4a4a8a', borderColor: '#77f', color: '#fff' },
+  btnSmall: {
+    padding: '4px 10px', border: '1px solid #555', borderRadius: 4,
+    background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 11,
+  },
+  input: {
+    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 13,
+  },
+  info: { fontSize: 11, color: '#888', marginBottom: 4 },
+  divider: { borderTop: '1px solid #333', margin: '12px 0' },
+};
+
+export function CollisionLeftPanel() {
+  const collisionGridData = useSceneStore((s) => s.collisionGridData);
+  const collisionLayer = useSceneStore((s) => s.collisionLayer);
+  const collisionHeight = useSceneStore((s) => s.collisionHeight);
+  const activeNavZone = useSceneStore((s) => s.activeNavZone);
+  const navZoneNames = useSceneStore((s) => s.navZoneNames);
+  const collisionBoxFill = useSceneStore((s) => s.collisionBoxFill);
+  const showCollision = useSceneStore((s) => s.showCollision);
+  const initCollisionGrid = useSceneStore((s) => s.initCollisionGrid);
+  const setCollisionLayer = useSceneStore((s) => s.setCollisionLayer);
+  const setCollisionHeight = useSceneStore((s) => s.setCollisionHeight);
+  const setActiveNavZone = useSceneStore((s) => s.setActiveNavZone);
+  const setCollisionBoxFill = useSceneStore((s) => s.setCollisionBoxFill);
+  const addNavZoneName = useSceneStore((s) => s.addNavZoneName);
+  const autoGenerateCollision = useSceneStore((s) => s.autoGenerateCollision);
+
+  const [gridW, setGridW] = useState(32);
+  const [gridH, setGridH] = useState(32);
+  const [cellSize, setCellSize] = useState(1);
+  const [slopeThreshold, setSlopeThreshold] = useState(5.0);
+  const [newZoneName, setNewZoneName] = useState('');
+
+  // Auto-show overlay
+  if (!showCollision) {
+    useSceneStore.getState().setShowCollision(true);
+  }
+
+  if (!collisionGridData) {
+    return (
+      <div style={styles.container}>
+        <span style={styles.label}>Create Collision Grid</span>
+        <div style={styles.row}>
+          <NumberInput label="W" value={gridW} min={1} onChange={setGridW} style={{ maxWidth: 60 }} />
+          <NumberInput label="H" value={gridH} min={1} onChange={setGridH} style={{ maxWidth: 60 }} />
+        </div>
+        <div style={styles.row}>
+          <NumberInput label="Cell" value={cellSize} step={0.5} min={0.1} onChange={setCellSize} style={{ maxWidth: 60 }} />
+        </div>
+        <button style={styles.btn} onClick={() => initCollisionGrid(gridW, gridH, cellSize)}>
+          Init Grid
+        </button>
+
+        <div style={styles.divider} />
+
+        <span style={styles.label}>Auto-generate</span>
+        <p style={styles.info}>Generate collision grid from voxel terrain data</p>
+        <div style={styles.row}>
+          <NumberInput label="Slope" value={slopeThreshold} step={0.5} min={0.5} max={20} onChange={setSlopeThreshold} style={{ maxWidth: 60 }} />
+        </div>
+        <button style={styles.btn} onClick={() => autoGenerateCollision(slopeThreshold)}>
+          Auto-generate from Terrain
+        </button>
+      </div>
+    );
+  }
+
+  const totalCells = collisionGridData.width * collisionGridData.height;
+  const solidCount = collisionGridData.solid.filter(Boolean).length;
+
+  return (
+    <div style={styles.container}>
+      {/* Grid info */}
+      <div style={styles.section}>
+        <span style={styles.label}>Collision Grid</span>
+        <div style={styles.info}>{collisionGridData.width}×{collisionGridData.height} (cell {collisionGridData.cell_size})</div>
+        <div style={styles.info}>{solidCount} solid / {totalCells - solidCount} walkable</div>
+      </div>
+
+      {/* Layer selector */}
+      <div style={styles.section}>
+        <span style={styles.label}>Edit Layer</span>
+        <div style={styles.row}>
+          {collisionLayers.map((cl) => (
+            <button
+              key={cl.id}
+              style={{
+                ...styles.btnSmall,
+                flex: 1,
+                ...(collisionLayer === cl.id ? styles.btnActive : {}),
+              }}
+              onClick={() => setCollisionLayer(cl.id)}
+            >
+              {cl.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Layer-specific tools */}
+      <div style={styles.section}>
+        <span style={styles.label}>Tools</span>
+
+        {/* Box fill toggle */}
+        <label style={{ ...styles.row, cursor: 'pointer', fontSize: 12 }}>
+          <input
+            type="checkbox"
+            checked={collisionBoxFill}
+            onChange={(e) => setCollisionBoxFill(e.target.checked)}
+          />
+          Box Fill (click two corners)
+        </label>
+
+        {collisionLayer === 'elevation' && (
+          <div style={styles.row}>
+            <NumberInput label="Height" step={0.5} value={collisionHeight} onChange={setCollisionHeight} style={styles.input} />
+          </div>
+        )}
+
+        {collisionLayer === 'nav_zone' && (
+          <>
+            <div style={styles.row}>
+              <select
+                style={styles.input}
+                value={activeNavZone}
+                onChange={(e) => setActiveNavZone(Number(e.target.value))}
+              >
+                <option value={0}>0: default</option>
+                {navZoneNames.map((name, i) => (
+                  <option key={i + 1} value={i + 1}>{i + 1}: {name}</option>
+                ))}
+              </select>
+            </div>
+            <div style={styles.row}>
+              <input
+                type="text"
+                value={newZoneName}
+                placeholder="zone name"
+                onChange={(e) => setNewZoneName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && newZoneName.trim()) {
+                    addNavZoneName(newZoneName.trim());
+                    setNewZoneName('');
+                  }
+                }}
+                style={styles.input}
+              />
+              <button
+                style={styles.btnSmall}
+                onClick={() => {
+                  if (newZoneName.trim()) {
+                    addNavZoneName(newZoneName.trim());
+                    setNewZoneName('');
+                  }
+                }}
+              >
+                +
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+
+      <div style={styles.divider} />
+
+      {/* Auto-generate */}
+      <div style={styles.section}>
+        <span style={styles.label}>Auto-generate</span>
+        <div style={styles.row}>
+          <NumberInput label="Slope" value={slopeThreshold} step={0.5} min={0.5} max={20} onChange={setSlopeThreshold} style={{ maxWidth: 60 }} />
+        </div>
+        <button style={styles.btn} onClick={() => autoGenerateCollision(slopeThreshold)}>
+          Regenerate from Terrain
+        </button>
+      </div>
+
+      <div style={styles.divider} />
+
+      <p style={styles.info}>Click cells in viewport to edit. Use Box Fill for rectangles.</p>
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 import { exportPly } from '../lib/plyExport.js';
 import { exportSceneJson } from '../lib/sceneExport.js';
+import { hasFileSystemAccess, openProjectDirectory, saveProject as saveProjectDir, loadProject as loadProjectDir } from '../lib/projectIO.js';
 import type { BricklayerFile } from '../store/types.js';
 
 const styles: Record<string, React.CSSProperties> = {
@@ -193,13 +194,61 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
     download(new Blob([json], { type: 'application/json' }), 'scene.json');
   };
 
+  const handleOpenProject = async () => {
+    if (!hasFileSystemAccess()) {
+      alert('File System Access API not available in this browser.');
+      return;
+    }
+    const handle = await openProjectDirectory();
+    if (handle) {
+      useSceneStore.getState().setProjectHandle(handle);
+      useSceneStore.getState().setProjectName(handle.name);
+      await loadProjectDir(handle);
+    }
+  };
+
+  const handleSaveProject = async () => {
+    const handle = useSceneStore.getState().projectHandle;
+    if (!handle) {
+      // Fall back to regular save
+      handleSave();
+      return;
+    }
+    await saveProjectDir(handle);
+  };
+
+  const handleImportAsset = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.ply,.png,.jpg,.jpeg,.wav,.mp3';
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      const handle = useSceneStore.getState().projectHandle;
+      if (handle) {
+        const { importAssetToProject } = await import('../lib/projectIO.js');
+        const path = await importAssetToProject(handle, file);
+        useSceneStore.getState().addAsset({
+          id: `asset_${Date.now()}`,
+          name: file.name,
+          type: file.name.endsWith('.ply') ? 'ply' : file.name.match(/\.(wav|mp3)$/i) ? 'audio' : 'texture',
+          path,
+        });
+      }
+    };
+    input.click();
+  };
+
   const fileItems: MenuItem[] = [
-    { label: 'New', action: handleNew },
-    { label: 'Save', action: handleSave },
-    { label: 'Load', action: handleLoad },
-    { label: 'Import Image...', action: onImport, separator: true },
+    { label: 'New Project', action: handleNew },
+    { label: 'Open Project...', action: handleOpenProject },
+    { label: 'Save Project', action: handleSaveProject },
+    { label: 'Import Asset...', action: handleImportAsset },
+    { label: 'Export Scene...', action: handleExportScene, separator: true },
+    { label: 'Import Image...', action: onImport },
     { label: 'Export PLY...', action: handleExportPly, separator: true },
-    { label: 'Export Scene...', action: handleExportScene },
+    { label: 'Save File', action: handleSave, separator: true },
+    { label: 'Load File', action: handleLoad },
   ];
 
   const editItems: MenuItem[] = [

--- a/tools/apps/bricklayer/src/panels/ProjectTree.tsx
+++ b/tools/apps/bricklayer/src/panels/ProjectTree.tsx
@@ -1,0 +1,304 @@
+import React, { useState } from 'react';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { NavigationNode, SettingsCategory } from '../store/types.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  tree: { fontSize: 12, userSelect: 'none' },
+  node: {
+    padding: '3px 6px',
+    cursor: 'pointer',
+    borderRadius: 3,
+    color: '#aaa',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 4,
+  },
+  nodeActive: { background: '#3a3a6a', color: '#fff' },
+  indent: { paddingLeft: 16 },
+  indent2: { paddingLeft: 32 },
+  arrow: { fontSize: 10, width: 12, textAlign: 'center' as const, color: '#888' },
+  count: { fontSize: 10, color: '#666', marginLeft: 4 },
+  addBtn: {
+    marginLeft: 'auto',
+    padding: '0 4px',
+    border: 'none',
+    background: 'transparent',
+    color: '#77f',
+    cursor: 'pointer',
+    fontSize: 14,
+    lineHeight: '1',
+  },
+  removeBtn: {
+    marginLeft: 'auto',
+    padding: '0 4px',
+    border: 'none',
+    background: 'transparent',
+    color: '#c66',
+    cursor: 'pointer',
+    fontSize: 12,
+    lineHeight: '1',
+  },
+  heading: {
+    fontSize: 11,
+    color: '#888',
+    textTransform: 'uppercase' as const,
+    letterSpacing: 1,
+    padding: '8px 0 4px',
+    borderBottom: '1px solid #333',
+    marginBottom: 4,
+  },
+};
+
+function nodesEqual(a: NavigationNode | null, b: NavigationNode): boolean {
+  if (!a) return false;
+  if (a.kind !== b.kind) return false;
+  switch (a.kind) {
+    case 'terrain': return b.kind === 'terrain' && a.terrainId === b.terrainId;
+    case 'collision': return b.kind === 'collision' && a.terrainId === b.terrainId;
+    case 'scene': return b.kind === 'scene';
+    case 'scene_category': return b.kind === 'scene_category' && a.category === b.category;
+    case 'scene_item': return b.kind === 'scene_item' && a.entityType === b.entityType && a.entityId === b.entityId;
+    case 'player': return b.kind === 'player';
+    case 'settings': return b.kind === 'settings';
+    case 'settings_category': return b.kind === 'settings_category' && a.category === b.category;
+  }
+}
+
+export function ProjectTree() {
+  const projectName = useSceneStore((s) => s.projectName);
+  const activeNode = useSceneStore((s) => s.activeNode);
+  const setActiveNode = useSceneStore((s) => s.setActiveNode);
+  const placedObjects = useSceneStore((s) => s.placedObjects);
+  const staticLights = useSceneStore((s) => s.staticLights);
+  const npcs = useSceneStore((s) => s.npcs);
+  const portals = useSceneStore((s) => s.portals);
+  const addLight = useSceneStore((s) => s.addLight);
+  const addNpc = useSceneStore((s) => s.addNpc);
+  const addPortal = useSceneStore((s) => s.addPortal);
+  const addPlacedObject = useSceneStore((s) => s.addPlacedObject);
+  const removePlacedObject = useSceneStore((s) => s.removePlacedObject);
+  const removeLight = useSceneStore((s) => s.removeLight);
+  const removeNpc = useSceneStore((s) => s.removeNpc);
+  const removePortal = useSceneStore((s) => s.removePortal);
+  const collisionGridData = useSceneStore((s) => s.collisionGridData);
+
+  const [sceneOpen, setSceneOpen] = useState(true);
+  const [objOpen, setObjOpen] = useState(true);
+  const [lightOpen, setLightOpen] = useState(true);
+  const [npcOpen, setNpcOpen] = useState(true);
+  const [portalOpen, setPortalOpen] = useState(true);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const click = (node: NavigationNode) => {
+    setActiveNode(node);
+    // Also update mode and selectedEntity for backward compat
+    const store = useSceneStore.getState();
+    if (node.kind === 'terrain' || node.kind === 'collision') {
+      store.setMode('terrain');
+      if (node.kind === 'collision') store.setShowCollision(true);
+    } else if (node.kind === 'scene' || node.kind === 'scene_category' || node.kind === 'scene_item' || node.kind === 'player') {
+      store.setMode('scene');
+      if (node.kind === 'scene_item') {
+        store.setSelectedEntity({ type: node.entityType, id: node.entityId });
+      } else if (node.kind === 'player') {
+        store.setSelectedEntity({ type: 'player', id: 'player' });
+      }
+    } else if (node.kind === 'settings' || node.kind === 'settings_category') {
+      store.setMode('settings');
+      if (node.kind === 'settings_category') {
+        store.setSelectedSettingsCategory(node.category);
+      }
+    }
+  };
+
+  const isActive = (node: NavigationNode) => nodesEqual(activeNode, node);
+
+  const settingsCategories: { id: SettingsCategory; label: string }[] = [
+    { id: 'gs_camera', label: 'GS Camera' },
+    { id: 'ambient', label: 'Ambient' },
+    { id: 'weather', label: 'Weather' },
+    { id: 'day_night', label: 'Day/Night' },
+    { id: 'vfx', label: 'VFX' },
+    { id: 'backgrounds', label: 'Backgrounds' },
+  ];
+
+  return (
+    <div style={styles.tree}>
+      {/* Project name */}
+      <div style={styles.heading}>{projectName}</div>
+
+      {/* Terrain */}
+      <div
+        style={{ ...styles.node, ...(isActive({ kind: 'terrain', terrainId: 'main' }) ? styles.nodeActive : {}) }}
+        onClick={() => click({ kind: 'terrain', terrainId: 'main' })}
+      >
+        Terrain
+      </div>
+      {collisionGridData && (
+        <div
+          style={{
+            ...styles.node,
+            ...styles.indent,
+            ...(isActive({ kind: 'collision', terrainId: 'main' }) ? styles.nodeActive : {}),
+          }}
+          onClick={() => click({ kind: 'collision', terrainId: 'main' })}
+        >
+          Collision
+        </div>
+      )}
+
+      {/* Scene */}
+      <div
+        style={{ ...styles.node, ...(isActive({ kind: 'scene' }) ? styles.nodeActive : {}), marginTop: 8 }}
+        onClick={() => { setSceneOpen(!sceneOpen); click({ kind: 'scene' }); }}
+      >
+        <span style={styles.arrow}>{sceneOpen ? '\u25BE' : '\u25B8'}</span>
+        Scene
+      </div>
+
+      {sceneOpen && (
+        <>
+          {/* Objects */}
+          <div style={{ ...styles.indent }}>
+            <div
+              style={{ ...styles.node, ...(isActive({ kind: 'scene_category', category: 'objects' }) ? styles.nodeActive : {}) }}
+              onClick={() => { setObjOpen(!objOpen); click({ kind: 'scene_category', category: 'objects' }); }}
+            >
+              <span style={styles.arrow}>{objOpen ? '\u25BE' : '\u25B8'}</span>
+              Objects
+              <span style={styles.count}>({placedObjects.length})</span>
+              <button style={styles.addBtn} onClick={(e) => { e.stopPropagation(); const f = window.prompt('PLY file:'); if (f) addPlacedObject(f); }}>+</button>
+            </div>
+            {objOpen && (
+              <div style={styles.indent}>
+                {placedObjects.map((obj) => (
+                  <div
+                    key={obj.id}
+                    style={{ ...styles.node, ...(isActive({ kind: 'scene_item', entityType: 'object', entityId: obj.id }) ? styles.nodeActive : {}) }}
+                    onClick={() => click({ kind: 'scene_item', entityType: 'object', entityId: obj.id })}
+                  >
+                    {obj.ply_file || obj.id.slice(0, 12)}
+                    <button style={styles.removeBtn} onClick={(e) => { e.stopPropagation(); removePlacedObject(obj.id); }}>&times;</button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Lights */}
+          <div style={{ ...styles.indent }}>
+            <div
+              style={{ ...styles.node, ...(isActive({ kind: 'scene_category', category: 'lights' }) ? styles.nodeActive : {}) }}
+              onClick={() => { setLightOpen(!lightOpen); click({ kind: 'scene_category', category: 'lights' }); }}
+            >
+              <span style={styles.arrow}>{lightOpen ? '\u25BE' : '\u25B8'}</span>
+              Lights
+              <span style={styles.count}>({staticLights.length})</span>
+              <button style={styles.addBtn} onClick={(e) => { e.stopPropagation(); addLight(); }}>+</button>
+            </div>
+            {lightOpen && (
+              <div style={styles.indent}>
+                {staticLights.map((l) => (
+                  <div
+                    key={l.id}
+                    style={{ ...styles.node, ...(isActive({ kind: 'scene_item', entityType: 'light', entityId: l.id }) ? styles.nodeActive : {}) }}
+                    onClick={() => click({ kind: 'scene_item', entityType: 'light', entityId: l.id })}
+                  >
+                    {l.id.slice(0, 12)}
+                    <button style={styles.removeBtn} onClick={(e) => { e.stopPropagation(); removeLight(l.id); }}>&times;</button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* NPCs */}
+          <div style={{ ...styles.indent }}>
+            <div
+              style={{ ...styles.node, ...(isActive({ kind: 'scene_category', category: 'npcs' }) ? styles.nodeActive : {}) }}
+              onClick={() => { setNpcOpen(!npcOpen); click({ kind: 'scene_category', category: 'npcs' }); }}
+            >
+              <span style={styles.arrow}>{npcOpen ? '\u25BE' : '\u25B8'}</span>
+              NPCs
+              <span style={styles.count}>({npcs.length})</span>
+              <button style={styles.addBtn} onClick={(e) => { e.stopPropagation(); addNpc(); }}>+</button>
+            </div>
+            {npcOpen && (
+              <div style={styles.indent}>
+                {npcs.map((n) => (
+                  <div
+                    key={n.id}
+                    style={{ ...styles.node, ...(isActive({ kind: 'scene_item', entityType: 'npc', entityId: n.id }) ? styles.nodeActive : {}) }}
+                    onClick={() => click({ kind: 'scene_item', entityType: 'npc', entityId: n.id })}
+                  >
+                    {n.name || n.id.slice(0, 12)}
+                    <button style={styles.removeBtn} onClick={(e) => { e.stopPropagation(); removeNpc(n.id); }}>&times;</button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Portals */}
+          <div style={{ ...styles.indent }}>
+            <div
+              style={{ ...styles.node, ...(isActive({ kind: 'scene_category', category: 'portals' }) ? styles.nodeActive : {}) }}
+              onClick={() => { setPortalOpen(!portalOpen); click({ kind: 'scene_category', category: 'portals' }); }}
+            >
+              <span style={styles.arrow}>{portalOpen ? '\u25BE' : '\u25B8'}</span>
+              Portals
+              <span style={styles.count}>({portals.length})</span>
+              <button style={styles.addBtn} onClick={(e) => { e.stopPropagation(); addPortal(); }}>+</button>
+            </div>
+            {portalOpen && (
+              <div style={styles.indent}>
+                {portals.map((p) => (
+                  <div
+                    key={p.id}
+                    style={{ ...styles.node, ...(isActive({ kind: 'scene_item', entityType: 'portal', entityId: p.id }) ? styles.nodeActive : {}) }}
+                    onClick={() => click({ kind: 'scene_item', entityType: 'portal', entityId: p.id })}
+                  >
+                    {p.target_scene || p.id.slice(0, 12)}
+                    <button style={styles.removeBtn} onClick={(e) => { e.stopPropagation(); removePortal(p.id); }}>&times;</button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Player */}
+          <div style={{ ...styles.indent }}>
+            <div
+              style={{ ...styles.node, ...(isActive({ kind: 'player' }) ? styles.nodeActive : {}) }}
+              onClick={() => click({ kind: 'player' })}
+            >
+              Player
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Settings */}
+      <div
+        style={{ ...styles.node, ...(isActive({ kind: 'settings' }) ? styles.nodeActive : {}), marginTop: 8 }}
+        onClick={() => { setSettingsOpen(!settingsOpen); click({ kind: 'settings' }); }}
+      >
+        <span style={styles.arrow}>{settingsOpen ? '\u25BE' : '\u25B8'}</span>
+        Settings
+      </div>
+      {settingsOpen && (
+        <div style={styles.indent}>
+          {settingsCategories.map((cat) => (
+            <div
+              key={cat.id}
+              style={{ ...styles.node, ...(isActive({ kind: 'settings_category', category: cat.id }) ? styles.nodeActive : {}) }}
+              onClick={() => click({ kind: 'settings_category', category: cat.id })}
+            >
+              {cat.label}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/panels/ProjectTree.tsx
+++ b/tools/apps/bricklayer/src/panels/ProjectTree.tsx
@@ -134,18 +134,17 @@ export function ProjectTree() {
       >
         Terrain
       </div>
-      {collisionGridData && (
-        <div
-          style={{
-            ...styles.node,
-            ...styles.indent,
-            ...(isActive({ kind: 'collision', terrainId: 'main' }) ? styles.nodeActive : {}),
-          }}
-          onClick={() => click({ kind: 'collision', terrainId: 'main' })}
-        >
-          Collision
-        </div>
-      )}
+      <div
+        style={{
+          ...styles.node,
+          ...styles.indent,
+          ...(isActive({ kind: 'collision', terrainId: 'main' }) ? styles.nodeActive : {}),
+        }}
+        onClick={() => click({ kind: 'collision', terrainId: 'main' })}
+      >
+        Collision
+        {!collisionGridData && <span style={styles.count}>(none)</span>}
+      </div>
 
       {/* Scene */}
       <div

--- a/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { NumberInput } from '../components/NumberInput.js';
 import { useSceneStore } from '../store/useSceneStore.js';
-import type { ToolType, CollisionLayer } from '../store/types.js';
+import type { ToolType } from '../store/types.js';
 
 const drawTools: { id: ToolType; label: string; key: string }[] = [
   { id: 'place', label: 'Place', key: 'V' },
@@ -14,12 +14,6 @@ const drawTools: { id: ToolType; label: string; key: string }[] = [
 const utilTools: { id: ToolType; label: string; key: string }[] = [
   { id: 'eyedropper', label: 'Eyedrop', key: 'I' },
   { id: 'select', label: 'Select', key: 'S' },
-];
-
-const collisionLayers: { id: CollisionLayer; label: string }[] = [
-  { id: 'solid', label: 'Solid' },
-  { id: 'elevation', label: 'Elevation' },
-  { id: 'nav_zone', label: 'NavZone' },
 ];
 
 const styles: Record<string, React.CSSProperties> = {
@@ -82,15 +76,6 @@ const styles: Record<string, React.CSSProperties> = {
     color: '#ddd',
     fontSize: 13,
   },
-  inputFlex: {
-    flex: 1,
-    padding: '4px 6px',
-    background: '#2a2a4a',
-    border: '1px solid #444',
-    borderRadius: 4,
-    color: '#ddd',
-    fontSize: 13,
-  },
   btn: {
     padding: '4px 10px',
     border: '1px solid #555',
@@ -99,22 +84,6 @@ const styles: Record<string, React.CSSProperties> = {
     color: '#ddd',
     cursor: 'pointer',
     fontSize: 12,
-  },
-  layerBtn: {
-    flex: 1,
-    padding: '4px 6px',
-    border: '1px solid #444',
-    borderRadius: 4,
-    background: '#2a2a4a',
-    color: '#ddd',
-    cursor: 'pointer',
-    fontSize: 12,
-    textAlign: 'center' as const,
-  },
-  layerBtnActive: {
-    background: '#4a4a8a',
-    borderColor: '#77f',
-    color: '#fff',
   },
   select: {
     flex: 1,
@@ -136,31 +105,11 @@ export function TerrainLeftPanel() {
   const setActiveColor = useSceneStore((s) => s.setActiveColor);
   const setBrushSize = useSceneStore((s) => s.setBrushSize);
   const setYLevelLock = useSceneStore((s) => s.setYLevelLock);
-  const showCollision = useSceneStore((s) => s.showCollision);
-  const collisionGridData = useSceneStore((s) => s.collisionGridData);
-  const collisionLayer = useSceneStore((s) => s.collisionLayer);
-  const setCollisionLayer = useSceneStore((s) => s.setCollisionLayer);
-  const collisionHeight = useSceneStore((s) => s.collisionHeight);
-  const setCollisionHeight = useSceneStore((s) => s.setCollisionHeight);
-  const activeNavZone = useSceneStore((s) => s.activeNavZone);
-  const setActiveNavZone = useSceneStore((s) => s.setActiveNavZone);
-  const navZoneNames = useSceneStore((s) => s.navZoneNames);
-  const addNavZoneName = useSceneStore((s) => s.addNavZoneName);
-  const initCollisionGrid = useSceneStore((s) => s.initCollisionGrid);
-  const collisionBoxFill = useSceneStore((s) => s.collisionBoxFill);
-  const setCollisionBoxFill = useSceneStore((s) => s.setCollisionBoxFill);
-  const autoGenerateCollision = useSceneStore((s) => s.autoGenerateCollision);
   const colorPalettes = useSceneStore((s) => s.colorPalettes);
   const activePaletteIndex = useSceneStore((s) => s.activePaletteIndex);
   const setActivePalette = useSceneStore((s) => s.setActivePalette);
   const addPalette = useSceneStore((s) => s.addPalette);
   const addColorToPalette = useSceneStore((s) => s.addColorToPalette);
-
-  const [gridW, setGridW] = useState(32);
-  const [gridH, setGridH] = useState(32);
-  const [cellSize, setCellSize] = useState(1.0);
-  const [newZoneName, setNewZoneName] = useState('');
-  const [slopeThreshold, setSlopeThreshold] = useState(2.0);
 
   const hexColor = `#${activeColor.slice(0, 3).map((c) => c.toString(16).padStart(2, '0')).join('')}`;
   const activePalette = colorPalettes[activePaletteIndex] ?? colorPalettes[0];
@@ -309,155 +258,6 @@ export function TerrainLeftPanel() {
         </div>
       </div>
 
-      {/* Collision section — always visible in TERRAIN mode */}
-      <div style={styles.section}>
-        <span style={styles.label}>Collision Grid</span>
-        {!showCollision && (
-          <button
-            style={{ ...styles.btn, marginBottom: 8 }}
-            onClick={() => useSceneStore.getState().setShowCollision(true)}
-          >
-            Show Overlay
-          </button>
-        )}
-        {!collisionGridData ? (
-            <>
-              <div style={styles.row}>
-                <NumberInput
-                  label="W"
-                  value={gridW}
-                  min={1}
-                  onChange={(v) => setGridW(v)}
-                  style={{ ...styles.inputFlex, maxWidth: 60 }}
-                />
-                <NumberInput
-                  label="H"
-                  value={gridH}
-                  min={1}
-                  onChange={(v) => setGridH(v)}
-                  style={{ ...styles.inputFlex, maxWidth: 60 }}
-                />
-              </div>
-              <div style={styles.row}>
-                <NumberInput
-                  label="Cell"
-                  value={cellSize}
-                  step={0.1}
-                  min={0.1}
-                  onChange={(v) => setCellSize(v)}
-                  style={{ ...styles.inputFlex, maxWidth: 60 }}
-                />
-              </div>
-              <button style={styles.btn} onClick={() => initCollisionGrid(gridW, gridH, cellSize)}>
-                Init Grid
-              </button>
-            </>
-          ) : (
-            <>
-              {/* Layer selector */}
-              <div style={styles.row}>
-                {collisionLayers.map((cl) => (
-                  <button
-                    key={cl.id}
-                    style={{
-                      ...styles.layerBtn,
-                      ...(collisionLayer === cl.id ? styles.layerBtnActive : {}),
-                    }}
-                    onClick={() => setCollisionLayer(cl.id)}
-                  >
-                    {cl.label}
-                  </button>
-                ))}
-              </div>
-
-              {/* Box fill toggle */}
-              <label style={{ ...styles.row, fontSize: 12, cursor: 'pointer' }}>
-                <input
-                  type="checkbox"
-                  checked={collisionBoxFill}
-                  onChange={(e) => setCollisionBoxFill(e.target.checked)}
-                />
-                Box Fill
-              </label>
-
-              {/* Auto-generate */}
-              <div style={styles.row}>
-                <NumberInput
-                  label="Slope"
-                  step={0.5}
-                  min={0}
-                  value={slopeThreshold}
-                  onChange={(v) => setSlopeThreshold(v)}
-                  style={{ ...styles.inputFlex, maxWidth: 60 }}
-                />
-                <button style={styles.btn} onClick={() => {
-                  useSceneStore.getState().pushUndo();
-                  autoGenerateCollision(slopeThreshold);
-                }}>
-                  Auto
-                </button>
-              </div>
-
-              {collisionLayer === 'elevation' && (
-                <div style={styles.row}>
-                  <span style={{ fontSize: 12, minWidth: 50 }}>Height</span>
-                  <NumberInput
-                    step={0.5}
-                    value={collisionHeight}
-                    onChange={setCollisionHeight}
-                    style={styles.inputFlex}
-                  />
-                </div>
-              )}
-
-              {collisionLayer === 'nav_zone' && (
-                <>
-                  <div style={styles.row}>
-                    <span style={{ fontSize: 12, minWidth: 50 }}>Zone</span>
-                    <select
-                      value={activeNavZone}
-                      onChange={(e) => setActiveNavZone(Number(e.target.value))}
-                      style={styles.inputFlex}
-                    >
-                      <option value={0}>0: default</option>
-                      {navZoneNames.map((name, i) => (
-                        <option key={i + 1} value={i + 1}>
-                          {i + 1}: {name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div style={styles.row}>
-                    <input
-                      type="text"
-                      value={newZoneName}
-                      placeholder="new zone name"
-                      onChange={(e) => setNewZoneName(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && newZoneName.trim()) {
-                          addNavZoneName(newZoneName.trim());
-                          setNewZoneName('');
-                        }
-                      }}
-                      style={styles.inputFlex}
-                    />
-                    <button
-                      style={styles.btn}
-                      onClick={() => {
-                        if (newZoneName.trim()) {
-                          addNavZoneName(newZoneName.trim());
-                          setNewZoneName('');
-                        }
-                      }}
-                    >
-                      +
-                    </button>
-                  </div>
-                </>
-              )}
-            </>
-          )}
-        </div>
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
@@ -3,29 +3,17 @@ import { NumberInput } from '../components/NumberInput.js';
 import { useSceneStore } from '../store/useSceneStore.js';
 import type { ToolType, CollisionLayer } from '../store/types.js';
 
-const tools: { id: ToolType; label: string; key: string }[] = [
+const drawTools: { id: ToolType; label: string; key: string }[] = [
   { id: 'place', label: 'Place', key: 'V' },
   { id: 'paint', label: 'Paint', key: 'B' },
   { id: 'erase', label: 'Erase', key: 'E' },
   { id: 'fill', label: 'Fill', key: 'G' },
   { id: 'extrude', label: 'Extrude', key: 'X' },
-  { id: 'eyedropper', label: 'Eyedrop', key: 'I' },
-  { id: 'select', label: 'Select', key: 'S' },
 ];
 
-const presetColors: [number, number, number, number][] = [
-  [34, 139, 34, 255],
-  [139, 90, 43, 255],
-  [100, 100, 100, 255],
-  [200, 200, 200, 255],
-  [60, 60, 180, 255],
-  [180, 60, 60, 255],
-  [180, 180, 60, 255],
-  [60, 180, 180, 255],
-  [220, 160, 80, 255],
-  [80, 40, 20, 255],
-  [160, 80, 160, 255],
-  [20, 20, 20, 255],
+const utilTools: { id: ToolType; label: string; key: string }[] = [
+  { id: 'eyedropper', label: 'Eyedrop', key: 'I' },
+  { id: 'select', label: 'Select', key: 'S' },
 ];
 
 const collisionLayers: { id: CollisionLayer; label: string }[] = [
@@ -52,32 +40,32 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    padding: '6px 10px',
+    padding: '5px 8px',
     border: '1px solid #444',
     borderRadius: 4,
     background: '#2a2a4a',
     color: '#ddd',
     cursor: 'pointer',
-    fontSize: 13,
+    fontSize: 12,
   },
   toolBtnActive: {
     background: '#4a4a8a',
     borderColor: '#77f',
   },
   shortcut: {
-    fontSize: 11,
+    fontSize: 10,
     color: '#777',
   },
   colorGrid: {
     display: 'grid',
-    gridTemplateColumns: 'repeat(4, 1fr)',
-    gap: 4,
+    gridTemplateColumns: 'repeat(8, 1fr)',
+    gap: 2,
   },
   colorSwatch: {
     width: '100%',
     aspectRatio: '1',
     border: '2px solid transparent',
-    borderRadius: 4,
+    borderRadius: 3,
     cursor: 'pointer',
   },
   row: {
@@ -128,6 +116,15 @@ const styles: Record<string, React.CSSProperties> = {
     borderColor: '#77f',
     color: '#fff',
   },
+  select: {
+    flex: 1,
+    padding: '4px 6px',
+    background: '#2a2a4a',
+    border: '1px solid #444',
+    borderRadius: 4,
+    color: '#ddd',
+    fontSize: 12,
+  },
 };
 
 export function TerrainLeftPanel() {
@@ -150,20 +147,48 @@ export function TerrainLeftPanel() {
   const navZoneNames = useSceneStore((s) => s.navZoneNames);
   const addNavZoneName = useSceneStore((s) => s.addNavZoneName);
   const initCollisionGrid = useSceneStore((s) => s.initCollisionGrid);
+  const collisionBoxFill = useSceneStore((s) => s.collisionBoxFill);
+  const setCollisionBoxFill = useSceneStore((s) => s.setCollisionBoxFill);
+  const autoGenerateCollision = useSceneStore((s) => s.autoGenerateCollision);
+  const colorPalettes = useSceneStore((s) => s.colorPalettes);
+  const activePaletteIndex = useSceneStore((s) => s.activePaletteIndex);
+  const setActivePalette = useSceneStore((s) => s.setActivePalette);
+  const addPalette = useSceneStore((s) => s.addPalette);
+  const addColorToPalette = useSceneStore((s) => s.addColorToPalette);
 
   const [gridW, setGridW] = useState(32);
   const [gridH, setGridH] = useState(32);
   const [cellSize, setCellSize] = useState(1.0);
   const [newZoneName, setNewZoneName] = useState('');
+  const [slopeThreshold, setSlopeThreshold] = useState(2.0);
 
   const hexColor = `#${activeColor.slice(0, 3).map((c) => c.toString(16).padStart(2, '0')).join('')}`;
+  const activePalette = colorPalettes[activePaletteIndex] ?? colorPalettes[0];
 
   return (
     <div style={{ flex: 1, overflowY: 'auto', padding: 0 }}>
-      {/* Tools */}
+      {/* Draw Tools */}
       <div style={styles.section}>
-        <span style={styles.label}>Tools</span>
-        {tools.map((t) => (
+        <span style={styles.label}>Draw</span>
+        {drawTools.map((t) => (
+          <button
+            key={t.id}
+            style={{
+              ...styles.toolBtn,
+              ...(activeTool === t.id ? styles.toolBtnActive : {}),
+            }}
+            onClick={() => setTool(t.id)}
+          >
+            {t.label}
+            <span style={styles.shortcut}>{t.key}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Utility Tools */}
+      <div style={styles.section}>
+        <span style={styles.label}>Utility</span>
+        {utilTools.map((t) => (
           <button
             key={t.id}
             style={{
@@ -192,20 +217,47 @@ export function TerrainLeftPanel() {
               const b = parseInt(hex.slice(5, 7), 16);
               setActiveColor([r, g, b, activeColor[3]]);
             }}
-            style={{ width: 40, height: 30, border: 'none', cursor: 'pointer' }}
+            style={{ width: 30, height: 24, border: 'none', cursor: 'pointer' }}
           />
           <div
             style={{
-              width: 30,
-              height: 30,
-              borderRadius: 4,
+              width: 24,
+              height: 24,
+              borderRadius: 3,
               background: `rgba(${activeColor.join(',')})`,
               border: '1px solid #666',
             }}
           />
+          <button
+            style={{ ...styles.btn, fontSize: 11, padding: '2px 6px' }}
+            onClick={() => addColorToPalette(activePaletteIndex, [...activeColor] as [number, number, number, number])}
+          >
+            + Palette
+          </button>
         </div>
+
+        {/* Palette selector */}
+        <div style={styles.row}>
+          <select
+            value={activePaletteIndex}
+            onChange={(e) => setActivePalette(Number(e.target.value))}
+            style={styles.select}
+          >
+            {colorPalettes.map((p, i) => (
+              <option key={i} value={i}>{p.name}</option>
+            ))}
+          </select>
+          <button
+            style={{ ...styles.btn, fontSize: 11, padding: '2px 6px' }}
+            onClick={() => addPalette(`Palette ${colorPalettes.length + 1}`)}
+          >
+            New
+          </button>
+        </div>
+
+        {/* 8-column color grid */}
         <div style={styles.colorGrid}>
-          {presetColors.map((c, i) => (
+          {(activePalette?.colors ?? []).map((c, i) => (
             <div
               key={i}
               style={{
@@ -257,7 +309,7 @@ export function TerrainLeftPanel() {
         </div>
       </div>
 
-      {/* Collision section — always shown in TERRAIN mode */}
+      {/* Collision section — always visible in TERRAIN mode */}
       <div style={styles.section}>
         <span style={styles.label}>Collision Grid</span>
         {!showCollision && (
@@ -302,6 +354,7 @@ export function TerrainLeftPanel() {
             </>
           ) : (
             <>
+              {/* Layer selector */}
               <div style={styles.row}>
                 {collisionLayers.map((cl) => (
                   <button
@@ -315,6 +368,34 @@ export function TerrainLeftPanel() {
                     {cl.label}
                   </button>
                 ))}
+              </div>
+
+              {/* Box fill toggle */}
+              <label style={{ ...styles.row, fontSize: 12, cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={collisionBoxFill}
+                  onChange={(e) => setCollisionBoxFill(e.target.checked)}
+                />
+                Box Fill
+              </label>
+
+              {/* Auto-generate */}
+              <div style={styles.row}>
+                <NumberInput
+                  label="Slope"
+                  step={0.5}
+                  min={0}
+                  value={slopeThreshold}
+                  onChange={(v) => setSlopeThreshold(v)}
+                  style={{ ...styles.inputFlex, maxWidth: 60 }}
+                />
+                <button style={styles.btn} onClick={() => {
+                  useSceneStore.getState().pushUndo();
+                  autoGenerateCollision(slopeThreshold);
+                }}>
+                  Auto
+                </button>
               </div>
 
               {collisionLayer === 'elevation' && (

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -182,6 +182,46 @@ export interface SelectedEntity {
   id: string;
 }
 
+// ── Project management ──
+
+export interface ProjectManifest {
+  name: string;
+  terrains: TerrainEntry[];
+  assets: AssetEntry[];
+}
+
+export interface TerrainEntry {
+  id: string;
+  name: string;
+  file: string;
+}
+
+export interface AssetEntry {
+  id: string;
+  name: string;
+  type: 'ply' | 'texture' | 'audio';
+  path: string;
+}
+
+// ── Navigation tree ──
+
+export type NavigationNode =
+  | { kind: 'terrain'; terrainId: string }
+  | { kind: 'collision'; terrainId: string }
+  | { kind: 'scene' }
+  | { kind: 'scene_category'; category: 'objects' | 'lights' | 'npcs' | 'portals' }
+  | { kind: 'scene_item'; entityType: string; entityId: string }
+  | { kind: 'player' }
+  | { kind: 'settings' }
+  | { kind: 'settings_category'; category: SettingsCategory };
+
+// ── Color palettes ──
+
+export interface ColorPalette {
+  name: string;
+  colors: [number, number, number, number][];
+}
+
 export interface Snapshot {
   voxels: [VoxelKey, Voxel][];
   collisionGridData: CollisionGridData | null;

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -21,6 +21,10 @@ import type {
   Snapshot,
   BricklayerFile,
   CollisionGridData,
+  TerrainEntry,
+  AssetEntry,
+  NavigationNode,
+  ColorPalette,
 } from './types.js';
 import { voxelKey, parseKey, floodFill3D, brushPositions } from '../lib/voxelUtils.js';
 
@@ -133,6 +137,26 @@ export interface SceneStoreState {
   gridWidth: number;
   gridDepth: number;
 
+  // Project management
+  projectName: string;
+  projectHandle: FileSystemDirectoryHandle | null;
+  terrains: TerrainEntry[];
+  currentTerrainId: string;
+  assets: AssetEntry[];
+  activeNode: NavigationNode | null;
+
+  // Collision box fill
+  collisionBoxFill: boolean;
+  collisionBoxStart: [number, number] | null;
+
+  // Grab mode
+  grabMode: boolean;
+  grabOriginalPosition: [number, number, number] | null;
+
+  // Color palettes
+  colorPalettes: ColorPalette[];
+  activePaletteIndex: number;
+
   // Voxel tools
   activeTool: ToolType;
   activeColor: [number, number, number, number];
@@ -224,6 +248,34 @@ export interface SceneStoreState {
   addNavZoneName: (name: string) => void;
   removeNavZoneName: (index: number) => void;
 
+  // Actions – project
+  setProjectName: (name: string) => void;
+  setProjectHandle: (handle: FileSystemDirectoryHandle | null) => void;
+  addTerrain: (terrain: TerrainEntry) => void;
+  removeTerrain: (id: string) => void;
+  switchTerrain: (id: string) => void;
+  addAsset: (asset: AssetEntry) => void;
+  removeAsset: (id: string) => void;
+  setActiveNode: (node: NavigationNode | null) => void;
+
+  // Actions – collision box fill
+  setCollisionBoxFill: (v: boolean) => void;
+  setCollisionBoxStart: (pos: [number, number] | null) => void;
+  setCellSolid: (x: number, z: number, val: boolean) => void;
+  autoGenerateCollision: (slopeThreshold: number) => void;
+
+  // Actions – grab
+  setGrabMode: (v: boolean) => void;
+  setGrabOriginalPosition: (pos: [number, number, number] | null) => void;
+
+  // Actions – palettes
+  addPalette: (name: string) => void;
+  removePalette: (index: number) => void;
+  setActivePalette: (index: number) => void;
+  setPaletteColor: (paletteIndex: number, colorIndex: number, color: [number, number, number, number]) => void;
+  addColorToPalette: (paletteIndex: number, color: [number, number, number, number]) => void;
+  extractColorsFromImage: (imageData: ImageData, maxColors: number) => void;
+
   // Actions – editor
   setMode: (mode: BricklayerMode) => void;
   setSelectedEntity: (e: SelectedEntity | null) => void;
@@ -247,10 +299,44 @@ export interface SceneStoreState {
   loadProject: (data: BricklayerFile) => void;
 }
 
+const defaultPalette: ColorPalette = {
+  name: 'Default',
+  colors: [
+    [34, 139, 34, 255],
+    [139, 90, 43, 255],
+    [100, 100, 100, 255],
+    [200, 200, 200, 255],
+    [60, 60, 180, 255],
+    [180, 60, 60, 255],
+    [180, 180, 60, 255],
+    [60, 180, 180, 255],
+    [220, 160, 80, 255],
+    [80, 40, 20, 255],
+    [160, 80, 160, 255],
+    [20, 20, 20, 255],
+  ],
+};
+
 export const useSceneStore = create<SceneStoreState>((set, get) => ({
   voxels: new Map(),
   gridWidth: 128,
   gridDepth: 96,
+
+  projectName: 'Untitled',
+  projectHandle: null,
+  terrains: [],
+  currentTerrainId: '',
+  assets: [],
+  activeNode: null,
+
+  collisionBoxFill: false,
+  collisionBoxStart: null,
+
+  grabMode: false,
+  grabOriginalPosition: null,
+
+  colorPalettes: [defaultPalette],
+  activePaletteIndex: 0,
 
   activeTool: 'place',
   activeColor: [34, 139, 34, 255],
@@ -586,6 +672,134 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
 
   removeNavZoneName: (index) => {
     set({ navZoneNames: get().navZoneNames.filter((_, i) => i !== index) });
+  },
+
+  // ── Project actions ──
+  setProjectName: (name) => set({ projectName: name }),
+  setProjectHandle: (handle) => set({ projectHandle: handle }),
+  addTerrain: (terrain) => set({ terrains: [...get().terrains, terrain] }),
+  removeTerrain: (id) => set({ terrains: get().terrains.filter((t) => t.id !== id) }),
+  switchTerrain: (id) => set({ currentTerrainId: id }),
+  addAsset: (asset) => set({ assets: [...get().assets, asset] }),
+  removeAsset: (id) => set({ assets: get().assets.filter((a) => a.id !== id) }),
+  setActiveNode: (node) => set({ activeNode: node }),
+
+  // ── Collision box fill ──
+  setCollisionBoxFill: (v) => set({ collisionBoxFill: v, collisionBoxStart: null }),
+  setCollisionBoxStart: (pos) => set({ collisionBoxStart: pos }),
+
+  setCellSolid: (x, z, val) => {
+    const { collisionGridData } = get();
+    if (!collisionGridData) return;
+    const idx = z * collisionGridData.width + x;
+    if (idx < 0 || idx >= collisionGridData.solid.length) return;
+    const solid = [...collisionGridData.solid];
+    solid[idx] = val;
+    set({ collisionGridData: { ...collisionGridData, solid } });
+  },
+
+  autoGenerateCollision: (slopeThreshold) => {
+    const { voxels, collisionGridData } = get();
+    if (!collisionGridData) return;
+    const g = collisionGridData;
+    const solid = [...g.solid];
+    const elevation = [...g.elevation];
+
+    // Build height map from voxels
+    const heightMap = new Map<string, number>();
+    for (const key of voxels.keys()) {
+      const parts = key.split(',');
+      const x = Number(parts[0]);
+      const y = Number(parts[1]);
+      const z = Number(parts[2]);
+      const mapKey = `${x},${z}`;
+      const existing = heightMap.get(mapKey) ?? -Infinity;
+      if (y > existing) heightMap.set(mapKey, y);
+    }
+
+    for (let cz = 0; cz < g.height; cz++) {
+      for (let cx = 0; cx < g.width; cx++) {
+        const idx = cz * g.width + cx;
+        const h = heightMap.get(`${cx},${cz}`) ?? 0;
+        elevation[idx] = h;
+
+        // Check slope against neighbors
+        let maxSlope = 0;
+        for (const [dx, dz] of [[1, 0], [-1, 0], [0, 1], [0, -1]] as const) {
+          const nh = heightMap.get(`${cx + dx},${cz + dz}`) ?? 0;
+          maxSlope = Math.max(maxSlope, Math.abs(h - nh));
+        }
+        solid[idx] = maxSlope > slopeThreshold;
+      }
+    }
+
+    set({ collisionGridData: { ...g, solid, elevation } });
+  },
+
+  // ── Grab actions ──
+  setGrabMode: (v) => set({ grabMode: v }),
+  setGrabOriginalPosition: (pos) => set({ grabOriginalPosition: pos }),
+
+  // ── Palette actions ──
+  addPalette: (name) => {
+    const palettes = [...get().colorPalettes, { name, colors: [] }];
+    set({ colorPalettes: palettes, activePaletteIndex: palettes.length - 1 });
+  },
+
+  removePalette: (index) => {
+    const palettes = get().colorPalettes.filter((_, i) => i !== index);
+    if (palettes.length === 0) palettes.push({ name: 'Default', colors: [] });
+    set({
+      colorPalettes: palettes,
+      activePaletteIndex: Math.min(get().activePaletteIndex, palettes.length - 1),
+    });
+  },
+
+  setActivePalette: (index) => set({ activePaletteIndex: index }),
+
+  setPaletteColor: (paletteIndex, colorIndex, color) => {
+    const palettes = [...get().colorPalettes];
+    if (!palettes[paletteIndex]) return;
+    const colors = [...palettes[paletteIndex].colors];
+    colors[colorIndex] = color;
+    palettes[paletteIndex] = { ...palettes[paletteIndex], colors };
+    set({ colorPalettes: palettes });
+  },
+
+  addColorToPalette: (paletteIndex, color) => {
+    const palettes = [...get().colorPalettes];
+    if (!palettes[paletteIndex]) return;
+    palettes[paletteIndex] = {
+      ...palettes[paletteIndex],
+      colors: [...palettes[paletteIndex].colors, color],
+    };
+    set({ colorPalettes: palettes });
+  },
+
+  extractColorsFromImage: (imageData, maxColors) => {
+    // Simple color quantization: sample unique colors
+    const colorSet = new Map<string, [number, number, number, number]>();
+    const data = imageData.data;
+    const step = Math.max(1, Math.floor(data.length / 4 / 1000)); // sample at most 1000 pixels
+    for (let i = 0; i < data.length; i += 4 * step) {
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+      const a = data[i + 3];
+      if (a < 10) continue;
+      // Quantize to 5-bit
+      const qr = (r >> 3) << 3;
+      const qg = (g >> 3) << 3;
+      const qb = (b >> 3) << 3;
+      const key = `${qr},${qg},${qb}`;
+      if (!colorSet.has(key)) {
+        colorSet.set(key, [qr, qg, qb, 255]);
+      }
+    }
+    const colors = Array.from(colorSet.values()).slice(0, maxColors);
+    const palettes = [...get().colorPalettes];
+    palettes.push({ name: 'Extracted', colors });
+    set({ colorPalettes: palettes, activePaletteIndex: palettes.length - 1 });
   },
 
   // ── Editor actions ──

--- a/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
+++ b/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 import { ThreeEvent } from '@react-three/fiber';
 
@@ -36,9 +36,34 @@ function Cell({ x, z, cellSize, elevation, color, opacity }: CellProps) {
   );
 }
 
+// Preview rectangle for box fill
+function BoxPreview({ startX, startZ, endX, endZ, cellSize }: {
+  startX: number; startZ: number; endX: number; endZ: number; cellSize: number;
+}) {
+  const minX = Math.min(startX, endX);
+  const maxX = Math.max(startX, endX);
+  const minZ = Math.min(startZ, endZ);
+  const maxZ = Math.max(startZ, endZ);
+  const width = (maxX - minX + 1) * cellSize;
+  const depth = (maxZ - minZ + 1) * cellSize;
+
+  return (
+    <mesh
+      position={[(minX + maxX) / 2 * cellSize, 0.02, (minZ + maxZ) / 2 * cellSize]}
+      rotation={[-Math.PI / 2, 0, 0]}
+    >
+      <planeGeometry args={[width, depth]} />
+      <meshBasicMaterial color="#77f" transparent opacity={0.2} depthWrite={false} />
+    </mesh>
+  );
+}
+
 export function CollisionOverlay() {
   const collisionGridData = useSceneStore((s) => s.collisionGridData);
   const showCollision = useSceneStore((s) => s.showCollision);
+  const collisionBoxFill = useSceneStore((s) => s.collisionBoxFill);
+  const collisionBoxStart = useSceneStore((s) => s.collisionBoxStart);
+  const [hoverCell, setHoverCell] = useState<[number, number] | null>(null);
 
   const handleClick = useCallback((e: ThreeEvent<MouseEvent>) => {
     e.stopPropagation();
@@ -55,6 +80,29 @@ export function CollisionOverlay() {
 
     if (cellX < 0 || cellX >= grid.width || cellZ < 0 || cellZ >= grid.height) return;
 
+    // Box fill mode
+    if (store.collisionBoxFill && store.collisionLayer === 'solid') {
+      if (!store.collisionBoxStart) {
+        store.setCollisionBoxStart([cellX, cellZ]);
+        return;
+      }
+      // Second click: fill rectangle
+      const [sx, sz] = store.collisionBoxStart;
+      const minX = Math.min(sx, cellX);
+      const maxX = Math.max(sx, cellX);
+      const minZ = Math.min(sz, cellZ);
+      const maxZ = Math.max(sz, cellZ);
+
+      store.pushUndo();
+      for (let z = minZ; z <= maxZ; z++) {
+        for (let x = minX; x <= maxX; x++) {
+          store.setCellSolid(x, z, true);
+        }
+      }
+      store.setCollisionBoxStart(null);
+      return;
+    }
+
     store.pushUndo();
 
     switch (store.collisionLayer) {
@@ -67,6 +115,18 @@ export function CollisionOverlay() {
       case 'nav_zone':
         store.setCellNavZone(cellX, cellZ, store.activeNavZone);
         break;
+    }
+  }, []);
+
+  const handlePointerMove = useCallback((e: ThreeEvent<MouseEvent>) => {
+    const store = useSceneStore.getState();
+    const grid = store.collisionGridData;
+    if (!grid || !store.collisionBoxFill || !store.collisionBoxStart) return;
+    const point = e.point;
+    const cellX = Math.round(point.x / grid.cell_size);
+    const cellZ = Math.round(point.z / grid.cell_size);
+    if (cellX >= 0 && cellX < grid.width && cellZ >= 0 && cellZ < grid.height) {
+      setHoverCell([cellX, cellZ]);
     }
   }, []);
 
@@ -152,6 +212,7 @@ export function CollisionOverlay() {
         ]}
         rotation={[-Math.PI / 2, 0, 0]}
         onClick={handleClick}
+        onPointerMove={handlePointerMove}
       >
         <planeGeometry args={[
           collisionGridData.width * collisionGridData.cell_size,
@@ -171,6 +232,17 @@ export function CollisionOverlay() {
           opacity={c.opacity}
         />
       ))}
+
+      {/* Box fill preview */}
+      {collisionBoxFill && collisionBoxStart && hoverCell && (
+        <BoxPreview
+          startX={collisionBoxStart[0]}
+          startZ={collisionBoxStart[1]}
+          endX={hoverCell[0]}
+          endZ={hoverCell[1]}
+          cellSize={collisionGridData.cell_size}
+        />
+      )}
     </group>
   );
 }

--- a/tools/apps/bricklayer/src/viewport/VoxelMesh.tsx
+++ b/tools/apps/bricklayer/src/viewport/VoxelMesh.tsx
@@ -23,6 +23,7 @@ const NEIGHBORS: [number, number, number][] = [
 export function VoxelMesh() {
   const meshRef = useRef<THREE.InstancedMesh>(null!);
   const voxels = useSceneStore((s) => s.voxels);
+  const showCollision = useSceneStore((s) => s.showCollision);
 
   // Filter to surface-only voxels (at least one exposed face)
   const surfaceEntries = useMemo(() => {
@@ -179,7 +180,7 @@ export function VoxelMesh() {
       frustumCulled={false}
     >
       <boxGeometry args={[1, 1, 1]} />
-      <meshLambertMaterial />
+      <meshLambertMaterial transparent={showCollision} opacity={showCollision ? 0.3 : 1} />
     </instancedMesh>
   );
 }

--- a/tools/tests/src/bricklayer-store.test.ts
+++ b/tools/tests/src/bricklayer-store.test.ts
@@ -54,6 +54,11 @@ interface GaussianSplatConfig {
   render_height: number;
 }
 
+interface ColorPalette {
+  name: string;
+  colors: [number, number, number, number][];
+}
+
 // ── Collision grid operations (mirrors store logic) ──
 
 function initCollisionGrid(width: number, height: number, cellSize: number): CollisionGridData {
@@ -76,6 +81,14 @@ function toggleCellSolid(grid: CollisionGridData, x: number, z: number): Collisi
   return { ...grid, solid };
 }
 
+function setCellSolid(grid: CollisionGridData, x: number, z: number, val: boolean): CollisionGridData {
+  const idx = z * grid.width + x;
+  if (idx < 0 || idx >= grid.solid.length) return grid;
+  const solid = [...grid.solid];
+  solid[idx] = val;
+  return { ...grid, solid };
+}
+
 function setCellElevation(grid: CollisionGridData, x: number, z: number, value: number): CollisionGridData {
   const idx = z * grid.width + x;
   if (idx < 0 || idx >= grid.elevation.length) return grid;
@@ -90,6 +103,46 @@ function setCellNavZone(grid: CollisionGridData, x: number, z: number, zone: num
   const nav_zone = [...grid.nav_zone];
   nav_zone[idx] = zone;
   return { ...grid, nav_zone };
+}
+
+function boxFillSolid(grid: CollisionGridData, x1: number, z1: number, x2: number, z2: number): CollisionGridData {
+  const minX = Math.min(x1, x2);
+  const maxX = Math.max(x1, x2);
+  const minZ = Math.min(z1, z2);
+  const maxZ = Math.max(z1, z2);
+  let result = grid;
+  for (let z = minZ; z <= maxZ; z++) {
+    for (let x = minX; x <= maxX; x++) {
+      result = setCellSolid(result, x, z, true);
+    }
+  }
+  return result;
+}
+
+function autoGenerateCollision(
+  grid: CollisionGridData,
+  heightMap: Map<string, number>,
+  slopeThreshold: number,
+): CollisionGridData {
+  const solid = [...grid.solid];
+  const elevation = [...grid.elevation];
+
+  for (let cz = 0; cz < grid.height; cz++) {
+    for (let cx = 0; cx < grid.width; cx++) {
+      const idx = cz * grid.width + cx;
+      const h = heightMap.get(`${cx},${cz}`) ?? 0;
+      elevation[idx] = h;
+
+      let maxSlope = 0;
+      for (const [dx, dz] of [[1, 0], [-1, 0], [0, 1], [0, -1]]) {
+        const nh = heightMap.get(`${cx + dx},${cz + dz}`) ?? 0;
+        maxSlope = Math.max(maxSlope, Math.abs(h - nh));
+      }
+      solid[idx] = maxSlope > slopeThreshold;
+    }
+  }
+
+  return { ...grid, solid, elevation };
 }
 
 // ── Scene export (mirrors lib/sceneExport.ts logic) ──
@@ -252,6 +305,37 @@ function loadProject(data: BricklayerFile): {
   };
 }
 
+// ── Palette operations (mirrors store logic) ──
+
+function addPalette(palettes: ColorPalette[], name: string): ColorPalette[] {
+  return [...palettes, { name, colors: [] }];
+}
+
+function removePalette(palettes: ColorPalette[], index: number): ColorPalette[] {
+  const result = palettes.filter((_, i) => i !== index);
+  if (result.length === 0) return [{ name: 'Default', colors: [] }];
+  return result;
+}
+
+function addColorToPalette(palettes: ColorPalette[], paletteIndex: number, color: [number, number, number, number]): ColorPalette[] {
+  const result = [...palettes];
+  if (!result[paletteIndex]) return result;
+  result[paletteIndex] = {
+    ...result[paletteIndex],
+    colors: [...result[paletteIndex].colors, color],
+  };
+  return result;
+}
+
+function setPaletteColor(palettes: ColorPalette[], paletteIndex: number, colorIndex: number, color: [number, number, number, number]): ColorPalette[] {
+  const result = [...palettes];
+  if (!result[paletteIndex]) return result;
+  const colors = [...result[paletteIndex].colors];
+  colors[colorIndex] = color;
+  result[paletteIndex] = { ...result[paletteIndex], colors };
+  return result;
+}
+
 // ---------- Test helpers ----------
 
 let passed = 0;
@@ -272,7 +356,7 @@ function assert(condition: boolean, message: string) {
 console.log('\n=== Bricklayer Store Tests ===\n');
 
 // ═══════════════════════════════════════════════════════════════
-// 1. CollisionGridData operations (8 tests)
+// 1. CollisionGridData operations (10 tests)
 // ═══════════════════════════════════════════════════════════════
 
 console.log('--- CollisionGridData operations ---\n');
@@ -344,6 +428,23 @@ console.log('--- CollisionGridData operations ---\n');
   const twice = toggleCellSolid(once, 1, 2);
   const idx = 2 * 4 + 1;
   assert(twice.solid[idx] === false, `solid[${idx}] is false after double toggle (got ${twice.solid[idx]})`);
+}
+
+{
+  console.log('Test 1.9: setCellSolid explicitly sets value');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const set1 = setCellSolid(grid, 2, 1, true);
+  const idx = 1 * 4 + 2;
+  assert(set1.solid[idx] === true, `solid[${idx}] is true after setCellSolid(true)`);
+  const set2 = setCellSolid(set1, 2, 1, false);
+  assert(set2.solid[idx] === false, `solid[${idx}] is false after setCellSolid(false)`);
+}
+
+{
+  console.log('Test 1.10: setCellSolid out-of-bounds returns grid unchanged');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const updated = setCellSolid(grid, 99, 99, true);
+  assert(updated.solid.every((v) => v === false), 'no cells changed on OOB setCellSolid');
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -609,6 +710,334 @@ console.log('\n--- File roundtrip ---\n');
   assert(loaded.navZoneNames[0] === 'forest', 'first name matches');
   assert(loaded.navZoneNames[1] === 'river', 'second name matches');
   assert(loaded.navZoneNames[2] === 'mountain', 'third name matches');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 5. Box fill (6 tests)
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- Box fill ---\n');
+
+{
+  console.log('Test 5.1: Box fill 2x2 area');
+  const grid = initCollisionGrid(8, 8, 1.0);
+  const filled = boxFillSolid(grid, 1, 1, 2, 2);
+  assert(filled.solid[1 * 8 + 1] === true, '(1,1) is solid');
+  assert(filled.solid[1 * 8 + 2] === true, '(2,1) is solid');
+  assert(filled.solid[2 * 8 + 1] === true, '(1,2) is solid');
+  assert(filled.solid[2 * 8 + 2] === true, '(2,2) is solid');
+  assert(filled.solid[0 * 8 + 0] === false, '(0,0) is still walkable');
+}
+
+{
+  console.log('Test 5.2: Box fill with reversed coordinates');
+  const grid = initCollisionGrid(8, 8, 1.0);
+  const filled = boxFillSolid(grid, 3, 3, 1, 1);
+  let count = 0;
+  for (const s of filled.solid) if (s) count++;
+  assert(count === 9, `3x3 box = 9 solid cells (got ${count})`);
+}
+
+{
+  console.log('Test 5.3: Box fill single cell');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const filled = boxFillSolid(grid, 2, 2, 2, 2);
+  let count = 0;
+  for (const s of filled.solid) if (s) count++;
+  assert(count === 1, `single cell box fill = 1 solid (got ${count})`);
+}
+
+{
+  console.log('Test 5.4: Box fill full row');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const filled = boxFillSolid(grid, 0, 0, 3, 0);
+  assert(filled.solid[0] === true, '(0,0) solid');
+  assert(filled.solid[1] === true, '(1,0) solid');
+  assert(filled.solid[2] === true, '(2,0) solid');
+  assert(filled.solid[3] === true, '(3,0) solid');
+  assert(filled.solid[4] === false, '(0,1) walkable');
+}
+
+{
+  console.log('Test 5.5: Box fill full column');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const filled = boxFillSolid(grid, 0, 0, 0, 3);
+  assert(filled.solid[0] === true, '(0,0) solid');
+  assert(filled.solid[4] === true, '(0,1) solid');
+  assert(filled.solid[8] === true, '(0,2) solid');
+  assert(filled.solid[12] === true, '(0,3) solid');
+  assert(filled.solid[1] === false, '(1,0) walkable');
+}
+
+{
+  console.log('Test 5.6: Box fill does not affect already-solid cells');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const preFilled = setCellSolid(grid, 1, 1, true);
+  const filled = boxFillSolid(preFilled, 0, 0, 2, 2);
+  let count = 0;
+  for (const s of filled.solid) if (s) count++;
+  assert(count === 9, `3x3 box fill = 9 solid (got ${count})`);
+  assert(filled.solid[1 * 4 + 1] === true, '(1,1) still solid');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 6. Auto-generate collision (5 tests)
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- Auto-generate collision ---\n');
+
+{
+  console.log('Test 6.1: Flat terrain -> interior cells not solid');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const heightMap = new Map<string, number>();
+  // Fill including neighbors outside grid to avoid edge effects
+  for (let z = -1; z <= 4; z++) for (let x = -1; x <= 4; x++) heightMap.set(`${x},${z}`, 5);
+  const result = autoGenerateCollision(grid, heightMap, 1.0);
+  // Interior cells (1,1), (2,2) should not be solid since all neighbors have same height
+  assert(result.solid[1 * 4 + 1] === false, 'interior cell (1,1) is not solid');
+  assert(result.solid[2 * 4 + 2] === false, 'interior cell (2,2) is not solid');
+}
+
+{
+  console.log('Test 6.2: Cliff face -> solid cells');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const heightMap = new Map<string, number>();
+  for (let z = 0; z < 4; z++) {
+    for (let x = 0; x < 4; x++) {
+      heightMap.set(`${x},${z}`, x >= 2 ? 10 : 0);
+    }
+  }
+  const result = autoGenerateCollision(grid, heightMap, 1.0);
+  // Cells at x=1 and x=2 should be solid (adjacent to cliff)
+  assert(result.solid[0 * 4 + 1] === true, '(1,0) is solid at cliff edge');
+  assert(result.solid[0 * 4 + 2] === true, '(2,0) is solid at cliff top');
+}
+
+{
+  console.log('Test 6.3: Elevation values are set from height map');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const heightMap = new Map<string, number>();
+  heightMap.set('2,1', 7.5);
+  const result = autoGenerateCollision(grid, heightMap, 100);
+  const idx = 1 * 4 + 2;
+  assert(result.elevation[idx] === 7.5, `elevation at (2,1) is 7.5 (got ${result.elevation[idx]})`);
+}
+
+{
+  console.log('Test 6.4: High threshold -> no solid');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  const heightMap = new Map<string, number>();
+  for (let z = 0; z < 4; z++) for (let x = 0; x < 4; x++) heightMap.set(`${x},${z}`, x);
+  const result = autoGenerateCollision(grid, heightMap, 10.0);
+  assert(result.solid.every((v) => v === false), 'high threshold = no solid cells');
+}
+
+{
+  console.log('Test 6.5: Zero threshold -> all cells with any neighbor difference are solid');
+  const grid = initCollisionGrid(3, 1, 1.0);
+  const heightMap = new Map<string, number>();
+  heightMap.set('0,0', 0);
+  heightMap.set('1,0', 1);
+  heightMap.set('2,0', 1);
+  const result = autoGenerateCollision(grid, heightMap, 0);
+  // Cell (0,0) neighbors (1,0) with diff 1 > 0 -> solid
+  assert(result.solid[0] === true, '(0,0) is solid with zero threshold');
+  // Cell (1,0) neighbors (0,0) with diff 1 > 0 -> solid
+  assert(result.solid[1] === true, '(1,0) is solid with zero threshold');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 7. Color palettes (10 tests)
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- Color palettes ---\n');
+
+{
+  console.log('Test 7.1: Add palette');
+  const palettes = addPalette([], 'Nature');
+  assert(palettes.length === 1, `palette count is 1 (got ${palettes.length})`);
+  assert(palettes[0].name === 'Nature', 'palette name matches');
+  assert(palettes[0].colors.length === 0, 'palette starts empty');
+}
+
+{
+  console.log('Test 7.2: Add color to palette');
+  let palettes: ColorPalette[] = [{ name: 'P1', colors: [] }];
+  palettes = addColorToPalette(palettes, 0, [255, 0, 0, 255]);
+  assert(palettes[0].colors.length === 1, 'color added');
+  assert(palettes[0].colors[0][0] === 255, 'red channel is 255');
+}
+
+{
+  console.log('Test 7.3: Set palette color');
+  let palettes: ColorPalette[] = [{ name: 'P1', colors: [[255, 0, 0, 255]] }];
+  palettes = setPaletteColor(palettes, 0, 0, [0, 255, 0, 255]);
+  assert(palettes[0].colors[0][1] === 255, 'green channel is 255 after set');
+}
+
+{
+  console.log('Test 7.4: Remove palette reverts to default');
+  let palettes: ColorPalette[] = [{ name: 'P1', colors: [] }];
+  palettes = removePalette(palettes, 0);
+  assert(palettes.length === 1, 'at least one palette remains');
+  assert(palettes[0].name === 'Default', 'fallback palette is named Default');
+}
+
+{
+  console.log('Test 7.5: Multiple palettes maintain independence');
+  let palettes = addPalette([], 'A');
+  palettes = addPalette(palettes, 'B');
+  palettes = addColorToPalette(palettes, 0, [1, 2, 3, 4]);
+  palettes = addColorToPalette(palettes, 1, [5, 6, 7, 8]);
+  assert(palettes[0].colors.length === 1, 'palette A has 1 color');
+  assert(palettes[1].colors.length === 1, 'palette B has 1 color');
+  assert(palettes[0].colors[0][0] === 1, 'palette A color[0] = 1');
+  assert(palettes[1].colors[0][0] === 5, 'palette B color[0] = 5');
+}
+
+{
+  console.log('Test 7.6: Remove palette by index preserves others');
+  let palettes = addPalette([], 'A');
+  palettes = addPalette(palettes, 'B');
+  palettes = addPalette(palettes, 'C');
+  palettes = removePalette(palettes, 1);
+  assert(palettes.length === 2, '2 palettes remain');
+  assert(palettes[0].name === 'A', 'first is A');
+  assert(palettes[1].name === 'C', 'second is C');
+}
+
+{
+  console.log('Test 7.7: Add multiple colors to same palette');
+  let palettes: ColorPalette[] = [{ name: 'P', colors: [] }];
+  palettes = addColorToPalette(palettes, 0, [10, 20, 30, 255]);
+  palettes = addColorToPalette(palettes, 0, [40, 50, 60, 255]);
+  palettes = addColorToPalette(palettes, 0, [70, 80, 90, 255]);
+  assert(palettes[0].colors.length === 3, '3 colors in palette');
+}
+
+{
+  console.log('Test 7.8: setPaletteColor on invalid index is safe');
+  let palettes: ColorPalette[] = [{ name: 'P', colors: [[1, 2, 3, 4]] }];
+  palettes = setPaletteColor(palettes, 5, 0, [9, 9, 9, 9]);
+  assert(palettes.length === 1, 'no crash on invalid palette index');
+  assert(palettes[0].colors[0][0] === 1, 'original color unchanged');
+}
+
+{
+  console.log('Test 7.9: addColorToPalette on invalid index is safe');
+  let palettes: ColorPalette[] = [{ name: 'P', colors: [] }];
+  palettes = addColorToPalette(palettes, 99, [1, 2, 3, 4]);
+  assert(palettes[0].colors.length === 0, 'no color added to invalid index');
+}
+
+{
+  console.log('Test 7.10: Palette serialization roundtrip');
+  let palettes: ColorPalette[] = [{ name: 'Test', colors: [[10, 20, 30, 255], [40, 50, 60, 128]] }];
+  const json = JSON.stringify(palettes);
+  const restored: ColorPalette[] = JSON.parse(json);
+  assert(restored[0].name === 'Test', 'name preserved');
+  assert(restored[0].colors.length === 2, '2 colors preserved');
+  assert(restored[0].colors[1][3] === 128, 'alpha preserved');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 8. Large grid and edge cases (8 tests)
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- Large grid and edge cases ---\n');
+
+{
+  console.log('Test 8.1: Large grid (128x128) initializes correctly');
+  const grid = initCollisionGrid(128, 128, 0.5);
+  assert(grid.solid.length === 128 * 128, `solid length is ${128 * 128} (got ${grid.solid.length})`);
+  assert(grid.cell_size === 0.5, 'cell_size is 0.5');
+}
+
+{
+  console.log('Test 8.2: Toggle corner cells');
+  const grid = initCollisionGrid(10, 10, 1.0);
+  let g = toggleCellSolid(grid, 0, 0);
+  g = toggleCellSolid(g, 9, 9);
+  g = toggleCellSolid(g, 0, 9);
+  g = toggleCellSolid(g, 9, 0);
+  assert(g.solid[0] === true, 'top-left corner solid');
+  assert(g.solid[99] === true, 'bottom-right corner solid');
+  assert(g.solid[90] === true, 'bottom-left corner solid');
+  assert(g.solid[9] === true, 'top-right corner solid');
+}
+
+{
+  console.log('Test 8.3: Grid with non-unit cell size');
+  const grid = initCollisionGrid(16, 16, 2.5);
+  assert(grid.cell_size === 2.5, 'cell_size preserved');
+  assert(grid.width === 16, 'width preserved');
+}
+
+{
+  console.log('Test 8.4: Voxel roundtrip preserves color precision');
+  const voxels = new Map<VoxelKey, Voxel>();
+  voxels.set(voxelKey(0, 0, 0), { color: [127, 63, 191, 200] });
+  const file = saveProject(voxels, 10, 10, null, [], []);
+  const loaded = loadProject(JSON.parse(JSON.stringify(file)));
+  const v = loaded.voxels.get(voxelKey(0, 0, 0));
+  assert(v !== undefined, 'voxel loaded');
+  assert(v!.color[0] === 127, 'red=127');
+  assert(v!.color[1] === 63, 'green=63');
+  assert(v!.color[2] === 191, 'blue=191');
+  assert(v!.color[3] === 200, 'alpha=200');
+}
+
+{
+  console.log('Test 8.5: Multiple nav zones on same grid');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  let g = setCellNavZone(grid, 0, 0, 1);
+  g = setCellNavZone(g, 1, 0, 2);
+  g = setCellNavZone(g, 2, 0, 3);
+  assert(g.nav_zone[0] === 1, 'zone 1');
+  assert(g.nav_zone[1] === 2, 'zone 2');
+  assert(g.nav_zone[2] === 3, 'zone 3');
+  assert(g.nav_zone[3] === 0, 'zone 0 (default)');
+}
+
+{
+  console.log('Test 8.6: Collision and elevation on same cell');
+  const grid = initCollisionGrid(4, 4, 1.0);
+  let g = toggleCellSolid(grid, 1, 1);
+  g = setCellElevation(g, 1, 1, 3.0);
+  const idx = 1 * 4 + 1;
+  assert(g.solid[idx] === true, 'cell is solid');
+  assert(g.elevation[idx] === 3.0, 'cell has elevation 3.0');
+}
+
+{
+  console.log('Test 8.7: Export with all entity types');
+  const input = baseInput();
+  input.staticLights = [{ position: [0, 0], radius: 5, height: 2, color: [1, 1, 1], intensity: 1 }];
+  input.npcs = [{ name: 'A', position: [0, 0, 0], facing: 'down' }];
+  input.portals = [{ position: [0, 0], size: [2, 2], target_scene: 'x', spawn_position: [0, 0, 0] }];
+  input.placedObjects = [{ id: 'o', ply_file: 'a.ply', position: [0, 0, 0], rotation: [0, 0, 0], scale: 1, is_static: true }];
+  const result = exportScene(input);
+  assert('static_lights' in result, 'has lights');
+  assert('npcs' in result, 'has npcs');
+  assert('portals' in result, 'has portals');
+  assert('placed_objects' in result, 'has objects');
+}
+
+{
+  console.log('Test 8.8: File roundtrip with collision + voxels + zones + objects');
+  const voxels = new Map<VoxelKey, Voxel>();
+  voxels.set(voxelKey(5, 5, 5), { color: [128, 64, 32, 255] });
+  const grid = initCollisionGrid(4, 4, 1.0);
+  grid.solid[0] = true;
+  grid.nav_zone[3] = 2;
+  const objs: PlacedObjectData[] = [{ id: 'x', ply_file: 'test.ply', position: [0, 0, 0], rotation: [0, 0, 0], scale: 1, is_static: false }];
+  const file = saveProject(voxels, 64, 48, grid, ['zone1'], objs);
+  const loaded = loadProject(JSON.parse(JSON.stringify(file)));
+  assert(loaded.voxels.size === 1, '1 voxel');
+  assert(loaded.collisionGridData!.solid[0] === true, 'solid preserved');
+  assert(loaded.collisionGridData!.nav_zone[3] === 2, 'nav_zone preserved');
+  assert(loaded.navZoneNames[0] === 'zone1', 'zone name preserved');
+  assert(loaded.placedObjects[0].ply_file === 'test.ply', 'object preserved');
 }
 
 // --- Summary ---


### PR DESCRIPTION
## Summary
Single clean branch combining all Bricklayer improvements.

### Project Format & Tree Navigator
- Project manifest type (terrains, assets, global settings)
- File System Access API integration (Chrome/Edge)
- Hierarchical project tree replaces mode tabs:
  Terrains → Collision, Scene → Objects/Lights/NPCs/Portals/Player, Settings
- Click node → right panel shows properties, appropriate tools activate

### Collision Mode
- Terrain becomes semi-transparent (0.3) during collision editing
- Box fill: click two corners to fill rectangle of cells
- Auto-generate from voxel terrain (slope threshold slider)
- All cells shown with subtle green grid (not just solid)
- Collision editing restricted to terrain mode only

### G-key Grab Mode (Blender style)
- Select entity → G → mouse moves on XZ plane → click confirms, Escape cancels
- OrbitControls disabled during grab
- Works for all entity types

### Draggable Viewport Markers
- Objects: drag with invisible solid mesh for click detection
- Lights: draggable with invisible hit sphere
- Yellow highlight + position readout while dragging

### NumberInput (Blender style)
- Text input (no spinner), horizontal drag-to-scrub
- 3px threshold: click = focus for typing, drag = scrub
- Replaced across all panels

### Color Palettes
- 8-column layout (smaller tiles, more visible)
- Multiple palettes with selector dropdown
- Auto-extract colors from imported images

### Navigation
- Double-click teleport, F-to-frame selected, H for home

## Tests
148 assertions: collision ops, export format, nav zones, roundtrip, box fill, auto-generate, palettes, edge cases

## Test plan
- [x] 148 store tests pass
- [x] `pnpm --filter @gseurat/bricklayer build` passes
- [x] Project tree navigation
- [x] Collision box fill + auto-generate
- [x] G-key grab mode
- [x] NumberInput drag-to-scrub + typing
- [x] Multiple color palettes

🤖 Generated with [Claude Code](https://claude.com/claude-code)