### PR TITLE
Bricklayer UI polish, save reliability, and engine export

### DIFF
--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -1,6 +1,7 @@
 import JSZip from 'jszip';
 import { useSceneStore } from '../store/useSceneStore.js';
 import { exportSceneJson } from './sceneExport.js';
+import { exportPly } from './plyExport.js';
 import type { BricklayerFile } from '../store/types.js';
 
 /**
@@ -31,17 +32,42 @@ export async function saveProject(handle: FileSystemDirectoryHandle): Promise<vo
   const data = store.saveProject();
   const json = JSON.stringify(data, null, 2);
 
+  // Write bricklayer project file
   const fileHandle = await handle.getFileHandle('scene.bricklayer', { create: true });
   const writable = await fileHandle.createWritable();
   await writable.write(json);
   await writable.close();
+
+  // Write engine scene.json
+  const sceneJson = JSON.stringify(exportSceneJson(store), null, 2);
+  const sceneHandle = await handle.getFileHandle(`${store.projectName || 'scene'}.json`, { create: true });
+  const sw = await sceneHandle.createWritable();
+  await sw.write(sceneJson);
+  await sw.close();
+
+  // Write terrain PLY to assets/maps/
+  if (store.voxels.size > 0) {
+    const assetsDir = await handle.getDirectoryHandle('assets', { create: true });
+    const mapsDir = await assetsDir.getDirectoryHandle('maps', { create: true });
+    const plyBlob = exportPly(store.voxels, store.gridWidth, store.gridDepth);
+    const plyHandle = await mapsDir.getFileHandle(`${store.projectName || 'map'}.ply`, { create: true });
+    const pw = await plyHandle.createWritable();
+    await pw.write(plyBlob);
+    await pw.close();
+  }
 
   // Write asset blobs to assets/ directory
   if (store.assetBlobs.size > 0) {
     const assetsDir = await handle.getDirectoryHandle('assets', { create: true });
     for (const [path, blob] of store.assetBlobs) {
       const name = path.startsWith('assets/') ? path.slice(7) : path;
-      const assetHandle = await assetsDir.getFileHandle(name, { create: true });
+      // Create subdirectories if needed (e.g., "props/house.ply")
+      const parts = name.split('/');
+      let dir = assetsDir;
+      for (let i = 0; i < parts.length - 1; i++) {
+        dir = await dir.getDirectoryHandle(parts[i], { create: true });
+      }
+      const assetHandle = await dir.getFileHandle(parts[parts.length - 1], { create: true });
       const w = await assetHandle.createWritable();
       await w.write(blob);
       await w.close();
@@ -103,12 +129,17 @@ export async function saveProjectAsZip(): Promise<Blob> {
 
   // Include the engine scene export
   const scene = exportSceneJson(store);
-  zip.file('scene.json', JSON.stringify(scene, null, 2));
+  zip.file(`${store.projectName || 'scene'}.json`, JSON.stringify(scene, null, 2));
+
+  // Include terrain PLY
+  if (store.voxels.size > 0) {
+    const plyBlob = exportPly(store.voxels, store.gridWidth, store.gridDepth);
+    zip.file(`assets/maps/${store.projectName || 'map'}.ply`, plyBlob);
+  }
 
   // Include all asset blobs (PLY files, textures, etc.)
   const assetsFolder = zip.folder('assets');
   for (const [path, blob] of store.assetBlobs) {
-    // path is "assets/filename.ply" — strip the "assets/" prefix
     const name = path.startsWith('assets/') ? path.slice(7) : path;
     assetsFolder!.file(name, blob);
   }

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -95,8 +95,10 @@ export function exportSceneJson(state: SceneStoreState): object {
     };
   }
 
+  // Terrain PLY path: assets/maps/<project_name>.ply
+  const terrainPly = `assets/maps/${state.projectName || 'map'}.ply`;
   scene.gaussian_splat = {
-    ply_file: 'map.ply',
+    ply_file: terrainPly,
     camera: state.gaussianSplat.camera,
     render_width: state.gaussianSplat.render_width,
     render_height: state.gaussianSplat.render_height,
@@ -106,15 +108,19 @@ export function exportSceneJson(state: SceneStoreState): object {
   };
 
   if (state.placedObjects.length > 0) {
-    scene.placed_objects = state.placedObjects.map((obj) => ({
-      id: obj.id,
-      ply_file: obj.ply_file,
-      position: obj.position,
-      rotation: obj.rotation,
-      scale: obj.scale,
-      is_static: obj.is_static,
-      ...(obj.character_manifest ? { character_manifest: obj.character_manifest } : {}),
-    }));
+    scene.placed_objects = state.placedObjects.map((obj) => {
+      // Ensure placed object PLY paths have assets/ prefix
+      const plyPath = obj.ply_file.startsWith('assets/') ? obj.ply_file : `assets/${obj.ply_file}`;
+      return {
+        id: obj.id,
+        ply_file: plyPath,
+        position: obj.position,
+        rotation: obj.rotation,
+        scale: obj.scale,
+        is_static: obj.is_static,
+        ...(obj.character_manifest ? { character_manifest: obj.character_manifest } : {}),
+      };
+    });
   }
 
   if (state.collisionGridData) {

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -271,14 +271,14 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
   const handleExportPly = () => {
     const s = useSceneStore.getState();
     const blob = exportPly(s.voxels, s.gridWidth, s.gridDepth);
-    download(blob, 'map.ply');
+    download(blob, `${s.projectName || 'map'}.ply`);
   };
 
   const handleExportScene = () => {
     const s = useSceneStore.getState();
     const scene = exportSceneJson(s);
     const json = JSON.stringify(scene, null, 2);
-    download(new Blob([json], { type: 'application/json' }), 'scene.json');
+    download(new Blob([json], { type: 'application/json' }), `${s.projectName || 'scene'}.json`);
   };
 
   const handleImportAsset = () => {


### PR DESCRIPTION
## Summary
**UI Polish:**
- Remove bottom panel in Scene/Settings modes
- Redesign navigation tree — icons, hover effects, active accent (inset box-shadow), indentation guides
- Icon-only tool buttons (32x32) with hover tooltip
- Brush size slider moved into Draw section
- 256-color default palette (HSL generated), 16-column grid
- Fixed 256-slot palettes with empty placeholders
- Sorted extracted palette colors by hue/lightness
- Extract up to 128 colors from images (was 24)
- Drag-to-scrub: thick blue bottom border indicator
- Default to Select tool on launch

**Save Reliability:**
- Dirty tracking with orange dot indicator in title bar
- Ctrl/Cmd+S keyboard shortcut
- Auto-save every 60s when project directory set
- beforeunload warning for unsaved changes
- Error feedback on save failure

**Fixes:**
- Drag-to-scrub no longer triggers on hover without click
- Y-level lock: ground plane moves to locked height, visible grid shown
- X-ray mode (T key): voxels go transparent + click-through for selecting objects behind them
- New entities spawn at camera target instead of (0,0,0)

**Engine Export:**
- scene.json now references terrain PLY as `assets/maps/<project>.ply`
- Placed objects get `assets/` prefix
- Project save auto-exports engine-ready scene.json + terrain PLY
- Both FSAPI and zip saves include all engine files

## Test plan
- [ ] Scene/Settings: nothing below ProjectTree
- [ ] Tree: icons, hover, active accent visible
- [ ] Tools: icon-only grid, tooltip on hover
- [ ] Palette: 256 colors, "From Image" extracts sorted colors
- [ ] Paint voxels → orange dot, Ctrl+S clears it
- [ ] Y-level lock: grid visible at locked height, Place works
- [ ] T key: voxels go transparent, can click objects behind
- [ ] Add light/NPC/object: spawns at camera center
- [ ] Save project → scene.json + assets/maps/name.ply exported
- [ ] Copy to engine assets/ → `./gseurat_demo --scene` loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)