### PR TITLE
Add Gaussian particle system and scene animation

### DIFF
--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -16,6 +16,7 @@ public:
     void init(VkDevice device, VmaAllocator allocator, VkDescriptorPool pool);
     void load_cloud(const GaussianCloud& cloud);
     void update_active_gaussians(const Gaussian* data, uint32_t count);
+    void update_gaussian_data(const Gaussian* data, uint32_t count);
     void resize_output(uint32_t width, uint32_t height);
     void render(VkCommandBuffer cmd, const glm::mat4& view, const glm::mat4& proj);
     VkImageView output_view() const { return output_view_; }

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -418,6 +418,26 @@ void GsRenderer::update_active_gaussians(const Gaussian* data, uint32_t count) {
     init_sort_buf(sort_b_ssbo_);
 }
 
+void GsRenderer::update_gaussian_data(const Gaussian* data, uint32_t count) {
+    if (count == 0 || count > max_gaussian_count_) return;
+
+    gaussian_count_ = count;
+
+    auto* gpu_data = static_cast<GpuGaussian*>(gaussian_ssbo_.mapped());
+    for (uint32_t i = 0; i < count; ++i) {
+        gpu_data[i].pos_opacity = glm::vec4(data[i].position, data[i].opacity);
+        float bone_f;
+        uint32_t bi = data[i].bone_index;
+        std::memcpy(&bone_f, &bi, sizeof(float));
+        gpu_data[i].scale_pad = glm::vec4(data[i].scale, bone_f);
+        gpu_data[i].rot = glm::vec4(data[i].rotation.x, data[i].rotation.y,
+                                     data[i].rotation.z, data[i].rotation.w);
+        gpu_data[i].color_pad = glm::vec4(data[i].color, data[i].emission);
+    }
+    // Sort keys are NOT reset — preprocess shader will recompute depth keys,
+    // and the radix sort will re-sort naturally without losing convergence.
+}
+
 void GsRenderer::upload_bone_transforms(const glm::mat4* transforms, uint32_t count) {
     if (!bone_ssbo_.mapped() || count == 0) return;
     uint32_t n = std::min(count, kMaxBones);

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -801,7 +801,7 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                     gs_active_buffer_.resize(gs_renderer_.max_gaussian_count());
                 }
 
-                gs_renderer_.update_active_gaussians(
+                gs_renderer_.update_gaussian_data(
                     gs_active_buffer_.data(),
                     static_cast<uint32_t>(gs_active_buffer_.size()));
             }


### PR DESCRIPTION
## Summary
- **Orthodox particles**: `GaussianParticleEmitter` spawns new Gaussian splats as 3D particles (dust puffs, spark showers, magic spirals) with configurable velocity, color, scale, emission, and lifetime
- **Scene animation**: `GaussianAnimator` applies particle-like effects (Detach, Float, Orbit, Dissolve, Reform) to subsets of existing scene Gaussians tagged by region
- **Render fixes**: Separate emissive/scene-lit color tracks in `gs_render.comp`, distance-scaled contact shadow threshold, data-only SSBO upload to preserve sort order during particle updates

## Test plan
- [x] `test_gs_particle.cpp`: 12 test cases covering emitter lifecycle, animator effects, gather output, capacity limits
- [ ] Visual: Launch GS demo, press J for particle burst, D for scatter animation — no scene distortion
- [ ] Performance: Particle count stays within `kParticleHeadroom` (2048), no SSBO overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)