### PR TITLE
Bricklayer viewport: orbit lock, Blender-style grab, height drag

### DIFF
--- a/assets/scenes/test_brickslayer.json
+++ b/assets/scenes/test_brickslayer.json
@@ -8,17 +8,31 @@
   "static_lights": [
     {
       "position": [
-        128,
-        20
+        44.2,
+        39.1
       ],
       "radius": 100,
-      "height": 10,
+      "height": 24.7,
       "color": [
-        0.2,
-        1.0,
-        0.3
+        0.984313725490196,
+        0.9568627450980393,
+        0.6352941176470588
       ],
-      "intensity": 10.0
+      "intensity": 5
+    },
+    {
+      "position": [
+        124.5,
+        -34
+      ],
+      "radius": 100,
+      "height": 2,
+      "color": [
+        0.6509803921568628,
+        0,
+        1
+      ],
+      "intensity": 10
     }
   ],
   "player_position": [
@@ -163,14 +177,14 @@
     "ply_file": "assets/maps/test_brickslayer.ply",
     "camera": {
       "position": [
-        0,
-        5,
-        10
+        128,
+        102.4,
+        192
       ],
       "target": [
+        128,
         0,
-        0,
-        0
+        64
       ],
       "fov": 45
     },

--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -112,21 +112,30 @@ function GrabOverlay() {
   const grabMode = useSceneStore((s) => s.grabMode);
   if (!grabMode) return null;
 
+  const handleConfirm = (e: React.PointerEvent) => {
+    if (e.button !== 0) return; // Only primary click
+    const store = useSceneStore.getState();
+    store.setGrabMode(false);
+    store.setGrabOriginalPosition(null);
+  };
+
   return (
-    <div style={{
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      zIndex: 10,
-      cursor: 'move',
-      display: 'flex',
-      alignItems: 'flex-end',
-      justifyContent: 'center',
-      paddingBottom: 12,
-      pointerEvents: 'none',
-    }}>
+    <div
+      onPointerDown={handleConfirm}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 10,
+        cursor: 'move',
+        display: 'flex',
+        alignItems: 'flex-end',
+        justifyContent: 'center',
+        paddingBottom: 12,
+      }}
+    >
       <div style={{
         background: 'rgba(0,0,0,0.7)',
         color: '#ffcc00',

--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Viewport, getOrbitControls } from './viewport/Viewport.js';
 import { MenuBar } from './panels/MenuBar.js';
 import { ImportDialog } from './panels/ImportDialog.js';
@@ -110,32 +110,42 @@ const toolKeys: Record<string, ToolType> = {
 
 function GrabOverlay() {
   const grabMode = useSceneStore((s) => s.grabMode);
+
+  // Window-level listener — immune to R3F pointer capture
+  useEffect(() => {
+    if (!grabMode) return;
+
+    const handleConfirm = (e: PointerEvent) => {
+      if (e.button !== 0) return; // Only primary click
+      const store = useSceneStore.getState();
+      store.setGrabMode(false);
+      store.setGrabOriginalPosition(null);
+    };
+
+    // Use capture phase to guarantee we get the event first
+    window.addEventListener('pointerdown', handleConfirm, { capture: true });
+    return () => {
+      window.removeEventListener('pointerdown', handleConfirm, { capture: true });
+    };
+  }, [grabMode]);
+
   if (!grabMode) return null;
 
-  const handleConfirm = (e: React.PointerEvent) => {
-    if (e.button !== 0) return; // Only primary click
-    const store = useSceneStore.getState();
-    store.setGrabMode(false);
-    store.setGrabOriginalPosition(null);
-  };
-
   return (
-    <div
-      onPointerDown={handleConfirm}
-      style={{
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        zIndex: 10,
-        cursor: 'move',
-        display: 'flex',
-        alignItems: 'flex-end',
-        justifyContent: 'center',
-        paddingBottom: 12,
-      }}
-    >
+    <div style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      zIndex: 10,
+      cursor: 'move',
+      display: 'flex',
+      alignItems: 'flex-end',
+      justifyContent: 'center',
+      paddingBottom: 12,
+      pointerEvents: 'none',
+    }}>
       <div style={{
         background: 'rgba(0,0,0,0.7)',
         color: '#ffcc00',

--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -135,7 +135,33 @@ function GrabOverlay() {
         fontSize: 12,
         pointerEvents: 'none',
       }}>
-        GRAB: Click to confirm, Esc to cancel
+        GRAB: Click to confirm, Esc to cancel, Shift = height
+      </div>
+    </div>
+  );
+}
+
+function OrbitLockIndicator() {
+  const orbitLocked = useSceneStore((s) => s.orbitLocked);
+  if (!orbitLocked) return null;
+
+  return (
+    <div style={{
+      position: 'absolute',
+      top: 8,
+      left: '50%',
+      transform: 'translateX(-50%)',
+      zIndex: 10,
+      pointerEvents: 'none',
+    }}>
+      <div style={{
+        background: 'rgba(0,0,0,0.7)',
+        color: '#88aaff',
+        padding: '3px 10px',
+        borderRadius: 4,
+        fontSize: 11,
+      }}>
+        ORBIT LOCKED
       </div>
     </div>
   );
@@ -354,6 +380,12 @@ export function App() {
         return;
       }
 
+      // Shift: lock orbit in terrain mode for drawing
+      if (e.key === 'Shift' && (store.mode === 'terrain' || store.activeNode?.kind === 'collision')) {
+        store.setOrbitLocked(true);
+        return;
+      }
+
       // H key: reset camera to home (default view)
       if (e.key.toLowerCase() === 'h' && !meta) {
         const controls = getOrbitControls();
@@ -370,8 +402,18 @@ export function App() {
       }
     };
 
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        useSceneStore.getState().setOrbitLocked(false);
+      }
+    };
+
     window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handler);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
   }, []);
 
   // Determine which contextual panel to show in left below ProjectTree
