### PR TITLE
Add GS particle emitters to scene.json and Bricklayer

### DIFF
--- a/docs/bricklayer.md
+++ b/docs/bricklayer.md
@@ -269,3 +269,80 @@ The GS tile rasterizer compute shader (`gs_render.comp`):
   ]
 }
 ```
+
+## Gaussian Particle Emitters
+
+Scene files can include a `gs_particle_emitters` array to place continuous 3D Gaussian
+particle effects (dust, sparks, magic) directly in the scene. Emitters spawn new Gaussian
+splats each frame — they are self-lit (bypass scene lighting) and render through the same
+compute pipeline as the scene.
+
+### Presets
+
+Three built-in presets provide common effects. Use `"preset"` and override any fields:
+
+| Preset | Description | Spawn Rate | Lifetime | Emission |
+|--------|-------------|------------|----------|----------|
+| `dust_puff` | Brown dust cloud, burst, slow fall | 120/s | 1-2.5s | 0 (scene-lit) |
+| `spark_shower` | Orange sparks with gravity, self-lit | 40/s | 0.3-0.8s | 0.8 |
+| `magic_spiral` | Blue-to-magenta rising particles | 50/s | 1.5-3s | 0 (scene-lit) |
+
+### Parameters
+
+All fields are optional. When `preset` is specified, its values load first, then explicit fields override.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `preset` | string | — | `"dust_puff"`, `"spark_shower"`, or `"magic_spiral"` |
+| `position` | [x,y,z] | [0,0,0] | Scene/voxel coordinates (same system as lights) |
+| `spawn_rate` | float | 10 | Particles spawned per second |
+| `lifetime_min` | float | 0.5 | Minimum particle lifetime (seconds) |
+| `lifetime_max` | float | 1.5 | Maximum particle lifetime (seconds) |
+| `velocity_min` | [x,y,z] | [-1,1,-1] | Minimum initial velocity |
+| `velocity_max` | [x,y,z] | [1,3,1] | Maximum initial velocity |
+| `acceleration` | [x,y,z] | [0,-9.8,0] | Constant acceleration (default: gravity) |
+| `color_start` | [r,g,b] | [1,0.8,0.3] | Color at birth |
+| `color_end` | [r,g,b] | [1,0.2,0] | Color at death |
+| `scale_min` | [x,y,z] | [0.3,0.3,0.3] | Minimum initial scale |
+| `scale_max` | [x,y,z] | [0.6,0.6,0.6] | Maximum initial scale |
+| `scale_end_factor` | float | 0 | Scale multiplier at death (0 = vanish) |
+| `opacity_start` | float | 1.0 | Opacity at birth |
+| `opacity_end` | float | 0.0 | Opacity at death |
+| `emission` | float | 0 | Self-illumination (>0 bypasses lighting, triggers bloom) |
+| `spawn_offset_min` | [x,y,z] | [0,0,0] | Min random offset from position |
+| `spawn_offset_max` | [x,y,z] | [0,0,0] | Max random offset from position |
+| `burst_duration` | float | 0 | 0 = continuous loop; >0 = auto-stop after N seconds |
+
+### Scene JSON Format
+
+```json
+{
+  "gs_particle_emitters": [
+    { "preset": "spark_shower", "position": [32, 8, 32] },
+    { "preset": "dust_puff", "position": [20, 2, 50], "spawn_rate": 50 },
+    {
+      "position": [10, 5, 10],
+      "spawn_rate": 20,
+      "color_start": [0.2, 0.8, 1.0],
+      "color_end": [0.0, 0.2, 0.5],
+      "emission": 2.0,
+      "scale_min": [0.1, 0.1, 0.1],
+      "velocity_min": [-0.5, 0.5, -0.5],
+      "velocity_max": [0.5, 2.0, 0.5]
+    }
+  ]
+}
+```
+
+### Coordinate System
+
+Emitter positions use the same scene/voxel coordinate system as lights:
+`[scene_x, height, scene_z]`. The engine transforms these to PLY world coordinates
+at load time using the cloud AABB offset.
+
+### Demo Visualization
+
+In the GS demo, press **N** to toggle the scene layer overlay. Particle emitters appear
+as magenta markers labeled **P0**, **P1**, etc. The HUD shows the total emitter count.
+Press **J** to spawn a spark shower at the camera target (runtime, not saved to scene).
+```

--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -310,6 +310,7 @@ export function App() {
           else if (sel.type === 'npc') store.updateNpc(sel.id, { position: pos });
           else if (sel.type === 'light') store.updateLight(sel.id, { position: [pos[0], pos[2]] });
           else if (sel.type === 'portal') store.updatePortal(sel.id, { position: [pos[0], pos[2]] });
+          else if (sel.type === 'gs_emitter') store.updateGsEmitter(sel.id, { position: pos });
           else if (sel.type === 'player') store.updatePlayer({ position: pos });
         }
         store.setGrabMode(false);
@@ -336,6 +337,9 @@ export function App() {
           } else if (sel.type === 'portal') {
             const portal = store.portals.find((p) => p.id === sel.id);
             if (portal) pos = [portal.position[0], 0, portal.position[1]];
+          } else if (sel.type === 'gs_emitter') {
+            const em = store.gsParticleEmitters.find((e) => e.id === sel.id);
+            if (em) pos = [...em.position];
           } else if (sel.type === 'player') {
             pos = [...store.player.position];
           }

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -151,6 +151,33 @@ export function exportSceneJson(state: SceneStoreState): object {
     });
   }
 
