### PR TITLE
Implement all missing Bricklayer plan items

### DIFF
--- a/tools/apps/bricklayer/package.json
+++ b/tools/apps/bricklayer/package.json
@@ -9,17 +9,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@gseurat/asset-types": "workspace:*",
+    "@gseurat/engine-client": "workspace:*",
+    "@gseurat/test-harness": "workspace:*",
+    "@gseurat/ui-kit": "workspace:*",
+    "@huggingface/transformers": "^3.4.0",
+    "@react-three/drei": "^9.117.0",
+    "@react-three/fiber": "^8.17.0",
+    "jszip": "^3.10.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "zustand": "^4.5.0",
     "three": "^0.170.0",
-    "@react-three/fiber": "^8.17.0",
-    "@react-three/drei": "^9.117.0",
-    "@huggingface/transformers": "^3.4.0",
-    "@gseurat/engine-client": "workspace:*",
-    "@gseurat/asset-types": "workspace:*",
-    "@gseurat/ui-kit": "workspace:*",
-    "@gseurat/test-harness": "workspace:*"
+    "zustand": "^4.5.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.0",

--- a/tools/apps/bricklayer/src/components/NumberInput.tsx
+++ b/tools/apps/bricklayer/src/components/NumberInput.tsx
@@ -150,22 +150,22 @@ export function NumberInput({
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}
         onPointerDown={(e) => {
-          // Only initiate drag if not already focused (typing mode)
+          // Only initiate drag tracking if not already focused (typing mode)
           if (document.activeElement !== e.currentTarget) {
+            e.preventDefault(); // prevent focus on mousedown — we'll focus on click
             dragStartX.current = e.clientX;
             dragStartValue.current = value;
-            dragging.current = false;  // Will become true on first move
-            (e.target as HTMLElement).setPointerCapture(e.pointerId);
+            dragging.current = false;
           }
         }}
         onPointerMove={(e) => {
-          if (!(e.target as HTMLElement).hasPointerCapture(e.pointerId)) return;
+          // Only track if we started from an unfocused state
+          if (focused) return;
           const dx = e.clientX - dragStartX.current;
-          // Start dragging only after 3px threshold (allows click-to-focus)
           if (!dragging.current && Math.abs(dx) < 3) return;
           if (!dragging.current) {
             dragging.current = true;
-            e.preventDefault();
+            (e.target as HTMLElement).setPointerCapture(e.pointerId);
           }
           const delta = Math.round(dx / 2) * step;
           const newVal = clamp(dragStartValue.current + delta, min, max);
@@ -174,11 +174,11 @@ export function NumberInput({
         onPointerUp={(e) => {
           if (dragging.current) {
             dragging.current = false;
-          } else {
+            try { (e.target as HTMLElement).releasePointerCapture(e.pointerId); } catch {}
+          } else if (!focused) {
             // No drag happened — allow focus for typing
             (e.target as HTMLInputElement).focus();
           }
-          try { (e.target as HTMLElement).releasePointerCapture(e.pointerId); } catch {}
         }}
         style={{ ...defaultInputStyle, cursor: focused ? 'text' : 'ew-resize', ...style }}
       />

--- a/tools/apps/bricklayer/src/lib/colorExtract.ts
+++ b/tools/apps/bricklayer/src/lib/colorExtract.ts
@@ -1,0 +1,108 @@
+/**
+ * Extract dominant colors from an image using histogram-based sampling.
+ * Returns up to `maxColors` RGBA tuples.
+ */
+export function extractColorsFromImage(
+  imageData: ImageData,
+  maxColors: number = 24,
+): [number, number, number, number][] {
+  const { data, width, height } = imageData;
+  const bucketBits = 4; // group into 16 bins per channel (4096 total buckets)
+  const shift = 8 - bucketBits;
+  const bucketCount = (1 << bucketBits) ** 3;
+
+  // Count pixels per bucket
+  const counts = new Uint32Array(bucketCount);
+  const sumR = new Float64Array(bucketCount);
+  const sumG = new Float64Array(bucketCount);
+  const sumB = new Float64Array(bucketCount);
+
+  const totalPixels = width * height;
+  for (let i = 0; i < totalPixels; i++) {
+    const off = i * 4;
+    const a = data[off + 3];
+    if (a < 128) continue; // skip transparent pixels
+
+    const r = data[off];
+    const g = data[off + 1];
+    const b = data[off + 2];
+
+    const ri = r >> shift;
+    const gi = g >> shift;
+    const bi = b >> shift;
+    const bucket = (ri << (bucketBits * 2)) | (gi << bucketBits) | bi;
+
+    counts[bucket]++;
+    sumR[bucket] += r;
+    sumG[bucket] += g;
+    sumB[bucket] += b;
+  }
+
+  // Collect non-empty buckets and sort by count descending
+  const entries: { count: number; r: number; g: number; b: number }[] = [];
+  for (let i = 0; i < bucketCount; i++) {
+    if (counts[i] > 0) {
+      entries.push({
+        count: counts[i],
+        r: Math.round(sumR[i] / counts[i]),
+        g: Math.round(sumG[i] / counts[i]),
+        b: Math.round(sumB[i] / counts[i]),
+      });
+    }
+  }
+  entries.sort((a, b) => b.count - a.count);
+
+  // Take top N, filtering colors that are too similar
+  const result: [number, number, number, number][] = [];
+  for (const entry of entries) {
+    if (result.length >= maxColors) break;
+
+    // Check minimum distance to already-selected colors
+    const tooClose = result.some(([r, g, b]) => {
+      const dr = entry.r - r;
+      const dg = entry.g - g;
+      const db = entry.b - b;
+      return (dr * dr + dg * dg + db * db) < 900; // ~30 distance threshold
+    });
+    if (tooClose) continue;
+
+    result.push([entry.r, entry.g, entry.b, 255]);
+  }
+
+  return result;
+}
+
+/**
+ * Load an image file and extract colors from it.
+ */
+export async function extractColorsFromFile(
+  file: File,
+  maxColors: number = 24,
+): Promise<[number, number, number, number][]> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    const url = URL.createObjectURL(file);
+    img.onload = () => {
+      // Sample at reduced resolution for performance
+      const maxDim = 256;
+      const scale = Math.min(1, maxDim / Math.max(img.width, img.height));
+      const w = Math.round(img.width * scale);
+      const h = Math.round(img.height * scale);
+
+      const canvas = document.createElement('canvas');
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext('2d')!;
+      ctx.drawImage(img, 0, 0, w, h);
+      const imageData = ctx.getImageData(0, 0, w, h);
+
+      URL.revokeObjectURL(url);
+      resolve(extractColorsFromImage(imageData, maxColors));
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      resolve([]);
+    };
+    img.src = url;
+  });
+}

--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -80,12 +80,18 @@ export function exportSceneJsonBlob(): Blob {
 
 /**
  * Save the current project as a zip file (fallback for browsers without FSAPI).
+ * Includes scene data and engine scene export.
  */
 export async function saveProjectAsZip(): Promise<Blob> {
   const store = useSceneStore.getState();
   const data = store.saveProject();
   const zip = new JSZip();
   zip.file('scene.bricklayer', JSON.stringify(data, null, 2));
+
+  // Also include the engine scene export
+  const scene = exportSceneJson(store);
+  zip.file('scene.json', JSON.stringify(scene, null, 2));
+
   return zip.generateAsync({ type: 'blob' });
 }
 

--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -35,6 +35,18 @@ export async function saveProject(handle: FileSystemDirectoryHandle): Promise<vo
   const writable = await fileHandle.createWritable();
   await writable.write(json);
   await writable.close();
+
+  // Write asset blobs to assets/ directory
+  if (store.assetBlobs.size > 0) {
+    const assetsDir = await handle.getDirectoryHandle('assets', { create: true });
+    for (const [path, blob] of store.assetBlobs) {
+      const name = path.startsWith('assets/') ? path.slice(7) : path;
+      const assetHandle = await assetsDir.getFileHandle(name, { create: true });
+      const w = await assetHandle.createWritable();
+      await w.write(blob);
+      await w.close();
+    }
+  }
 }
 
 /**
@@ -88,9 +100,17 @@ export async function saveProjectAsZip(): Promise<Blob> {
   const zip = new JSZip();
   zip.file('scene.bricklayer', JSON.stringify(data, null, 2));
 
-  // Also include the engine scene export
+  // Include the engine scene export
   const scene = exportSceneJson(store);
   zip.file('scene.json', JSON.stringify(scene, null, 2));
+
+  // Include all asset blobs (PLY files, textures, etc.)
+  const assetsFolder = zip.folder('assets');
+  for (const [path, blob] of store.assetBlobs) {
+    // path is "assets/filename.ply" — strip the "assets/" prefix
+    const name = path.startsWith('assets/') ? path.slice(7) : path;
+    assetsFolder!.file(name, blob);
+  }
 
   return zip.generateAsync({ type: 'blob' });
 }
@@ -106,6 +126,20 @@ export async function loadProjectFromZip(file: File): Promise<boolean> {
     const text = await sceneFile.async('text');
     const data = JSON.parse(text) as BricklayerFile;
     useSceneStore.getState().loadProject(data);
+
+    // Restore asset blobs from zip
+    const assetsFolder = zip.folder('assets');
+    if (assetsFolder) {
+      const store = useSceneStore.getState();
+      assetsFolder.forEach((relativePath, zipEntry) => {
+        if (!zipEntry.dir) {
+          zipEntry.async('blob').then((blob) => {
+            store.storeAssetBlob(`assets/${relativePath}`, blob);
+          });
+        }
+      });
+    }
+
     return true;
   } catch {
     return false;

--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -1,3 +1,4 @@
+import JSZip from 'jszip';
 import { useSceneStore } from '../store/useSceneStore.js';
 import { exportSceneJson } from './sceneExport.js';
 import type { BricklayerFile } from '../store/types.js';
@@ -75,4 +76,32 @@ export function exportSceneJsonBlob(): Blob {
   const scene = exportSceneJson(state);
   const json = JSON.stringify(scene, null, 2);
   return new Blob([json], { type: 'application/json' });
+}
+
+/**
+ * Save the current project as a zip file (fallback for browsers without FSAPI).
+ */
+export async function saveProjectAsZip(): Promise<Blob> {
+  const store = useSceneStore.getState();
+  const data = store.saveProject();
+  const zip = new JSZip();
+  zip.file('scene.bricklayer', JSON.stringify(data, null, 2));
+  return zip.generateAsync({ type: 'blob' });
+}
+
+/**
+ * Load a project from a zip file (fallback for browsers without FSAPI).
+ */
+export async function loadProjectFromZip(file: File): Promise<boolean> {
+  try {
+    const zip = await JSZip.loadAsync(file);
+    const sceneFile = zip.file('scene.bricklayer');
+    if (!sceneFile) return false;
+    const text = await sceneFile.async('text');
+    const data = JSON.parse(text) as BricklayerFile;
+    useSceneStore.getState().loadProject(data);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/tools/apps/bricklayer/src/panels/CollisionLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/CollisionLeftPanel.tsx
@@ -38,12 +38,14 @@ export function CollisionLeftPanel() {
   const activeNavZone = useSceneStore((s) => s.activeNavZone);
   const navZoneNames = useSceneStore((s) => s.navZoneNames);
   const collisionBoxFill = useSceneStore((s) => s.collisionBoxFill);
+  const collisionFloodFillMode = useSceneStore((s) => s.collisionFloodFillMode);
   const showCollision = useSceneStore((s) => s.showCollision);
   const initCollisionGrid = useSceneStore((s) => s.initCollisionGrid);
   const setCollisionLayer = useSceneStore((s) => s.setCollisionLayer);
   const setCollisionHeight = useSceneStore((s) => s.setCollisionHeight);
   const setActiveNavZone = useSceneStore((s) => s.setActiveNavZone);
   const setCollisionBoxFill = useSceneStore((s) => s.setCollisionBoxFill);
+  const setCollisionFloodFillMode = useSceneStore((s) => s.setCollisionFloodFillMode);
   const addNavZoneName = useSceneStore((s) => s.addNavZoneName);
   const autoGenerateCollision = useSceneStore((s) => s.autoGenerateCollision);
 
@@ -131,6 +133,16 @@ export function CollisionLeftPanel() {
             onChange={(e) => setCollisionBoxFill(e.target.checked)}
           />
           Box Fill (click two corners)
+        </label>
+
+        {/* Flood fill toggle */}
+        <label style={{ ...styles.row, cursor: 'pointer', fontSize: 12 }}>
+          <input
+            type="checkbox"
+            checked={collisionFloodFillMode}
+            onChange={(e) => setCollisionFloodFillMode(e.target.checked)}
+          />
+          Flood Fill (click region)
         </label>
 
         {collisionLayer === 'elevation' && (

--- a/tools/apps/bricklayer/src/panels/CollisionLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/CollisionLeftPanel.tsx
@@ -82,7 +82,12 @@ export function CollisionLeftPanel() {
         <div style={styles.row}>
           <NumberInput label="Slope" value={slopeThreshold} step={0.5} min={0.5} max={20} onChange={setSlopeThreshold} style={{ maxWidth: 60 }} />
         </div>
-        <button style={styles.btn} onClick={() => autoGenerateCollision(slopeThreshold)}>
+        <button style={styles.btn} onClick={() => {
+          // Create grid first if it doesn't exist, then auto-generate
+          initCollisionGrid(gridW, gridH, cellSize);
+          // Use setTimeout to ensure grid state is set before auto-generate runs
+          setTimeout(() => autoGenerateCollision(slopeThreshold), 0);
+        }}>
           Auto-generate from Terrain
         </button>
       </div>

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -20,7 +20,9 @@ const styles: Record<string, React.CSSProperties> = {
   menuBtn: {
     padding: '4px 12px',
     background: 'transparent',
-    border: '1px solid transparent',
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: 'transparent',
     borderRadius: 4,
     color: '#ccc',
     cursor: 'pointer',

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 import { exportPly } from '../lib/plyExport.js';
 import { exportSceneJson } from '../lib/sceneExport.js';
-import { hasFileSystemAccess, openProjectDirectory, saveProject as saveProjectDir, loadProject as loadProjectDir } from '../lib/projectIO.js';
+import { hasFileSystemAccess, openProjectDirectory, saveProject as saveProjectDir, loadProject as loadProjectDir, saveProjectAsZip, loadProjectFromZip } from '../lib/projectIO.js';
 import type { BricklayerFile } from '../store/types.js';
 
 const styles: Record<string, React.CSSProperties> = {
@@ -195,26 +195,43 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
   };
 
   const handleOpenProject = async () => {
-    if (!hasFileSystemAccess()) {
-      alert('File System Access API not available in this browser.');
-      return;
-    }
-    const handle = await openProjectDirectory();
-    if (handle) {
-      useSceneStore.getState().setProjectHandle(handle);
-      useSceneStore.getState().setProjectName(handle.name);
-      await loadProjectDir(handle);
+    if (hasFileSystemAccess()) {
+      const handle = await openProjectDirectory();
+      if (handle) {
+        useSceneStore.getState().setProjectHandle(handle);
+        useSceneStore.getState().setProjectName(handle.name);
+        await loadProjectDir(handle);
+      }
+    } else {
+      // Zip fallback
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = '.zip';
+      input.onchange = async () => {
+        const file = input.files?.[0];
+        if (file) {
+          const ok = await loadProjectFromZip(file);
+          if (ok) {
+            useSceneStore.getState().setProjectName(file.name.replace(/\.zip$/, ''));
+          } else {
+            alert('Failed to load project zip.');
+          }
+        }
+      };
+      input.click();
     }
   };
 
   const handleSaveProject = async () => {
     const handle = useSceneStore.getState().projectHandle;
-    if (!handle) {
-      // Fall back to regular save
-      handleSave();
-      return;
+    if (handle) {
+      await saveProjectDir(handle);
+    } else {
+      // Zip fallback
+      const blob = await saveProjectAsZip();
+      const name = useSceneStore.getState().projectName || 'project';
+      download(blob, `${name}.zip`);
     }
-    await saveProjectDir(handle);
   };
 
   const handleImportAsset = () => {

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 import { exportPly } from '../lib/plyExport.js';
 import { exportSceneJson } from '../lib/sceneExport.js';
-import { hasFileSystemAccess, openProjectDirectory, saveProject as saveProjectDir, loadProject as loadProjectDir, saveProjectAsZip, loadProjectFromZip } from '../lib/projectIO.js';
+import { hasFileSystemAccess, openProjectDirectory, saveProject as saveProjectDir, loadProject as loadProjectDir, saveProjectAsZip, loadProjectFromZip, importAssetToProject } from '../lib/projectIO.js';
 import type { BricklayerFile } from '../store/types.js';
 
 const styles: Record<string, React.CSSProperties> = {
@@ -147,7 +147,6 @@ function DropdownMenu({
 }
 
 export function MenuBar({ onImport }: { onImport: () => void }) {
-  const fileRef = useRef<HTMLInputElement>(null);
   const [openMenu, setOpenMenu] = useState<string | null>(null);
 
   const closeMenu = useCallback(() => setOpenMenu(null), []);
@@ -156,31 +155,87 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
     [],
   );
 
-  const handleNew = () => {
-    if (!confirm('Create new scene? Unsaved changes will be lost.')) return;
-    useSceneStore.getState().newScene(128, 96);
+  // Pick a working directory (shared by New/Open/Save)
+  const pickDirectory = async (): Promise<FileSystemDirectoryHandle | null> => {
+    if (!hasFileSystemAccess()) {
+      alert('Your browser does not support the File System Access API.\nUse Chrome or Edge for directory-based projects.\nFalling back to zip download/upload.');
+      return null;
+    }
+    return openProjectDirectory();
   };
 
-  const handleSave = () => {
-    const data = useSceneStore.getState().saveProject();
-    const json = JSON.stringify(data, null, 2);
-    download(new Blob([json], { type: 'application/json' }), 'scene.bricklayer');
+  const handleNew = async () => {
+    if (!confirm('Create new project? Unsaved changes will be lost.')) return;
+    const handle = await pickDirectory();
+    if (handle) {
+      useSceneStore.getState().newScene(128, 96);
+      useSceneStore.getState().setProjectHandle(handle);
+      useSceneStore.getState().setProjectName(handle.name);
+      await saveProjectDir(handle);
+    } else if (!hasFileSystemAccess()) {
+      useSceneStore.getState().newScene(128, 96);
+      useSceneStore.getState().setProjectHandle(null);
+      useSceneStore.getState().setProjectName('Untitled');
+    }
   };
 
-  const handleLoad = () => {
-    fileRef.current?.click();
+  const handleOpen = async () => {
+    if (hasFileSystemAccess()) {
+      const handle = await pickDirectory();
+      if (handle) {
+        useSceneStore.getState().setProjectHandle(handle);
+        useSceneStore.getState().setProjectName(handle.name);
+        await loadProjectDir(handle);
+      }
+    } else {
+      // Zip fallback
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = '.zip,.bricklayer,.json';
+      input.onchange = async () => {
+        const file = input.files?.[0];
+        if (!file) return;
+        if (file.name.endsWith('.zip')) {
+          const ok = await loadProjectFromZip(file);
+          if (ok) {
+            useSceneStore.getState().setProjectName(file.name.replace(/\.zip$/, ''));
+          } else {
+            alert('Failed to load project zip.');
+          }
+        } else {
+          // Legacy .bricklayer/.json file
+          const reader = new FileReader();
+          reader.onload = () => {
+            const data = JSON.parse(reader.result as string) as BricklayerFile;
+            useSceneStore.getState().loadProject(data);
+            useSceneStore.getState().setProjectName(file.name.replace(/\.(bricklayer|json)$/, ''));
+          };
+          reader.readAsText(file);
+        }
+      };
+      input.click();
+    }
   };
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => {
-      const data = JSON.parse(reader.result as string) as BricklayerFile;
-      useSceneStore.getState().loadProject(data);
-    };
-    reader.readAsText(file);
-    e.target.value = '';
+  const handleSave = async () => {
+    const handle = useSceneStore.getState().projectHandle;
+    if (handle) {
+      // Auto-save to working directory
+      await saveProjectDir(handle);
+    } else if (hasFileSystemAccess()) {
+      // No directory set yet — prompt for one, then save
+      const newHandle = await pickDirectory();
+      if (newHandle) {
+        useSceneStore.getState().setProjectHandle(newHandle);
+        useSceneStore.getState().setProjectName(newHandle.name);
+        await saveProjectDir(newHandle);
+      }
+    } else {
+      // Zip fallback
+      const blob = await saveProjectAsZip();
+      const name = useSceneStore.getState().projectName || 'project';
+      download(blob, `${name}.zip`);
+    }
   };
 
   const handleExportPly = () => {
@@ -196,46 +251,6 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
     download(new Blob([json], { type: 'application/json' }), 'scene.json');
   };
 
-  const handleOpenProject = async () => {
-    if (hasFileSystemAccess()) {
-      const handle = await openProjectDirectory();
-      if (handle) {
-        useSceneStore.getState().setProjectHandle(handle);
-        useSceneStore.getState().setProjectName(handle.name);
-        await loadProjectDir(handle);
-      }
-    } else {
-      // Zip fallback
-      const input = document.createElement('input');
-      input.type = 'file';
-      input.accept = '.zip';
-      input.onchange = async () => {
-        const file = input.files?.[0];
-        if (file) {
-          const ok = await loadProjectFromZip(file);
-          if (ok) {
-            useSceneStore.getState().setProjectName(file.name.replace(/\.zip$/, ''));
-          } else {
-            alert('Failed to load project zip.');
-          }
-        }
-      };
-      input.click();
-    }
-  };
-
-  const handleSaveProject = async () => {
-    const handle = useSceneStore.getState().projectHandle;
-    if (handle) {
-      await saveProjectDir(handle);
-    } else {
-      // Zip fallback
-      const blob = await saveProjectAsZip();
-      const name = useSceneStore.getState().projectName || 'project';
-      download(blob, `${name}.zip`);
-    }
-  };
-
   const handleImportAsset = () => {
     const input = document.createElement('input');
     input.type = 'file';
@@ -243,31 +258,32 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
     input.onchange = async () => {
       const file = input.files?.[0];
       if (!file) return;
+      // Store blob in memory
+      const path = `assets/${file.name}`;
+      useSceneStore.getState().storeAssetBlob(path, file);
+      useSceneStore.getState().addAsset({
+        id: `asset_${Date.now()}`,
+        name: file.name,
+        type: file.name.endsWith('.ply') ? 'ply' : file.name.match(/\.(wav|mp3)$/i) ? 'audio' : 'texture',
+        path,
+      });
+      // Copy to FSAPI project directory if available
       const handle = useSceneStore.getState().projectHandle;
       if (handle) {
-        const { importAssetToProject } = await import('../lib/projectIO.js');
-        const path = await importAssetToProject(handle, file);
-        useSceneStore.getState().addAsset({
-          id: `asset_${Date.now()}`,
-          name: file.name,
-          type: file.name.endsWith('.ply') ? 'ply' : file.name.match(/\.(wav|mp3)$/i) ? 'audio' : 'texture',
-          path,
-        });
+        await importAssetToProject(handle, file);
       }
     };
     input.click();
   };
 
   const fileItems: MenuItem[] = [
-    { label: 'New Project', action: handleNew },
-    { label: 'Open Project...', action: handleOpenProject },
-    { label: 'Save Project', action: handleSaveProject },
-    { label: 'Import Asset...', action: handleImportAsset },
-    { label: 'Export Scene...', action: handleExportScene, separator: true },
+    { label: 'New Project...', action: handleNew },
+    { label: 'Open Project...', action: handleOpen },
+    { label: 'Save Project', action: handleSave },
+    { label: 'Import Asset...', action: handleImportAsset, separator: true },
     { label: 'Import Image...', action: onImport },
-    { label: 'Export PLY...', action: handleExportPly, separator: true },
-    { label: 'Save File', action: handleSave, separator: true },
-    { label: 'Load File', action: handleLoad },
+    { label: 'Export Scene...', action: handleExportScene, separator: true },
+    { label: 'Export PLY...', action: handleExportPly },
   ];
 
   const editItems: MenuItem[] = [
@@ -322,14 +338,7 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
         onToggle={() => toggleMenu('view')}
         onClose={closeMenu}
       />
-      <input
-        ref={fileRef}
-        type="file"
-        accept=".bricklayer,.json"
-        style={{ display: 'none' }}
-        onChange={handleFileChange}
-      />
-      <span style={styles.title}>Bricklayer</span>
+      <span style={styles.title}>Bricklayer{useSceneStore.getState().projectHandle ? ` — ${useSceneStore.getState().projectName}` : ''}</span>
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/panels/ProjectTree.tsx
+++ b/tools/apps/bricklayer/src/panels/ProjectTree.tsx
@@ -12,6 +12,14 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     alignItems: 'center',
     gap: 4,
+    overflow: 'hidden',
+  },
+  nodeLabel: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as const,
+    flex: 1,
+    minWidth: 0,
   },
   nodeActive: { background: '#3a3a6a', color: '#fff' },
   indent: { paddingLeft: 16 },
@@ -186,7 +194,7 @@ export function ProjectTree() {
                     style={{ ...styles.node, ...(isActive({ kind: 'scene_item', entityType: 'object', entityId: obj.id }) ? styles.nodeActive : {}) }}
                     onClick={() => click({ kind: 'scene_item', entityType: 'object', entityId: obj.id })}
                   >
-                    {obj.ply_file || obj.id.slice(0, 12)}
+                    <span style={styles.nodeLabel}>{obj.ply_file || obj.id.slice(0, 12)}</span>
                     <button style={styles.removeBtn} onClick={(e) => { e.stopPropagation(); removePlacedObject(obj.id); }}>&times;</button>
                   </div>
                 ))}
@@ -207,13 +215,13 @@ export function ProjectTree() {
             </div>
             {lightOpen && (
               <div style={styles.indent}>
-                {staticLights.map((l) => (
+                {staticLights.map((l, i) => (
                   <div
                     key={l.id}
                     style={{ ...styles.node, ...(isActive({ kind: 'scene_item', entityType: 'light', entityId: l.id }) ? styles.nodeActive : {}) }}
                     onClick={() => click({ kind: 'scene_item', entityType: 'light', entityId: l.id })}
                   >
-                    {l.id.slice(0, 12)}
+                    <span style={styles.nodeLabel}>Light {i + 1}</span>
                     <button style={styles.removeBtn} onClick={(e) => { e.stopPropagation(); removeLight(l.id); }}>&times;</button>
                   </div>
                 ))}
@@ -240,7 +248,7 @@ export function ProjectTree() {
                     style={{ ...styles.node, ...(isActive({ kind: 'scene_item', entityType: 'npc', entityId: n.id }) ? styles.nodeActive : {}) }}
                     onClick={() => click({ kind: 'scene_item', entityType: 'npc', entityId: n.id })}
                   >
-                    {n.name || n.id.slice(0, 12)}
+                    <span style={styles.nodeLabel}>{n.name || n.id.slice(0, 12)}</span>
                     <button style={styles.removeBtn} onClick={(e) => { e.stopPropagation(); removeNpc(n.id); }}>&times;</button>
                   </div>
                 ))}
@@ -261,13 +269,13 @@ export function ProjectTree() {
             </div>
             {portalOpen && (
               <div style={styles.indent}>
-                {portals.map((p) => (
+                {portals.map((p, i) => (
                   <div
                     key={p.id}
                     style={{ ...styles.node, ...(isActive({ kind: 'scene_item', entityType: 'portal', entityId: p.id }) ? styles.nodeActive : {}) }}
                     onClick={() => click({ kind: 'scene_item', entityType: 'portal', entityId: p.id })}
                   >
-                    {p.target_scene || p.id.slice(0, 12)}
+                    <span style={styles.nodeLabel}>{p.target_scene || `Portal ${i + 1}`}</span>
                     <button style={styles.removeBtn} onClick={(e) => { e.stopPropagation(); removePortal(p.id); }}>&times;</button>
                   </div>
                 ))}

--- a/tools/apps/bricklayer/src/panels/ProjectTree.tsx
+++ b/tools/apps/bricklayer/src/panels/ProjectTree.tsx
@@ -179,9 +179,17 @@ export function ProjectTree() {
                 const input = document.createElement('input');
                 input.type = 'file';
                 input.accept = '.ply';
-                input.onchange = () => {
+                input.onchange = async () => {
                   const file = input.files?.[0];
-                  if (file) addPlacedObject(file.name);
+                  if (!file) return;
+                  // Store PLY blob and add object
+                  addPlacedObject(file.name, file);
+                  // Copy to FSAPI project directory if available
+                  const handle = useSceneStore.getState().projectHandle;
+                  if (handle) {
+                    const { importAssetToProject } = await import('../lib/projectIO.js');
+                    await importAssetToProject(handle, file);
+                  }
                 };
                 input.click();
               }}>+</button>

--- a/tools/apps/bricklayer/src/panels/ProjectTree.tsx
+++ b/tools/apps/bricklayer/src/panels/ProjectTree.tsx
@@ -166,7 +166,17 @@ export function ProjectTree() {
               <span style={styles.arrow}>{objOpen ? '\u25BE' : '\u25B8'}</span>
               Objects
               <span style={styles.count}>({placedObjects.length})</span>
-              <button style={styles.addBtn} onClick={(e) => { e.stopPropagation(); const f = window.prompt('PLY file:'); if (f) addPlacedObject(f); }}>+</button>
+              <button style={styles.addBtn} onClick={(e) => {
+                e.stopPropagation();
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.accept = '.ply';
+                input.onchange = () => {
+                  const file = input.files?.[0];
+                  if (file) addPlacedObject(file.name);
+                };
+                input.click();
+              }}>+</button>
             </div>
             {objOpen && (
               <div style={styles.indent}>

--- a/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
@@ -88,12 +88,15 @@ const styles: Record<string, React.CSSProperties> = {
   },
   select: {
     flex: 1,
+    minWidth: 0,
     padding: '4px 6px',
     background: '#2a2a4a',
     border: '1px solid #444',
     borderRadius: 4,
     color: '#ddd',
     fontSize: 12,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
 };
 

--- a/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/TerrainLeftPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { NumberInput } from '../components/NumberInput.js';
 import { useSceneStore } from '../store/useSceneStore.js';
+import { extractColorsFromFile } from '../lib/colorExtract.js';
 import type { ToolType } from '../store/types.js';
 
 const drawTools: { id: ToolType; label: string; key: string }[] = [
@@ -201,6 +202,26 @@ export function TerrainLeftPanel() {
             onClick={() => addPalette(`Palette ${colorPalettes.length + 1}`)}
           >
             New
+          </button>
+          <button
+            style={{ ...styles.btn, fontSize: 11, padding: '2px 6px' }}
+            onClick={() => {
+              const input = document.createElement('input');
+              input.type = 'file';
+              input.accept = 'image/*';
+              input.onchange = async () => {
+                const file = input.files?.[0];
+                if (!file) return;
+                const colors = await extractColorsFromFile(file, 24);
+                if (colors.length > 0) {
+                  const palettes = [...useSceneStore.getState().colorPalettes, { name: file.name, colors }];
+                  useSceneStore.setState({ colorPalettes: palettes, activePaletteIndex: palettes.length - 1 });
+                }
+              };
+              input.click();
+            }}
+          >
+            From Image
           </button>
         </div>
 

--- a/tools/apps/bricklayer/src/panels/TerrainRightPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/TerrainRightPanel.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { NumberInput } from '../components/NumberInput.js';
 import { useSceneStore } from '../store/useSceneStore.js';
 
 const styles: Record<string, React.CSSProperties> = {
@@ -6,18 +7,32 @@ const styles: Record<string, React.CSSProperties> = {
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
   info: { fontSize: 12, color: '#aaa' },
   row: { display: 'flex', alignItems: 'center', gap: 8 },
+  colorSwatch: {
+    width: 20, height: 20, borderRadius: 3, border: '1px solid #666', flexShrink: 0,
+  },
+  input: {
+    width: 60, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 13,
+  },
 };
 
 export function TerrainRightPanel() {
   const voxels = useSceneStore((s) => s.voxels);
   const gridWidth = useSceneStore((s) => s.gridWidth);
   const gridDepth = useSceneStore((s) => s.gridDepth);
-  const showCollision = useSceneStore((s) => s.showCollision);
-  const collisionGridData = useSceneStore((s) => s.collisionGridData);
-  const collisionLayer = useSceneStore((s) => s.collisionLayer);
+  const selectedVoxel = useSceneStore((s) => s.selectedVoxel);
+  const yClipMin = useSceneStore((s) => s.yClipMin);
+  const yClipMax = useSceneStore((s) => s.yClipMax);
+  const mirrorX = useSceneStore((s) => s.mirrorX);
+  const mirrorZ = useSceneStore((s) => s.mirrorZ);
+  const setYClipMin = useSceneStore((s) => s.setYClipMin);
+  const setYClipMax = useSceneStore((s) => s.setYClipMax);
+  const setMirrorX = useSceneStore((s) => s.setMirrorX);
+  const setMirrorZ = useSceneStore((s) => s.setMirrorZ);
 
   return (
     <div>
+      {/* Terrain info */}
       <div style={styles.section}>
         <span style={styles.label}>Terrain Info</span>
         <span style={styles.info}>
@@ -28,20 +43,47 @@ export function TerrainRightPanel() {
         </span>
       </div>
 
-      {showCollision && collisionGridData && (
+      {/* Selected voxel info */}
+      {selectedVoxel && (
         <div style={styles.section}>
-          <span style={styles.label}>Collision Grid</span>
+          <span style={styles.label}>Selected Voxel</span>
           <span style={styles.info}>
-            {collisionGridData.width} x {collisionGridData.height} (cell {collisionGridData.cell_size})
+            Position: ({selectedVoxel.x}, {selectedVoxel.y}, {selectedVoxel.z})
           </span>
-          <span style={styles.info}>
-            {collisionGridData.solid.filter(Boolean).length} solid / {collisionGridData.solid.length - collisionGridData.solid.filter(Boolean).length} walkable
-          </span>
-          <span style={styles.info}>
-            Active layer: {collisionLayer}
-          </span>
+          <div style={styles.row}>
+            <span style={styles.info}>Color:</span>
+            <div style={{
+              ...styles.colorSwatch,
+              background: `rgba(${selectedVoxel.color.join(',')})`,
+            }} />
+            <span style={{ fontSize: 11, color: '#777' }}>
+              {selectedVoxel.color[0]}, {selectedVoxel.color[1]}, {selectedVoxel.color[2]}, {selectedVoxel.color[3]}
+            </span>
+          </div>
         </div>
       )}
+
+      {/* Y-Clip */}
+      <div style={styles.section}>
+        <span style={styles.label}>Y-Clip</span>
+        <div style={styles.row}>
+          <NumberInput label="Min" value={yClipMin} min={0} max={yClipMax} onChange={setYClipMin} style={styles.input} />
+          <NumberInput label="Max" value={yClipMax} min={yClipMin} max={255} onChange={setYClipMax} style={styles.input} />
+        </div>
+      </div>
+
+      {/* Mirror */}
+      <div style={styles.section}>
+        <span style={styles.label}>Mirror</span>
+        <label style={{ ...styles.row, fontSize: 12, cursor: 'pointer' }}>
+          <input type="checkbox" checked={mirrorX} onChange={(e) => setMirrorX(e.target.checked)} />
+          Mirror X
+        </label>
+        <label style={{ ...styles.row, fontSize: 12, cursor: 'pointer' }}>
+          <input type="checkbox" checked={mirrorZ} onChange={(e) => setMirrorZ(e.target.checked)} />
+          Mirror Z
+        </label>
+      </div>
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -185,6 +185,7 @@ export interface SelectedEntity {
 // ── Project management ──
 
 export interface ProjectManifest {
+  version: number;
   name: string;
   terrains: TerrainEntry[];
   assets: AssetEntry[];
@@ -235,6 +236,9 @@ export interface BricklayerFile {
   collision: string[];  // legacy format
   collisionGridData?: CollisionGridData;
   nav_zone_names?: string[];
+  color_palettes?: ColorPalette[];
+  terrains?: TerrainEntry[];
+  assets?: AssetEntry[];
   scene: {
     ambientColor: [number, number, number, number];
     staticLights: StaticLight[];

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -144,6 +144,7 @@ export interface SceneStoreState {
   terrains: TerrainEntry[];
   currentTerrainId: string;
   assets: AssetEntry[];
+  assetBlobs: Map<string, Blob>;
   activeNode: NavigationNode | null;
 
   // Collision box fill
@@ -236,7 +237,8 @@ export interface SceneStoreState {
   addPortal: () => void;
   updatePortal: (id: string, patch: Partial<PortalData>) => void;
   removePortal: (id: string) => void;
-  addPlacedObject: (plyFile: string) => void;
+  addPlacedObject: (plyFile: string, blob?: Blob) => void;
+  storeAssetBlob: (path: string, blob: Blob) => void;
   updatePlacedObject: (id: string, patch: Partial<PlacedObjectData>) => void;
   removePlacedObject: (id: string) => void;
   updatePlayer: (patch: Partial<PlayerData>) => void;
@@ -353,6 +355,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   terrains: [],
   currentTerrainId: '',
   assets: [],
+  assetBlobs: new Map(),
   activeNode: null,
 
   collisionBoxFill: false,
@@ -610,7 +613,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     portals: get().portals.filter((p) => p.id !== id),
   }),
 
-  addPlacedObject: (plyFile) => {
+  addPlacedObject: (plyFile, blob?) => {
     const obj: PlacedObjectData = {
       id: genId('obj'),
       ply_file: plyFile,
@@ -620,7 +623,20 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       is_static: true,
       character_manifest: '',
     };
-    set({ placedObjects: [...get().placedObjects, obj] });
+    const s = get();
+    const updates: Partial<typeof s> = { placedObjects: [...s.placedObjects, obj] };
+    if (blob) {
+      const path = `assets/${plyFile}`;
+      const blobs = new Map(s.assetBlobs);
+      blobs.set(path, blob);
+      (updates as any).assetBlobs = blobs;
+    }
+    set(updates as any);
+  },
+  storeAssetBlob: (path, blob) => {
+    const blobs = new Map(get().assetBlobs);
+    blobs.set(path, blob);
+    set({ assetBlobs: blobs });
   },
   updatePlacedObject: (id, patch) => set({
     placedObjects: get().placedObjects.map((o) => (o.id === id ? { ...o, ...patch } : o)),

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -27,6 +27,7 @@ import type {
   ColorPalette,
 } from './types.js';
 import { voxelKey, parseKey, floodFill3D, brushPositions } from '../lib/voxelUtils.js';
+import { extractColorsFromImage as extractColorsFromImageData } from '../lib/colorExtract.js';
 
 function defaultEmitter(): EmitterConfig {
   return {
@@ -147,6 +148,7 @@ export interface SceneStoreState {
 
   // Collision box fill
   collisionBoxFill: boolean;
+  collisionFloodFillMode: boolean;
   collisionBoxStart: [number, number] | null;
 
   // Grab mode
@@ -162,6 +164,10 @@ export interface SceneStoreState {
   activeColor: [number, number, number, number];
   brushSize: number;
   yLevelLock: number | null;
+  yClipMin: number;
+  yClipMax: number;
+  mirrorX: boolean;
+  mirrorZ: boolean;
 
   // Scene elements
   ambientColor: [number, number, number, number];
@@ -184,6 +190,7 @@ export interface SceneStoreState {
   // Editor state
   mode: BricklayerMode;
   selectedEntity: SelectedEntity | null;
+  selectedVoxel: { x: number; y: number; z: number; color: [number, number, number, number] } | null;
   inspectorTab: InspectorTab;
   showGrid: boolean;
   showCollision: boolean;
@@ -213,6 +220,10 @@ export interface SceneStoreState {
   setActiveColor: (color: [number, number, number, number]) => void;
   setBrushSize: (size: number) => void;
   setYLevelLock: (y: number | null) => void;
+  setYClipMin: (v: number) => void;
+  setYClipMax: (v: number) => void;
+  setMirrorX: (v: boolean) => void;
+  setMirrorZ: (v: boolean) => void;
 
   // Actions – scene
   setAmbientColor: (c: [number, number, number, number]) => void;
@@ -247,6 +258,7 @@ export interface SceneStoreState {
   setCellNavZone: (x: number, z: number, zone: number) => void;
   addNavZoneName: (name: string) => void;
   removeNavZoneName: (index: number) => void;
+  collisionFloodFill: (x: number, z: number, fillSolid: boolean) => void;
 
   // Actions – project
   setProjectName: (name: string) => void;
@@ -260,6 +272,7 @@ export interface SceneStoreState {
 
   // Actions – collision box fill
   setCollisionBoxFill: (v: boolean) => void;
+  setCollisionFloodFillMode: (v: boolean) => void;
   setCollisionBoxStart: (pos: [number, number] | null) => void;
   setCellSolid: (x: number, z: number, val: boolean) => void;
   autoGenerateCollision: (slopeThreshold: number) => void;
@@ -279,6 +292,7 @@ export interface SceneStoreState {
   // Actions – editor
   setMode: (mode: BricklayerMode) => void;
   setSelectedEntity: (e: SelectedEntity | null) => void;
+  setSelectedVoxel: (v: { x: number; y: number; z: number; color: [number, number, number, number] } | null) => void;
   setInspectorTab: (tab: InspectorTab) => void;
   setShowGrid: (v: boolean) => void;
   setShowCollision: (v: boolean) => void;
@@ -297,6 +311,18 @@ export interface SceneStoreState {
   importImage: (imageData: ImageData, mode: 'flat' | 'luminance' | 'depth', maxHeight: number, depthMap?: Float32Array, budget?: number) => void;
   saveProject: () => BricklayerFile;
   loadProject: (data: BricklayerFile) => void;
+}
+
+function mirrorPositions(
+  x: number, y: number, z: number,
+  mirrorX: boolean, mirrorZ: boolean,
+  gridWidth: number, gridDepth: number,
+): [number, number, number][] {
+  const positions: [number, number, number][] = [[x, y, z]];
+  if (mirrorX) positions.push([gridWidth - 1 - x, y, z]);
+  if (mirrorZ) positions.push([x, y, gridDepth - 1 - z]);
+  if (mirrorX && mirrorZ) positions.push([gridWidth - 1 - x, y, gridDepth - 1 - z]);
+  return positions;
 }
 
 const defaultPalette: ColorPalette = {
@@ -330,6 +356,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   activeNode: null,
 
   collisionBoxFill: false,
+  collisionFloodFillMode: false,
   collisionBoxStart: null,
 
   grabMode: false,
@@ -342,6 +369,10 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   activeColor: [34, 139, 34, 255],
   brushSize: 1,
   yLevelLock: null,
+  yClipMin: 0,
+  yClipMax: 255,
+  mirrorX: false,
+  mirrorZ: false,
 
   ambientColor: [0.25, 0.28, 0.45, 1],
   staticLights: [],
@@ -362,6 +393,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
 
   mode: 'terrain',
   selectedEntity: null,
+  selectedVoxel: null,
   inspectorTab: 'scene',
   showGrid: true,
   showCollision: false,
@@ -409,44 +441,52 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
 
   // ── Voxel actions ──
   placeVoxel: (x, y, z) => {
-    const { voxels, activeColor } = get();
-    const next = new Map(voxels);
-    next.set(voxelKey(x, y, z), { color: [...activeColor] });
+    const s = get();
+    const next = new Map(s.voxels);
+    const positions = mirrorPositions(x, y, z, s.mirrorX, s.mirrorZ, s.gridWidth, s.gridDepth);
+    for (const [mx, my, mz] of positions) {
+      next.set(voxelKey(mx, my, mz), { color: [...s.activeColor] });
+    }
     set({ voxels: next });
   },
 
   placeVoxels: (positions) => {
-    const { voxels, activeColor } = get();
-    const next = new Map(voxels);
+    const s = get();
+    const next = new Map(s.voxels);
     for (const [x, y, z] of positions) {
-      next.set(voxelKey(x, y, z), { color: [...activeColor] });
+      for (const [mx, my, mz] of mirrorPositions(x, y, z, s.mirrorX, s.mirrorZ, s.gridWidth, s.gridDepth)) {
+        next.set(voxelKey(mx, my, mz), { color: [...s.activeColor] });
+      }
     }
     set({ voxels: next });
   },
 
   paintVoxel: (x, y, z) => {
-    const { voxels, activeColor } = get();
-    const key = voxelKey(x, y, z);
-    if (!voxels.has(key)) return;
-    const next = new Map(voxels);
-    next.set(key, { color: [...activeColor] });
+    const s = get();
+    const next = new Map(s.voxels);
+    for (const [mx, my, mz] of mirrorPositions(x, y, z, s.mirrorX, s.mirrorZ, s.gridWidth, s.gridDepth)) {
+      const key = voxelKey(mx, my, mz);
+      if (next.has(key)) next.set(key, { color: [...s.activeColor] });
+    }
     set({ voxels: next });
   },
 
   eraseVoxel: (x, y, z) => {
-    const { voxels } = get();
-    const key = voxelKey(x, y, z);
-    if (!voxels.has(key)) return;
-    const next = new Map(voxels);
-    next.delete(key);
+    const s = get();
+    const next = new Map(s.voxels);
+    for (const [mx, my, mz] of mirrorPositions(x, y, z, s.mirrorX, s.mirrorZ, s.gridWidth, s.gridDepth)) {
+      next.delete(voxelKey(mx, my, mz));
+    }
     set({ voxels: next });
   },
 
   eraseVoxels: (positions) => {
-    const { voxels } = get();
-    const next = new Map(voxels);
+    const s = get();
+    const next = new Map(s.voxels);
     for (const [x, y, z] of positions) {
-      next.delete(voxelKey(x, y, z));
+      for (const [mx, my, mz] of mirrorPositions(x, y, z, s.mirrorX, s.mirrorZ, s.gridWidth, s.gridDepth)) {
+        next.delete(voxelKey(mx, my, mz));
+      }
     }
     set({ voxels: next });
   },
@@ -494,6 +534,10 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   setActiveColor: (color) => set({ activeColor: color }),
   setBrushSize: (size) => set({ brushSize: Math.max(1, Math.min(8, size)) }),
   setYLevelLock: (y) => set({ yLevelLock: y }),
+  setYClipMin: (v) => set({ yClipMin: v }),
+  setYClipMax: (v) => set({ yClipMax: v }),
+  setMirrorX: (v) => set({ mirrorX: v }),
+  setMirrorZ: (v) => set({ mirrorZ: v }),
 
   // ── Scene actions ──
   setAmbientColor: (c) => set({ ambientColor: c }),
@@ -685,7 +729,8 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   setActiveNode: (node) => set({ activeNode: node }),
 
   // ── Collision box fill ──
-  setCollisionBoxFill: (v) => set({ collisionBoxFill: v, collisionBoxStart: null }),
+  setCollisionBoxFill: (v) => set({ collisionBoxFill: v, collisionBoxStart: null, collisionFloodFillMode: false }),
+  setCollisionFloodFillMode: (v) => set({ collisionFloodFillMode: v, collisionBoxFill: false, collisionBoxStart: null }),
   setCollisionBoxStart: (pos) => set({ collisionBoxStart: pos }),
 
   setCellSolid: (x, z, val) => {
@@ -695,6 +740,37 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     if (idx < 0 || idx >= collisionGridData.solid.length) return;
     const solid = [...collisionGridData.solid];
     solid[idx] = val;
+    set({ collisionGridData: { ...collisionGridData, solid } });
+  },
+
+  collisionFloodFill: (startX, startZ, fillSolid) => {
+    const { collisionGridData } = get();
+    if (!collisionGridData) return;
+    const { width, height, solid: origSolid } = collisionGridData;
+    const idx = (x: number, z: number) => z * width + x;
+    const startIdx = idx(startX, startZ);
+    if (startIdx < 0 || startIdx >= origSolid.length) return;
+    const targetState = origSolid[startIdx];
+    if (targetState === fillSolid) return; // already the target state
+    const solid = [...origSolid];
+    const visited = new Uint8Array(solid.length);
+    const queue: [number, number][] = [[startX, startZ]];
+    visited[startIdx] = 1;
+    while (queue.length > 0) {
+      const [cx, cz] = queue.pop()!;
+      const ci = idx(cx, cz);
+      solid[ci] = fillSolid;
+      for (const [dx, dz] of [[1, 0], [-1, 0], [0, 1], [0, -1]] as const) {
+        const nx = cx + dx;
+        const nz = cz + dz;
+        if (nx < 0 || nx >= width || nz < 0 || nz >= height) continue;
+        const ni = idx(nx, nz);
+        if (visited[ni]) continue;
+        if (solid[ni] !== targetState) continue;
+        visited[ni] = 1;
+        queue.push([nx, nz]);
+      }
+    }
     set({ collisionGridData: { ...collisionGridData, solid } });
   },
 
@@ -777,26 +853,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   },
 
   extractColorsFromImage: (imageData, maxColors) => {
-    // Simple color quantization: sample unique colors
-    const colorSet = new Map<string, [number, number, number, number]>();
-    const data = imageData.data;
-    const step = Math.max(1, Math.floor(data.length / 4 / 1000)); // sample at most 1000 pixels
-    for (let i = 0; i < data.length; i += 4 * step) {
-      const r = data[i];
-      const g = data[i + 1];
-      const b = data[i + 2];
-      const a = data[i + 3];
-      if (a < 10) continue;
-      // Quantize to 5-bit
-      const qr = (r >> 3) << 3;
-      const qg = (g >> 3) << 3;
-      const qb = (b >> 3) << 3;
-      const key = `${qr},${qg},${qb}`;
-      if (!colorSet.has(key)) {
-        colorSet.set(key, [qr, qg, qb, 255]);
-      }
-    }
-    const colors = Array.from(colorSet.values()).slice(0, maxColors);
+    const colors = extractColorsFromImageData(imageData, maxColors);
     const palettes = [...get().colorPalettes];
     palettes.push({ name: 'Extracted', colors });
     set({ colorPalettes: palettes, activePaletteIndex: palettes.length - 1 });
@@ -805,6 +862,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   // ── Editor actions ──
   setMode: (mode) => set({ mode }),
   setSelectedEntity: (e) => set({ selectedEntity: e }),
+  setSelectedVoxel: (v) => set({ selectedVoxel: v }),
   setInspectorTab: (tab) => set({ inspectorTab: tab }),
   setShowGrid: (v) => set({ showGrid: v }),
   setShowCollision: (v) => set({ showCollision: v }),
@@ -923,6 +981,9 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       collision: [],
       collisionGridData: s.collisionGridData ?? undefined,
       nav_zone_names: s.navZoneNames.length > 0 ? s.navZoneNames : undefined,
+      color_palettes: s.colorPalettes.length > 0 ? s.colorPalettes : undefined,
+      terrains: s.terrains.length > 0 ? s.terrains : undefined,
+      assets: s.assets.length > 0 ? s.assets : undefined,
       scene: {
         ambientColor: s.ambientColor,
         staticLights: s.staticLights,
@@ -953,6 +1014,10 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       gridDepth: data.gridDepth,
       collisionGridData: data.collisionGridData ?? null,
       navZoneNames: data.nav_zone_names ?? [],
+      colorPalettes: data.color_palettes ?? [defaultPalette],
+      activePaletteIndex: 0,
+      terrains: data.terrains ?? [],
+      assets: data.assets ?? [],
       ambientColor: data.scene.ambientColor,
       staticLights: data.scene.staticLights,
       npcs: data.scene.npcs,

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -511,14 +511,16 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   },
 
   extrudeVoxels: (positions, direction) => {
-    const { voxels, activeColor } = get();
-    const next = new Map(voxels);
+    const s = get();
+    const next = new Map(s.voxels);
     for (const [x, y, z] of positions) {
-      const existing = voxels.get(voxelKey(x, y, z));
+      const existing = s.voxels.get(voxelKey(x, y, z));
       if (!existing) continue;
       const ny = direction === 'up' ? y + 1 : y - 1;
       if (ny < 0) continue;
-      next.set(voxelKey(x, ny, z), { color: existing.color });
+      for (const [mx, , mz] of mirrorPositions(x, ny, z, s.mirrorX, s.mirrorZ, s.gridWidth, s.gridDepth)) {
+        next.set(voxelKey(mx, ny, mz), { color: existing.color });
+      }
     }
     set({ voxels: next });
   },

--- a/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
+++ b/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
@@ -105,6 +105,13 @@ export function CollisionOverlay() {
 
     store.pushUndo();
 
+    // Flood fill mode
+    if (store.collisionFloodFillMode && store.collisionLayer === 'solid') {
+      const currentState = grid.solid[cellZ * grid.width + cellX];
+      store.collisionFloodFill(cellX, cellZ, !currentState);
+      return;
+    }
+
     switch (store.collisionLayer) {
       case 'solid':
         store.toggleCellSolid(cellX, cellZ);

--- a/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
+++ b/tools/apps/bricklayer/src/viewport/CollisionOverlay.tsx
@@ -68,8 +68,8 @@ export function CollisionOverlay() {
   const handleClick = useCallback((e: ThreeEvent<MouseEvent>) => {
     e.stopPropagation();
     const store = useSceneStore.getState();
-    // Only handle clicks in TERRAIN mode
-    if (store.mode !== 'terrain') return;
+    // Only handle clicks in collision editing mode
+    if (store.activeNode?.kind !== 'collision') return;
     const grid = store.collisionGridData;
     if (!grid) return;
 
@@ -81,7 +81,7 @@ export function CollisionOverlay() {
     if (cellX < 0 || cellX >= grid.width || cellZ < 0 || cellZ >= grid.height) return;
 
     // Box fill mode
-    if (store.collisionBoxFill && store.collisionLayer === 'solid') {
+    if (store.collisionBoxFill) {
       if (!store.collisionBoxStart) {
         store.setCollisionBoxStart([cellX, cellZ]);
         return;
@@ -96,7 +96,11 @@ export function CollisionOverlay() {
       store.pushUndo();
       for (let z = minZ; z <= maxZ; z++) {
         for (let x = minX; x <= maxX; x++) {
-          store.setCellSolid(x, z, true);
+          switch (store.collisionLayer) {
+            case 'solid': store.setCellSolid(x, z, true); break;
+            case 'elevation': store.setCellElevation(x, z, store.collisionHeight); break;
+            case 'nav_zone': store.setCellNavZone(x, z, store.activeNavZone); break;
+          }
         }
       }
       store.setCollisionBoxStart(null);
@@ -105,7 +109,7 @@ export function CollisionOverlay() {
 
     store.pushUndo();
 
-    // Flood fill mode
+    // Flood fill mode (solid layer only — elevation/nav_zone don't have contiguous regions)
     if (store.collisionFloodFillMode && store.collisionLayer === 'solid') {
       const currentState = grid.solid[cellZ * grid.width + cellX];
       store.collisionFloodFill(cellX, cellZ, !currentState);

--- a/tools/apps/bricklayer/src/viewport/NpcMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/NpcMarkers.tsx
@@ -1,41 +1,128 @@
-import React from 'react';
-import { Line } from '@react-three/drei';
+import React, { useCallback, useState } from 'react';
+import * as THREE from 'three';
+import { useThree } from '@react-three/fiber';
+import { Html, Line } from '@react-three/drei';
 import { useSceneStore } from '../store/useSceneStore.js';
+
+const _plane = new THREE.Plane();
+const _raycaster = new THREE.Raycaster();
+const _intersection = new THREE.Vector3();
+
+function DraggableNpc({ id, position, isSelected, onSelect, waypoints }: {
+  id: string;
+  position: [number, number, number];
+  isSelected: boolean;
+  onSelect: () => void;
+  waypoints: [number, number][];
+}) {
+  const { camera, gl } = useThree();
+  const [dragging, setDragging] = useState(false);
+  const [dragPos, setDragPos] = useState<[number, number, number] | null>(null);
+
+  const displayPos = dragPos ?? position;
+
+  const handlePointerDown = useCallback((e: any) => {
+    e.stopPropagation();
+    onSelect();
+
+    if (useSceneStore.getState().mode !== 'scene') return;
+
+    const el = gl.domElement;
+    _plane.set(new THREE.Vector3(0, 1, 0), -position[1]);
+    setDragging(true);
+
+    const onMove = (ev: PointerEvent) => {
+      const rect = el.getBoundingClientRect();
+      const pointer = new THREE.Vector2(
+        ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+        -((ev.clientY - rect.top) / rect.height) * 2 + 1,
+      );
+      _raycaster.setFromCamera(pointer, camera);
+      if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
+        setDragPos([
+          Math.round(_intersection.x * 10) / 10,
+          position[1],
+          Math.round(_intersection.z * 10) / 10,
+        ]);
+      }
+    };
+
+    const onUp = () => {
+      el.removeEventListener('pointermove', onMove);
+      el.removeEventListener('pointerup', onUp);
+      setDragging(false);
+      const snapped: [number, number, number] = [
+        Math.round(_intersection.x * 10) / 10,
+        position[1],
+        Math.round(_intersection.z * 10) / 10,
+      ];
+      useSceneStore.getState().updateNpc(id, { position: snapped });
+      setDragPos(null);
+    };
+
+    el.addEventListener('pointermove', onMove);
+    el.addEventListener('pointerup', onUp);
+  }, [id, position, camera, gl, onSelect]);
+
+  return (
+    <group key={id}>
+      {/* Invisible hit box */}
+      <mesh position={displayPos} onPointerDown={handlePointerDown}>
+        <cylinderGeometry args={[0.5, 0.5, 1.8, 8]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+      {/* Visible mesh */}
+      <mesh position={displayPos}>
+        <cylinderGeometry args={[0.3, 0.3, 1.5, 8]} />
+        <meshStandardMaterial
+          color={dragging ? '#ffcc00' : isSelected ? '#ffffff' : '#4fc3f7'}
+          transparent
+          opacity={dragging ? 0.9 : isSelected ? 0.8 : 0.7}
+        />
+      </mesh>
+      {waypoints.length > 1 && (
+        <Line
+          points={waypoints.map(([wx, wz]) => [wx, displayPos[1] + 0.1, wz] as [number, number, number])}
+          color="#4fc3f7"
+          lineWidth={2}
+          dashed
+          dashSize={0.5}
+          gapSize={0.3}
+        />
+      )}
+      {dragging && (
+        <Html position={[displayPos[0], displayPos[1] + 1.5, displayPos[2]]} center>
+          <div style={{
+            background: 'rgba(0,0,0,0.8)', color: '#ffcc00',
+            padding: '2px 6px', borderRadius: 4, fontSize: 11, whiteSpace: 'nowrap',
+          }}>
+            {displayPos[0].toFixed(1)}, {displayPos[1].toFixed(1)}, {displayPos[2].toFixed(1)}
+          </div>
+        </Html>
+      )}
+    </group>
+  );
+}
 
 export function NpcMarkers() {
   const npcs = useSceneStore((s) => s.npcs);
   const showGizmos = useSceneStore((s) => s.showGizmos);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
   const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
-  const setInspectorTab = useSceneStore((s) => s.setInspectorTab);
 
   if (!showGizmos) return null;
 
   return (
     <group>
       {npcs.map((npc) => (
-        <group key={npc.id}>
-          <mesh
-            position={npc.position}
-            onClick={(e) => {
-              e.stopPropagation();
-              setSelectedEntity({ type: 'npc', id: npc.id });
-              setInspectorTab('entities');
-            }}
-          >
-            <cylinderGeometry args={[0.3, 0.3, 1.5, 8]} />
-            <meshStandardMaterial color="#4fc3f7" transparent opacity={0.7} />
-          </mesh>
-          {npc.waypoints.length > 1 && (
-            <Line
-              points={npc.waypoints.map(([wx, wz]) => [wx, npc.position[1] + 0.1, wz] as [number, number, number])}
-              color="#4fc3f7"
-              lineWidth={2}
-              dashed
-              dashSize={0.5}
-              gapSize={0.3}
-            />
-          )}
-        </group>
+        <DraggableNpc
+          key={npc.id}
+          id={npc.id}
+          position={npc.position}
+          isSelected={selectedEntity?.type === 'npc' && selectedEntity.id === npc.id}
+          onSelect={() => setSelectedEntity({ type: 'npc', id: npc.id })}
+          waypoints={npc.waypoints}
+        />
       ))}
     </group>
   );

--- a/tools/apps/bricklayer/src/viewport/PlayerMarker.tsx
+++ b/tools/apps/bricklayer/src/viewport/PlayerMarker.tsx
@@ -1,31 +1,101 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
+import * as THREE from 'three';
+import { useThree } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
 import { useSceneStore } from '../store/useSceneStore.js';
+
+const _plane = new THREE.Plane();
+const _raycaster = new THREE.Raycaster();
+const _intersection = new THREE.Vector3();
 
 export function PlayerMarker() {
   const player = useSceneStore((s) => s.player);
   const showGizmos = useSceneStore((s) => s.showGizmos);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
   const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
-  const setInspectorTab = useSceneStore((s) => s.setInspectorTab);
+  const { camera, gl } = useThree();
+  const [dragging, setDragging] = useState(false);
+  const [dragPos, setDragPos] = useState<[number, number, number] | null>(null);
+
+  const isSelected = selectedEntity?.type === 'player';
+  const displayPos = dragPos ?? player.position;
+
+  const handlePointerDown = useCallback((e: any) => {
+    e.stopPropagation();
+    setSelectedEntity({ type: 'player', id: 'player' });
+
+    if (useSceneStore.getState().mode !== 'scene') return;
+
+    const el = gl.domElement;
+    _plane.set(new THREE.Vector3(0, 1, 0), -player.position[1]);
+    setDragging(true);
+
+    const onMove = (ev: PointerEvent) => {
+      const rect = el.getBoundingClientRect();
+      const pointer = new THREE.Vector2(
+        ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+        -((ev.clientY - rect.top) / rect.height) * 2 + 1,
+      );
+      _raycaster.setFromCamera(pointer, camera);
+      if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
+        setDragPos([
+          Math.round(_intersection.x * 10) / 10,
+          player.position[1],
+          Math.round(_intersection.z * 10) / 10,
+        ]);
+      }
+    };
+
+    const onUp = () => {
+      el.removeEventListener('pointermove', onMove);
+      el.removeEventListener('pointerup', onUp);
+      setDragging(false);
+      const snapped: [number, number, number] = [
+        Math.round(_intersection.x * 10) / 10,
+        player.position[1],
+        Math.round(_intersection.z * 10) / 10,
+      ];
+      useSceneStore.getState().updatePlayer({ position: snapped });
+      setDragPos(null);
+    };
+
+    el.addEventListener('pointermove', onMove);
+    el.addEventListener('pointerup', onUp);
+  }, [player.position, camera, gl, setSelectedEntity]);
 
   if (!showGizmos) return null;
 
   return (
-    <group
-      position={player.position}
-      onClick={(e) => {
-        e.stopPropagation();
-        setSelectedEntity({ type: 'player', id: 'player' });
-        setInspectorTab('entities');
-      }}
-    >
+    <group position={displayPos}>
+      {/* Invisible hit box */}
+      <mesh position={[0, 0.75, 0]} onPointerDown={handlePointerDown}>
+        <cylinderGeometry args={[0.5, 0.5, 2, 8]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+      {/* Visible cylinder */}
       <mesh position={[0, 0.75, 0]}>
         <cylinderGeometry args={[0.3, 0.3, 1.5, 8]} />
-        <meshStandardMaterial color="#66bb6a" transparent opacity={0.7} />
+        <meshStandardMaterial
+          color={dragging ? '#ffcc00' : isSelected ? '#ffffff' : '#66bb6a'}
+          transparent
+          opacity={dragging ? 0.9 : isSelected ? 0.8 : 0.7}
+        />
       </mesh>
+      {/* Direction arrow */}
       <mesh position={[0, 1.8, 0]} rotation={[Math.PI, 0, 0]}>
         <coneGeometry args={[0.25, 0.5, 8]} />
-        <meshStandardMaterial color="#66bb6a" />
+        <meshStandardMaterial color={dragging ? '#ffcc00' : '#66bb6a'} />
       </mesh>
+      {dragging && (
+        <Html position={[0, 2.5, 0]} center>
+          <div style={{
+            background: 'rgba(0,0,0,0.8)', color: '#ffcc00',
+            padding: '2px 6px', borderRadius: 4, fontSize: 11, whiteSpace: 'nowrap',
+          }}>
+            {displayPos[0].toFixed(1)}, {displayPos[1].toFixed(1)}, {displayPos[2].toFixed(1)}
+          </div>
+        </Html>
+      )}
     </group>
   );
 }

--- a/tools/apps/bricklayer/src/viewport/PortalMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/PortalMarkers.tsx
@@ -1,33 +1,123 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
+import * as THREE from 'three';
+import { useThree } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
 import { useSceneStore } from '../store/useSceneStore.js';
+
+const _plane = new THREE.Plane();
+const _raycaster = new THREE.Raycaster();
+const _intersection = new THREE.Vector3();
+
+function DraggablePortal({ id, position, size, isSelected, onSelect, targetScene }: {
+  id: string;
+  position: [number, number];
+  size: [number, number];
+  isSelected: boolean;
+  onSelect: () => void;
+  targetScene: string;
+}) {
+  const { camera, gl } = useThree();
+  const [dragging, setDragging] = useState(false);
+  const [dragPos, setDragPos] = useState<[number, number] | null>(null);
+
+  const displayPos = dragPos ?? position;
+
+  const handlePointerDown = useCallback((e: any) => {
+    e.stopPropagation();
+    onSelect();
+
+    if (useSceneStore.getState().mode !== 'scene') return;
+
+    const el = gl.domElement;
+    _plane.set(new THREE.Vector3(0, 1, 0), -1);
+    setDragging(true);
+
+    const onMove = (ev: PointerEvent) => {
+      const rect = el.getBoundingClientRect();
+      const pointer = new THREE.Vector2(
+        ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+        -((ev.clientY - rect.top) / rect.height) * 2 + 1,
+      );
+      _raycaster.setFromCamera(pointer, camera);
+      if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
+        setDragPos([
+          Math.round(_intersection.x * 10) / 10,
+          Math.round(_intersection.z * 10) / 10,
+        ]);
+      }
+    };
+
+    const onUp = () => {
+      el.removeEventListener('pointermove', onMove);
+      el.removeEventListener('pointerup', onUp);
+      setDragging(false);
+      const snapped: [number, number] = [
+        Math.round(_intersection.x * 10) / 10,
+        Math.round(_intersection.z * 10) / 10,
+      ];
+      useSceneStore.getState().updatePortal(id, { position: snapped });
+      setDragPos(null);
+    };
+
+    el.addEventListener('pointermove', onMove);
+    el.addEventListener('pointerup', onUp);
+  }, [id, position, camera, gl, onSelect]);
+
+  return (
+    <>
+      {/* Invisible hit box */}
+      <mesh
+        position={[displayPos[0] + size[0] / 2, 1, displayPos[1] + size[1] / 2]}
+        onPointerDown={handlePointerDown}
+      >
+        <boxGeometry args={[size[0] + 0.4, 2.4, size[1] + 0.4]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+      {/* Visible wireframe */}
+      <mesh position={[displayPos[0] + size[0] / 2, 1, displayPos[1] + size[1] / 2]}>
+        <boxGeometry args={[size[0], 2, size[1]]} />
+        <meshBasicMaterial
+          color={dragging ? '#ffcc00' : isSelected ? '#ffffff' : '#ab47bc'}
+          wireframe
+          transparent
+          opacity={dragging ? 0.9 : isSelected ? 0.8 : 0.6}
+        />
+      </mesh>
+      {dragging && (
+        <Html position={[displayPos[0] + size[0] / 2, 3, displayPos[1] + size[1] / 2]} center>
+          <div style={{
+            background: 'rgba(0,0,0,0.8)', color: '#ffcc00',
+            padding: '2px 6px', borderRadius: 4, fontSize: 11, whiteSpace: 'nowrap',
+          }}>
+            {displayPos[0].toFixed(1)}, {displayPos[1].toFixed(1)}
+            {targetScene ? ` → ${targetScene}` : ''}
+          </div>
+        </Html>
+      )}
+    </>
+  );
+}
 
 export function PortalMarkers() {
   const portals = useSceneStore((s) => s.portals);
   const showGizmos = useSceneStore((s) => s.showGizmos);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
   const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
-  const setInspectorTab = useSceneStore((s) => s.setInspectorTab);
 
   if (!showGizmos) return null;
 
   return (
     <group>
       {portals.map((portal) => (
-        <mesh
+        <DraggablePortal
           key={portal.id}
-          position={[
-            portal.position[0] + portal.size[0] / 2,
-            1,
-            portal.position[1] + portal.size[1] / 2,
-          ]}
-          onClick={(e) => {
-            e.stopPropagation();
-            setSelectedEntity({ type: 'portal', id: portal.id });
-            setInspectorTab('entities');
-          }}
-        >
-          <boxGeometry args={[portal.size[0], 2, portal.size[1]]} />
-          <meshBasicMaterial color="#ab47bc" wireframe transparent opacity={0.6} />
-        </mesh>
+          id={portal.id}
+          position={portal.position}
+          size={portal.size}
+          isSelected={selectedEntity?.type === 'portal' && selectedEntity.id === portal.id}
+          onSelect={() => setSelectedEntity({ type: 'portal', id: portal.id })}
+          targetScene={portal.target_scene}
+        />
       ))}
     </group>
   );

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -68,6 +68,7 @@ function SceneContent() {
   const gridWidth = useSceneStore((s) => s.gridWidth);
   const gridDepth = useSceneStore((s) => s.gridDepth);
   const showGrid = useSceneStore((s) => s.showGrid);
+  const grabMode = useSceneStore((s) => s.grabMode);
   const controlsRef = useRef<OrbitControlsRef | null>(null);
 
   return (
@@ -107,6 +108,7 @@ function SceneContent() {
           controlsRef.current = r;
           orbitControlsRef = r;
         }}
+        enabled={!grabMode}
         target={[gridWidth / 2, 0, gridDepth / 2]}
         makeDefault
         screenSpacePanning

--- a/tools/apps/bricklayer/src/viewport/VoxelMesh.tsx
+++ b/tools/apps/bricklayer/src/viewport/VoxelMesh.tsx
@@ -123,6 +123,9 @@ export function VoxelMesh() {
       store.setSelectedVoxel({ x, y, z, color: vox.color });
     }
 
+    // Only process brush tools in terrain mode (not collision or scene)
+    if (store.mode !== 'terrain' || store.activeNode?.kind === 'collision') return;
+
     switch (store.activeTool) {
       case 'place': {
         if (!normal) return;

--- a/tools/apps/bricklayer/src/viewport/VoxelMesh.tsx
+++ b/tools/apps/bricklayer/src/viewport/VoxelMesh.tsx
@@ -24,10 +24,15 @@ export function VoxelMesh() {
   const meshRef = useRef<THREE.InstancedMesh>(null!);
   const voxels = useSceneStore((s) => s.voxels);
   const showCollision = useSceneStore((s) => s.showCollision);
+  const yClipMin = useSceneStore((s) => s.yClipMin);
+  const yClipMax = useSceneStore((s) => s.yClipMax);
 
-  // Filter to surface-only voxels (at least one exposed face)
+  // Filter to surface-only voxels (at least one exposed face), respecting Y-clip
   const surfaceEntries = useMemo(() => {
-    const all = Array.from(voxels.entries());
+    const all = Array.from(voxels.entries()).filter(([key]) => {
+      const [, y] = parseKey(key);
+      return y >= yClipMin && y <= yClipMax;
+    });
     if (all.length < 1000) return all; // skip culling for small sets
 
     return all.filter(([key]) => {
@@ -39,7 +44,7 @@ export function VoxelMesh() {
       }
       return false; // fully enclosed — cull
     });
-  }, [voxels]);
+  }, [voxels, yClipMin, yClipMax]);
 
   const count = surfaceEntries.length;
 
@@ -111,6 +116,12 @@ export function VoxelMesh() {
     const [x, y, z] = parseKey(key);
     const store = useSceneStore.getState();
     const normal = e.face?.normal;
+
+    // Update selected voxel info for right panel
+    const vox = store.voxels.get(key);
+    if (vox) {
+      store.setSelectedVoxel({ x, y, z, color: vox.color });
+    }
 
     switch (store.activeTool) {
       case 'place': {

--- a/tools/pnpm-lock.yaml
+++ b/tools/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@react-three/fiber':
         specifier: ^8.17.0
         version: 8.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -1695,6 +1698,9 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
@@ -2017,6 +2023,9 @@ packages:
   is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2040,6 +2049,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -2186,6 +2198,9 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2219,6 +2234,9 @@ packages:
 
   potpack@1.0.2:
     resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -2300,6 +2318,9 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -2319,6 +2340,9 @@ packages:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -2355,6 +2379,9 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -2445,6 +2472,9 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -2575,6 +2605,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   utility-types@3.11.0:
     resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
@@ -3864,6 +3897,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  core-util-is@1.0.3: {}
+
   create-require@1.1.1: {}
 
   cross-env@7.0.3:
@@ -4238,6 +4273,8 @@ snapshots:
 
   is-promise@2.2.2: {}
 
+  isarray@1.0.0: {}
+
   isexe@2.0.0: {}
 
   its-fine@1.2.5(@types/react@18.3.28)(react@18.3.1):
@@ -4254,6 +4291,13 @@ snapshots:
   json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
 
   lie@3.3.0:
     dependencies:
@@ -4381,6 +4425,8 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.0.2
 
+  pako@1.0.11: {}
+
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
@@ -4404,6 +4450,8 @@ snapshots:
       source-map-js: 1.2.1
 
   potpack@1.0.2: {}
+
+  process-nextick-args@2.0.1: {}
 
   progress@2.0.3: {}
 
@@ -4519,6 +4567,16 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -4564,6 +4622,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.59.0
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
+
+  safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
 
@@ -4613,6 +4673,8 @@ snapshots:
       send: 0.19.2
     transitivePeerDependencies:
       - supports-color
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -4762,6 +4824,10 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-ansi@6.0.1:
     dependencies:
@@ -4917,6 +4983,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  util-deprecate@1.0.2: {}
 
   utility-types@3.11.0: {}
 


### PR DESCRIPTION
## Summary
- **Draggable markers** for NPCs, Portals, Player (XZ plane raycaster, matching Objects/Lights behavior)
- **Persist color palettes** in save/load (added to BricklayerFile format)
- **Serialize terrains/assets** arrays in project file
- **Selected voxel info** shown in right panel (position + color swatch)
- **Y-clip min/max** controls filtering visible voxels
- **Mirror X/Z** controls for symmetric voxel placement
- **Flood fill** for collision cells (fills contiguous walkable/solid region)
- **File picker** for PLY import (replaces window.prompt)
- **Zip fallback** for project save/load (JSZip for browsers without FSAPI)
- **Auto-extract palette from image** (histogram-based color sampling with distance filtering)
- **Version field** on ProjectManifest type

## Test plan
- [x] Drag NPCs, portals, player in scene mode — verify position updates
- [x] Save project, reload — verify palettes, terrains, assets persist
- [x] Y-clip: adjust min/max sliders, verify voxel visibility changes
- [x] Mirror X/Z: place voxels, verify symmetric placement
- [x] Collision flood fill: enable toggle, click region, verify fill spreads
- [x] Add object via "+" button — verify file picker appears
- [x] Save/Open project in browser without FSAPI — verify zip download/upload
- [x] "From Image" button — verify palette extracted from image
- [x] Build passes: `pnpm --filter @gseurat/bricklayer build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)