@@ -409,6 +451,7 @@ export function App() {
         <div style={styles.viewport}>
           <Viewport />
           <GrabOverlay />
+          <OrbitLockIndicator />
         </div>
 
         <ResizeHandle side="right" onDrag={handleRightDrag} />

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -160,6 +160,9 @@ export interface SceneStoreState {
   grabMode: boolean;
   grabOriginalPosition: [number, number, number] | null;
 
+  // Orbit lock (Shift-held drawing lock)
+  orbitLocked: boolean;
+
   // Color palettes
   colorPalettes: ColorPalette[];
   activePaletteIndex: number;
@@ -289,6 +292,7 @@ export interface SceneStoreState {
   // Actions – grab
   setGrabMode: (v: boolean) => void;
   setGrabOriginalPosition: (pos: [number, number, number] | null) => void;
+  setOrbitLocked: (v: boolean) => void;
 
   // Actions – palettes
   addPalette: (name: string) => void;
@@ -394,6 +398,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
 
   grabMode: false,
   grabOriginalPosition: null,
+  orbitLocked: false,
 
   colorPalettes: [defaultPalette],
   activePaletteIndex: 0,
@@ -867,6 +872,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   // ── Grab actions ──
   setGrabMode: (v) => set({ grabMode: v }),
   setGrabOriginalPosition: (pos) => set({ grabOriginalPosition: pos }),
+  setOrbitLocked: (v) => set({ orbitLocked: v }),
 
   // ── Palette actions ──
   addPalette: (name) => {

--- a/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
+++ b/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { useThree } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
@@ -20,32 +20,57 @@ function DraggableLight({ id, position, height, radius, color, isSelected, onSel
   const { camera, gl } = useThree();
   const [dragging, setDragging] = useState(false);
   const [dragPos, setDragPos] = useState<[number, number] | null>(null);
+  const [dragHeight, setDragHeight] = useState<number | null>(null);
+  const [heightMode, setHeightMode] = useState(false);
+  const lastClientY = useRef(0);
+  const currentHeight = useRef(0);
+  const currentXZ = useRef<[number, number]>([0, 0]);
 
   const displayPos = dragPos ?? position;
+  const displayHeight = dragHeight ?? height;
   const colorStr = `rgb(${Math.round(color[0] * 255)},${Math.round(color[1] * 255)},${Math.round(color[2] * 255)})`;
 
   const handlePointerDown = useCallback((e: any) => {
     e.stopPropagation();
     onSelect();
 
-    if (useSceneStore.getState().mode !== 'scene') return;
+    const storeState = useSceneStore.getState();
+    if (storeState.mode !== 'scene') return;
+    if (storeState.grabMode) return; // Grab plane handles movement
 
     const el = gl.domElement;
+    currentHeight.current = height;
+    currentXZ.current = [...position];
+    lastClientY.current = e.clientY;
     _plane.set(new THREE.Vector3(0, 1, 0), -height);
     setDragging(true);
+    setHeightMode(false);
 
     const onMove = (ev: PointerEvent) => {
-      const rect = el.getBoundingClientRect();
-      const pointer = new THREE.Vector2(
-        ((ev.clientX - rect.left) / rect.width) * 2 - 1,
-        -((ev.clientY - rect.top) / rect.height) * 2 + 1,
-      );
-      _raycaster.setFromCamera(pointer, camera);
-      if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
-        setDragPos([
-          Math.round(_intersection.x * 10) / 10,
-          Math.round(_intersection.z * 10) / 10,
-        ]);
+      if (ev.shiftKey) {
+        // Shift held: vertical mouse movement adjusts height
+        setHeightMode(true);
+        const deltaY = (lastClientY.current - ev.clientY) * 0.05;
+        lastClientY.current = ev.clientY;
+        currentHeight.current = Math.round((currentHeight.current + deltaY) * 10) / 10;
+        setDragHeight(currentHeight.current);
+      } else {
+        // Normal XZ plane drag
+        setHeightMode(false);
+        lastClientY.current = ev.clientY;
+        const rect = el.getBoundingClientRect();
+        const pointer = new THREE.Vector2(
+          ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+          -((ev.clientY - rect.top) / rect.height) * 2 + 1,
+        );
+        _plane.set(new THREE.Vector3(0, 1, 0), -currentHeight.current);
+        _raycaster.setFromCamera(pointer, camera);
+        if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
+          const sx = Math.round(_intersection.x * 10) / 10;
+          const sz = Math.round(_intersection.z * 10) / 10;
+          currentXZ.current = [sx, sz];
+          setDragPos([sx, sz]);
+        }
       }
     };
 
@@ -53,12 +78,13 @@ function DraggableLight({ id, position, height, radius, color, isSelected, onSel
       el.removeEventListener('pointermove', onMove);
       el.removeEventListener('pointerup', onUp);
       setDragging(false);
-      const snapped: [number, number] = [
-        Math.round(_intersection.x * 10) / 10,
-        Math.round(_intersection.z * 10) / 10,
-      ];
-      useSceneStore.getState().updateLight(id, { position: snapped });
+      setHeightMode(false);
+      useSceneStore.getState().updateLight(id, {
+        position: currentXZ.current,
+        height: currentHeight.current,
+      });
       setDragPos(null);
+      setDragHeight(null);
     };
 
     el.addEventListener('pointermove', onMove);
@@ -66,7 +92,7 @@ function DraggableLight({ id, position, height, radius, color, isSelected, onSel
   }, [id, position, height, camera, gl, onSelect]);
 
   return (
-    <group position={[displayPos[0], height, displayPos[1]]}>
+    <group position={[displayPos[0], displayHeight, displayPos[1]]}>
       {/* Invisible hit box for pointer events */}
       <mesh onPointerDown={handlePointerDown}>
         <sphereGeometry args={[0.5, 8, 8]} />
@@ -85,10 +111,10 @@ function DraggableLight({ id, position, height, radius, color, isSelected, onSel
       {dragging && (
         <Html position={[0, 1.5, 0]} center>
           <div style={{
-            background: 'rgba(0,0,0,0.8)', color: '#ffcc00',
+            background: 'rgba(0,0,0,0.8)', color: heightMode ? '#88aaff' : '#ffcc00',
             padding: '2px 6px', borderRadius: 4, fontSize: 11, whiteSpace: 'nowrap',
           }}>
-            {displayPos[0].toFixed(1)}, {displayPos[1].toFixed(1)}
+            {displayPos[0].toFixed(1)}, {displayPos[1].toFixed(1)}{heightMode ? ` H:${displayHeight.toFixed(1)}` : ''}
           </div>
         </Html>
       )}

--- a/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
+++ b/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
@@ -1,15 +1,7 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
-import { Html } from '@react-three/drei';
+import React from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 
-const _plane = new THREE.Plane();
-const _raycaster = new THREE.Raycaster();
-const _intersection = new THREE.Vector3();
-
-function DraggableLight({ id, position, height, radius, color, isSelected, onSelect }: {
-  id: string;
+function LightMarker({ position, height, radius, color, isSelected, onSelect }: {
   position: [number, number];
   height: number;
   radius: number;
@@ -17,118 +9,25 @@ function DraggableLight({ id, position, height, radius, color, isSelected, onSel
   isSelected: boolean;
   onSelect: () => void;
 }) {
-  const { camera, gl } = useThree();
-  const [dragging, setDragging] = useState(false);
-  const [dragPos, setDragPos] = useState<[number, number] | null>(null);
-  const [dragHeight, setDragHeight] = useState<number | null>(null);
-  const [heightMode, setHeightMode] = useState(false);
-  const lastClientY = useRef(0);
-  const currentHeight = useRef(0);
-  const currentXZ = useRef<[number, number]>([0, 0]);
-
-  const grabMode = useSceneStore((s) => s.grabMode);
-
-  // Clear local drag state when grab mode activates
-  useEffect(() => {
-    if (grabMode) {
-      setDragging(false);
-      setDragPos(null);
-      setDragHeight(null);
-    }
-  }, [grabMode]);
-
-  const displayPos = dragPos ?? position;
-  const displayHeight = dragHeight ?? height;
   const colorStr = `rgb(${Math.round(color[0] * 255)},${Math.round(color[1] * 255)},${Math.round(color[2] * 255)})`;
 
-  const handlePointerDown = useCallback((e: any) => {
-    e.stopPropagation();
-    onSelect();
-
-    const storeState = useSceneStore.getState();
-    if (storeState.mode !== 'scene') return;
-    if (storeState.grabMode) return; // Grab plane handles movement
-
-    const el = gl.domElement;
-    currentHeight.current = height;
-    currentXZ.current = [...position];
-    lastClientY.current = e.clientY;
-    _plane.set(new THREE.Vector3(0, 1, 0), -height);
-    setDragging(true);
-    setHeightMode(false);
-
-    const onMove = (ev: PointerEvent) => {
-      if (ev.shiftKey) {
-        // Shift held: vertical mouse movement adjusts height
-        setHeightMode(true);
-        const deltaY = (lastClientY.current - ev.clientY) * 0.05;
-        lastClientY.current = ev.clientY;
-        currentHeight.current = Math.round((currentHeight.current + deltaY) * 10) / 10;
-        setDragHeight(currentHeight.current);
-      } else {
-        // Normal XZ plane drag
-        setHeightMode(false);
-        lastClientY.current = ev.clientY;
-        const rect = el.getBoundingClientRect();
-        const pointer = new THREE.Vector2(
-          ((ev.clientX - rect.left) / rect.width) * 2 - 1,
-          -((ev.clientY - rect.top) / rect.height) * 2 + 1,
-        );
-        _plane.set(new THREE.Vector3(0, 1, 0), -currentHeight.current);
-        _raycaster.setFromCamera(pointer, camera);
-        if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
-          const sx = Math.round(_intersection.x * 10) / 10;
-          const sz = Math.round(_intersection.z * 10) / 10;
-          currentXZ.current = [sx, sz];
-          setDragPos([sx, sz]);
-        }
-      }
-    };
-
-    const onUp = () => {
-      el.removeEventListener('pointermove', onMove);
-      el.removeEventListener('pointerup', onUp);
-      setDragging(false);
-      setHeightMode(false);
-      useSceneStore.getState().updateLight(id, {
-        position: currentXZ.current,
-        height: currentHeight.current,
-      });
-      setDragPos(null);
-      setDragHeight(null);
-    };
-
-    el.addEventListener('pointermove', onMove);
-    el.addEventListener('pointerup', onUp);
-  }, [id, position, height, camera, gl, onSelect]);
-
   return (
-    <group position={[displayPos[0], displayHeight, displayPos[1]]}>
+    <group position={[position[0], height, position[1]]}>
       {/* Invisible hit box for pointer events */}
-      <mesh onPointerDown={handlePointerDown}>
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
         <sphereGeometry args={[0.5, 8, 8]} />
         <meshBasicMaterial visible={false} />
       </mesh>
       {/* Visible sphere */}
       <mesh>
         <sphereGeometry args={[0.3, 8, 8]} />
-        <meshBasicMaterial color={dragging ? '#ffcc00' : isSelected ? '#ffffff' : colorStr} />
+        <meshBasicMaterial color={isSelected ? '#ffffff' : colorStr} />
       </mesh>
       {/* Radius ring */}
       <mesh rotation={[-Math.PI / 2, 0, 0]}>
         <ringGeometry args={[radius - 0.05, radius + 0.05, 32]} />
         <meshBasicMaterial color={colorStr} transparent opacity={0.5} side={2} />
       </mesh>
-      {dragging && (
-        <Html position={[0, 1.5, 0]} center>
-          <div style={{
-            background: 'rgba(0,0,0,0.8)', color: heightMode ? '#88aaff' : '#ffcc00',
-            padding: '2px 6px', borderRadius: 4, fontSize: 11, whiteSpace: 'nowrap',
-          }}>
-            {displayPos[0].toFixed(1)}, {displayPos[1].toFixed(1)}{heightMode ? ` H:${displayHeight.toFixed(1)}` : ''}
-          </div>
-        </Html>
-      )}
     </group>
   );
 }
@@ -144,9 +43,8 @@ export function LightGizmos() {
   return (
     <group>
       {lights.map((light) => (
-        <DraggableLight
+        <LightMarker
           key={light.id}
-          id={light.id}
           position={light.position}
           height={light.height}
           radius={light.radius}

--- a/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
+++ b/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { useThree } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
@@ -25,6 +25,17 @@ function DraggableLight({ id, position, height, radius, color, isSelected, onSel
   const lastClientY = useRef(0);
   const currentHeight = useRef(0);
   const currentXZ = useRef<[number, number]>([0, 0]);
+
+  const grabMode = useSceneStore((s) => s.grabMode);
+
+  // Clear local drag state when grab mode activates
+  useEffect(() => {
+    if (grabMode) {
+      setDragging(false);
+      setDragPos(null);
+      setDragHeight(null);
+    }
+  }, [grabMode]);
 
   const displayPos = dragPos ?? position;
   const displayHeight = dragHeight ?? height;

--- a/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
+++ b/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
@@ -15,17 +15,17 @@ function LightMarker({ position, height, radius, color, isSelected, onSelect }: 
     <group position={[position[0], height, position[1]]}>
       {/* Invisible hit box for pointer events */}
       <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
-        <sphereGeometry args={[0.5, 8, 8]} />
+        <sphereGeometry args={[1.0, 12, 12]} />
         <meshBasicMaterial visible={false} />
       </mesh>
       {/* Visible sphere */}
       <mesh>
-        <sphereGeometry args={[0.3, 8, 8]} />
+        <sphereGeometry args={[0.6, 12, 12]} />
         <meshBasicMaterial color={isSelected ? '#ffffff' : colorStr} />
       </mesh>
       {/* Radius ring */}
       <mesh rotation={[-Math.PI / 2, 0, 0]}>
-        <ringGeometry args={[radius - 0.05, radius + 0.05, 32]} />
+        <ringGeometry args={[radius - 0.1, radius + 0.1, 32]} />
         <meshBasicMaterial color={colorStr} transparent opacity={0.5} side={2} />
       </mesh>
     </group>

--- a/tools/apps/bricklayer/src/viewport/NpcMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/NpcMarkers.tsx
@@ -1,135 +1,39 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
-import { Html, Line } from '@react-three/drei';
+import React from 'react';
+import { Line } from '@react-three/drei';
 import { useSceneStore } from '../store/useSceneStore.js';
 
-const _plane = new THREE.Plane();
-const _raycaster = new THREE.Raycaster();
-const _intersection = new THREE.Vector3();
-
-function DraggableNpc({ id, position, isSelected, onSelect, waypoints }: {
+function NpcMarker({ id, position, isSelected, onSelect, waypoints }: {
   id: string;
   position: [number, number, number];
   isSelected: boolean;
   onSelect: () => void;
   waypoints: [number, number][];
 }) {
-  const { camera, gl } = useThree();
-  const [dragging, setDragging] = useState(false);
-  const [dragPos, setDragPos] = useState<[number, number, number] | null>(null);
-  const [heightMode, setHeightMode] = useState(false);
-  const lastClientY = useRef(0);
-  const currentY = useRef(0);
-  const currentXZ = useRef<[number, number]>([0, 0]);
-
-  const grabMode = useSceneStore((s) => s.grabMode);
-
-  useEffect(() => {
-    if (grabMode) {
-      setDragging(false);
-      setDragPos(null);
-      setHeightMode(false);
-    }
-  }, [grabMode]);
-
-  const displayPos = dragPos ?? position;
-
-  const handlePointerDown = useCallback((e: any) => {
-    e.stopPropagation();
-    onSelect();
-
-    const storeState = useSceneStore.getState();
-    if (storeState.mode !== 'scene') return;
-    if (storeState.grabMode) return; // Grab plane handles movement
-
-    const el = gl.domElement;
-    currentY.current = position[1];
-    currentXZ.current = [position[0], position[2]];
-    lastClientY.current = e.clientY;
-    _plane.set(new THREE.Vector3(0, 1, 0), -position[1]);
-    setDragging(true);
-    setHeightMode(false);
-
-    const onMove = (ev: PointerEvent) => {
-      if (ev.shiftKey) {
-        setHeightMode(true);
-        const deltaY = (lastClientY.current - ev.clientY) * 0.05;
-        lastClientY.current = ev.clientY;
-        currentY.current = Math.round((currentY.current + deltaY) * 10) / 10;
-        setDragPos([currentXZ.current[0], currentY.current, currentXZ.current[1]]);
-      } else {
-        setHeightMode(false);
-        lastClientY.current = ev.clientY;
-        const rect = el.getBoundingClientRect();
-        const pointer = new THREE.Vector2(
-          ((ev.clientX - rect.left) / rect.width) * 2 - 1,
-          -((ev.clientY - rect.top) / rect.height) * 2 + 1,
-        );
-        _plane.set(new THREE.Vector3(0, 1, 0), -currentY.current);
-        _raycaster.setFromCamera(pointer, camera);
-        if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
-          const sx = Math.round(_intersection.x * 10) / 10;
-          const sz = Math.round(_intersection.z * 10) / 10;
-          currentXZ.current = [sx, sz];
-          setDragPos([sx, currentY.current, sz]);
-        }
-      }
-    };
-
-    const onUp = () => {
-      el.removeEventListener('pointermove', onMove);
-      el.removeEventListener('pointerup', onUp);
-      setDragging(false);
-      setHeightMode(false);
-      const snapped: [number, number, number] = [
-        currentXZ.current[0],
-        currentY.current,
-        currentXZ.current[1],
-      ];
-      useSceneStore.getState().updateNpc(id, { position: snapped });
-      setDragPos(null);
-    };
-
-    el.addEventListener('pointermove', onMove);
-    el.addEventListener('pointerup', onUp);
-  }, [id, position, camera, gl, onSelect]);
-
   return (
     <group key={id}>
       {/* Invisible hit box */}
-      <mesh position={displayPos} onPointerDown={handlePointerDown}>
+      <mesh position={position} onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
         <cylinderGeometry args={[0.5, 0.5, 1.8, 8]} />
         <meshBasicMaterial visible={false} />
       </mesh>
       {/* Visible mesh */}
-      <mesh position={displayPos}>
+      <mesh position={position}>
         <cylinderGeometry args={[0.3, 0.3, 1.5, 8]} />
         <meshStandardMaterial
-          color={dragging ? '#ffcc00' : isSelected ? '#ffffff' : '#4fc3f7'}
+          color={isSelected ? '#ffffff' : '#4fc3f7'}
           transparent
-          opacity={dragging ? 0.9 : isSelected ? 0.8 : 0.7}
+          opacity={isSelected ? 0.8 : 0.7}
         />
       </mesh>
       {waypoints.length > 1 && (
         <Line
-          points={waypoints.map(([wx, wz]) => [wx, displayPos[1] + 0.1, wz] as [number, number, number])}
+          points={waypoints.map(([wx, wz]) => [wx, position[1] + 0.1, wz] as [number, number, number])}
           color="#4fc3f7"
           lineWidth={2}
           dashed
           dashSize={0.5}
           gapSize={0.3}
         />
-      )}
-      {dragging && (
-        <Html position={[displayPos[0], displayPos[1] + 1.5, displayPos[2]]} center>
-          <div style={{
-            background: 'rgba(0,0,0,0.8)', color: heightMode ? '#88aaff' : '#ffcc00',
-            padding: '2px 6px', borderRadius: 4, fontSize: 11, whiteSpace: 'nowrap',
-          }}>
-            {displayPos[0].toFixed(1)}, {heightMode ? `Y:${displayPos[1].toFixed(1)}` : displayPos[1].toFixed(1)}, {displayPos[2].toFixed(1)}
-          </div>
-        </Html>
       )}
     </group>
   );
@@ -146,7 +50,7 @@ export function NpcMarkers() {
   return (
     <group>
       {npcs.map((npc) => (
-        <DraggableNpc
+        <NpcMarker
           key={npc.id}
           id={npc.id}
           position={npc.position}

--- a/tools/apps/bricklayer/src/viewport/NpcMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/NpcMarkers.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { useThree } from '@react-three/fiber';
 import { Html, Line } from '@react-three/drei';
@@ -22,6 +22,16 @@ function DraggableNpc({ id, position, isSelected, onSelect, waypoints }: {
   const lastClientY = useRef(0);
   const currentY = useRef(0);
   const currentXZ = useRef<[number, number]>([0, 0]);
+
+  const grabMode = useSceneStore((s) => s.grabMode);
+
+  useEffect(() => {
+    if (grabMode) {
+      setDragging(false);
+      setDragPos(null);
+      setHeightMode(false);
+    }
+  }, [grabMode]);
 
   const displayPos = dragPos ?? position;
 

--- a/tools/apps/bricklayer/src/viewport/NpcMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/NpcMarkers.tsx
@@ -13,12 +13,12 @@ function NpcMarker({ id, position, isSelected, onSelect, waypoints }: {
     <group key={id}>
       {/* Invisible hit box */}
       <mesh position={position} onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
-        <cylinderGeometry args={[0.5, 0.5, 1.8, 8]} />
+        <cylinderGeometry args={[1.0, 1.0, 2.5, 12]} />
         <meshBasicMaterial visible={false} />
       </mesh>
       {/* Visible mesh */}
       <mesh position={position}>
-        <cylinderGeometry args={[0.3, 0.3, 1.5, 8]} />
+        <cylinderGeometry args={[0.6, 0.6, 2.0, 12]} />
         <meshStandardMaterial
           color={isSelected ? '#ffffff' : '#4fc3f7'}
           transparent
@@ -29,7 +29,7 @@ function NpcMarker({ id, position, isSelected, onSelect, waypoints }: {
         <Line
           points={waypoints.map(([wx, wz]) => [wx, position[1] + 0.1, wz] as [number, number, number])}
           color="#4fc3f7"
-          lineWidth={2}
+          lineWidth={4}
           dashed
           dashSize={0.5}
           gapSize={0.3}

--- a/tools/apps/bricklayer/src/viewport/NpcMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/NpcMarkers.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { useThree } from '@react-three/fiber';
 import { Html, Line } from '@react-three/drei';
@@ -18,6 +18,10 @@ function DraggableNpc({ id, position, isSelected, onSelect, waypoints }: {
   const { camera, gl } = useThree();
   const [dragging, setDragging] = useState(false);
   const [dragPos, setDragPos] = useState<[number, number, number] | null>(null);
+  const [heightMode, setHeightMode] = useState(false);
+  const lastClientY = useRef(0);
+  const currentY = useRef(0);
+  const currentXZ = useRef<[number, number]>([0, 0]);
 
   const displayPos = dragPos ?? position;
 
@@ -25,25 +29,41 @@ function DraggableNpc({ id, position, isSelected, onSelect, waypoints }: {
     e.stopPropagation();
     onSelect();
 
-    if (useSceneStore.getState().mode !== 'scene') return;
+    const storeState = useSceneStore.getState();
+    if (storeState.mode !== 'scene') return;
+    if (storeState.grabMode) return; // Grab plane handles movement
 
     const el = gl.domElement;
+    currentY.current = position[1];
+    currentXZ.current = [position[0], position[2]];
+    lastClientY.current = e.clientY;
     _plane.set(new THREE.Vector3(0, 1, 0), -position[1]);
     setDragging(true);
+    setHeightMode(false);
 
     const onMove = (ev: PointerEvent) => {
-      const rect = el.getBoundingClientRect();
-      const pointer = new THREE.Vector2(
-        ((ev.clientX - rect.left) / rect.width) * 2 - 1,
-        -((ev.clientY - rect.top) / rect.height) * 2 + 1,
-      );
-      _raycaster.setFromCamera(pointer, camera);
-      if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
-        setDragPos([
-          Math.round(_intersection.x * 10) / 10,
-          position[1],
-          Math.round(_intersection.z * 10) / 10,
-        ]);
+      if (ev.shiftKey) {
+        setHeightMode(true);
+        const deltaY = (lastClientY.current - ev.clientY) * 0.05;
+        lastClientY.current = ev.clientY;
+        currentY.current = Math.round((currentY.current + deltaY) * 10) / 10;
+        setDragPos([currentXZ.current[0], currentY.current, currentXZ.current[1]]);
+      } else {
+        setHeightMode(false);
+        lastClientY.current = ev.clientY;
+        const rect = el.getBoundingClientRect();
+        const pointer = new THREE.Vector2(
+          ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+          -((ev.clientY - rect.top) / rect.height) * 2 + 1,
+        );
+        _plane.set(new THREE.Vector3(0, 1, 0), -currentY.current);
+        _raycaster.setFromCamera(pointer, camera);
+        if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
+          const sx = Math.round(_intersection.x * 10) / 10;
+          const sz = Math.round(_intersection.z * 10) / 10;
+          currentXZ.current = [sx, sz];
+          setDragPos([sx, currentY.current, sz]);
+        }
       }
     };
 
@@ -51,10 +71,11 @@ function DraggableNpc({ id, position, isSelected, onSelect, waypoints }: {
       el.removeEventListener('pointermove', onMove);
       el.removeEventListener('pointerup', onUp);
       setDragging(false);
+      setHeightMode(false);
       const snapped: [number, number, number] = [
-        Math.round(_intersection.x * 10) / 10,
-        position[1],
-        Math.round(_intersection.z * 10) / 10,
+        currentXZ.current[0],
+        currentY.current,
+        currentXZ.current[1],
       ];
       useSceneStore.getState().updateNpc(id, { position: snapped });
       setDragPos(null);
@@ -93,10 +114,10 @@ function DraggableNpc({ id, position, isSelected, onSelect, waypoints }: {
       {dragging && (
         <Html position={[displayPos[0], displayPos[1] + 1.5, displayPos[2]]} center>
           <div style={{
-            background: 'rgba(0,0,0,0.8)', color: '#ffcc00',
+            background: 'rgba(0,0,0,0.8)', color: heightMode ? '#88aaff' : '#ffcc00',
             padding: '2px 6px', borderRadius: 4, fontSize: 11, whiteSpace: 'nowrap',
           }}>
-            {displayPos[0].toFixed(1)}, {displayPos[1].toFixed(1)}, {displayPos[2].toFixed(1)}
+            {displayPos[0].toFixed(1)}, {heightMode ? `Y:${displayPos[1].toFixed(1)}` : displayPos[1].toFixed(1)}, {displayPos[2].toFixed(1)}
           </div>
         </Html>
       )}

--- a/tools/apps/bricklayer/src/viewport/ObjectMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/ObjectMarkers.tsx
@@ -15,12 +15,12 @@ function Marker({ position, scale, color, isSelected, onSelect }: {
         position={position}
         onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}
       >
-        <boxGeometry args={[scale * 1.2, scale * 1.2, scale * 1.2]} />
+        <boxGeometry args={[scale * 1.5, scale * 1.5, scale * 1.5]} />
         <meshBasicMaterial visible={false} />
       </mesh>
       {/* Visible wireframe */}
       <mesh position={position}>
-        <boxGeometry args={[scale, scale, scale]} />
+        <boxGeometry args={[scale * 1.2, scale * 1.2, scale * 1.2]} />
         <meshBasicMaterial
           color={isSelected ? '#ffffff' : color}
           wireframe

--- a/tools/apps/bricklayer/src/viewport/ObjectMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/ObjectMarkers.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { useThree } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
@@ -23,6 +23,17 @@ function DraggableMarker({ id, position, scale, color, isSelected, onSelect }: {
   const lastClientY = useRef(0);
   const currentY = useRef(0);
   const currentXZ = useRef<[number, number]>([0, 0]);
+
+  const grabMode = useSceneStore((s) => s.grabMode);
+
+  // Clear local drag state when grab mode activates
+  useEffect(() => {
+    if (grabMode) {
+      setDragging(false);
+      setDragPos(null);
+      setHeightMode(false);
+    }
+  }, [grabMode]);
 
   const displayPos = dragPos ?? position;
 

--- a/tools/apps/bricklayer/src/viewport/ObjectMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/ObjectMarkers.tsx
@@ -1,134 +1,33 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
-import { Html } from '@react-three/drei';
+import React from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 
-const _plane = new THREE.Plane();
-const _raycaster = new THREE.Raycaster();
-const _intersection = new THREE.Vector3();
-
-function DraggableMarker({ id, position, scale, color, isSelected, onSelect }: {
-  id: string;
+function Marker({ position, scale, color, isSelected, onSelect }: {
   position: [number, number, number];
   scale: number;
   color: string;
   isSelected: boolean;
   onSelect: () => void;
 }) {
-  const { camera, gl } = useThree();
-  const [dragging, setDragging] = useState(false);
-  const [dragPos, setDragPos] = useState<[number, number, number] | null>(null);
-  const [heightMode, setHeightMode] = useState(false);
-  const lastClientY = useRef(0);
-  const currentY = useRef(0);
-  const currentXZ = useRef<[number, number]>([0, 0]);
-
-  const grabMode = useSceneStore((s) => s.grabMode);
-
-  // Clear local drag state when grab mode activates
-  useEffect(() => {
-    if (grabMode) {
-      setDragging(false);
-      setDragPos(null);
-      setHeightMode(false);
-    }
-  }, [grabMode]);
-
-  const displayPos = dragPos ?? position;
-
-  const handlePointerDown = useCallback((e: any) => {
-    e.stopPropagation();
-    onSelect();
-
-    const storeState = useSceneStore.getState();
-    if (storeState.mode !== 'scene') return;
-    if (storeState.grabMode) return; // Grab plane handles movement
-
-    const el = gl.domElement;
-    currentY.current = position[1];
-    currentXZ.current = [position[0], position[2]];
-    lastClientY.current = e.clientY;
-    _plane.set(new THREE.Vector3(0, 1, 0), -position[1]);
-    setDragging(true);
-    setHeightMode(false);
-
-    const onMove = (ev: PointerEvent) => {
-      if (ev.shiftKey) {
-        // Shift held: vertical mouse movement adjusts Y
-        setHeightMode(true);
-        const deltaY = (lastClientY.current - ev.clientY) * 0.05;
-        lastClientY.current = ev.clientY;
-        currentY.current = Math.round((currentY.current + deltaY) * 10) / 10;
-        setDragPos([currentXZ.current[0], currentY.current, currentXZ.current[1]]);
-      } else {
-        // Normal XZ plane drag
-        setHeightMode(false);
-        lastClientY.current = ev.clientY;
-        const rect = el.getBoundingClientRect();
-        const pointer = new THREE.Vector2(
-          ((ev.clientX - rect.left) / rect.width) * 2 - 1,
-          -((ev.clientY - rect.top) / rect.height) * 2 + 1,
-        );
-        _plane.set(new THREE.Vector3(0, 1, 0), -currentY.current);
-        _raycaster.setFromCamera(pointer, camera);
-        if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
-          const sx = Math.round(_intersection.x * 10) / 10;
-          const sz = Math.round(_intersection.z * 10) / 10;
-          currentXZ.current = [sx, sz];
-          setDragPos([sx, currentY.current, sz]);
-        }
-      }
-    };
-
-    const onUp = () => {
-      el.removeEventListener('pointermove', onMove);
-      el.removeEventListener('pointerup', onUp);
-      setDragging(false);
-      setHeightMode(false);
-      const snapped: [number, number, number] = [
-        currentXZ.current[0],
-        currentY.current,
-        currentXZ.current[1],
-      ];
-      useSceneStore.getState().updatePlacedObject(id, { position: snapped });
-      setDragPos(null);
-    };
-
-    el.addEventListener('pointermove', onMove);
-    el.addEventListener('pointerup', onUp);
-  }, [id, position, camera, gl, onSelect]);
-
   return (
     <>
-      {/* Invisible solid mesh for click/drag detection */}
+      {/* Invisible solid mesh for click detection */}
       <mesh
-        position={displayPos}
-        onPointerDown={handlePointerDown}
+        position={position}
+        onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}
       >
         <boxGeometry args={[scale * 1.2, scale * 1.2, scale * 1.2]} />
         <meshBasicMaterial visible={false} />
       </mesh>
       {/* Visible wireframe */}
-      <mesh position={displayPos}>
+      <mesh position={position}>
         <boxGeometry args={[scale, scale, scale]} />
         <meshBasicMaterial
-          color={dragging ? '#ffcc00' : isSelected ? '#ffffff' : color}
+          color={isSelected ? '#ffffff' : color}
           wireframe
           transparent
-          opacity={dragging ? 0.9 : isSelected ? 0.8 : 0.6}
+          opacity={isSelected ? 0.8 : 0.6}
         />
       </mesh>
-      {dragging && (
-        <Html position={[displayPos[0], displayPos[1] + scale + 0.5, displayPos[2]]} center>
-          <div style={{
-            background: 'rgba(0,0,0,0.8)', color: heightMode ? '#88aaff' : '#ffcc00',
-            padding: '2px 6px', borderRadius: 4, fontSize: 11, whiteSpace: 'nowrap',
-          }}>
-            {displayPos[0].toFixed(1)}, {heightMode ? `Y:${displayPos[1].toFixed(1)}` : displayPos[1].toFixed(1)}, {displayPos[2].toFixed(1)}
-          </div>
-        </Html>
-      )}
     </>
   );
 }
@@ -144,9 +43,8 @@ export function ObjectMarkers() {
   return (
     <group>
       {placedObjects.map((obj) => (
-        <DraggableMarker
+        <Marker
           key={obj.id}
-          id={obj.id}
           position={obj.position}
           scale={obj.scale}
           color={obj.is_static ? '#00bcd4' : '#ff9800'}

--- a/tools/apps/bricklayer/src/viewport/ObjectMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/ObjectMarkers.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { useThree } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
@@ -19,6 +19,10 @@ function DraggableMarker({ id, position, scale, color, isSelected, onSelect }: {
   const { camera, gl } = useThree();
   const [dragging, setDragging] = useState(false);
   const [dragPos, setDragPos] = useState<[number, number, number] | null>(null);
+  const [heightMode, setHeightMode] = useState(false);
+  const lastClientY = useRef(0);
+  const currentY = useRef(0);
+  const currentXZ = useRef<[number, number]>([0, 0]);
 
   const displayPos = dragPos ?? position;
 
@@ -26,25 +30,43 @@ function DraggableMarker({ id, position, scale, color, isSelected, onSelect }: {
     e.stopPropagation();
     onSelect();
 
-    if (useSceneStore.getState().mode !== 'scene') return;
+    const storeState = useSceneStore.getState();
+    if (storeState.mode !== 'scene') return;
+    if (storeState.grabMode) return; // Grab plane handles movement
 
     const el = gl.domElement;
+    currentY.current = position[1];
+    currentXZ.current = [position[0], position[2]];
+    lastClientY.current = e.clientY;
     _plane.set(new THREE.Vector3(0, 1, 0), -position[1]);
     setDragging(true);
+    setHeightMode(false);
 
     const onMove = (ev: PointerEvent) => {
-      const rect = el.getBoundingClientRect();
-      const pointer = new THREE.Vector2(
-        ((ev.clientX - rect.left) / rect.width) * 2 - 1,
-        -((ev.clientY - rect.top) / rect.height) * 2 + 1,
-      );
-      _raycaster.setFromCamera(pointer, camera);
-      if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
-        setDragPos([
-          Math.round(_intersection.x * 10) / 10,
-          position[1],
-          Math.round(_intersection.z * 10) / 10,
-        ]);
+      if (ev.shiftKey) {
+        // Shift held: vertical mouse movement adjusts Y
+        setHeightMode(true);
+        const deltaY = (lastClientY.current - ev.clientY) * 0.05;
+        lastClientY.current = ev.clientY;
+        currentY.current = Math.round((currentY.current + deltaY) * 10) / 10;
+        setDragPos([currentXZ.current[0], currentY.current, currentXZ.current[1]]);
+      } else {
+        // Normal XZ plane drag
+        setHeightMode(false);
+        lastClientY.current = ev.clientY;
+        const rect = el.getBoundingClientRect();
+        const pointer = new THREE.Vector2(
+          ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+          -((ev.clientY - rect.top) / rect.height) * 2 + 1,
+        );
+        _plane.set(new THREE.Vector3(0, 1, 0), -currentY.current);
+        _raycaster.setFromCamera(pointer, camera);
+        if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
+          const sx = Math.round(_intersection.x * 10) / 10;
+          const sz = Math.round(_intersection.z * 10) / 10;
+          currentXZ.current = [sx, sz];
+          setDragPos([sx, currentY.current, sz]);
+        }
       }
     };
 
@@ -52,10 +74,11 @@ function DraggableMarker({ id, position, scale, color, isSelected, onSelect }: {
       el.removeEventListener('pointermove', onMove);
       el.removeEventListener('pointerup', onUp);
       setDragging(false);
+      setHeightMode(false);
       const snapped: [number, number, number] = [
-        Math.round(_intersection.x * 10) / 10,
-        position[1],
-        Math.round(_intersection.z * 10) / 10,
+        currentXZ.current[0],
+        currentY.current,
+        currentXZ.current[1],
       ];
       useSceneStore.getState().updatePlacedObject(id, { position: snapped });
       setDragPos(null);
@@ -88,10 +111,10 @@ function DraggableMarker({ id, position, scale, color, isSelected, onSelect }: {
       {dragging && (
         <Html position={[displayPos[0], displayPos[1] + scale + 0.5, displayPos[2]]} center>
           <div style={{
-            background: 'rgba(0,0,0,0.8)', color: '#ffcc00',
+            background: 'rgba(0,0,0,0.8)', color: heightMode ? '#88aaff' : '#ffcc00',
             padding: '2px 6px', borderRadius: 4, fontSize: 11, whiteSpace: 'nowrap',
           }}>
-            {displayPos[0].toFixed(1)}, {displayPos[1].toFixed(1)}, {displayPos[2].toFixed(1)}
+            {displayPos[0].toFixed(1)}, {heightMode ? `Y:${displayPos[1].toFixed(1)}` : displayPos[1].toFixed(1)}, {displayPos[2].toFixed(1)}
           </div>
         </Html>
       )}

--- a/tools/apps/bricklayer/src/viewport/PlayerMarker.tsx
+++ b/tools/apps/bricklayer/src/viewport/PlayerMarker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { useThree } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
@@ -22,6 +22,16 @@ export function PlayerMarker() {
   const currentXZ = useRef<[number, number]>([0, 0]);
 
   const isSelected = selectedEntity?.type === 'player';
+  const grabMode = useSceneStore((s) => s.grabMode);
+
+  useEffect(() => {
+    if (grabMode) {
+      setDragging(false);
+      setDragPos(null);
+      setHeightMode(false);
+    }
+  }, [grabMode]);
+
   const displayPos = dragPos ?? player.position;
 
   const handlePointerDown = useCallback((e: any) => {

--- a/tools/apps/bricklayer/src/viewport/PlayerMarker.tsx
+++ b/tools/apps/bricklayer/src/viewport/PlayerMarker.tsx
@@ -1,105 +1,23 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
-import { Html } from '@react-three/drei';
+import React from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
-
-const _plane = new THREE.Plane();
-const _raycaster = new THREE.Raycaster();
-const _intersection = new THREE.Vector3();
 
 export function PlayerMarker() {
   const player = useSceneStore((s) => s.player);
   const showGizmos = useSceneStore((s) => s.showGizmos);
   const selectedEntity = useSceneStore((s) => s.selectedEntity);
   const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
-  const { camera, gl } = useThree();
-  const [dragging, setDragging] = useState(false);
-  const [dragPos, setDragPos] = useState<[number, number, number] | null>(null);
-  const [heightMode, setHeightMode] = useState(false);
-  const lastClientY = useRef(0);
-  const currentY = useRef(0);
-  const currentXZ = useRef<[number, number]>([0, 0]);
 
   const isSelected = selectedEntity?.type === 'player';
-  const grabMode = useSceneStore((s) => s.grabMode);
-
-  useEffect(() => {
-    if (grabMode) {
-      setDragging(false);
-      setDragPos(null);
-      setHeightMode(false);
-    }
-  }, [grabMode]);
-
-  const displayPos = dragPos ?? player.position;
-
-  const handlePointerDown = useCallback((e: any) => {
-    e.stopPropagation();
-    setSelectedEntity({ type: 'player', id: 'player' });
-
-    const storeState = useSceneStore.getState();
-    if (storeState.mode !== 'scene') return;
-    if (storeState.grabMode) return; // Grab plane handles movement
-
-    const el = gl.domElement;
-    currentY.current = player.position[1];
-    currentXZ.current = [player.position[0], player.position[2]];
-    lastClientY.current = e.clientY;
-    _plane.set(new THREE.Vector3(0, 1, 0), -player.position[1]);
-    setDragging(true);
-    setHeightMode(false);
-
-    const onMove = (ev: PointerEvent) => {
-      if (ev.shiftKey) {
-        setHeightMode(true);
-        const deltaY = (lastClientY.current - ev.clientY) * 0.05;
-        lastClientY.current = ev.clientY;
-        currentY.current = Math.round((currentY.current + deltaY) * 10) / 10;
-        setDragPos([currentXZ.current[0], currentY.current, currentXZ.current[1]]);
-      } else {
-        setHeightMode(false);
-        lastClientY.current = ev.clientY;
-        const rect = el.getBoundingClientRect();
-        const pointer = new THREE.Vector2(
-          ((ev.clientX - rect.left) / rect.width) * 2 - 1,
-          -((ev.clientY - rect.top) / rect.height) * 2 + 1,
-        );
-        _plane.set(new THREE.Vector3(0, 1, 0), -currentY.current);
-        _raycaster.setFromCamera(pointer, camera);
-        if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
-          const sx = Math.round(_intersection.x * 10) / 10;
-          const sz = Math.round(_intersection.z * 10) / 10;
-          currentXZ.current = [sx, sz];
-          setDragPos([sx, currentY.current, sz]);
-        }
-      }
-    };
-
-    const onUp = () => {
-      el.removeEventListener('pointermove', onMove);
-      el.removeEventListener('pointerup', onUp);
-      setDragging(false);
-      setHeightMode(false);
-      const snapped: [number, number, number] = [
-        currentXZ.current[0],
-        currentY.current,
-        currentXZ.current[1],
-      ];
-      useSceneStore.getState().updatePlayer({ position: snapped });
-      setDragPos(null);
-    };
-
-    el.addEventListener('pointermove', onMove);
-    el.addEventListener('pointerup', onUp);
-  }, [player.position, camera, gl, setSelectedEntity]);
 
   if (!showGizmos) return null;
 
   return (
-    <group position={displayPos}>
+    <group position={player.position}>
       {/* Invisible hit box */}
-      <mesh position={[0, 0.75, 0]} onPointerDown={handlePointerDown}>
+      <mesh
+        position={[0, 0.75, 0]}
+        onPointerDown={(e) => { e.stopPropagation(); setSelectedEntity({ type: 'player', id: 'player' }); }}
+      >
         <cylinderGeometry args={[0.5, 0.5, 2, 8]} />
         <meshBasicMaterial visible={false} />
       </mesh>
@@ -107,26 +25,16 @@ export function PlayerMarker() {
       <mesh position={[0, 0.75, 0]}>
         <cylinderGeometry args={[0.3, 0.3, 1.5, 8]} />
         <meshStandardMaterial
-          color={dragging ? '#ffcc00' : isSelected ? '#ffffff' : '#66bb6a'}
+          color={isSelected ? '#ffffff' : '#66bb6a'}
           transparent
-          opacity={dragging ? 0.9 : isSelected ? 0.8 : 0.7}
+          opacity={isSelected ? 0.8 : 0.7}
         />
       </mesh>
       {/* Direction arrow */}
       <mesh position={[0, 1.8, 0]} rotation={[Math.PI, 0, 0]}>
         <coneGeometry args={[0.25, 0.5, 8]} />
-        <meshStandardMaterial color={dragging ? '#ffcc00' : '#66bb6a'} />
+        <meshStandardMaterial color="#66bb6a" />
       </mesh>
-      {dragging && (
-        <Html position={[0, 2.5, 0]} center>
-          <div style={{
-            background: 'rgba(0,0,0,0.8)', color: heightMode ? '#88aaff' : '#ffcc00',
-            padding: '2px 6px', borderRadius: 4, fontSize: 11, whiteSpace: 'nowrap',
-          }}>
-            {displayPos[0].toFixed(1)}, {heightMode ? `Y:${displayPos[1].toFixed(1)}` : displayPos[1].toFixed(1)}, {displayPos[2].toFixed(1)}
-          </div>
-        </Html>
-      )}
     </group>
   );
 }

--- a/tools/apps/bricklayer/src/viewport/PlayerMarker.tsx
+++ b/tools/apps/bricklayer/src/viewport/PlayerMarker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { useThree } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
@@ -16,6 +16,10 @@ export function PlayerMarker() {
   const { camera, gl } = useThree();
   const [dragging, setDragging] = useState(false);
   const [dragPos, setDragPos] = useState<[number, number, number] | null>(null);
+  const [heightMode, setHeightMode] = useState(false);
+  const lastClientY = useRef(0);
+  const currentY = useRef(0);
+  const currentXZ = useRef<[number, number]>([0, 0]);
 
   const isSelected = selectedEntity?.type === 'player';
   const displayPos = dragPos ?? player.position;
@@ -24,25 +28,41 @@ export function PlayerMarker() {
     e.stopPropagation();
     setSelectedEntity({ type: 'player', id: 'player' });
 
-    if (useSceneStore.getState().mode !== 'scene') return;
+    const storeState = useSceneStore.getState();
+    if (storeState.mode !== 'scene') return;
+    if (storeState.grabMode) return; // Grab plane handles movement
 
     const el = gl.domElement;
+    currentY.current = player.position[1];
+    currentXZ.current = [player.position[0], player.position[2]];
+    lastClientY.current = e.clientY;
     _plane.set(new THREE.Vector3(0, 1, 0), -player.position[1]);
     setDragging(true);
+    setHeightMode(false);
 
     const onMove = (ev: PointerEvent) => {
-      const rect = el.getBoundingClientRect();
-      const pointer = new THREE.Vector2(
-        ((ev.clientX - rect.left) / rect.width) * 2 - 1,
-        -((ev.clientY - rect.top) / rect.height) * 2 + 1,
-      );
-      _raycaster.setFromCamera(pointer, camera);
-      if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
-        setDragPos([
-          Math.round(_intersection.x * 10) / 10,
-          player.position[1],
-          Math.round(_intersection.z * 10) / 10,
-        ]);
+      if (ev.shiftKey) {
+        setHeightMode(true);
+        const deltaY = (lastClientY.current - ev.clientY) * 0.05;
+        lastClientY.current = ev.clientY;
+        currentY.current = Math.round((currentY.current + deltaY) * 10) / 10;
+        setDragPos([currentXZ.current[0], currentY.current, currentXZ.current[1]]);
+      } else {
+        setHeightMode(false);
+        lastClientY.current = ev.clientY;
+        const rect = el.getBoundingClientRect();
+        const pointer = new THREE.Vector2(
+          ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+          -((ev.clientY - rect.top) / rect.height) * 2 + 1,
+        );
+        _plane.set(new THREE.Vector3(0, 1, 0), -currentY.current);
+        _raycaster.setFromCamera(pointer, camera);
+        if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
+          const sx = Math.round(_intersection.x * 10) / 10;
+          const sz = Math.round(_intersection.z * 10) / 10;
+          currentXZ.current = [sx, sz];
+          setDragPos([sx, currentY.current, sz]);
+        }
       }
     };
 
@@ -50,10 +70,11 @@ export function PlayerMarker() {
       el.removeEventListener('pointermove', onMove);
       el.removeEventListener('pointerup', onUp);
       setDragging(false);
+      setHeightMode(false);
       const snapped: [number, number, number] = [
-        Math.round(_intersection.x * 10) / 10,
-        player.position[1],
-        Math.round(_intersection.z * 10) / 10,
+        currentXZ.current[0],
+        currentY.current,
+        currentXZ.current[1],
       ];
       useSceneStore.getState().updatePlayer({ position: snapped });
       setDragPos(null);
@@ -89,10 +110,10 @@ export function PlayerMarker() {
       {dragging && (
         <Html position={[0, 2.5, 0]} center>
           <div style={{
-            background: 'rgba(0,0,0,0.8)', color: '#ffcc00',
+            background: 'rgba(0,0,0,0.8)', color: heightMode ? '#88aaff' : '#ffcc00',
             padding: '2px 6px', borderRadius: 4, fontSize: 11, whiteSpace: 'nowrap',
           }}>
-            {displayPos[0].toFixed(1)}, {displayPos[1].toFixed(1)}, {displayPos[2].toFixed(1)}
+            {displayPos[0].toFixed(1)}, {heightMode ? `Y:${displayPos[1].toFixed(1)}` : displayPos[1].toFixed(1)}, {displayPos[2].toFixed(1)}
           </div>
         </Html>
       )}

--- a/tools/apps/bricklayer/src/viewport/PlayerMarker.tsx
+++ b/tools/apps/bricklayer/src/viewport/PlayerMarker.tsx
@@ -15,15 +15,15 @@ export function PlayerMarker() {
     <group position={player.position}>
       {/* Invisible hit box */}
       <mesh
-        position={[0, 0.75, 0]}
+        position={[0, 1.0, 0]}
         onPointerDown={(e) => { e.stopPropagation(); setSelectedEntity({ type: 'player', id: 'player' }); }}
       >
-        <cylinderGeometry args={[0.5, 0.5, 2, 8]} />
+        <cylinderGeometry args={[1.0, 1.0, 2.8, 12]} />
         <meshBasicMaterial visible={false} />
       </mesh>
       {/* Visible cylinder */}
-      <mesh position={[0, 0.75, 0]}>
-        <cylinderGeometry args={[0.3, 0.3, 1.5, 8]} />
+      <mesh position={[0, 1.0, 0]}>
+        <cylinderGeometry args={[0.6, 0.6, 2.0, 12]} />
         <meshStandardMaterial
           color={isSelected ? '#ffffff' : '#66bb6a'}
           transparent
@@ -31,8 +31,8 @@ export function PlayerMarker() {
         />
       </mesh>
       {/* Direction arrow */}
-      <mesh position={[0, 1.8, 0]} rotation={[Math.PI, 0, 0]}>
-        <coneGeometry args={[0.25, 0.5, 8]} />
+      <mesh position={[0, 2.3, 0]} rotation={[Math.PI, 0, 0]}>
+        <coneGeometry args={[0.4, 0.7, 8]} />
         <meshStandardMaterial color="#66bb6a" />
       </mesh>
     </group>

--- a/tools/apps/bricklayer/src/viewport/PortalMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/PortalMarkers.tsx
@@ -14,12 +14,12 @@ function PortalMarker({ position, size, isSelected, onSelect }: {
         position={[position[0] + size[0] / 2, 1, position[1] + size[1] / 2]}
         onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}
       >
-        <boxGeometry args={[size[0] + 0.4, 2.4, size[1] + 0.4]} />
+        <boxGeometry args={[size[0] + 0.8, 3.0, size[1] + 0.8]} />
         <meshBasicMaterial visible={false} />
       </mesh>
       {/* Visible wireframe */}
       <mesh position={[position[0] + size[0] / 2, 1, position[1] + size[1] / 2]}>
-        <boxGeometry args={[size[0], 2, size[1]]} />
+        <boxGeometry args={[size[0] + 0.2, 2.4, size[1] + 0.2]} />
         <meshBasicMaterial
           color={isSelected ? '#ffffff' : '#ab47bc'}
           wireframe

--- a/tools/apps/bricklayer/src/viewport/PortalMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/PortalMarkers.tsx
@@ -1,101 +1,32 @@
-import React, { useCallback, useState } from 'react';
-import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
-import { Html } from '@react-three/drei';
+import React from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 
-const _plane = new THREE.Plane();
-const _raycaster = new THREE.Raycaster();
-const _intersection = new THREE.Vector3();
-
-function DraggablePortal({ id, position, size, isSelected, onSelect, targetScene }: {
-  id: string;
+function PortalMarker({ position, size, isSelected, onSelect }: {
   position: [number, number];
   size: [number, number];
   isSelected: boolean;
   onSelect: () => void;
-  targetScene: string;
 }) {
-  const { camera, gl } = useThree();
-  const [dragging, setDragging] = useState(false);
-  const [dragPos, setDragPos] = useState<[number, number] | null>(null);
-
-  const displayPos = dragPos ?? position;
-
-  const handlePointerDown = useCallback((e: any) => {
-    e.stopPropagation();
-    onSelect();
-
-    const storeState = useSceneStore.getState();
-    if (storeState.mode !== 'scene') return;
-    if (storeState.grabMode) return; // Grab plane handles movement
-
-    const el = gl.domElement;
-    _plane.set(new THREE.Vector3(0, 1, 0), -1);
-    setDragging(true);
-
-    const onMove = (ev: PointerEvent) => {
-      const rect = el.getBoundingClientRect();
-      const pointer = new THREE.Vector2(
-        ((ev.clientX - rect.left) / rect.width) * 2 - 1,
-        -((ev.clientY - rect.top) / rect.height) * 2 + 1,
-      );
-      _raycaster.setFromCamera(pointer, camera);
-      if (_raycaster.ray.intersectPlane(_plane, _intersection)) {
-        setDragPos([
-          Math.round(_intersection.x * 10) / 10,
-          Math.round(_intersection.z * 10) / 10,
-        ]);
-      }
-    };
-
-    const onUp = () => {
-      el.removeEventListener('pointermove', onMove);
-      el.removeEventListener('pointerup', onUp);
-      setDragging(false);
-      const snapped: [number, number] = [
-        Math.round(_intersection.x * 10) / 10,
-        Math.round(_intersection.z * 10) / 10,
-      ];
-      useSceneStore.getState().updatePortal(id, { position: snapped });
-      setDragPos(null);
-    };
-
-    el.addEventListener('pointermove', onMove);
-    el.addEventListener('pointerup', onUp);
-  }, [id, position, camera, gl, onSelect]);
-
   return (
     <>
       {/* Invisible hit box */}
       <mesh
-        position={[displayPos[0] + size[0] / 2, 1, displayPos[1] + size[1] / 2]}
-        onPointerDown={handlePointerDown}
+        position={[position[0] + size[0] / 2, 1, position[1] + size[1] / 2]}
+        onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}
       >
         <boxGeometry args={[size[0] + 0.4, 2.4, size[1] + 0.4]} />
         <meshBasicMaterial visible={false} />
       </mesh>
       {/* Visible wireframe */}
-      <mesh position={[displayPos[0] + size[0] / 2, 1, displayPos[1] + size[1] / 2]}>
+      <mesh position={[position[0] + size[0] / 2, 1, position[1] + size[1] / 2]}>
         <boxGeometry args={[size[0], 2, size[1]]} />
         <meshBasicMaterial
-          color={dragging ? '#ffcc00' : isSelected ? '#ffffff' : '#ab47bc'}
+          color={isSelected ? '#ffffff' : '#ab47bc'}
           wireframe
           transparent
-          opacity={dragging ? 0.9 : isSelected ? 0.8 : 0.6}
+          opacity={isSelected ? 0.8 : 0.6}
         />
       </mesh>
-      {dragging && (
-        <Html position={[displayPos[0] + size[0] / 2, 3, displayPos[1] + size[1] / 2]} center>
-          <div style={{
-            background: 'rgba(0,0,0,0.8)', color: '#ffcc00',
-            padding: '2px 6px', borderRadius: 4, fontSize: 11, whiteSpace: 'nowrap',
-          }}>
-            {displayPos[0].toFixed(1)}, {displayPos[1].toFixed(1)}
-            {targetScene ? ` → ${targetScene}` : ''}
-          </div>
-        </Html>
-      )}
     </>
   );
 }
@@ -111,14 +42,12 @@ export function PortalMarkers() {
   return (
     <group>
       {portals.map((portal) => (
-        <DraggablePortal
+        <PortalMarker
           key={portal.id}
-          id={portal.id}
           position={portal.position}
           size={portal.size}
           isSelected={selectedEntity?.type === 'portal' && selectedEntity.id === portal.id}
           onSelect={() => setSelectedEntity({ type: 'portal', id: portal.id })}
-          targetScene={portal.target_scene}
         />
       ))}
     </group>

--- a/tools/apps/bricklayer/src/viewport/PortalMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/PortalMarkers.tsx
@@ -26,7 +26,9 @@ function DraggablePortal({ id, position, size, isSelected, onSelect, targetScene
     e.stopPropagation();
     onSelect();
 
-    if (useSceneStore.getState().mode !== 'scene') return;
+    const storeState = useSceneStore.getState();
+    if (storeState.mode !== 'scene') return;
+    if (storeState.grabMode) return; // Grab plane handles movement
 
     const el = gl.domElement;
     _plane.set(new THREE.Vector3(0, 1, 0), -1);

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -1,6 +1,6 @@
-import React, { useRef, useCallback } from 'react';
-import { Canvas, useThree } from '@react-three/fiber';
-import { OrbitControls, Grid } from '@react-three/drei';
+import React, { useRef, useCallback, useEffect, useState } from 'react';
+import { Canvas, useThree, ThreeEvent } from '@react-three/fiber';
+import { OrbitControls, Grid, Html } from '@react-three/drei';
 import * as THREE from 'three';
 import { VoxelMesh } from './VoxelMesh.js';
 import { GroundPlane } from './GroundPlane.js';
@@ -64,11 +64,196 @@ function TeleportPlane() {
   );
 }
 
+/**
+ * Helper: get the 3D position and Y height of the currently grabbed entity.
+ */
+function getGrabbedEntityY(): number {
+  const store = useSceneStore.getState();
+  const sel = store.selectedEntity;
+  if (!sel) return 0;
+
+  if (sel.type === 'object') {
+    const obj = store.placedObjects.find((o) => o.id === sel.id);
+    return obj?.position[1] ?? 0;
+  }
+  if (sel.type === 'npc') {
+    const npc = store.npcs.find((n) => n.id === sel.id);
+    return npc?.position[1] ?? 0;
+  }
+  if (sel.type === 'light') {
+    const light = store.staticLights.find((l) => l.id === sel.id);
+    return light?.height ?? 0;
+  }
+  if (sel.type === 'player') {
+    return store.player.position[1];
+  }
+  // portal: always Y=0
+  return 0;
+}
+
+/**
+ * Updates the grabbed entity's position in the store.
+ */
+function updateGrabbedEntity(x: number, y: number, z: number) {
+  const store = useSceneStore.getState();
+  const sel = store.selectedEntity;
+  if (!sel) return;
+
+  if (sel.type === 'object') {
+    store.updatePlacedObject(sel.id, { position: [x, y, z] });
+  } else if (sel.type === 'npc') {
+    store.updateNpc(sel.id, { position: [x, y, z] });
+  } else if (sel.type === 'light') {
+    store.updateLight(sel.id, { position: [x, z], height: y });
+  } else if (sel.type === 'portal') {
+    store.updatePortal(sel.id, { position: [x, z] });
+  } else if (sel.type === 'player') {
+    store.updatePlayer({ position: [x, y, z] });
+  }
+}
+
+/**
+ * Blender-style grab plane: object follows mouse on XZ plane.
+ * Hold Shift to adjust Y height via vertical mouse movement.
+ * Click to confirm, Esc to cancel (handled in App.tsx).
+ */
+function GrabPlane() {
+  const grabMode = useSceneStore((s) => s.grabMode);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const { camera, gl } = useThree();
+  const [shiftHeld, setShiftHeld] = useState(false);
+  const lastClientY = useRef(0);
+  const currentY = useRef(0);
+  const labelPos = useRef<[number, number, number]>([0, 0, 0]);
+  const [labelText, setLabelText] = useState('');
+
+  // Track Shift key
+  useEffect(() => {
+    if (!grabMode) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') setShiftHeld(true);
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') setShiftHeld(false);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+  }, [grabMode]);
+
+  // Initialize currentY when grab starts
+  useEffect(() => {
+    if (grabMode) {
+      currentY.current = getGrabbedEntityY();
+    }
+  }, [grabMode]);
+
+  // Pointer tracking via DOM events for smooth grab
+  useEffect(() => {
+    if (!grabMode || !selectedEntity) return;
+
+    const el = gl.domElement;
+    const plane = new THREE.Plane();
+    const raycaster = new THREE.Raycaster();
+    const intersection = new THREE.Vector3();
+
+    const onMove = (ev: PointerEvent) => {
+      if (shiftHeld) {
+        // Shift mode: vertical mouse movement adjusts Y
+        const deltaY = (lastClientY.current - ev.clientY) * 0.05;
+        lastClientY.current = ev.clientY;
+        currentY.current = Math.round((currentY.current + deltaY) * 10) / 10;
+
+        // Get current XZ from entity
+        const store = useSceneStore.getState();
+        const sel = store.selectedEntity;
+        if (!sel) return;
+
+        let cx = 0, cz = 0;
+        if (sel.type === 'object') {
+          const obj = store.placedObjects.find((o) => o.id === sel.id);
+          if (obj) { cx = obj.position[0]; cz = obj.position[2]; }
+        } else if (sel.type === 'npc') {
+          const npc = store.npcs.find((n) => n.id === sel.id);
+          if (npc) { cx = npc.position[0]; cz = npc.position[2]; }
+        } else if (sel.type === 'light') {
+          const light = store.staticLights.find((l) => l.id === sel.id);
+          if (light) { cx = light.position[0]; cz = light.position[1]; }
+        } else if (sel.type === 'portal') {
+          const portal = store.portals.find((p) => p.id === sel.id);
+          if (portal) { cx = portal.position[0]; cz = portal.position[1]; }
+        } else if (sel.type === 'player') {
+          cx = store.player.position[0]; cz = store.player.position[2];
+        }
+
+        updateGrabbedEntity(cx, currentY.current, cz);
+        labelPos.current = [cx, currentY.current + 1.5, cz];
+        setLabelText(`${cx.toFixed(1)}, Y:${currentY.current.toFixed(1)}, ${cz.toFixed(1)}`);
+      } else {
+        // Normal mode: XZ plane follow
+        lastClientY.current = ev.clientY;
+        const rect = el.getBoundingClientRect();
+        const pointer = new THREE.Vector2(
+          ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+          -((ev.clientY - rect.top) / rect.height) * 2 + 1,
+        );
+        plane.set(new THREE.Vector3(0, 1, 0), -currentY.current);
+        raycaster.setFromCamera(pointer, camera);
+        if (raycaster.ray.intersectPlane(plane, intersection)) {
+          const sx = Math.round(intersection.x * 10) / 10;
+          const sz = Math.round(intersection.z * 10) / 10;
+          updateGrabbedEntity(sx, currentY.current, sz);
+          labelPos.current = [sx, currentY.current + 1.5, sz];
+          setLabelText(`${sx.toFixed(1)}, ${currentY.current.toFixed(1)}, ${sz.toFixed(1)}`);
+        }
+      }
+    };
+
+    const onClick = () => {
+      // Confirm grab — position is already committed
+      const store = useSceneStore.getState();
+      store.setGrabMode(false);
+      store.setGrabOriginalPosition(null);
+      setLabelText('');
+    };
+
+    el.addEventListener('pointermove', onMove);
+    el.addEventListener('click', onClick);
+    return () => {
+      el.removeEventListener('pointermove', onMove);
+      el.removeEventListener('click', onClick);
+    };
+  }, [grabMode, selectedEntity, shiftHeld, camera, gl]);
+
+  if (!grabMode || !labelText) return null;
+
+  return (
+    <Html position={labelPos.current} center>
+      <div style={{
+        background: 'rgba(0,0,0,0.8)',
+        color: shiftHeld ? '#88aaff' : '#ffcc00',
+        padding: '2px 6px',
+        borderRadius: 4,
+        fontSize: 11,
+        whiteSpace: 'nowrap',
+        pointerEvents: 'none',
+      }}>
+        {labelText}
+      </div>
+    </Html>
+  );
+}
+
 function SceneContent() {
   const gridWidth = useSceneStore((s) => s.gridWidth);
   const gridDepth = useSceneStore((s) => s.gridDepth);
   const showGrid = useSceneStore((s) => s.showGrid);
   const grabMode = useSceneStore((s) => s.grabMode);
+  const orbitLocked = useSceneStore((s) => s.orbitLocked);
   const controlsRef = useRef<OrbitControlsRef | null>(null);
 
   return (
@@ -102,13 +287,14 @@ function SceneContent() {
       <PlayerMarker />
       <CollisionOverlay />
       <TeleportPlane />
+      <GrabPlane />
 
       <OrbitControls
         ref={(r: OrbitControlsRef | null) => {
           controlsRef.current = r;
           orbitControlsRef = r;
         }}
-        enabled={!grabMode}
+        enabled={!grabMode && !orbitLocked}
         target={[gridWidth / 2, 0, gridDepth / 2]}
         makeDefault
         screenSpacePanning

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -146,10 +146,12 @@ function GrabPlane() {
     };
   }, [grabMode]);
 
-  // Initialize currentY when grab starts
+  // Initialize currentY when grab starts, clear label when grab ends
   useEffect(() => {
     if (grabMode) {
       currentY.current = getGrabbedEntityY();
+    } else {
+      setLabelText('');
     }
   }, [grabMode]);
 

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -213,7 +213,9 @@ function GrabPlane() {
       }
     };
 
-    const onClick = () => {
+    const onConfirm = (ev: PointerEvent) => {
+      // Only confirm on left button
+      if (ev.button !== 0) return;
       // Confirm grab — position is already committed
       const store = useSceneStore.getState();
       store.setGrabMode(false);
@@ -222,10 +224,11 @@ function GrabPlane() {
     };
 
     el.addEventListener('pointermove', onMove);
-    el.addEventListener('click', onClick);
+    // Use pointerdown instead of click — click doesn't fire when mouse moved
+    el.addEventListener('pointerdown', onConfirm);
     return () => {
       el.removeEventListener('pointermove', onMove);
-      el.removeEventListener('click', onClick);
+      el.removeEventListener('pointerdown', onConfirm);
     };
   }, [grabMode, selectedEntity, shiftHeld, camera, gl]);
 

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -35,6 +35,7 @@ function TeleportPlane() {
 
   const handleDoubleClick = useCallback(() => {
     if (!planeRef.current || !orbitControlsRef) return;
+    if (useSceneStore.getState().orbitLocked || useSceneStore.getState().grabMode) return;
 
     raycaster.setFromCamera(pointer, camera);
 

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -153,7 +153,8 @@ function GrabPlane() {
     }
   }, [grabMode]);
 
-  // Pointer tracking via DOM events for smooth grab
+  // Pointer tracking via window events for smooth grab
+  // Uses window so the overlay div doesn't block pointermove
   useEffect(() => {
     if (!grabMode || !selectedEntity) return;
 
@@ -214,22 +215,9 @@ function GrabPlane() {
       }
     };
 
-    const onConfirm = (ev: PointerEvent) => {
-      // Only confirm on left button
-      if (ev.button !== 0) return;
-      // Confirm grab — position is already committed
-      const store = useSceneStore.getState();
-      store.setGrabMode(false);
-      store.setGrabOriginalPosition(null);
-      setLabelText('');
-    };
-
-    el.addEventListener('pointermove', onMove);
-    // Use pointerdown instead of click — click doesn't fire when mouse moved
-    el.addEventListener('pointerdown', onConfirm);
+    window.addEventListener('pointermove', onMove);
     return () => {
-      el.removeEventListener('pointermove', onMove);
-      el.removeEventListener('pointerdown', onConfirm);
+      window.removeEventListener('pointermove', onMove);
     };
   }, [grabMode, selectedEntity, shiftHeld, camera, gl]);
 

--- a/tools/tests/package.json
+++ b/tools/tests/package.json
@@ -21,7 +21,8 @@
     "test:normal-map": "node --import tsx/esm --conditions source src/normal-map.test.ts",
     "test:pose-templates": "node --import tsx/esm --conditions source src/pose-templates.test.ts",
     "test:echidna-ply-export": "node --import tsx/esm --conditions source src/echidna-ply-export.test.ts",
-    "test:bricklayer-store": "node --import tsx/esm --conditions source src/bricklayer-store.test.ts"
+    "test:bricklayer-store": "node --import tsx/esm --conditions source src/bricklayer-store.test.ts",
+    "test:bricklayer-grab": "node --import tsx/esm --conditions source src/bricklayer-grab.test.ts"
   },
   "dependencies": {
     "@gseurat/test-harness": "workspace:*",

--- a/tools/tests/src/bricklayer-grab.test.ts
+++ b/tools/tests/src/bricklayer-grab.test.ts
@@ -1,0 +1,655 @@
+/**
+ * Unit tests for Bricklayer grab-mode logic.
+ *
+ * Verifies the state machine: enter grab → move → confirm/cancel,
+ * including Shift-height mode and entity position updates.
+ *
+ * Run: pnpm test:bricklayer-grab
+ */
+
+// ── Types (inlined to avoid React/Three.js imports) ──
+
+type EntityType = 'object' | 'light' | 'npc' | 'portal' | 'player';
+
+interface SelectedEntity {
+  type: EntityType;
+  id: string;
+}
+
+interface PlacedObject {
+  id: string;
+  position: [number, number, number];
+}
+
+interface StaticLight {
+  id: string;
+  position: [number, number]; // [x, z]
+  height: number;
+}
+
+interface NpcData {
+  id: string;
+  position: [number, number, number];
+}
+
+interface PortalData {
+  id: string;
+  position: [number, number]; // [x, z]
+}
+
+interface PlayerData {
+  position: [number, number, number];
+}
+
+// ── Minimal grab-mode state machine (mirrors store + GrabPlane logic) ──
+
+interface GrabState {
+  grabMode: boolean;
+  grabOriginalPosition: [number, number, number] | null;
+  selectedEntity: SelectedEntity | null;
+  placedObjects: PlacedObject[];
+  staticLights: StaticLight[];
+  npcs: NpcData[];
+  portals: PortalData[];
+  player: PlayerData;
+  orbitLocked: boolean;
+}
+
+function createInitialState(): GrabState {
+  return {
+    grabMode: false,
+    grabOriginalPosition: null,
+    selectedEntity: null,
+    placedObjects: [
+      { id: 'obj1', position: [10, 5, 20] },
+      { id: 'obj2', position: [30, 0, 40] },
+    ],
+    staticLights: [
+      { id: 'light1', position: [15, 25], height: 8 },
+    ],
+    npcs: [
+      { id: 'npc1', position: [50, 2, 60] },
+    ],
+    portals: [
+      { id: 'portal1', position: [70, 80] },
+    ],
+    player: { position: [0, 1, 0] },
+    orbitLocked: false,
+  };
+}
+
+// ── Actions (mirror store actions) ──
+
+function selectEntity(state: GrabState, entity: SelectedEntity): GrabState {
+  return { ...state, selectedEntity: entity };
+}
+
+/** Enter grab mode — saves original position. Returns null if no entity selected. */
+function enterGrab(state: GrabState): GrabState | null {
+  const sel = state.selectedEntity;
+  if (!sel) return null;
+
+  let pos: [number, number, number] | null = null;
+  if (sel.type === 'object') {
+    const obj = state.placedObjects.find((o) => o.id === sel.id);
+    if (obj) pos = [...obj.position];
+  } else if (sel.type === 'light') {
+    const light = state.staticLights.find((l) => l.id === sel.id);
+    if (light) pos = [light.position[0], light.height, light.position[1]];
+  } else if (sel.type === 'npc') {
+    const npc = state.npcs.find((n) => n.id === sel.id);
+    if (npc) pos = [...npc.position];
+  } else if (sel.type === 'portal') {
+    const portal = state.portals.find((p) => p.id === sel.id);
+    if (portal) pos = [portal.position[0], 0, portal.position[1]];
+  } else if (sel.type === 'player') {
+    pos = [...state.player.position];
+  }
+
+  if (!pos) return null;
+  return { ...state, grabMode: true, grabOriginalPosition: pos };
+}
+
+/** Update grabbed entity position (mirrors GrabPlane pointermove). */
+function updateGrabbedEntity(state: GrabState, x: number, y: number, z: number): GrabState {
+  const sel = state.selectedEntity;
+  if (!sel) return state;
+
+  if (sel.type === 'object') {
+    return {
+      ...state,
+      placedObjects: state.placedObjects.map((o) =>
+        o.id === sel.id ? { ...o, position: [x, y, z] as [number, number, number] } : o,
+      ),
+    };
+  }
+  if (sel.type === 'light') {
+    return {
+      ...state,
+      staticLights: state.staticLights.map((l) =>
+        l.id === sel.id ? { ...l, position: [x, z] as [number, number], height: y } : l,
+      ),
+    };
+  }
+  if (sel.type === 'npc') {
+    return {
+      ...state,
+      npcs: state.npcs.map((n) =>
+        n.id === sel.id ? { ...n, position: [x, y, z] as [number, number, number] } : n,
+      ),
+    };
+  }
+  if (sel.type === 'portal') {
+    return {
+      ...state,
+      portals: state.portals.map((p) =>
+        p.id === sel.id ? { ...p, position: [x, z] as [number, number] } : p,
+      ),
+    };
+  }
+  if (sel.type === 'player') {
+    return { ...state, player: { position: [x, y, z] } };
+  }
+  return state;
+}
+
+/** Confirm grab — clears grab mode, keeps new position. */
+function confirmGrab(state: GrabState): GrabState {
+  return { ...state, grabMode: false, grabOriginalPosition: null };
+}
+
+/** Cancel grab — restores original position. */
+function cancelGrab(state: GrabState): GrabState {
+  if (!state.grabOriginalPosition || !state.selectedEntity) {
+    return { ...state, grabMode: false, grabOriginalPosition: null };
+  }
+  const pos = state.grabOriginalPosition;
+  const restored = updateGrabbedEntity(state, pos[0], pos[1], pos[2]);
+  return { ...restored, grabMode: false, grabOriginalPosition: null };
+}
+
+/** Simulate XZ move during grab (non-shift). Snaps to 0.1. */
+function grabMoveXZ(state: GrabState, rawX: number, rawZ: number): GrabState {
+  if (!state.grabMode || !state.selectedEntity) return state;
+  const x = Math.round(rawX * 10) / 10;
+  const z = Math.round(rawZ * 10) / 10;
+  // Y stays at the grabbed entity's current Y
+  const currentY = getEntityY(state);
+  return updateGrabbedEntity(state, x, currentY, z);
+}
+
+/** Simulate Shift-height move during grab. */
+function grabMoveY(state: GrabState, deltaPixels: number): GrabState {
+  if (!state.grabMode || !state.selectedEntity) return state;
+  const currentY = getEntityY(state);
+  const newY = Math.round((currentY + deltaPixels * 0.05) * 10) / 10;
+  const sel = state.selectedEntity;
+
+  // Get current XZ
+  let cx = 0, cz = 0;
+  if (sel.type === 'object') {
+    const obj = state.placedObjects.find((o) => o.id === sel.id);
+    if (obj) { cx = obj.position[0]; cz = obj.position[2]; }
+  } else if (sel.type === 'light') {
+    const light = state.staticLights.find((l) => l.id === sel.id);
+    if (light) { cx = light.position[0]; cz = light.position[1]; }
+  } else if (sel.type === 'npc') {
+    const npc = state.npcs.find((n) => n.id === sel.id);
+    if (npc) { cx = npc.position[0]; cz = npc.position[2]; }
+  } else if (sel.type === 'portal') {
+    const portal = state.portals.find((p) => p.id === sel.id);
+    if (portal) { cx = portal.position[0]; cz = portal.position[1]; }
+  } else if (sel.type === 'player') {
+    cx = state.player.position[0]; cz = state.player.position[2];
+  }
+
+  return updateGrabbedEntity(state, cx, newY, cz);
+}
+
+function getEntityY(state: GrabState): number {
+  const sel = state.selectedEntity;
+  if (!sel) return 0;
+  if (sel.type === 'object') {
+    const obj = state.placedObjects.find((o) => o.id === sel.id);
+    return obj?.position[1] ?? 0;
+  }
+  if (sel.type === 'light') {
+    const light = state.staticLights.find((l) => l.id === sel.id);
+    return light?.height ?? 0;
+  }
+  if (sel.type === 'npc') {
+    const npc = state.npcs.find((n) => n.id === sel.id);
+    return npc?.position[1] ?? 0;
+  }
+  if (sel.type === 'player') return state.player.position[1];
+  return 0;
+}
+
+/** Simulate the full grab flow as event sequence. */
+type GrabEvent =
+  | { type: 'select'; entity: SelectedEntity }
+  | { type: 'press_g' }
+  | { type: 'move_xz'; x: number; z: number }
+  | { type: 'move_y'; deltaPixels: number }
+  | { type: 'confirm' }   // pointerdown / click
+  | { type: 'cancel' };   // Escape key
+
+function applyGrabEvent(state: GrabState, event: GrabEvent): GrabState {
+  switch (event.type) {
+    case 'select':
+      return selectEntity(state, event.entity);
+    case 'press_g': {
+      const result = enterGrab(state);
+      return result ?? state;
+    }
+    case 'move_xz':
+      return grabMoveXZ(state, event.x, event.z);
+    case 'move_y':
+      return grabMoveY(state, event.deltaPixels);
+    case 'confirm':
+      return confirmGrab(state);
+    case 'cancel':
+      return cancelGrab(state);
+  }
+}
+
+function applyEvents(state: GrabState, events: GrabEvent[]): GrabState {
+  return events.reduce(applyGrabEvent, state);
+}
+
+// ── Test runner ──
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, message: string) {
+  if (!condition) {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  } else {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  }
+}
+
+function assertPos(actual: [number, number, number], expected: [number, number, number], label: string) {
+  const match = actual[0] === expected[0] && actual[1] === expected[1] && actual[2] === expected[2];
+  if (!match) {
+    console.error(`  FAIL: ${label} — expected [${expected}], got [${actual}]`);
+    failed++;
+  } else {
+    console.log(`  PASS: ${label}`);
+    passed++;
+  }
+}
+
+// ── Tests ──
+
+console.log('\n=== Bricklayer Grab Mode Tests ===\n');
+
+// ═══════════════════════════════════════════════════════════════
+// 1. Basic grab lifecycle
+// ═══════════════════════════════════════════════════════════════
+
+console.log('--- 1. Basic grab lifecycle ---\n');
+
+{
+  console.log('Test 1.1: Cannot enter grab without selected entity');
+  const state = createInitialState();
+  const result = enterGrab(state);
+  assert(result === null, 'enterGrab returns null when nothing selected');
+}
+
+{
+  console.log('Test 1.2: Enter grab saves original position');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  assert(state.grabMode === true, 'grabMode is true');
+  assertPos(state.grabOriginalPosition!, [10, 5, 20], 'original position saved');
+}
+
+{
+  console.log('Test 1.3: Confirm grab clears grab state');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  state = confirmGrab(state);
+  assert(state.grabMode === false, 'grabMode is false after confirm');
+  assert(state.grabOriginalPosition === null, 'grabOriginalPosition cleared');
+}
+
+{
+  console.log('Test 1.4: Cancel grab restores original position');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  // Move to new position
+  state = updateGrabbedEntity(state, 99, 5, 88);
+  assertPos(state.placedObjects[0].position, [99, 5, 88], 'moved to new position');
+  // Cancel
+  state = cancelGrab(state);
+  assert(state.grabMode === false, 'grabMode is false after cancel');
+  assertPos(state.placedObjects[0].position, [10, 5, 20], 'position restored to original');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 2. XZ movement
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- 2. XZ movement ---\n');
+
+{
+  console.log('Test 2.1: XZ move preserves Y');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  state = grabMoveXZ(state, 50.123, 60.789);
+  const obj = state.placedObjects[0];
+  assert(obj.position[0] === 50.1, `X snapped to 50.1 (got ${obj.position[0]})`);
+  assert(obj.position[1] === 5, `Y unchanged at 5 (got ${obj.position[1]})`);
+  assert(obj.position[2] === 60.8, `Z snapped to 60.8 (got ${obj.position[2]})`);
+}
+
+{
+  console.log('Test 2.2: XZ move does nothing outside grab mode');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  // Not in grab mode
+  state = grabMoveXZ(state, 99, 99);
+  assertPos(state.placedObjects[0].position, [10, 5, 20], 'position unchanged');
+}
+
+{
+  console.log('Test 2.3: Multiple XZ moves, only last position kept');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  state = grabMoveXZ(state, 1, 1);
+  state = grabMoveXZ(state, 2, 2);
+  state = grabMoveXZ(state, 30, 40);
+  assertPos(state.placedObjects[0].position, [30, 5, 40], 'last move wins');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 3. Shift-height (Y) adjustment
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- 3. Shift-height (Y) adjustment ---\n');
+
+{
+  console.log('Test 3.1: Y adjustment preserves XZ');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' }); // pos [10, 5, 20]
+  state = enterGrab(state)!;
+  // Move up 20 pixels → +1.0 units
+  state = grabMoveY(state, 20);
+  const obj = state.placedObjects[0];
+  assert(obj.position[0] === 10, `X unchanged (got ${obj.position[0]})`);
+  assert(obj.position[1] === 6, `Y moved to 6 (got ${obj.position[1]})`);
+  assert(obj.position[2] === 20, `Z unchanged (got ${obj.position[2]})`);
+}
+
+{
+  console.log('Test 3.2: Y moves accumulate');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' }); // Y=5
+  state = enterGrab(state)!;
+  state = grabMoveY(state, 20);  // Y = 5 + 1.0 = 6.0
+  state = grabMoveY(state, -40); // Y = 6.0 - 2.0 = 4.0
+  assert(state.placedObjects[0].position[1] === 4, `Y is 4 (got ${state.placedObjects[0].position[1]})`);
+}
+
+{
+  console.log('Test 3.3: Mixed XZ and Y moves');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' }); // [10, 5, 20]
+  state = enterGrab(state)!;
+  state = grabMoveXZ(state, 50, 60);   // [50, 5, 60]
+  state = grabMoveY(state, 40);         // [50, 7, 60]
+  state = grabMoveXZ(state, 70, 80);   // [70, 7, 80] - Y preserved from height mode
+  assertPos(state.placedObjects[0].position, [70, 7, 80], 'XZ updated, Y preserved from height move');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 4. Full event sequence
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- 4. Full event sequence ---\n');
+
+{
+  console.log('Test 4.1: Select → G → move → confirm');
+  const state = applyEvents(createInitialState(), [
+    { type: 'select', entity: { type: 'object', id: 'obj1' } },
+    { type: 'press_g' },
+    { type: 'move_xz', x: 100, z: 200 },
+    { type: 'confirm' },
+  ]);
+  assert(state.grabMode === false, 'grab ended');
+  assertPos(state.placedObjects[0].position, [100, 5, 200], 'object at new position');
+}
+
+{
+  console.log('Test 4.2: Select → G → move → cancel');
+  const state = applyEvents(createInitialState(), [
+    { type: 'select', entity: { type: 'object', id: 'obj1' } },
+    { type: 'press_g' },
+    { type: 'move_xz', x: 100, z: 200 },
+    { type: 'cancel' },
+  ]);
+  assert(state.grabMode === false, 'grab ended');
+  assertPos(state.placedObjects[0].position, [10, 5, 20], 'object at original position');
+}
+
+{
+  console.log('Test 4.3: Select → G → height adjust → confirm');
+  const state = applyEvents(createInitialState(), [
+    { type: 'select', entity: { type: 'object', id: 'obj1' } },
+    { type: 'press_g' },
+    { type: 'move_y', deltaPixels: 100 }, // +5.0 units
+    { type: 'confirm' },
+  ]);
+  assert(state.grabMode === false, 'grab ended');
+  assertPos(state.placedObjects[0].position, [10, 10, 20], 'Y raised by 5');
+}
+
+{
+  console.log('Test 4.4: Select → G → height adjust → cancel restores Y');
+  const state = applyEvents(createInitialState(), [
+    { type: 'select', entity: { type: 'object', id: 'obj1' } },
+    { type: 'press_g' },
+    { type: 'move_y', deltaPixels: 100 },
+    { type: 'cancel' },
+  ]);
+  assertPos(state.placedObjects[0].position, [10, 5, 20], 'Y restored');
+}
+
+{
+  console.log('Test 4.5: G without selection does nothing');
+  const state = applyEvents(createInitialState(), [
+    { type: 'press_g' },
+  ]);
+  assert(state.grabMode === false, 'still not in grab mode');
+}
+
+{
+  console.log('Test 4.6: Confirm without grab does nothing harmful');
+  const state = applyEvents(createInitialState(), [
+    { type: 'confirm' },
+  ]);
+  assert(state.grabMode === false, 'no crash, grabMode stays false');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 5. Different entity types
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- 5. Different entity types ---\n');
+
+{
+  console.log('Test 5.1: Grab light — stores [x, height, z] as original');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'light', id: 'light1' }); // pos [15, 25], height 8
+  state = enterGrab(state)!;
+  assertPos(state.grabOriginalPosition!, [15, 8, 25], 'original = [x, height, z]');
+}
+
+{
+  console.log('Test 5.2: Move light updates position and height');
+  const state = applyEvents(createInitialState(), [
+    { type: 'select', entity: { type: 'light', id: 'light1' } },
+    { type: 'press_g' },
+    { type: 'move_xz', x: 50, z: 60 },
+    { type: 'confirm' },
+  ]);
+  const light = state.staticLights[0];
+  assert(light.position[0] === 50, `light X = 50 (got ${light.position[0]})`);
+  assert(light.position[1] === 60, `light Z = 60 (got ${light.position[1]})`);
+  assert(light.height === 8, `light height unchanged at 8 (got ${light.height})`);
+}
+
+{
+  console.log('Test 5.3: Shift-height adjusts light height');
+  const state = applyEvents(createInitialState(), [
+    { type: 'select', entity: { type: 'light', id: 'light1' } },
+    { type: 'press_g' },
+    { type: 'move_y', deltaPixels: 40 }, // +2.0 units
+    { type: 'confirm' },
+  ]);
+  const light = state.staticLights[0];
+  assert(light.height === 10, `light height = 10 (got ${light.height})`);
+  assert(light.position[0] === 15, `light X unchanged (got ${light.position[0]})`);
+}
+
+{
+  console.log('Test 5.4: Cancel light grab restores position and height');
+  const state = applyEvents(createInitialState(), [
+    { type: 'select', entity: { type: 'light', id: 'light1' } },
+    { type: 'press_g' },
+    { type: 'move_xz', x: 99, z: 99 },
+    { type: 'move_y', deltaPixels: 200 },
+    { type: 'cancel' },
+  ]);
+  const light = state.staticLights[0];
+  assert(light.position[0] === 15, `X restored (got ${light.position[0]})`);
+  assert(light.position[1] === 25, `Z restored (got ${light.position[1]})`);
+  assert(light.height === 8, `height restored (got ${light.height})`);
+}
+
+{
+  console.log('Test 5.5: Grab NPC');
+  const state = applyEvents(createInitialState(), [
+    { type: 'select', entity: { type: 'npc', id: 'npc1' } },
+    { type: 'press_g' },
+    { type: 'move_xz', x: 10, z: 20 },
+    { type: 'confirm' },
+  ]);
+  assertPos(state.npcs[0].position, [10, 2, 20], 'NPC moved, Y preserved');
+}
+
+{
+  console.log('Test 5.6: Grab portal (Y always 0)');
+  const state = applyEvents(createInitialState(), [
+    { type: 'select', entity: { type: 'portal', id: 'portal1' } },
+    { type: 'press_g' },
+    { type: 'move_xz', x: 5, z: 10 },
+    { type: 'confirm' },
+  ]);
+  assert(state.portals[0].position[0] === 5, `portal X (got ${state.portals[0].position[0]})`);
+  assert(state.portals[0].position[1] === 10, `portal Z (got ${state.portals[0].position[1]})`);
+}
+
+{
+  console.log('Test 5.7: Grab player');
+  const state = applyEvents(createInitialState(), [
+    { type: 'select', entity: { type: 'player', id: 'player' } },
+    { type: 'press_g' },
+    { type: 'move_xz', x: 25, z: 35 },
+    { type: 'move_y', deltaPixels: 60 }, // +3.0 units, Y was 1 → 4
+    { type: 'confirm' },
+  ]);
+  assertPos(state.player.position, [25, 4, 35], 'player at new position with height');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 6. Edge cases
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- 6. Edge cases ---\n');
+
+{
+  console.log('Test 6.1: Double-G does not re-enter (already in grab)');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  // Move
+  state = grabMoveXZ(state, 50, 60);
+  // Press G again while in grab mode — should not overwrite original position
+  // (In real code, the G handler checks grabMode first. We test the state machine.)
+  const origPos = state.grabOriginalPosition;
+  assertPos(origPos!, [10, 5, 20], 'original position still from first G press');
+}
+
+{
+  console.log('Test 6.2: Grab non-existent entity');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'nonexistent' });
+  const result = enterGrab(state);
+  assert(result === null, 'enterGrab returns null for missing entity');
+}
+
+{
+  console.log('Test 6.3: Only selected object moves, others stay');
+  const state = applyEvents(createInitialState(), [
+    { type: 'select', entity: { type: 'object', id: 'obj1' } },
+    { type: 'press_g' },
+    { type: 'move_xz', x: 99, z: 99 },
+    { type: 'confirm' },
+  ]);
+  assertPos(state.placedObjects[0].position, [99, 5, 99], 'obj1 moved');
+  assertPos(state.placedObjects[1].position, [30, 0, 40], 'obj2 unchanged');
+}
+
+{
+  console.log('Test 6.4: Rapid confirm (no move) keeps original position');
+  const state = applyEvents(createInitialState(), [
+    { type: 'select', entity: { type: 'object', id: 'obj1' } },
+    { type: 'press_g' },
+    { type: 'confirm' }, // Immediate confirm without moving
+  ]);
+  assertPos(state.placedObjects[0].position, [10, 5, 20], 'position unchanged');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 7. Orbit lock
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- 7. Orbit lock ---\n');
+
+{
+  console.log('Test 7.1: Orbit locked state');
+  let state = createInitialState();
+  assert(state.orbitLocked === false, 'starts unlocked');
+  state = { ...state, orbitLocked: true };
+  assert(state.orbitLocked === true, 'can be locked');
+  state = { ...state, orbitLocked: false };
+  assert(state.orbitLocked === false, 'can be unlocked');
+}
+
+{
+  console.log('Test 7.2: Orbit lock is independent of grab mode');
+  let state = createInitialState();
+  state = { ...state, orbitLocked: true };
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  assert(state.grabMode === true, 'grab mode active');
+  assert(state.orbitLocked === true, 'orbit still locked');
+  state = confirmGrab(state);
+  assert(state.orbitLocked === true, 'orbit lock persists through grab');
+}
+
+// --- Summary ---
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ${passed} passed, ${failed} failed`);
+console.log('='.repeat(40));
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- **Shift-to-lock orbit**: Hold Shift in terrain mode to disable camera orbit while drawing. Shows "ORBIT LOCKED" indicator.
- **Blender-style grab mode**: Press G with a selected entity — object follows mouse on XZ plane. Click to confirm, Esc to cancel. Replaces the old unreliable direct-drag on markers.
- **Shift+drag height**: During grab mode, hold Shift to adjust Y height with vertical mouse movement.
- **Simplified markers**: All markers are now click-to-select only. All movement goes through grab mode, eliminating drag/grab state conflicts.
- **Larger gizmos**: Spheres, cylinders, wireframes, and waypoint lines are ~2× bigger for easier selection.
- **51 standalone tests** for grab-mode state machine (lifecycle, XZ/Y movement, all entity types, edge cases).

## Test plan
- [ ] Open Bricklayer with a map that has objects/lights/NPCs
- [ ] In terrain mode, hold Shift and click/drag on voxels — camera should not orbit
- [ ] In scene mode, click a light/object/NPC to select, press G, move mouse — entity follows
- [ ] During grab, hold Shift and move mouse vertically — entity height changes
- [ ] Click to confirm placement, or Esc to revert
- [ ] Verify gizmo sizes are comfortable to click
- [ ] Run `pnpm --filter @gseurat/tests test:bricklayer-grab` — 51 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)