+  if (state.gsParticleEmitters.length > 0) {
+    scene.gs_particle_emitters = state.gsParticleEmitters.map((e) => {
+      const out: Record<string, unknown> = {
+        position: e.position,
+        spawn_rate: e.spawn_rate,
+        lifetime_min: e.lifetime_min,
+        lifetime_max: e.lifetime_max,
+        velocity_min: e.velocity_min,
+        velocity_max: e.velocity_max,
+        acceleration: e.acceleration,
+        color_start: e.color_start,
+        color_end: e.color_end,
+        scale_min: e.scale_min,
+        scale_max: e.scale_max,
+        scale_end_factor: e.scale_end_factor,
+        opacity_start: e.opacity_start,
+        opacity_end: e.opacity_end,
+        emission: e.emission,
+        spawn_offset_min: e.spawn_offset_min,
+        spawn_offset_max: e.spawn_offset_max,
+      };
+      if (e.preset) out.preset = e.preset;
+      if (e.burst_duration > 0) out.burst_duration = e.burst_duration;
+      return out;
+    });
+  }
+
   if (state.collisionGridData) {
     const g = state.collisionGridData;
     scene.collision = {

--- a/tools/apps/bricklayer/src/panels/GsEmittersTab.tsx
+++ b/tools/apps/bricklayer/src/panels/GsEmittersTab.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { NumberInput } from '../components/NumberInput.js';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { GsParticleEmitterData } from '../store/types.js';
+
+const PRESETS: Record<string, Partial<GsParticleEmitterData>> = {
+  dust_puff: {
+    spawn_rate: 120, lifetime_min: 1, lifetime_max: 2.5,
+    velocity_min: [-3, 1, -3], velocity_max: [3, 5, 3],
+    acceleration: [0, -2, 0],
+    color_start: [0.6, 0.55, 0.45], color_end: [0.5, 0.48, 0.4],
+    scale_min: [0.1, 0.1, 0.1], scale_max: [0.3, 0.3, 0.3],
+    scale_end_factor: 0.1, opacity_start: 0.4, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-2, 0, -2], spawn_offset_max: [2, 1, 2],
+  },
+  spark_shower: {
+    spawn_rate: 40, lifetime_min: 0.3, lifetime_max: 0.8,
+    velocity_min: [-4, 8, -4], velocity_max: [4, 15, 4],
+    acceleration: [0, -15, 0],
+    color_start: [0.8, 0.6, 0.3], color_end: [0.5, 0.2, 0],
+    scale_min: [0.05, 0.05, 0.05], scale_max: [0.15, 0.15, 0.15],
+    scale_end_factor: 0, opacity_start: 0.5, opacity_end: 0, emission: 0.8,
+    spawn_offset_min: [-1, 0, -1], spawn_offset_max: [1, 1, 1],
+  },
+  magic_spiral: {
+    spawn_rate: 50, lifetime_min: 1.5, lifetime_max: 3,
+    velocity_min: [-2, 3, -2], velocity_max: [2, 6, 2],
+    acceleration: [0, 0.5, 0],
+    color_start: [0.4, 0.6, 1], color_end: [0.8, 0.3, 1],
+    scale_min: [0.5, 0.5, 0.5], scale_max: [1, 1, 1],
+    scale_end_factor: 0.3, opacity_start: 0.9, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-1, -0.5, -1], spawn_offset_max: [1, 0.5, 1],
+  },
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+  input: {
+    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 13,
+  },
+  btn: {
+    padding: '4px 10px', border: '1px solid #555', borderRadius: 4,
+    background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 12,
+  },
+  btnDanger: {
+    padding: '4px 10px', border: '1px solid #c33', borderRadius: 4,
+    background: '#4a2020', color: '#faa', cursor: 'pointer', fontSize: 12,
+  },
+  item: {
+    padding: 8, border: '1px solid #444', borderRadius: 4, background: '#22223a',
+    display: 'flex', flexDirection: 'column', gap: 6,
+  },
+  itemSelected: { borderColor: '#77f' },
+  select: {
+    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 13,
+  },
+  sectionLabel: { fontSize: 10, color: '#666', marginTop: 4 },
+};
+
+function rgbToHex(c: [number, number, number]): string {
+  return '#' + c.map((v) => Math.round(v * 255).toString(16).padStart(2, '0')).join('');
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  return [r, g, b];
+}
+
+function Vec3Input({ label, value, onChange, style }: {
+  label: string;
+  value: [number, number, number];
+  onChange: (v: [number, number, number]) => void;
+  style: React.CSSProperties;
+}) {
+  return (
+    <div style={styles.row}>
+      <span style={{ fontSize: 12, minWidth: 70 }}>{label}</span>
+      <NumberInput value={value[0]} onChange={(v) => onChange([v, value[1], value[2]])} step={0.1} style={style} />
+      <NumberInput value={value[1]} onChange={(v) => onChange([value[0], v, value[2]])} step={0.1} style={style} />
+      <NumberInput value={value[2]} onChange={(v) => onChange([value[0], value[1], v])} step={0.1} style={style} />
+    </div>
+  );
+}
+
+function EmitterEditor({ emitter }: { emitter: GsParticleEmitterData }) {
+  const updateGsEmitter = useSceneStore((s) => s.updateGsEmitter);
+  const removeGsEmitter = useSceneStore((s) => s.removeGsEmitter);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
+
+  const isSelected = selectedEntity?.type === 'gs_emitter' && selectedEntity.id === emitter.id;
+
+  const applyPreset = (name: string) => {
+    const preset = PRESETS[name];
+    if (preset) {
+      updateGsEmitter(emitter.id, { ...preset, preset: name });
+    } else {
+      updateGsEmitter(emitter.id, { preset: '' });
+    }
+  };
+
+  return (
+    <div
+      style={{ ...styles.item, ...(isSelected ? styles.itemSelected : {}) }}
+      onClick={() => setSelectedEntity({ type: 'gs_emitter', id: emitter.id })}
+    >
+      <div style={styles.row}>
+        <span style={{ fontSize: 13, flex: 1 }}>Emitter</span>
+        <button style={styles.btnDanger} onClick={(e) => { e.stopPropagation(); removeGsEmitter(emitter.id); }}>
+          Remove
+        </button>
+      </div>
+
+      {/* Preset */}
+      <div style={styles.row}>
+        <span style={{ fontSize: 12, minWidth: 70 }}>Preset</span>
+        <select style={styles.select} value={emitter.preset} onChange={(e) => applyPreset(e.target.value)}>
+          <option value="">Custom</option>
+          <option value="dust_puff">Dust Puff</option>
+          <option value="spark_shower">Spark Shower</option>
+          <option value="magic_spiral">Magic Spiral</option>
+        </select>
+      </div>
+
+      {/* Position */}
+      <Vec3Input label="Position" value={emitter.position}
+        onChange={(v) => updateGsEmitter(emitter.id, { position: v })} style={styles.input} />
+
+      {/* Spawn */}
+      <span style={styles.sectionLabel}>Spawn</span>
+      <div style={styles.row}>
+        <span style={{ fontSize: 12, minWidth: 70 }}>Rate</span>
+        <NumberInput value={emitter.spawn_rate} min={0} step={1}
+          onChange={(v) => updateGsEmitter(emitter.id, { spawn_rate: v })} style={styles.input} />
+      </div>
+      <div style={styles.row}>
+        <span style={{ fontSize: 12, minWidth: 70 }}>Life</span>
+        <NumberInput value={emitter.lifetime_min} min={0} step={0.1}
+          onChange={(v) => updateGsEmitter(emitter.id, { lifetime_min: v })} style={styles.input} />
+        <NumberInput value={emitter.lifetime_max} min={0} step={0.1}
+          onChange={(v) => updateGsEmitter(emitter.id, { lifetime_max: v })} style={styles.input} />
+      </div>
+      <Vec3Input label="Offset Min" value={emitter.spawn_offset_min}
+        onChange={(v) => updateGsEmitter(emitter.id, { spawn_offset_min: v })} style={styles.input} />
+      <Vec3Input label="Offset Max" value={emitter.spawn_offset_max}
+        onChange={(v) => updateGsEmitter(emitter.id, { spawn_offset_max: v })} style={styles.input} />
+
+      {/* Motion */}
+      <span style={styles.sectionLabel}>Motion</span>
+      <Vec3Input label="Vel Min" value={emitter.velocity_min}
+        onChange={(v) => updateGsEmitter(emitter.id, { velocity_min: v })} style={styles.input} />
+      <Vec3Input label="Vel Max" value={emitter.velocity_max}
+        onChange={(v) => updateGsEmitter(emitter.id, { velocity_max: v })} style={styles.input} />
+      <Vec3Input label="Accel" value={emitter.acceleration}
+        onChange={(v) => updateGsEmitter(emitter.id, { acceleration: v })} style={styles.input} />
+
+      {/* Appearance */}
+      <span style={styles.sectionLabel}>Appearance</span>
+      <div style={styles.row}>
+        <span style={{ fontSize: 12, minWidth: 70 }}>Color Start</span>
+        <input type="color" value={rgbToHex(emitter.color_start)}
+          onChange={(e) => updateGsEmitter(emitter.id, { color_start: hexToRgb(e.target.value) })} />
+        <span style={{ fontSize: 12, minWidth: 50 }}>End</span>
+        <input type="color" value={rgbToHex(emitter.color_end)}
+          onChange={(e) => updateGsEmitter(emitter.id, { color_end: hexToRgb(e.target.value) })} />
+      </div>
+      <Vec3Input label="Scale Min" value={emitter.scale_min}
+        onChange={(v) => updateGsEmitter(emitter.id, { scale_min: v })} style={styles.input} />
+      <Vec3Input label="Scale Max" value={emitter.scale_max}
+        onChange={(v) => updateGsEmitter(emitter.id, { scale_max: v })} style={styles.input} />
+      <div style={styles.row}>
+        <span style={{ fontSize: 12, minWidth: 70 }}>Scale End</span>
+        <NumberInput value={emitter.scale_end_factor} min={0} max={1} step={0.05}
+          onChange={(v) => updateGsEmitter(emitter.id, { scale_end_factor: v })} style={styles.input} />
+      </div>
+      <div style={styles.row}>
+        <span style={{ fontSize: 12, minWidth: 70 }}>Opacity</span>
+        <NumberInput value={emitter.opacity_start} min={0} max={1} step={0.05}
+          onChange={(v) => updateGsEmitter(emitter.id, { opacity_start: v })} style={styles.input} />
+        <NumberInput value={emitter.opacity_end} min={0} max={1} step={0.05}
+          onChange={(v) => updateGsEmitter(emitter.id, { opacity_end: v })} style={styles.input} />
+      </div>
+      <div style={styles.row}>
+        <span style={{ fontSize: 12, minWidth: 70 }}>Emission</span>
+        <NumberInput value={emitter.emission} min={0} step={0.1}
+          onChange={(v) => updateGsEmitter(emitter.id, { emission: v })} style={styles.input} />
+      </div>
+      <div style={styles.row}>
+        <span style={{ fontSize: 12, minWidth: 70 }}>Burst Dur</span>
+        <NumberInput value={emitter.burst_duration} min={0} step={0.1}
+          onChange={(v) => updateGsEmitter(emitter.id, { burst_duration: v })} style={styles.input} />
+      </div>
+    </div>
+  );
+}
+
+export function GsEmittersTab() {
+  const emitters = useSceneStore((s) => s.gsParticleEmitters);
+  const addGsEmitter = useSceneStore((s) => s.addGsEmitter);
+
+  return (
+    <div>
+      <div style={{ ...styles.row, marginBottom: 12 }}>
+        <span style={{ ...styles.label, flex: 1 }}>GS Particle Emitters ({emitters.length})</span>
+        <button style={styles.btn} onClick={() => addGsEmitter()}>+ Add</button>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {emitters.map((e) => <EmitterEditor key={e.id} emitter={e} />)}
+      </div>
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/panels/Inspector.tsx
+++ b/tools/apps/bricklayer/src/panels/Inspector.tsx
@@ -9,6 +9,7 @@ import { EntitiesTab } from './EntitiesTab.js';
 import { BackgroundTab } from './BackgroundTab.js';
 import { GaussianTab } from './GaussianTab.js';
 import { ObjectsTab } from './ObjectsTab.js';
+import { GsEmittersTab } from './GsEmittersTab.js';
 import { NavZoneTab } from './NavZoneTab.js';
 
 const tabs: { id: InspectorTab; label: string }[] = [
@@ -20,6 +21,7 @@ const tabs: { id: InspectorTab; label: string }[] = [
   { id: 'objects', label: 'Objects' },
   { id: 'backgrounds', label: 'BG' },
   { id: 'gaussian', label: 'GS' },
+  { id: 'gs_emitters', label: 'Emit' },
   { id: 'nav_zone', label: 'Nav' },
 ];
 
@@ -85,6 +87,7 @@ export function Inspector() {
         {inspectorTab === 'objects' && <ObjectsTab />}
         {inspectorTab === 'backgrounds' && <BackgroundTab />}
         {inspectorTab === 'gaussian' && <GaussianTab />}
+        {inspectorTab === 'gs_emitters' && <GsEmittersTab />}
         {inspectorTab === 'nav_zone' && <NavZoneTab />}
       </div>
     </div>

--- a/tools/apps/bricklayer/src/panels/ProjectTree.tsx
+++ b/tools/apps/bricklayer/src/panels/ProjectTree.tsx
@@ -24,6 +24,7 @@ const icons: Record<string, string> = {
   lights: '\u2600',      // ☀
   npcs: '\u263A',        // ☺
   portals: '\u29C9',     // ⧉
+  emitters: '\u2728',     // ✨
   player: '\u2666',      // ♦
   settings: '\u2699',    // ⚙
   gs_camera: '\u25CE',   // ◎
@@ -158,11 +159,14 @@ export function ProjectTree() {
   const addLight = useSceneStore((st) => st.addLight);
   const addNpc = useSceneStore((st) => st.addNpc);
   const addPortal = useSceneStore((st) => st.addPortal);
+  const gsParticleEmitters = useSceneStore((st) => st.gsParticleEmitters);
   const addPlacedObject = useSceneStore((st) => st.addPlacedObject);
   const removePlacedObject = useSceneStore((st) => st.removePlacedObject);
   const removeLight = useSceneStore((st) => st.removeLight);
   const removeNpc = useSceneStore((st) => st.removeNpc);
   const removePortal = useSceneStore((st) => st.removePortal);
+  const addGsEmitter = useSceneStore((st) => st.addGsEmitter);
+  const removeGsEmitter = useSceneStore((st) => st.removeGsEmitter);
   const collisionGridData = useSceneStore((st) => st.collisionGridData);
 
   const [sceneOpen, setSceneOpen] = useState(true);
@@ -170,6 +174,7 @@ export function ProjectTree() {
   const [lightOpen, setLightOpen] = useState(true);
   const [npcOpen, setNpcOpen] = useState(true);
   const [portalOpen, setPortalOpen] = useState(true);
+  const [emitterOpen, setEmitterOpen] = useState(true);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   const click = (node: NavigationNode) => {
@@ -323,6 +328,27 @@ export function ProjectTree() {
                 isActive={isActive({ kind: 'scene_item', entityType: 'portal', entityId: p.id })}
                 onClick={() => click({ kind: 'scene_item', entityType: 'portal', entityId: p.id })}
                 actions={removeBtn(() => removePortal(p.id))}
+              />
+            ))}
+          </TreeNode>
+
+          {/* Emitters */}
+          <TreeNode
+            icon={icons.emitters} label="Emitters" count={gsParticleEmitters.length}
+            arrow={emitterOpen ? '\u25BE' : '\u25B8'}
+            isActive={isActive({ kind: 'scene_category', category: 'emitters' as any })}
+            onClick={() => { setEmitterOpen(!emitterOpen); click({ kind: 'scene_category', category: 'emitters' as any }); }}
+            actions={addBtn(() => addGsEmitter(getCameraTarget().xyz))}
+            isOpen={emitterOpen}
+          >
+            {gsParticleEmitters.map((e, i) => (
+              <TreeNode
+                key={e.id}
+                icon={icons.emitters}
+                label={e.preset || `Emitter ${i + 1}`}
+                isActive={isActive({ kind: 'scene_item', entityType: 'gs_emitter', entityId: e.id })}
+                onClick={() => click({ kind: 'scene_item', entityType: 'gs_emitter', entityId: e.id })}
+                actions={removeBtn(() => removeGsEmitter(e.id))}
               />
             ))}
           </TreeNode>

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -7,6 +7,7 @@ import type {
   PortalData,
   PlacedObjectData,
   PlayerData,
+  GsParticleEmitterData,
 } from '../store/types.js';
 
 const styles: Record<string, React.CSSProperties> = {
@@ -588,6 +589,181 @@ function PlayerProperties({ player }: { player: PlayerData }) {
   );
 }
 
+const GS_PRESETS: Record<string, Partial<GsParticleEmitterData>> = {
+  dust_puff: {
+    spawn_rate: 120, lifetime_min: 1, lifetime_max: 2.5,
+    velocity_min: [-3, 1, -3], velocity_max: [3, 5, 3], acceleration: [0, -2, 0],
+    color_start: [0.6, 0.55, 0.45], color_end: [0.5, 0.48, 0.4],
+    scale_min: [0.1, 0.1, 0.1], scale_max: [0.3, 0.3, 0.3],
+    scale_end_factor: 0.1, opacity_start: 0.4, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-2, 0, -2], spawn_offset_max: [2, 1, 2],
+  },
+  spark_shower: {
+    spawn_rate: 40, lifetime_min: 0.3, lifetime_max: 0.8,
+    velocity_min: [-4, 8, -4], velocity_max: [4, 15, 4], acceleration: [0, -15, 0],
+    color_start: [0.8, 0.6, 0.3], color_end: [0.5, 0.2, 0],
+    scale_min: [0.05, 0.05, 0.05], scale_max: [0.15, 0.15, 0.15],
+    scale_end_factor: 0, opacity_start: 0.5, opacity_end: 0, emission: 0.8,
+    spawn_offset_min: [-1, 0, -1], spawn_offset_max: [1, 1, 1],
+  },
+  magic_spiral: {
+    spawn_rate: 50, lifetime_min: 1.5, lifetime_max: 3,
+    velocity_min: [-2, 3, -2], velocity_max: [2, 6, 2], acceleration: [0, 0.5, 0],
+    color_start: [0.4, 0.6, 1], color_end: [0.8, 0.3, 1],
+    scale_min: [0.5, 0.5, 0.5], scale_max: [1, 1, 1],
+    scale_end_factor: 0.3, opacity_start: 0.9, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-1, -0.5, -1], spawn_offset_max: [1, 0.5, 1],
+  },
+};
+
+function rgbToHex(c: [number, number, number]): string {
+  return '#' + c.map((v) => Math.round(v * 255).toString(16).padStart(2, '0')).join('');
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  return [
+    parseInt(hex.slice(1, 3), 16) / 255,
+    parseInt(hex.slice(3, 5), 16) / 255,
+    parseInt(hex.slice(5, 7), 16) / 255,
+  ];
+}
+
+function GsEmitterProperties({ emitter }: { emitter: GsParticleEmitterData }) {
+  const update = useSceneStore((s) => s.updateGsEmitter);
+  const remove = useSceneStore((s) => s.removeGsEmitter);
+
+  const applyPreset = (name: string) => {
+    const preset = GS_PRESETS[name];
+    if (preset) {
+      update(emitter.id, { ...preset, preset: name });
+    } else {
+      update(emitter.id, { preset: '' });
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ ...styles.row, marginBottom: 12 }}>
+        <span style={{ ...styles.label, flex: 1 }}>Particle Emitter</span>
+        <button style={styles.btnDanger} onClick={() => remove(emitter.id)}>Remove</button>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Preset</span>
+        <select
+          style={styles.select}
+          value={emitter.preset}
+          onChange={(e) => applyPreset(e.target.value)}
+        >
+          <option value="">Custom</option>
+          <option value="dust_puff">Dust Puff</option>
+          <option value="spark_shower">Spark Shower</option>
+          <option value="magic_spiral">Magic Spiral</option>
+        </select>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Position</span>
+        <Vec3Input value={emitter.position} onChange={(v) => update(emitter.id, { position: v })} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Spawn Rate</span>
+        <NumberInput value={emitter.spawn_rate} min={0} step={1}
+          onChange={(v) => update(emitter.id, { spawn_rate: v })} style={styles.input} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Lifetime</span>
+        <div style={styles.row}>
+          <NumberInput label="Min" value={emitter.lifetime_min} min={0} step={0.1}
+            onChange={(v) => update(emitter.id, { lifetime_min: v })} style={styles.input} />
+          <NumberInput label="Max" value={emitter.lifetime_max} min={0} step={0.1}
+            onChange={(v) => update(emitter.id, { lifetime_max: v })} style={styles.input} />
+        </div>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Velocity Min</span>
+        <Vec3Input value={emitter.velocity_min} onChange={(v) => update(emitter.id, { velocity_min: v })} />
+      </div>
+      <div style={styles.section}>
+        <span style={styles.label}>Velocity Max</span>
+        <Vec3Input value={emitter.velocity_max} onChange={(v) => update(emitter.id, { velocity_max: v })} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Acceleration</span>
+        <Vec3Input value={emitter.acceleration} onChange={(v) => update(emitter.id, { acceleration: v })} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Spawn Offset Min</span>
+        <Vec3Input value={emitter.spawn_offset_min} onChange={(v) => update(emitter.id, { spawn_offset_min: v })} />
+      </div>
+      <div style={styles.section}>
+        <span style={styles.label}>Spawn Offset Max</span>
+        <Vec3Input value={emitter.spawn_offset_max} onChange={(v) => update(emitter.id, { spawn_offset_max: v })} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Color</span>
+        <div style={styles.row}>
+          <span style={{ fontSize: 12 }}>Start</span>
+          <input type="color" value={rgbToHex(emitter.color_start)}
+            onChange={(e) => update(emitter.id, { color_start: hexToRgb(e.target.value) })}
+            style={{ width: 40, height: 24, border: 'none', cursor: 'pointer' }} />
+          <span style={{ fontSize: 12 }}>End</span>
+          <input type="color" value={rgbToHex(emitter.color_end)}
+            onChange={(e) => update(emitter.id, { color_end: hexToRgb(e.target.value) })}
+            style={{ width: 40, height: 24, border: 'none', cursor: 'pointer' }} />
+        </div>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Scale Min</span>
+        <Vec3Input value={emitter.scale_min} onChange={(v) => update(emitter.id, { scale_min: v })} />
+      </div>
+      <div style={styles.section}>
+        <span style={styles.label}>Scale Max</span>
+        <Vec3Input value={emitter.scale_max} onChange={(v) => update(emitter.id, { scale_max: v })} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Scale End Factor</span>
+        <NumberInput value={emitter.scale_end_factor} min={0} max={1} step={0.05}
+          onChange={(v) => update(emitter.id, { scale_end_factor: v })} style={styles.input} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Opacity</span>
+        <div style={styles.row}>
+          <NumberInput label="Start" value={emitter.opacity_start} min={0} max={1} step={0.05}
+            onChange={(v) => update(emitter.id, { opacity_start: v })} style={styles.input} />
+          <NumberInput label="End" value={emitter.opacity_end} min={0} max={1} step={0.05}
+            onChange={(v) => update(emitter.id, { opacity_end: v })} style={styles.input} />
+        </div>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Emission</span>
+        <NumberInput value={emitter.emission} min={0} step={0.1}
+          onChange={(v) => update(emitter.id, { emission: v })} style={styles.input} />
+        <span style={{ fontSize: 10, color: '#666' }}>
+          {'> 0 = self-lit (bypasses scene lighting, triggers bloom)'}
+        </span>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Burst Duration</span>
+        <NumberInput value={emitter.burst_duration} min={0} step={0.1}
+          onChange={(v) => update(emitter.id, { burst_duration: v })} style={styles.input} />
+        <span style={{ fontSize: 10, color: '#666' }}>0 = continuous loop</span>
+      </div>
+    </div>
+  );
+}
+
 // ── Main component ──
 
 export function ScenePropertiesPanel() {
@@ -596,6 +772,7 @@ export function ScenePropertiesPanel() {
   const staticLights = useSceneStore((s) => s.staticLights);
   const npcs = useSceneStore((s) => s.npcs);
   const portals = useSceneStore((s) => s.portals);
+  const gsParticleEmitters = useSceneStore((s) => s.gsParticleEmitters);
   const player = useSceneStore((s) => s.player);
 
   if (!selectedEntity) {
@@ -624,6 +801,12 @@ export function ScenePropertiesPanel() {
     const portal = portals.find((p) => p.id === selectedEntity.id);
     if (!portal) return <div style={styles.empty}>Portal not found</div>;
     return <PortalProperties portal={portal} />;
+  }
+
+  if (selectedEntity.type === 'gs_emitter') {
+    const emitter = gsParticleEmitters.find((e) => e.id === selectedEntity.id);
+    if (!emitter) return <div style={styles.empty}>Emitter not found</div>;
+    return <GsEmitterProperties emitter={emitter} />;
   }
 
   if (selectedEntity.type === 'player') {

--- a/tools/apps/bricklayer/src/panels/SceneTreePanel.tsx
+++ b/tools/apps/bricklayer/src/panels/SceneTreePanel.tsx
@@ -132,10 +132,12 @@ export function SceneTreePanel() {
   const player = useSceneStore((s) => s.player);
   const selectedEntity = useSceneStore((s) => s.selectedEntity);
   const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
+  const gsParticleEmitters = useSceneStore((s) => s.gsParticleEmitters);
   const addPlacedObject = useSceneStore((s) => s.addPlacedObject);
   const addLight = useSceneStore((s) => s.addLight);
   const addNpc = useSceneStore((s) => s.addNpc);
   const addPortal = useSceneStore((s) => s.addPortal);
+  const addGsEmitter = useSceneStore((s) => s.addGsEmitter);
 
   const [showAdd, setShowAdd] = useState(false);
   const addRef = useRef<HTMLDivElement>(null);
@@ -199,6 +201,14 @@ export function SceneTreePanel() {
               >
                 Portal
               </button>
+              <button
+                style={styles.dropdownItem}
+                onClick={() => { addGsEmitter(); setShowAdd(false); }}
+                onMouseEnter={(e) => { (e.target as HTMLElement).style.background = '#3a3a6a'; }}
+                onMouseLeave={(e) => { (e.target as HTMLElement).style.background = 'transparent'; }}
+              >
+                Particle Emitter
+              </button>
             </div>
           )}
         </div>
@@ -248,6 +258,18 @@ export function SceneTreePanel() {
             label={p.target_scene || p.id.slice(0, 16)}
             selected={selectedEntity?.type === 'portal' && selectedEntity.id === p.id}
             onClick={() => setSelectedEntity({ type: 'portal', id: p.id })}
+          />
+        ))}
+      </CollapsibleSection>
+
+      {/* Particle Emitters */}
+      <CollapsibleSection title="Emitters" count={gsParticleEmitters.length}>
+        {gsParticleEmitters.map((e) => (
+          <TreeItem
+            key={e.id}
+            label={e.preset || 'Custom Emitter'}
+            selected={selectedEntity?.type === 'gs_emitter' && selectedEntity.id === e.id}
+            onClick={() => setSelectedEntity({ type: 'gs_emitter', id: e.id })}
           />
         ))}
       </CollapsibleSection>

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -151,6 +151,7 @@ export type InspectorTab =
   | 'objects'
   | 'backgrounds'
   | 'gaussian'
+  | 'gs_emitters'
   | 'nav_zone';
 
 export type CollisionLayer = 'solid' | 'elevation' | 'nav_zone';
@@ -162,6 +163,29 @@ export type SettingsCategory =
   | 'day_night'
   | 'vfx'
   | 'backgrounds';
+
+export interface GsParticleEmitterData {
+  id: string;
+  preset: string;  // '' | 'dust_puff' | 'spark_shower' | 'magic_spiral'
+  position: [number, number, number];  // [scene_x, height, scene_z]
+  spawn_rate: number;
+  lifetime_min: number;
+  lifetime_max: number;
+  velocity_min: [number, number, number];
+  velocity_max: [number, number, number];
+  acceleration: [number, number, number];
+  color_start: [number, number, number];
+  color_end: [number, number, number];
+  scale_min: [number, number, number];
+  scale_max: [number, number, number];
+  scale_end_factor: number;
+  opacity_start: number;
+  opacity_end: number;
+  emission: number;
+  spawn_offset_min: [number, number, number];
+  spawn_offset_max: [number, number, number];
+  burst_duration: number;
+}
 
 export interface PlacedObjectData {
   id: string;
@@ -260,5 +284,6 @@ export interface BricklayerFile {
     dayNight: DayNightData;
     gaussianSplat: GaussianSplatConfig;
     placedObjects: PlacedObjectData[];
+    gsParticleEmitters?: GsParticleEmitterData[];
   };
 }

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -6,6 +6,7 @@ import type {
   NpcData,
   PortalData,
   PlacedObjectData,
+  GsParticleEmitterData,
   EmitterConfig,
   BackgroundLayer,
   WeatherData,
@@ -184,6 +185,7 @@ export interface SceneStoreState {
   npcs: NpcData[];
   portals: PortalData[];
   placedObjects: PlacedObjectData[];
+  gsParticleEmitters: GsParticleEmitterData[];
   player: PlayerData;
   backgroundLayers: BackgroundLayer[];
   torchEmitter: EmitterConfig;
@@ -251,6 +253,9 @@ export interface SceneStoreState {
   storeAssetBlob: (path: string, blob: Blob) => void;
   updatePlacedObject: (id: string, patch: Partial<PlacedObjectData>) => void;
   removePlacedObject: (id: string) => void;
+  addGsEmitter: (position?: [number, number, number]) => void;
+  updateGsEmitter: (id: string, patch: Partial<GsParticleEmitterData>) => void;
+  removeGsEmitter: (id: string) => void;
   updatePlayer: (patch: Partial<PlayerData>) => void;
   addBackgroundLayer: () => void;
   updateBackgroundLayer: (id: string, patch: Partial<BackgroundLayer>) => void;
@@ -420,6 +425,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   npcs: [],
   portals: [],
   placedObjects: [],
+  gsParticleEmitters: [],
   player: defaultPlayer(),
   backgroundLayers: [],
   torchEmitter: defaultEmitter(),
@@ -684,6 +690,38 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   }),
   removePlacedObject: (id) => set({
     placedObjects: get().placedObjects.filter((o) => o.id !== id), isDirty: true,
+  }),
+
+  addGsEmitter: (pos?) => {
+    const emitter: GsParticleEmitterData = {
+      id: genId('gs_emitter'),
+      preset: '',
+      position: pos ?? [0, 2, 0],
+      spawn_rate: 10,
+      lifetime_min: 0.5,
+      lifetime_max: 1.5,
+      velocity_min: [-1, 1, -1],
+      velocity_max: [1, 3, 1],
+      acceleration: [0, -9.8, 0],
+      color_start: [1, 0.8, 0.3],
+      color_end: [1, 0.2, 0],
+      scale_min: [0.3, 0.3, 0.3],
+      scale_max: [0.6, 0.6, 0.6],
+      scale_end_factor: 0,
+      opacity_start: 1,
+      opacity_end: 0,
+      emission: 0,
+      spawn_offset_min: [0, 0, 0],
+      spawn_offset_max: [0, 0, 0],
+      burst_duration: 0,
+    };
+    set({ gsParticleEmitters: [...get().gsParticleEmitters, emitter], isDirty: true });
+  },
+  updateGsEmitter: (id, patch) => set({
+    gsParticleEmitters: get().gsParticleEmitters.map((e) => (e.id === id ? { ...e, ...patch } : e)), isDirty: true,
+  }),
+  removeGsEmitter: (id) => set({
+    gsParticleEmitters: get().gsParticleEmitters.filter((e) => e.id !== id), isDirty: true,
   }),
 
   updatePlayer: (patch) => set({ player: { ...get().player, ...patch }, isDirty: true }),
@@ -955,6 +993,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     npcs: [],
     portals: [],
     placedObjects: [],
+    gsParticleEmitters: [],
     player: defaultPlayer(),
     backgroundLayers: [],
     torchPositions: [],
@@ -1072,6 +1111,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
         dayNight: s.dayNight,
         gaussianSplat: s.gaussianSplat,
         placedObjects: s.placedObjects,
+        gsParticleEmitters: s.gsParticleEmitters,
       },
     };
   },
@@ -1097,6 +1137,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       npcs: data.scene.npcs,
       portals: data.scene.portals,
       placedObjects: data.scene.placedObjects ?? [],
+      gsParticleEmitters: data.scene.gsParticleEmitters ?? [],
       player: data.scene.player,
       backgroundLayers: data.scene.backgroundLayers,
       torchEmitter: data.scene.torchEmitter,

--- a/tools/apps/bricklayer/src/viewport/GsEmitterMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/GsEmitterMarkers.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Html } from '@react-three/drei';
+import { useSceneStore } from '../store/useSceneStore.js';
+
+function EmitterMarker({ position, preset, isSelected, onSelect }: {
+  position: [number, number, number];
+  preset: string;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  const label = preset || 'Custom';
+
+  return (
+    <group position={[position[0], position[1], position[2]]}>
+      {/* Invisible hit box */}
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
+        <sphereGeometry args={[1.0, 12, 12]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+      {/* Outer glow */}
+      <mesh>
+        <sphereGeometry args={[0.7, 12, 12]} />
+        <meshBasicMaterial
+          color={isSelected ? '#ffffff' : '#ff4dc8'}
+          transparent
+          opacity={0.3}
+        />
+      </mesh>
+      {/* Center sphere */}
+      <mesh>
+        <sphereGeometry args={[0.4, 12, 12]} />
+        <meshBasicMaterial color={isSelected ? '#ffffff' : '#ff4dc8'} />
+      </mesh>
+      {/* Label */}
+      {isSelected && (
+        <Html position={[0, 1.2, 0]} center>
+          <div style={{
+            background: 'rgba(0,0,0,0.7)', color: '#ff80dd',
+            padding: '1px 5px', borderRadius: 3, fontSize: 10, whiteSpace: 'nowrap',
+          }}>
+            {label}
+          </div>
+        </Html>
+      )}
+    </group>
+  );
+}
+
+export function GsEmitterMarkers() {
+  const emitters = useSceneStore((s) => s.gsParticleEmitters);
+  const showGizmos = useSceneStore((s) => s.showGizmos);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
+
+  if (!showGizmos) return null;
+
+  return (
+    <group>
+      {emitters.map((e) => (
+        <EmitterMarker
+          key={e.id}
+          position={e.position}
+          preset={e.preset}
+          isSelected={selectedEntity?.type === 'gs_emitter' && selectedEntity.id === e.id}
+          onSelect={() => setSelectedEntity({ type: 'gs_emitter', id: e.id })}
+        />
+      ))}
+    </group>
+  );
+}

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -9,6 +9,7 @@ import { LightGizmos } from './LightGizmos.js';
 import { NpcMarkers } from './NpcMarkers.js';
 import { PortalMarkers } from './PortalMarkers.js';
 import { ObjectMarkers } from './ObjectMarkers.js';
+import { GsEmitterMarkers } from './GsEmitterMarkers.js';
 import { PlayerMarker } from './PlayerMarker.js';
 import { CollisionOverlay } from './CollisionOverlay.js';
 import { useSceneStore } from '../store/useSceneStore.js';
@@ -88,6 +89,10 @@ function getGrabbedEntityY(): number {
   if (sel.type === 'player') {
     return store.player.position[1];
   }
+  if (sel.type === 'gs_emitter') {
+    const em = store.gsParticleEmitters.find((e) => e.id === sel.id);
+    return em?.position[1] ?? 0;
+  }
   // portal: always Y=0
   return 0;
 }
@@ -108,6 +113,8 @@ function updateGrabbedEntity(x: number, y: number, z: number) {
     store.updateLight(sel.id, { position: [x, z], height: y });
   } else if (sel.type === 'portal') {
     store.updatePortal(sel.id, { position: [x, z] });
+  } else if (sel.type === 'gs_emitter') {
+    store.updateGsEmitter(sel.id, { position: [x, y, z] });
   } else if (sel.type === 'player') {
     store.updatePlayer({ position: [x, y, z] });
   }
@@ -277,6 +284,7 @@ function SceneContent() {
       <LightGizmos />
       <NpcMarkers />
       <PortalMarkers />
+      <GsEmitterMarkers />
       <ObjectMarkers />
       <PlayerMarker />
       <CollisionOverlay />

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -197,6 +197,9 @@ function GrabPlane() {
         } else if (sel.type === 'portal') {
           const portal = store.portals.find((p) => p.id === sel.id);
           if (portal) { cx = portal.position[0]; cz = portal.position[1]; }
+        } else if (sel.type === 'gs_emitter') {
+          const em = store.gsParticleEmitters.find((e) => e.id === sel.id);
+          if (em) { cx = em.position[0]; cz = em.position[2]; }
         } else if (sel.type === 'player') {
           cx = store.player.position[0]; cz = store.player.position[2];
         }

--- a/tools/tests/package.json
+++ b/tools/tests/package.json
@@ -22,7 +22,8 @@
     "test:pose-templates": "node --import tsx/esm --conditions source src/pose-templates.test.ts",
     "test:echidna-ply-export": "node --import tsx/esm --conditions source src/echidna-ply-export.test.ts",
     "test:bricklayer-store": "node --import tsx/esm --conditions source src/bricklayer-store.test.ts",
-    "test:bricklayer-grab": "node --import tsx/esm --conditions source src/bricklayer-grab.test.ts"
+    "test:bricklayer-grab": "node --import tsx/esm --conditions source src/bricklayer-grab.test.ts",
+    "test:bricklayer-gs-emitters": "node --import tsx/esm --conditions source src/bricklayer-gs-emitters.test.ts"
   },
   "dependencies": {
     "@gseurat/test-harness": "workspace:*",

--- a/tools/tests/src/bricklayer-gs-emitters.test.ts
+++ b/tools/tests/src/bricklayer-gs-emitters.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Unit tests for Bricklayer GS particle emitter integration.
+ *
+ * Tests store operations (add/update/remove), scene export, and
+ * save/load roundtrip for Gaussian particle emitters.
+ *
+ * Run: pnpm test:bricklayer-gs-emitters
+ */
+
+// ── Types (inlined to avoid React/Three.js imports) ──
+
+interface GsParticleEmitterData {
+  id: string;
+  preset: string;
+  position: [number, number, number];
+  spawn_rate: number;
+  lifetime_min: number;
+  lifetime_max: number;
+  velocity_min: [number, number, number];
+  velocity_max: [number, number, number];
+  acceleration: [number, number, number];
+  color_start: [number, number, number];
+  color_end: [number, number, number];
+  scale_min: [number, number, number];
+  scale_max: [number, number, number];
+  scale_end_factor: number;
+  opacity_start: number;
+  opacity_end: number;
+  emission: number;
+  spawn_offset_min: [number, number, number];
+  spawn_offset_max: [number, number, number];
+  burst_duration: number;
+}
+
+// ── Store operations (mirrors useSceneStore logic) ──
+
+let idCounter = 0;
+function genId(prefix: string): string {
+  return `${prefix}_${Date.now()}_${++idCounter}`;
+}
+
+function defaultEmitter(pos?: [number, number, number]): GsParticleEmitterData {
+  return {
+    id: genId('gs_emitter'),
+    preset: '',
+    position: pos ?? [0, 2, 0],
+    spawn_rate: 10,
+    lifetime_min: 0.5,
+    lifetime_max: 1.5,
+    velocity_min: [-1, 1, -1],
+    velocity_max: [1, 3, 1],
+    acceleration: [0, -9.8, 0],
+    color_start: [1, 0.8, 0.3],
+    color_end: [1, 0.2, 0],
+    scale_min: [0.3, 0.3, 0.3],
+    scale_max: [0.6, 0.6, 0.6],
+    scale_end_factor: 0,
+    opacity_start: 1,
+    opacity_end: 0,
+    emission: 0,
+    spawn_offset_min: [0, 0, 0],
+    spawn_offset_max: [0, 0, 0],
+    burst_duration: 0,
+  };
+}
+
+function addEmitter(list: GsParticleEmitterData[], pos?: [number, number, number]): GsParticleEmitterData[] {
+  return [...list, defaultEmitter(pos)];
+}
+
+function updateEmitter(list: GsParticleEmitterData[], id: string, patch: Partial<GsParticleEmitterData>): GsParticleEmitterData[] {
+  return list.map((e) => (e.id === id ? { ...e, ...patch } : e));
+}
+
+function removeEmitter(list: GsParticleEmitterData[], id: string): GsParticleEmitterData[] {
+  return list.filter((e) => e.id !== id);
+}
+
+// ── Preset application (mirrors GsEmittersTab logic) ──
+
+const PRESETS: Record<string, Partial<GsParticleEmitterData>> = {
+  dust_puff: {
+    spawn_rate: 120, lifetime_min: 1, lifetime_max: 2.5,
+    velocity_min: [-3, 1, -3], velocity_max: [3, 5, 3], acceleration: [0, -2, 0],
+    color_start: [0.6, 0.55, 0.45], color_end: [0.5, 0.48, 0.4],
+    scale_min: [0.1, 0.1, 0.1], scale_max: [0.3, 0.3, 0.3],
+    scale_end_factor: 0.1, opacity_start: 0.4, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-2, 0, -2], spawn_offset_max: [2, 1, 2],
+  },
+  spark_shower: {
+    spawn_rate: 40, lifetime_min: 0.3, lifetime_max: 0.8,
+    emission: 0.8,
+  },
+  magic_spiral: {
+    spawn_rate: 50, lifetime_min: 1.5, lifetime_max: 3,
+  },
+};
+
+function applyPreset(emitter: GsParticleEmitterData, presetName: string): GsParticleEmitterData {
+  const preset = PRESETS[presetName];
+  if (!preset) return { ...emitter, preset: '' };
+  return { ...emitter, ...preset, preset: presetName };
+}
+
+// ── Scene export (mirrors sceneExport.ts logic) ──
+
+function exportEmitters(list: GsParticleEmitterData[]): Record<string, unknown>[] | null {
+  if (list.length === 0) return null;
+  return list.map((e) => {
+    const out: Record<string, unknown> = {
+      position: e.position,
+      spawn_rate: e.spawn_rate,
+      lifetime_min: e.lifetime_min,
+      lifetime_max: e.lifetime_max,
+      velocity_min: e.velocity_min,
+      velocity_max: e.velocity_max,
+      acceleration: e.acceleration,
+      color_start: e.color_start,
+      color_end: e.color_end,
+      scale_min: e.scale_min,
+      scale_max: e.scale_max,
+      scale_end_factor: e.scale_end_factor,
+      opacity_start: e.opacity_start,
+      opacity_end: e.opacity_end,
+      emission: e.emission,
+      spawn_offset_min: e.spawn_offset_min,
+      spawn_offset_max: e.spawn_offset_max,
+    };
+    if (e.preset) out.preset = e.preset;
+    if (e.burst_duration > 0) out.burst_duration = e.burst_duration;
+    return out;
+  });
+}
+
+// ── Save/load (mirrors store saveProject/loadProject for emitters) ──
+
+interface SavedScene {
+  gsParticleEmitters?: GsParticleEmitterData[];
+}
+
+function saveEmitters(list: GsParticleEmitterData[]): SavedScene {
+  return { gsParticleEmitters: list };
+}
+
+function loadEmitters(data: SavedScene): GsParticleEmitterData[] {
+  return data.gsParticleEmitters ?? [];
+}
+
+// ── Grab mode (mirrors Viewport.tsx logic) ──
+
+function getEmitterY(list: GsParticleEmitterData[], id: string): number {
+  const em = list.find((e) => e.id === id);
+  return em?.position[1] ?? 0;
+}
+
+function updateEmitterPosition(list: GsParticleEmitterData[], id: string, x: number, y: number, z: number): GsParticleEmitterData[] {
+  return updateEmitter(list, id, { position: [x, y, z] });
+}
+
+// ── Test harness ──
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, message: string) {
+  if (!condition) {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  } else {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  }
+}
+
+// ── Tests ──
+
+console.log('\n=== Bricklayer GS Particle Emitter Tests ===\n');
+
+// 1. Store operations
+console.log('--- Store operations ---\n');
+
+{
+  console.log('Test 1.1: Add emitter -> list grows');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  assert(list.length === 1, `list length is 1 (got ${list.length})`);
+  assert(list[0].preset === '', 'default preset is empty');
+  assert(list[0].position[1] === 2, 'default height is 2');
+}
+
+{
+  console.log('Test 1.2: Add emitter with custom position');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list, [10, 5, 20]);
+  assert(list[0].position[0] === 10, 'x = 10');
+  assert(list[0].position[1] === 5, 'y = 5');
+  assert(list[0].position[2] === 20, 'z = 20');
+}
+
+{
+  console.log('Test 1.3: Add multiple emitters -> unique IDs');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  list = addEmitter(list);
+  list = addEmitter(list);
+  assert(list.length === 3, 'list has 3 emitters');
+  assert(list[0].id !== list[1].id, 'IDs are unique (0 != 1)');
+  assert(list[1].id !== list[2].id, 'IDs are unique (1 != 2)');
+}
+
+{
+  console.log('Test 1.4: Update emitter -> changes applied');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  const id = list[0].id;
+  list = updateEmitter(list, id, { spawn_rate: 100, emission: 2.5 });
+  assert(list[0].spawn_rate === 100, 'spawn_rate updated to 100');
+  assert(list[0].emission === 2.5, 'emission updated to 2.5');
+  assert(list[0].position[1] === 2, 'position unchanged');
+}
+
+{
+  console.log('Test 1.5: Update nonexistent ID -> no crash');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  list = updateEmitter(list, 'nonexistent', { spawn_rate: 999 });
+  assert(list[0].spawn_rate === 10, 'original emitter unchanged');
+}
+
+{
+  console.log('Test 1.6: Remove emitter -> list shrinks');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  list = addEmitter(list);
+  const id = list[0].id;
+  list = removeEmitter(list, id);
+  assert(list.length === 1, 'list has 1 emitter after remove');
+  assert(list[0].id !== id, 'removed emitter is gone');
+}
+
+{
+  console.log('Test 1.7: Remove nonexistent ID -> no crash');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  list = removeEmitter(list, 'nonexistent');
+  assert(list.length === 1, 'list unchanged');
+}
+
+{
+  console.log('Test 1.8: Default emitter has valid acceleration (gravity)');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  assert(list[0].acceleration[1] === -9.8, 'default gravity is -9.8');
+}
+
+// 2. Preset application
+console.log('\n--- Preset application ---\n');
+
+{
+  console.log('Test 2.1: Apply dust_puff preset');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  const updated = applyPreset(list[0], 'dust_puff');
+  assert(updated.preset === 'dust_puff', 'preset name set');
+  assert(updated.spawn_rate === 120, 'spawn_rate from preset');
+  assert(updated.opacity_start === 0.4, 'opacity from preset');
+}
+
+{
+  console.log('Test 2.2: Apply spark_shower preset');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  const updated = applyPreset(list[0], 'spark_shower');
+  assert(updated.preset === 'spark_shower', 'preset name set');
+  assert(updated.emission === 0.8, 'emission from preset');
+}
+
+{
+  console.log('Test 2.3: Apply unknown preset -> clears preset name');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  const withPreset = applyPreset(list[0], 'dust_puff');
+  const cleared = applyPreset(withPreset, '');
+  assert(cleared.preset === '', 'preset cleared');
+}
+
+{
+  console.log('Test 2.4: Preset preserves position');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list, [99, 88, 77]);
+  const updated = applyPreset(list[0], 'dust_puff');
+  assert(updated.position[0] === 99, 'position x preserved');
+  assert(updated.position[1] === 88, 'position y preserved');
+}
+
+// 3. Scene export
+console.log('\n--- Scene export ---\n');
+
+{
+  console.log('Test 3.1: Empty list -> null');
+  const result = exportEmitters([]);
+  assert(result === null, 'empty list returns null');
+}
+
+{
+  console.log('Test 3.2: Single emitter -> array with position');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list, [5, 3, 7]);
+  const result = exportEmitters(list)!;
+  assert(result.length === 1, 'one emitter exported');
+  const pos = result[0].position as number[];
+  assert(pos[0] === 5 && pos[1] === 3 && pos[2] === 7, 'position matches');
+}
+
+{
+  console.log('Test 3.3: Preset name included when set');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  list = updateEmitter(list, list[0].id, { preset: 'spark_shower' });
+  const result = exportEmitters(list)!;
+  assert(result[0].preset === 'spark_shower', 'preset in export');
+}
+
+{
+  console.log('Test 3.4: Preset name omitted when empty');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  const result = exportEmitters(list)!;
+  assert(!('preset' in result[0]), 'no preset key when empty');
+}
+
+{
+  console.log('Test 3.5: burst_duration omitted when 0');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  const result = exportEmitters(list)!;
+  assert(!('burst_duration' in result[0]), 'no burst_duration when 0');
+}
+
+{
+  console.log('Test 3.6: burst_duration included when > 0');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  list = updateEmitter(list, list[0].id, { burst_duration: 2.5 });
+  const result = exportEmitters(list)!;
+  assert(result[0].burst_duration === 2.5, 'burst_duration exported');
+}
+
+// 4. Save/load roundtrip
+console.log('\n--- Save/load roundtrip ---\n');
+
+{
+  console.log('Test 4.1: Empty emitters -> load -> empty');
+  const saved = saveEmitters([]);
+  const loaded = loadEmitters(JSON.parse(JSON.stringify(saved)));
+  assert(loaded.length === 0, 'empty list after roundtrip');
+}
+
+{
+  console.log('Test 4.2: Save with emitters -> load -> preserved');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list, [10, 5, 20]);
+  list = updateEmitter(list, list[0].id, { preset: 'dust_puff', spawn_rate: 120 });
+  const saved = saveEmitters(list);
+  const loaded = loadEmitters(JSON.parse(JSON.stringify(saved)));
+  assert(loaded.length === 1, '1 emitter after roundtrip');
+  assert(loaded[0].preset === 'dust_puff', 'preset preserved');
+  assert(loaded[0].spawn_rate === 120, 'spawn_rate preserved');
+  assert(loaded[0].position[0] === 10, 'position preserved');
+}
+
+{
+  console.log('Test 4.3: Load from file without gsParticleEmitters -> empty array');
+  const loaded = loadEmitters({});
+  assert(loaded.length === 0, 'missing field defaults to empty');
+}
+
+{
+  console.log('Test 4.4: Multiple emitters survive roundtrip');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list, [1, 2, 3]);
+  list = addEmitter(list, [4, 5, 6]);
+  list = addEmitter(list, [7, 8, 9]);
+  const saved = saveEmitters(list);
+  const loaded = loadEmitters(JSON.parse(JSON.stringify(saved)));
+  assert(loaded.length === 3, '3 emitters after roundtrip');
+  assert(loaded[2].position[0] === 7, 'third emitter position preserved');
+}
+
+// 5. Grab mode
+console.log('\n--- Grab mode ---\n');
+
+{
+  console.log('Test 5.1: Get emitter Y position');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list, [0, 7.5, 0]);
+  const y = getEmitterY(list, list[0].id);
+  assert(y === 7.5, `Y is 7.5 (got ${y})`);
+}
+
+{
+  console.log('Test 5.2: Get Y for nonexistent ID -> 0');
+  const y = getEmitterY([], 'fake');
+  assert(y === 0, `Y is 0 for missing (got ${y})`);
+}
+
+{
+  console.log('Test 5.3: Update emitter position via grab');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  const id = list[0].id;
+  list = updateEmitterPosition(list, id, 15, 10, 25);
+  assert(list[0].position[0] === 15, 'x updated');
+  assert(list[0].position[1] === 10, 'y updated');
+  assert(list[0].position[2] === 25, 'z updated');
+}
+
+// --- Summary ---
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ${passed} passed, ${failed} failed`);
+console.log('='.repeat(40));
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- **Scene JSON**: New `gs_particle_emitters` array with preset support (`dust_puff`, `spark_shower`, `magic_spiral`) and full per-field override. Emitters use scene/voxel coordinates (same as lights), transformed at load time.
- **Bricklayer**: Emitters section in project tree with add/remove, full property editor (preset dropdown, position, spawn/motion/appearance params), magenta sphere gizmos in viewport, G-key grab with Shift-height support.
- **Demo**: Magenta markers (P0, P1...) in scene layer overlay, HUD emitter count.
- **Docs**: Full parameter reference in `docs/bricklayer.md`.

## Test plan
- [x] C++ tests: `gs_resolve_preset`, scene JSON round-trip (13/13 pass)
- [x] TS tests: 45 cases — store add/update/remove, preset application, scene export, save/load roundtrip, grab mode (`pnpm test:bricklayer-gs-emitters`)
- [x] Visual: Add emitter in Bricklayer tree → gizmo appears, G to grab, Shift for height
- [x] Export: File > Export Scene → `gs_particle_emitters` in JSON
- [x] Engine: Load exported scene in GS demo → emitters spawn at placed positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)