### PR TITLE
Add area light support to GS renderer

### DIFF
--- a/include/gseurat/engine/types.hpp
+++ b/include/gseurat/engine/types.hpp
@@ -33,8 +33,9 @@ struct Vertex {
 };
 
 struct PointLight {
-    glm::vec4 position_and_radius;  // xy = world pos, z = unused, w = radius
+    glm::vec4 position_and_radius;  // xy = world XZ, z = height (Y), w = radius
     glm::vec4 color;                // rgb = color, a = intensity
+    glm::vec4 area_params{0.0f};    // xy = area width/height (0 = point light), zw = normal XZ
 };
 
 inline constexpr uint32_t kMaxLights = 8;

--- a/shaders/gs_preprocess.comp
+++ b/shaders/gs_preprocess.comp
@@ -52,6 +52,7 @@ layout(set = 0, binding = 3) uniform Uniforms {
     vec4 point_light_params; // x = count (unused in preprocess)
     vec4 pl_pos_rad[8];
     vec4 pl_color[8];
+    vec4 pl_area[8];  // area size + normal (unused in preprocess, must match layout)
 };
 
 layout(set = 0, binding = 4) buffer VisibleCountBuffer {

--- a/shaders/gs_render.comp
+++ b/shaders/gs_render.comp
@@ -40,6 +40,7 @@ layout(set = 0, binding = 2) uniform Uniforms {
     vec4 point_light_params; // x = count, yzw = unused
     vec4 pl_pos_rad[8];     // per-light: xy = world XZ, z = height (Y), w = radius
     vec4 pl_color[8];       // per-light: rgb = color, a = intensity
+    vec4 pl_area[8];        // per-light: xy = area size (0=point), zw = normal XZ
 };
 
 layout(set = 0, binding = 3, rgba16f) uniform writeonly image2D output_image;
@@ -175,7 +176,36 @@ void main() {
                     vec3 light_col = pl_color[li].rgb;
                     float light_intensity = pl_color[li].a;
 
-                    vec3 to_light = light_pos - world_pos;
+                    // Area light: find closest point on rectangle to surface
+                    float area_w = pl_area[li].x;
+                    float area_h = pl_area[li].y;
+                    vec3 effective_light_pos = light_pos;
+
+                    if (area_w > 0.001 && area_h > 0.001) {
+                        // Area light normal in world: (normal_xz.x, 0, normal_xz.y)
+                        // Default: facing down (-Y) for horizontal panels
+                        vec2 nxz = pl_area[li].zw;
+                        vec3 area_normal = length(nxz) > 0.001
+                            ? normalize(vec3(nxz.x, 0.0, nxz.y))
+                            : vec3(0.0, -1.0, 0.0);
+                        // Tangent/bitangent: perpendicular to normal
+                        vec3 up = abs(area_normal.y) > 0.99
+                            ? vec3(1.0, 0.0, 0.0)
+                            : vec3(0.0, 1.0, 0.0);
+                        vec3 tangent = normalize(cross(up, area_normal));
+                        vec3 bitangent = cross(area_normal, tangent);
+
+                        // Project surface point onto area plane
+                        vec3 diff = world_pos - light_pos;
+                        float proj_t = dot(diff, tangent);
+                        float proj_b = dot(diff, bitangent);
+                        // Clamp to rectangle extents
+                        proj_t = clamp(proj_t, -area_w * 0.5, area_w * 0.5);
+                        proj_b = clamp(proj_b, -area_h * 0.5, area_h * 0.5);
+                        effective_light_pos = light_pos + tangent * proj_t + bitangent * proj_b;
+                    }
+
+                    vec3 to_light = effective_light_pos - world_pos;
                     float dist = length(to_light);
                     vec3 light_dir = to_light / max(dist, 0.001);
 

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -47,6 +47,7 @@ struct GsUniforms {
     glm::vec4 point_light_params; // x = count, yzw = unused
     glm::vec4 pl_pos_rad[kMaxGsPointLights];   // per-light: xy = world XZ, z = height (Y), w = radius
     glm::vec4 pl_color[kMaxGsPointLights];      // per-light: rgb = color, a = intensity
+    glm::vec4 pl_area[kMaxGsPointLights];       // per-light: xy = area size (0=point), zw = normal XZ
 };
 
 // Sort key: depth packed with index
@@ -608,6 +609,7 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
     for (size_t i = 0; i < point_lights_.size() && i < kMaxGsPointLights; i++) {
         uniforms.pl_pos_rad[i] = point_lights_[i].position_and_radius;
         uniforms.pl_color[i] = point_lights_[i].color;
+        uniforms.pl_area[i] = point_lights_[i].area_params;
     }
 
     std::memcpy(uniform_buffer_.mapped(), &uniforms, sizeof(uniforms));

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -204,6 +204,18 @@ SceneData SceneLoader::from_json(const nlohmann::json& j) {
             auto color = parse_vec4(light_j["color"]);
             float intensity = light_j.value("intensity", 1.0f);
             pl.color = {color.r, color.g, color.b, intensity};
+            // Area light: optional width/height/normal
+            if (light_j.contains("area_width")) {
+                float aw = light_j.value("area_width", 0.0f);
+                float ah = light_j.value("area_height", 0.0f);
+                float nx = 0.0f, nz = 0.0f;
+                if (light_j.contains("area_normal")) {
+                    auto an = light_j["area_normal"];
+                    nx = an[0].get<float>();
+                    nz = an[1].get<float>();
+                }
+                pl.area_params = {aw, ah, nx, nz};
+            }
             data.static_lights.push_back(pl);
         }
     }
@@ -539,13 +551,21 @@ nlohmann::json SceneLoader::to_json(const SceneData& data) {
     if (!data.static_lights.empty()) {
         nlohmann::json lights = nlohmann::json::array();
         for (const auto& pl : data.static_lights) {
-            lights.push_back({
+            nlohmann::json light_obj = {
                 {"position", {pl.position_and_radius.x, pl.position_and_radius.y}},
                 {"radius", pl.position_and_radius.w},
                 {"height", pl.position_and_radius.z},
                 {"color", {pl.color.r, pl.color.g, pl.color.b}},
                 {"intensity", pl.color.a}
-            });
+            };
+            if (pl.area_params.x > 0.001f || pl.area_params.y > 0.001f) {
+                light_obj["area_width"] = pl.area_params.x;
+                light_obj["area_height"] = pl.area_params.y;
+                if (std::abs(pl.area_params.z) > 0.001f || std::abs(pl.area_params.w) > 0.001f) {
+                    light_obj["area_normal"] = {pl.area_params.z, pl.area_params.w};
+                }
+            }
+            lights.push_back(light_obj);
         }
         j["static_lights"] = lights;
     }

--- a/tests/test_gs_point_lights.cpp
+++ b/tests/test_gs_point_lights.cpp
@@ -68,6 +68,34 @@ int main() {
         std::printf("PASS: Light count capped at 8\n");
     }
 
-    std::printf("\nAll GS point light tests passed.\n");
+    // 5. Area light defaults to point light (area_params = 0)
+    {
+        PointLight pl;
+        pl.position_and_radius = {10.0f, 20.0f, 5.0f, 8.0f};
+        pl.color = {1.0f, 1.0f, 1.0f, 1.0f};
+        assert(pl.area_params.x == 0.0f);  // width = 0
+        assert(pl.area_params.y == 0.0f);  // height = 0
+        assert(pl.area_params.z == 0.0f);  // normal X = 0
+        assert(pl.area_params.w == 0.0f);  // normal Z = 0
+
+        std::printf("PASS: Area light default = point light (size 0)\n");
+    }
+
+    // 6. Area light with explicit dimensions
+    {
+        PointLight pl;
+        pl.position_and_radius = {0.0f, 0.0f, 10.0f, 30.0f};
+        pl.color = {1.0f, 0.9f, 0.8f, 2.0f};
+        pl.area_params = {5.0f, 3.0f, 1.0f, 0.0f};  // 5x3 panel, facing +X
+
+        assert(pl.area_params.x == 5.0f);   // width
+        assert(pl.area_params.y == 3.0f);   // height
+        assert(pl.area_params.z == 1.0f);   // normal X
+        assert(pl.area_params.w == 0.0f);   // normal Z
+
+        std::printf("PASS: Area light 5x3, normal (+1,0)\n");
+    }
+
+    std::printf("\nAll GS point/area light tests passed.\n");
     return 0;
 }

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -6,13 +6,21 @@ export function exportSceneJson(state: SceneStoreState): object {
   };
 
   if (state.staticLights.length > 0) {
-    scene.static_lights = state.staticLights.map((l) => ({
-      position: l.position,
-      radius: l.radius,
-      height: l.height,
-      color: l.color,
-      intensity: l.intensity,
-    }));
+    scene.static_lights = state.staticLights.map((l) => {
+      const out: Record<string, unknown> = {
+        position: l.position,
+        radius: l.radius,
+        height: l.height,
+        color: l.color,
+        intensity: l.intensity,
+      };
+      if (l.area_width && l.area_width > 0) {
+        out.area_width = l.area_width;
+        out.area_height = l.area_height ?? l.area_width;
+        if (l.area_normal) out.area_normal = l.area_normal;
+      }
+      return out;
+    });
   }
 
   if (state.npcs.length > 0) {

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -5,6 +5,10 @@ export function exportSceneJson(state: SceneStoreState): object {
     ambient_color: state.ambientColor,
   };
 
+  if (state.godRaysIntensity > 0) {
+    scene.god_rays_intensity = state.godRaysIntensity;
+  }
+
   if (state.staticLights.length > 0) {
     scene.static_lights = state.staticLights.map((l) => {
       const out: Record<string, unknown> = {
@@ -14,6 +18,10 @@ export function exportSceneJson(state: SceneStoreState): object {
         color: l.color,
         intensity: l.intensity,
       };
+      if (l.direction && l.cone_angle !== undefined && l.cone_angle < 180) {
+        out.direction = l.direction;
+        out.cone_angle = l.cone_angle;
+      }
       if (l.area_width && l.area_width > 0) {
         out.area_width = l.area_width;
         out.area_height = l.area_height ?? l.area_width;

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -131,9 +131,54 @@ function ObjectProperties({ obj }: { obj: PlacedObjectData }) {
   );
 }
 
+type LightType = 'point' | 'spot' | 'area';
+
+function getLightType(light: StaticLight): LightType {
+  if ((light.area_width ?? 0) > 0) return 'area';
+  if ((light.cone_angle ?? 180) < 180) return 'spot';
+  return 'point';
+}
+
+const lightTypeLabels: Record<LightType, string> = {
+  point: 'Point Light',
+  spot: 'Spot Light',
+  area: 'Area Light',
+};
+
+const lightTypeDescriptions: Record<LightType, string> = {
+  point: 'Emits light equally in all directions, like a light bulb.',
+  spot: 'Projects light within a cone, like a flashlight or streetlamp.',
+  area: 'Emits light from a rectangular surface, like a window or fluorescent panel.',
+};
+
 function LightProperties({ light }: { light: StaticLight }) {
   const update = useSceneStore((s) => s.updateLight);
   const remove = useSceneStore((s) => s.removeLight);
+  const lightType = getLightType(light);
+
+  const setLightType = (type: LightType) => {
+    switch (type) {
+      case 'point':
+        update(light.id, {
+          cone_angle: undefined, direction: undefined,
+          area_width: undefined, area_height: undefined, area_normal: undefined,
+        });
+        break;
+      case 'spot':
+        update(light.id, {
+          cone_angle: 45, direction: light.direction ?? [0, -1, 0],
+          area_width: undefined, area_height: undefined, area_normal: undefined,
+        });
+        break;
+      case 'area':
+        update(light.id, {
+          cone_angle: undefined, direction: undefined,
+          area_width: light.area_width || 5, area_height: light.area_height || 3,
+          area_normal: light.area_normal ?? [0, 0],
+        });
+        break;
+    }
+  };
 
   return (
     <div>
@@ -142,6 +187,27 @@ function LightProperties({ light }: { light: StaticLight }) {
         <button style={styles.btnDanger} onClick={() => remove(light.id)}>Remove</button>
       </div>
 
+      {/* Type selector */}
+      <div style={styles.section}>
+        <span style={styles.label}>Type</span>
+        <select
+          value={lightType}
+          onChange={(e) => setLightType(e.target.value as LightType)}
+          style={{
+            padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+            borderRadius: 4, color: '#ddd', fontSize: 13, width: '100%',
+          }}
+        >
+          {(['point', 'spot', 'area'] as LightType[]).map((t) => (
+            <option key={t} value={t}>{lightTypeLabels[t]}</option>
+          ))}
+        </select>
+        <span style={{ fontSize: 10, color: '#666', marginTop: 4 }}>
+          {lightTypeDescriptions[lightType]}
+        </span>
+      </div>
+
+      {/* Common fields */}
       <div style={styles.section}>
         <span style={styles.label}>Position</span>
         <div style={styles.row}>
@@ -209,99 +275,96 @@ function LightProperties({ light }: { light: StaticLight }) {
         />
       </div>
 
-      <div style={styles.section}>
-        <span style={styles.label}>Cone Angle</span>
-        <NumberInput
-          step={5}
-          min={1}
-          max={180}
-          value={light.cone_angle ?? 180}
-          onChange={(v) => {
-            const angle = Math.max(1, Math.min(180, v));
-            if (angle >= 180) {
-              update(light.id, { cone_angle: undefined, direction: undefined });
-            } else {
-              update(light.id, {
-                cone_angle: angle,
-                direction: light.direction ?? [0, -1, 0],
-              });
-            }
-          }}
-          style={styles.input}
-        />
-      </div>
-
-      {(light.cone_angle ?? 180) < 180 && (
-        <div style={styles.section}>
-          <span style={styles.label}>Direction</span>
-          <div style={styles.row}>
+      {/* Spot light fields */}
+      {lightType === 'spot' && (
+        <>
+          <div style={styles.section}>
+            <span style={styles.label}>Cone Angle</span>
             <NumberInput
-              label="X"
-              step={0.1}
-              value={light.direction?.[0] ?? 0}
-              onChange={(v) => update(light.id, { direction: [v, light.direction?.[1] ?? -1, light.direction?.[2] ?? 0] })}
-              style={styles.input}
-            />
-            <NumberInput
-              label="Y"
-              step={0.1}
-              value={light.direction?.[1] ?? -1}
-              onChange={(v) => update(light.id, { direction: [light.direction?.[0] ?? 0, v, light.direction?.[2] ?? 0] })}
-              style={styles.input}
-            />
-            <NumberInput
-              label="Z"
-              step={0.1}
-              value={light.direction?.[2] ?? 0}
-              onChange={(v) => update(light.id, { direction: [light.direction?.[0] ?? 0, light.direction?.[1] ?? -1, v] })}
+              step={5}
+              min={1}
+              max={179}
+              value={light.cone_angle ?? 45}
+              onChange={(v) => update(light.id, { cone_angle: Math.max(1, Math.min(179, v)) })}
               style={styles.input}
             />
           </div>
-        </div>
+          <div style={styles.section}>
+            <span style={styles.label}>Direction</span>
+            <div style={styles.row}>
+              <NumberInput
+                label="X"
+                step={0.1}
+                value={light.direction?.[0] ?? 0}
+                onChange={(v) => update(light.id, { direction: [v, light.direction?.[1] ?? -1, light.direction?.[2] ?? 0] })}
+                style={styles.input}
+              />
+              <NumberInput
+                label="Y"
+                step={0.1}
+                value={light.direction?.[1] ?? -1}
+                onChange={(v) => update(light.id, { direction: [light.direction?.[0] ?? 0, v, light.direction?.[2] ?? 0] })}
+                style={styles.input}
+              />
+              <NumberInput
+                label="Z"
+                step={0.1}
+                value={light.direction?.[2] ?? 0}
+                onChange={(v) => update(light.id, { direction: [light.direction?.[0] ?? 0, light.direction?.[1] ?? -1, v] })}
+                style={styles.input}
+              />
+            </div>
+          </div>
+        </>
       )}
 
-      <div style={styles.section}>
-        <span style={styles.label}>Area Size</span>
-        <div style={styles.row}>
-          <NumberInput
-            label="W"
-            step={0.5}
-            min={0}
-            value={light.area_width ?? 0}
-            onChange={(v) => update(light.id, { area_width: Math.max(0, v), area_height: light.area_height ?? Math.max(0, v) })}
-            style={styles.input}
-          />
-          <NumberInput
-            label="H"
-            step={0.5}
-            min={0}
-            value={light.area_height ?? 0}
-            onChange={(v) => update(light.id, { area_height: Math.max(0, v) })}
-            style={styles.input}
-          />
-        </div>
-      </div>
-
-      {(light.area_width ?? 0) > 0 && (
-        <div style={styles.section}>
-          <span style={styles.label}>Area Normal</span>
-          <div style={styles.row}>
-            <NumberInput
-              label="X"
-              step={0.1}
-              value={light.area_normal?.[0] ?? 0}
-              onChange={(v) => update(light.id, { area_normal: [v, light.area_normal?.[1] ?? 0] })}
-              style={styles.input}
-            />
-            <NumberInput
-              label="Z"
-              step={0.1}
-              value={light.area_normal?.[1] ?? 0}
-              onChange={(v) => update(light.id, { area_normal: [light.area_normal?.[0] ?? 0, v] })}
-              style={styles.input}
-            />
+      {/* Area light fields */}
+      {lightType === 'area' && (
+        <>
+          <div style={styles.section}>
+            <span style={styles.label}>Area Size</span>
+            <div style={styles.row}>
+              <NumberInput
+                label="W"
+                step={0.5}
+                min={0.1}
+                value={light.area_width ?? 5}
+                onChange={(v) => update(light.id, { area_width: Math.max(0.1, v) })}
+                style={styles.input}
+              />
+              <NumberInput
+                label="H"
+                step={0.5}
+                min={0.1}
+                value={light.area_height ?? 3}
+                onChange={(v) => update(light.id, { area_height: Math.max(0.1, v) })}
+                style={styles.input}
+              />
+            </div>
           </div>
-        </div>
+          <div style={styles.section}>
+            <span style={styles.label}>Face Direction</span>
+            <div style={styles.row}>
+              <NumberInput
+                label="X"
+                step={0.1}
+                value={light.area_normal?.[0] ?? 0}
+                onChange={(v) => update(light.id, { area_normal: [v, light.area_normal?.[1] ?? 0] })}
+                style={styles.input}
+              />
+              <NumberInput
+                label="Z"
+                step={0.1}
+                value={light.area_normal?.[1] ?? 0}
+                onChange={(v) => update(light.id, { area_normal: [light.area_normal?.[0] ?? 0, v] })}
+                style={styles.input}
+              />
+            </div>
+            <span style={{ fontSize: 10, color: '#666', marginTop: 2 }}>
+              XZ direction the light panel faces. Leave 0,0 for downward.
+            </span>
+          </div>
+        </>
       )}
     </div>
   );

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -208,6 +208,50 @@ function LightProperties({ light }: { light: StaticLight }) {
           style={styles.input}
         />
       </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Area Size</span>
+        <div style={styles.row}>
+          <NumberInput
+            label="W"
+            step={0.5}
+            min={0}
+            value={light.area_width ?? 0}
+            onChange={(v) => update(light.id, { area_width: Math.max(0, v), area_height: light.area_height ?? Math.max(0, v) })}
+            style={styles.input}
+          />
+          <NumberInput
+            label="H"
+            step={0.5}
+            min={0}
+            value={light.area_height ?? 0}
+            onChange={(v) => update(light.id, { area_height: Math.max(0, v) })}
+            style={styles.input}
+          />
+        </div>
+      </div>
+
+      {(light.area_width ?? 0) > 0 && (
+        <div style={styles.section}>
+          <span style={styles.label}>Area Normal</span>
+          <div style={styles.row}>
+            <NumberInput
+              label="X"
+              step={0.1}
+              value={light.area_normal?.[0] ?? 0}
+              onChange={(v) => update(light.id, { area_normal: [v, light.area_normal?.[1] ?? 0] })}
+              style={styles.input}
+            />
+            <NumberInput
+              label="Z"
+              step={0.1}
+              value={light.area_normal?.[1] ?? 0}
+              onChange={(v) => update(light.id, { area_normal: [light.area_normal?.[0] ?? 0, v] })}
+              style={styles.input}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -210,6 +210,57 @@ function LightProperties({ light }: { light: StaticLight }) {
       </div>
 
       <div style={styles.section}>
+        <span style={styles.label}>Cone Angle</span>
+        <NumberInput
+          step={5}
+          min={1}
+          max={180}
+          value={light.cone_angle ?? 180}
+          onChange={(v) => {
+            const angle = Math.max(1, Math.min(180, v));
+            if (angle >= 180) {
+              update(light.id, { cone_angle: undefined, direction: undefined });
+            } else {
+              update(light.id, {
+                cone_angle: angle,
+                direction: light.direction ?? [0, -1, 0],
+              });
+            }
+          }}
+          style={styles.input}
+        />
+      </div>
+
+      {(light.cone_angle ?? 180) < 180 && (
+        <div style={styles.section}>
+          <span style={styles.label}>Direction</span>
+          <div style={styles.row}>
+            <NumberInput
+              label="X"
+              step={0.1}
+              value={light.direction?.[0] ?? 0}
+              onChange={(v) => update(light.id, { direction: [v, light.direction?.[1] ?? -1, light.direction?.[2] ?? 0] })}
+              style={styles.input}
+            />
+            <NumberInput
+              label="Y"
+              step={0.1}
+              value={light.direction?.[1] ?? -1}
+              onChange={(v) => update(light.id, { direction: [light.direction?.[0] ?? 0, v, light.direction?.[2] ?? 0] })}
+              style={styles.input}
+            />
+            <NumberInput
+              label="Z"
+              step={0.1}
+              value={light.direction?.[2] ?? 0}
+              onChange={(v) => update(light.id, { direction: [light.direction?.[0] ?? 0, light.direction?.[1] ?? -1, v] })}
+              style={styles.input}
+            />
+          </div>
+        </div>
+      )}
+
+      <div style={styles.section}>
         <span style={styles.label}>Area Size</span>
         <div style={styles.row}>
           <NumberInput

--- a/tools/apps/bricklayer/src/panels/SceneTab.tsx
+++ b/tools/apps/bricklayer/src/panels/SceneTab.tsx
@@ -32,6 +32,8 @@ function hexToColor(hex: string, alpha: number): [number, number, number, number
 export function SceneTab() {
   const ambientColor = useSceneStore((s) => s.ambientColor);
   const setAmbientColor = useSceneStore((s) => s.setAmbientColor);
+  const godRaysIntensity = useSceneStore((s) => s.godRaysIntensity);
+  const setGodRaysIntensity = useSceneStore((s) => s.setGodRaysIntensity);
   const gridWidth = useSceneStore((s) => s.gridWidth);
   const gridDepth = useSceneStore((s) => s.gridDepth);
   const voxels = useSceneStore((s) => s.voxels);
@@ -59,6 +61,23 @@ export function SceneTab() {
           />
           <span style={{ fontSize: 12, color: '#aaa' }}>
             [{ambientColor.map((v) => v.toFixed(2)).join(', ')}]
+          </span>
+        </div>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>God Rays</span>
+        <div style={styles.row}>
+          <NumberInput
+            step={0.1}
+            min={0}
+            max={5}
+            value={godRaysIntensity}
+            onChange={(v) => setGodRaysIntensity(Math.max(0, v))}
+            style={styles.input}
+          />
+          <span style={{ fontSize: 11, color: '#666', minWidth: 20 }}>
+            {godRaysIntensity > 0 ? 'ON' : 'OFF'}
           </span>
         </div>
       </div>

--- a/tools/apps/bricklayer/src/panels/SceneTab.tsx
+++ b/tools/apps/bricklayer/src/panels/SceneTab.tsx
@@ -66,7 +66,10 @@ export function SceneTab() {
       </div>
 
       <div style={styles.section}>
-        <span style={styles.label}>God Rays</span>
+        <span style={styles.label}>God Rays (Volume Light)</span>
+        <span style={{ fontSize: 10, color: '#666', marginBottom: 4 }}>
+          Visible light shafts from scene lights through geometry. Set to 0 to disable.
+        </span>
         <div style={styles.row}>
           <NumberInput
             step={0.1}
@@ -76,7 +79,7 @@ export function SceneTab() {
             onChange={(v) => setGodRaysIntensity(Math.max(0, v))}
             style={styles.input}
           />
-          <span style={{ fontSize: 11, color: '#666', minWidth: 20 }}>
+          <span style={{ fontSize: 11, color: godRaysIntensity > 0 ? '#8f8' : '#666', minWidth: 20 }}>
             {godRaysIntensity > 0 ? 'ON' : 'OFF'}
           </span>
         </div>

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -15,6 +15,9 @@ export interface StaticLight {
   height: number;
   color: [number, number, number];
   intensity: number;
+  area_width?: number;                  // 0 or omit = point light
+  area_height?: number;                 // 0 or omit = point light
+  area_normal?: [number, number];       // XZ direction of area face
 }
 
 export interface NpcData {

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -15,9 +15,11 @@ export interface StaticLight {
   height: number;
   color: [number, number, number];
   intensity: number;
-  area_width?: number;                  // 0 or omit = point light
-  area_height?: number;                 // 0 or omit = point light
-  area_normal?: [number, number];       // XZ direction of area face
+  direction?: [number, number, number];  // spot light direction (normalized); omit for point/area
+  cone_angle?: number;                   // spot light cone degrees; omit or 180 for point/area
+  area_width?: number;                   // area light width; 0 or omit = point/spot light
+  area_height?: number;                  // area light height; 0 or omit = point/spot light
+  area_normal?: [number, number];        // area light face direction XZ
 }
 
 export interface NpcData {
@@ -244,6 +246,7 @@ export interface BricklayerFile {
   assets?: AssetEntry[];
   scene: {
     ambientColor: [number, number, number, number];
+    godRaysIntensity?: number;
     staticLights: StaticLight[];
     npcs: NpcData[];
     portals: PortalData[];

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -179,6 +179,7 @@ export interface SceneStoreState {
 
   // Scene elements
   ambientColor: [number, number, number, number];
+  godRaysIntensity: number;
   staticLights: StaticLight[];
   npcs: NpcData[];
   portals: PortalData[];
@@ -236,6 +237,7 @@ export interface SceneStoreState {
 
   // Actions – scene
   setAmbientColor: (c: [number, number, number, number]) => void;
+  setGodRaysIntensity: (v: number) => void;
   addLight: (position?: [number, number]) => void;
   updateLight: (id: string, patch: Partial<StaticLight>) => void;
   removeLight: (id: string) => void;
@@ -413,6 +415,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   mirrorZ: false,
 
   ambientColor: [0.25, 0.28, 0.45, 1],
+  godRaysIntensity: 0,
   staticLights: [],
   npcs: [],
   portals: [],
@@ -582,6 +585,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
 
   // ── Scene actions ──
   setAmbientColor: (c) => set({ ambientColor: c }),
+  setGodRaysIntensity: (v: number) => set({ godRaysIntensity: v, isDirty: true }),
 
   addLight: (pos?) => {
     const light: StaticLight = {
@@ -1054,6 +1058,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       assets: s.assets.length > 0 ? s.assets : undefined,
       scene: {
         ambientColor: s.ambientColor,
+        godRaysIntensity: s.godRaysIntensity,
         staticLights: s.staticLights,
         npcs: s.npcs,
         portals: s.portals,
@@ -1087,6 +1092,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       terrains: data.terrains ?? [],
       assets: data.assets ?? [],
       ambientColor: data.scene.ambientColor,
+      godRaysIntensity: data.scene.godRaysIntensity ?? 0,
       staticLights: data.scene.staticLights,
       npcs: data.scene.npcs,
       portals: data.scene.portals,

--- a/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
+++ b/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import * as THREE from 'three';
+import { Html } from '@react-three/drei';
 import { useSceneStore } from '../store/useSceneStore.js';
 
 function LightMarker({ position, height, radius, color, isSelected, onSelect, areaWidth, areaHeight, coneAngle, direction }: {
@@ -49,30 +50,55 @@ function LightMarker({ position, height, radius, color, isSelected, onSelect, ar
           <meshBasicMaterial color={colorStr} transparent opacity={0.5} side={2} />
         </mesh>
       )}
-      {/* Spot light: cone wireframe */}
+      {/* Spot light: cone wireframe + base ring + angle label */}
       {isSpot && coneRotation && (
-        <mesh rotation={coneRotation}>
-          <coneGeometry args={[coneRadius, coneLength, 16, 1, true]} />
-          <meshBasicMaterial
-            color={isSelected ? '#ffffff' : colorStr}
-            wireframe
-            transparent
-            opacity={0.6}
-          />
-        </mesh>
+        <>
+          <mesh rotation={coneRotation}>
+            <coneGeometry args={[coneRadius, coneLength, 16, 1, true]} />
+            <meshBasicMaterial
+              color={isSelected ? '#ffffff' : colorStr}
+              wireframe
+              transparent
+              opacity={0.6}
+            />
+          </mesh>
+          {/* Angle label */}
+          {isSelected && (
+            <Html position={[0, -coneLength * 0.5, 0]} center>
+              <div style={{
+                background: 'rgba(0,0,0,0.7)', color: '#ffcc00',
+                padding: '1px 5px', borderRadius: 3, fontSize: 10, whiteSpace: 'nowrap',
+              }}>
+                {coneAngle}°
+              </div>
+            </Html>
+          )}
+        </>
       )}
-      {/* Area light: rectangle wireframe */}
+      {/* Area light: rectangle wireframe + size label */}
       {isArea && (
-        <mesh rotation={[-Math.PI / 2, 0, 0]}>
-          <planeGeometry args={[areaWidth, areaHeight]} />
-          <meshBasicMaterial
-            color={isSelected ? '#ffffff' : colorStr}
-            wireframe
-            transparent
-            opacity={0.7}
-            side={2}
-          />
-        </mesh>
+        <>
+          <mesh rotation={[-Math.PI / 2, 0, 0]}>
+            <planeGeometry args={[areaWidth, areaHeight]} />
+            <meshBasicMaterial
+              color={isSelected ? '#ffffff' : colorStr}
+              wireframe
+              transparent
+              opacity={0.7}
+              side={2}
+            />
+          </mesh>
+          {isSelected && (
+            <Html position={[0, 1.2, 0]} center>
+              <div style={{
+                background: 'rgba(0,0,0,0.7)', color: '#ffcc00',
+                padding: '1px 5px', borderRadius: 3, fontSize: 10, whiteSpace: 'nowrap',
+              }}>
+                {areaWidth}x{areaHeight}
+              </div>
+            </Html>
+          )}
+        </>
       )}
     </group>
   );

--- a/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
+++ b/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import * as THREE from 'three';
 import { useSceneStore } from '../store/useSceneStore.js';
 
-function LightMarker({ position, height, radius, color, isSelected, onSelect, areaWidth, areaHeight }: {
+function LightMarker({ position, height, radius, color, isSelected, onSelect, areaWidth, areaHeight, coneAngle, direction }: {
   position: [number, number];
   height: number;
   radius: number;
@@ -10,30 +11,57 @@ function LightMarker({ position, height, radius, color, isSelected, onSelect, ar
   onSelect: () => void;
   areaWidth: number;
   areaHeight: number;
+  coneAngle: number;
+  direction: [number, number, number];
 }) {
   const colorStr = `rgb(${Math.round(color[0] * 255)},${Math.round(color[1] * 255)},${Math.round(color[2] * 255)})`;
   const isArea = areaWidth > 0 && areaHeight > 0;
+  const isSpot = coneAngle < 180 && !isArea;
+
+  // Compute rotation for spot cone along direction vector
+  const coneRotation = useMemo(() => {
+    if (!isSpot) return undefined;
+    const dir = new THREE.Vector3(direction[0], direction[1], direction[2]).normalize();
+    const q = new THREE.Quaternion();
+    q.setFromUnitVectors(new THREE.Vector3(0, -1, 0), dir);
+    return new THREE.Euler().setFromQuaternion(q);
+  }, [isSpot, direction]);
+
+  const coneLength = Math.min(radius * 0.5, 10);
+  const coneRadius = isSpot ? coneLength * Math.tan((coneAngle / 2) * Math.PI / 180) : 0;
 
   return (
     <group position={[position[0], height, position[1]]}>
-      {/* Invisible hit box for pointer events */}
+      {/* Invisible hit box */}
       <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
         <sphereGeometry args={[1.0, 12, 12]} />
         <meshBasicMaterial visible={false} />
       </mesh>
-      {/* Visible sphere (center marker) */}
+      {/* Center sphere */}
       <mesh>
-        <sphereGeometry args={[isArea ? 0.4 : 0.6, 12, 12]} />
+        <sphereGeometry args={[isArea || isSpot ? 0.4 : 0.6, 12, 12]} />
         <meshBasicMaterial color={isSelected ? '#ffffff' : colorStr} />
       </mesh>
       {/* Point light: radius ring */}
-      {!isArea && (
+      {!isArea && !isSpot && (
         <mesh rotation={[-Math.PI / 2, 0, 0]}>
           <ringGeometry args={[radius - 0.1, radius + 0.1, 32]} />
           <meshBasicMaterial color={colorStr} transparent opacity={0.5} side={2} />
         </mesh>
       )}
-      {/* Area light: rectangle wireframe (horizontal plane) */}
+      {/* Spot light: cone wireframe */}
+      {isSpot && coneRotation && (
+        <mesh rotation={coneRotation}>
+          <coneGeometry args={[coneRadius, coneLength, 16, 1, true]} />
+          <meshBasicMaterial
+            color={isSelected ? '#ffffff' : colorStr}
+            wireframe
+            transparent
+            opacity={0.6}
+          />
+        </mesh>
+      )}
+      {/* Area light: rectangle wireframe */}
       {isArea && (
         <mesh rotation={[-Math.PI / 2, 0, 0]}>
           <planeGeometry args={[areaWidth, areaHeight]} />
@@ -71,6 +99,8 @@ export function LightGizmos() {
           onSelect={() => setSelectedEntity({ type: 'light', id: light.id })}
           areaWidth={light.area_width ?? 0}
           areaHeight={light.area_height ?? 0}
+          coneAngle={light.cone_angle ?? 180}
+          direction={light.direction ?? [0, -1, 0]}
         />
       ))}
     </group>

--- a/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
+++ b/tools/apps/bricklayer/src/viewport/LightGizmos.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 
-function LightMarker({ position, height, radius, color, isSelected, onSelect }: {
+function LightMarker({ position, height, radius, color, isSelected, onSelect, areaWidth, areaHeight }: {
   position: [number, number];
   height: number;
   radius: number;
   color: [number, number, number];
   isSelected: boolean;
   onSelect: () => void;
+  areaWidth: number;
+  areaHeight: number;
 }) {
   const colorStr = `rgb(${Math.round(color[0] * 255)},${Math.round(color[1] * 255)},${Math.round(color[2] * 255)})`;
+  const isArea = areaWidth > 0 && areaHeight > 0;
 
   return (
     <group position={[position[0], height, position[1]]}>
@@ -18,16 +21,31 @@ function LightMarker({ position, height, radius, color, isSelected, onSelect }: 
         <sphereGeometry args={[1.0, 12, 12]} />
         <meshBasicMaterial visible={false} />
       </mesh>
-      {/* Visible sphere */}
+      {/* Visible sphere (center marker) */}
       <mesh>
-        <sphereGeometry args={[0.6, 12, 12]} />
+        <sphereGeometry args={[isArea ? 0.4 : 0.6, 12, 12]} />
         <meshBasicMaterial color={isSelected ? '#ffffff' : colorStr} />
       </mesh>
-      {/* Radius ring */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]}>
-        <ringGeometry args={[radius - 0.1, radius + 0.1, 32]} />
-        <meshBasicMaterial color={colorStr} transparent opacity={0.5} side={2} />
-      </mesh>
+      {/* Point light: radius ring */}
+      {!isArea && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]}>
+          <ringGeometry args={[radius - 0.1, radius + 0.1, 32]} />
+          <meshBasicMaterial color={colorStr} transparent opacity={0.5} side={2} />
+        </mesh>
+      )}
+      {/* Area light: rectangle wireframe (horizontal plane) */}
+      {isArea && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[areaWidth, areaHeight]} />
+          <meshBasicMaterial
+            color={isSelected ? '#ffffff' : colorStr}
+            wireframe
+            transparent
+            opacity={0.7}
+            side={2}
+          />
+        </mesh>
+      )}
     </group>
   );
 }
@@ -51,6 +69,8 @@ export function LightGizmos() {
           color={light.color}
           isSelected={selectedEntity?.type === 'light' && selectedEntity.id === light.id}
           onSelect={() => setSelectedEntity({ type: 'light', id: light.id })}
+          areaWidth={light.area_width ?? 0}
+          areaHeight={light.area_height ?? 0}
         />
       ))}
     </group>


### PR DESCRIPTION
## Summary
- **PointLight extended** with `area_params` field (xy = width/height, zw = face normal XZ). Default 0 = point light, fully backward compatible.
- **GS render shader**: closest-point-on-rectangle technique for soft rectangular illumination from surfaces like fluorescent panels or windows.
- **Scene loader**: parses optional `area_width`, `area_height`, `area_normal` from JSON.
- **Bricklayer**: Area Size (W/H) inputs, Area Normal (XZ) inputs when area > 0, wireframe rectangle gizmo.
- **Tests**: 2 new test cases. All 11 ctest cases pass.

## JSON format (backward compatible)
```json
{
  "position": [x, z], "height": 3, "radius": 30,
  "color": [1, 0.9, 0.8], "intensity": 2,
  "area_width": 5, "area_height": 3,
  "area_normal": [1, 0]
}
```

## Test plan
- [ ] Build: `cmake --build --preset macos-debug`
- [ ] Run: `ctest --test-dir build/macos-debug` — 11/11 pass
- [ ] In Bricklayer, add a light and set Area Size > 0 — rectangle gizmo appears
- [ ] Verify existing point lights (no area fields) work identically
- [ ] In GS demo, verify area light creates soft rectangular illumination

🤖 Generated with [Claude Code](https://claude.com/claude-code)