### PR TITLE
Add 8 particle emitter presets

### DIFF
--- a/docs/bricklayer.md
+++ b/docs/bricklayer.md
@@ -286,6 +286,14 @@ Three built-in presets provide common effects. Use `"preset"` and override any f
 | `dust_puff` | Brown dust cloud, burst, slow fall | 120/s | 1-2.5s | 0 (scene-lit) |
 | `spark_shower` | Orange sparks with gravity, self-lit | 40/s | 0.3-0.8s | 0.8 |
 | `magic_spiral` | Blue-to-magenta rising particles | 50/s | 1.5-3s | 0 (scene-lit) |
+| `fire` | Rising orange-red flames, self-lit | 80/s | 0.4-1.2s | 1.5 |
+| `smoke` | Slow gray plume, expanding scale | 30/s | 2-4s | 0 (scene-lit) |
+| `rain` | Fast downward blue-white streaks, wide area | 200/s | 0.5-1s | 0 (scene-lit) |
+| `snow` | Gentle white drift with horizontal sway | 60/s | 3-6s | 0 (scene-lit) |
+| `leaves` | Falling green-to-brown leaves, slow | 15/s | 3-6s | 0 (scene-lit) |
+| `fireflies` | Tiny glowing yellow-green dots, random drift | 8/s | 3-7s | 1.0 |
+| `steam` | White rising wisps, fast fade, expanding | 40/s | 0.5-1.5s | 0 (scene-lit) |
+| `waterfall_mist` | Blue-white spray, horizontal spread | 100/s | 1-2.5s | 0 (scene-lit) |
 
 ### Parameters
 

--- a/include/gseurat/engine/gs_particle.hpp
+++ b/include/gseurat/engine/gs_particle.hpp
@@ -87,6 +87,14 @@ private:
 GsEmitterConfig gs_preset_dust_puff();
 GsEmitterConfig gs_preset_spark_shower();
 GsEmitterConfig gs_preset_magic_spiral();
+GsEmitterConfig gs_preset_fire();
+GsEmitterConfig gs_preset_smoke();
+GsEmitterConfig gs_preset_rain();
+GsEmitterConfig gs_preset_snow();
+GsEmitterConfig gs_preset_leaves();
+GsEmitterConfig gs_preset_fireflies();
+GsEmitterConfig gs_preset_steam();
+GsEmitterConfig gs_preset_waterfall_mist();
 
 // Resolve a preset name to its config. Returns std::nullopt if name is unknown.
 std::optional<GsEmitterConfig> gs_resolve_preset(const std::string& name);

--- a/src/engine/gs_particle.cpp
+++ b/src/engine/gs_particle.cpp
@@ -204,10 +204,194 @@ GsEmitterConfig gs_preset_magic_spiral() {
     return c;
 }
 
+GsEmitterConfig gs_preset_fire() {
+    GsEmitterConfig c;
+    c.spawn_rate = 80.0f;
+    c.lifetime_min = 0.4f;
+    c.lifetime_max = 1.2f;
+    c.velocity_min = {-1.5f, 3.0f, -1.5f};
+    c.velocity_max = { 1.5f, 8.0f,  1.5f};
+    c.acceleration = {0.0f, 1.0f, 0.0f};
+    c.color_start = {1.0f, 0.6f, 0.1f};
+    c.color_end = {0.8f, 0.1f, 0.0f};
+    c.scale_min = {0.2f, 0.2f, 0.2f};
+    c.scale_max = {0.5f, 0.5f, 0.5f};
+    c.scale_end_factor = 0.0f;
+    c.opacity_start = 0.8f;
+    c.opacity_end = 0.0f;
+    c.emission = 1.5f;
+    c.spawn_offset_min = {-0.5f, 0.0f, -0.5f};
+    c.spawn_offset_max = { 0.5f, 0.5f,  0.5f};
+    c.burst_duration = 0.0f;
+    return c;
+}
+
+GsEmitterConfig gs_preset_smoke() {
+    GsEmitterConfig c;
+    c.spawn_rate = 30.0f;
+    c.lifetime_min = 2.0f;
+    c.lifetime_max = 4.0f;
+    c.velocity_min = {-0.5f, 1.0f, -0.5f};
+    c.velocity_max = { 0.5f, 3.0f,  0.5f};
+    c.acceleration = {0.0f, 0.3f, 0.0f};
+    c.color_start = {0.4f, 0.4f, 0.42f};
+    c.color_end = {0.3f, 0.3f, 0.32f};
+    c.scale_min = {0.3f, 0.3f, 0.3f};
+    c.scale_max = {0.8f, 0.8f, 0.8f};
+    c.scale_end_factor = 2.0f;
+    c.opacity_start = 0.5f;
+    c.opacity_end = 0.0f;
+    c.emission = 0.0f;
+    c.spawn_offset_min = {-1.0f, 0.0f, -1.0f};
+    c.spawn_offset_max = { 1.0f, 0.5f,  1.0f};
+    c.burst_duration = 0.0f;
+    return c;
+}
+
+GsEmitterConfig gs_preset_rain() {
+    GsEmitterConfig c;
+    c.spawn_rate = 200.0f;
+    c.lifetime_min = 0.5f;
+    c.lifetime_max = 1.0f;
+    c.velocity_min = {-0.5f, -20.0f, -0.5f};
+    c.velocity_max = { 0.5f, -15.0f,  0.5f};
+    c.acceleration = {0.0f, 0.0f, 0.0f};
+    c.color_start = {0.7f, 0.75f, 0.9f};
+    c.color_end = {0.5f, 0.55f, 0.8f};
+    c.scale_min = {0.02f, 0.15f, 0.02f};
+    c.scale_max = {0.03f, 0.25f, 0.03f};
+    c.scale_end_factor = 1.0f;
+    c.opacity_start = 0.4f;
+    c.opacity_end = 0.1f;
+    c.emission = 0.0f;
+    c.spawn_offset_min = {-15.0f, 10.0f, -15.0f};
+    c.spawn_offset_max = { 15.0f, 15.0f,  15.0f};
+    c.burst_duration = 0.0f;
+    return c;
+}
+
+GsEmitterConfig gs_preset_snow() {
+    GsEmitterConfig c;
+    c.spawn_rate = 60.0f;
+    c.lifetime_min = 3.0f;
+    c.lifetime_max = 6.0f;
+    c.velocity_min = {-1.0f, -2.0f, -1.0f};
+    c.velocity_max = { 1.0f, -0.5f,  1.0f};
+    c.acceleration = {0.0f, -0.1f, 0.0f};
+    c.color_start = {0.95f, 0.95f, 1.0f};
+    c.color_end = {0.9f, 0.9f, 0.95f};
+    c.scale_min = {0.05f, 0.05f, 0.05f};
+    c.scale_max = {0.15f, 0.15f, 0.15f};
+    c.scale_end_factor = 0.5f;
+    c.opacity_start = 0.7f;
+    c.opacity_end = 0.0f;
+    c.emission = 0.0f;
+    c.spawn_offset_min = {-12.0f, 8.0f, -12.0f};
+    c.spawn_offset_max = { 12.0f, 12.0f,  12.0f};
+    c.burst_duration = 0.0f;
+    return c;
+}
+
+GsEmitterConfig gs_preset_leaves() {
+    GsEmitterConfig c;
+    c.spawn_rate = 15.0f;
+    c.lifetime_min = 3.0f;
+    c.lifetime_max = 6.0f;
+    c.velocity_min = {-2.0f, -1.5f, -2.0f};
+    c.velocity_max = { 2.0f, -0.5f,  2.0f};
+    c.acceleration = {0.0f, -0.3f, 0.0f};
+    c.color_start = {0.4f, 0.6f, 0.15f};
+    c.color_end = {0.5f, 0.35f, 0.1f};
+    c.scale_min = {0.1f, 0.02f, 0.1f};
+    c.scale_max = {0.2f, 0.04f, 0.2f};
+    c.scale_end_factor = 0.8f;
+    c.opacity_start = 0.9f;
+    c.opacity_end = 0.2f;
+    c.emission = 0.0f;
+    c.spawn_offset_min = {-8.0f, 5.0f, -8.0f};
+    c.spawn_offset_max = { 8.0f, 10.0f,  8.0f};
+    c.burst_duration = 0.0f;
+    return c;
+}
+
+GsEmitterConfig gs_preset_fireflies() {
+    GsEmitterConfig c;
+    c.spawn_rate = 8.0f;
+    c.lifetime_min = 3.0f;
+    c.lifetime_max = 7.0f;
+    c.velocity_min = {-0.5f, -0.3f, -0.5f};
+    c.velocity_max = { 0.5f,  0.5f,  0.5f};
+    c.acceleration = {0.0f, 0.0f, 0.0f};
+    c.color_start = {0.8f, 1.0f, 0.3f};
+    c.color_end = {0.6f, 0.9f, 0.2f};
+    c.scale_min = {0.03f, 0.03f, 0.03f};
+    c.scale_max = {0.06f, 0.06f, 0.06f};
+    c.scale_end_factor = 0.5f;
+    c.opacity_start = 0.8f;
+    c.opacity_end = 0.0f;
+    c.emission = 1.0f;
+    c.spawn_offset_min = {-6.0f, 0.5f, -6.0f};
+    c.spawn_offset_max = { 6.0f, 4.0f,  6.0f};
+    c.burst_duration = 0.0f;
+    return c;
+}
+
+GsEmitterConfig gs_preset_steam() {
+    GsEmitterConfig c;
+    c.spawn_rate = 40.0f;
+    c.lifetime_min = 0.5f;
+    c.lifetime_max = 1.5f;
+    c.velocity_min = {-0.8f, 2.0f, -0.8f};
+    c.velocity_max = { 0.8f, 5.0f,  0.8f};
+    c.acceleration = {0.0f, 0.5f, 0.0f};
+    c.color_start = {0.9f, 0.9f, 0.92f};
+    c.color_end = {0.85f, 0.85f, 0.88f};
+    c.scale_min = {0.15f, 0.15f, 0.15f};
+    c.scale_max = {0.4f, 0.4f, 0.4f};
+    c.scale_end_factor = 2.5f;
+    c.opacity_start = 0.4f;
+    c.opacity_end = 0.0f;
+    c.emission = 0.0f;
+    c.spawn_offset_min = {-0.5f, 0.0f, -0.5f};
+    c.spawn_offset_max = { 0.5f, 0.3f,  0.5f};
+    c.burst_duration = 0.0f;
+    return c;
+}
+
+GsEmitterConfig gs_preset_waterfall_mist() {
+    GsEmitterConfig c;
+    c.spawn_rate = 100.0f;
+    c.lifetime_min = 1.0f;
+    c.lifetime_max = 2.5f;
+    c.velocity_min = {-4.0f, 0.5f, -4.0f};
+    c.velocity_max = { 4.0f, 3.0f,  4.0f};
+    c.acceleration = {0.0f, -1.0f, 0.0f};
+    c.color_start = {0.75f, 0.8f, 0.95f};
+    c.color_end = {0.7f, 0.75f, 0.9f};
+    c.scale_min = {0.1f, 0.1f, 0.1f};
+    c.scale_max = {0.3f, 0.3f, 0.3f};
+    c.scale_end_factor = 1.5f;
+    c.opacity_start = 0.35f;
+    c.opacity_end = 0.0f;
+    c.emission = 0.0f;
+    c.spawn_offset_min = {-3.0f, -0.5f, -3.0f};
+    c.spawn_offset_max = { 3.0f,  1.0f,  3.0f};
+    c.burst_duration = 0.0f;
+    return c;
+}
+
 std::optional<GsEmitterConfig> gs_resolve_preset(const std::string& name) {
-    if (name == "dust_puff")     return gs_preset_dust_puff();
-    if (name == "spark_shower")  return gs_preset_spark_shower();
-    if (name == "magic_spiral")  return gs_preset_magic_spiral();
+    if (name == "dust_puff")       return gs_preset_dust_puff();
+    if (name == "spark_shower")    return gs_preset_spark_shower();
+    if (name == "magic_spiral")    return gs_preset_magic_spiral();
+    if (name == "fire")            return gs_preset_fire();
+    if (name == "smoke")           return gs_preset_smoke();
+    if (name == "rain")            return gs_preset_rain();
+    if (name == "snow")            return gs_preset_snow();
+    if (name == "leaves")          return gs_preset_leaves();
+    if (name == "fireflies")       return gs_preset_fireflies();
+    if (name == "steam")           return gs_preset_steam();
+    if (name == "waterfall_mist")  return gs_preset_waterfall_mist();
     return std::nullopt;
 }
 

--- a/tests/test_gs_particle.cpp
+++ b/tests/test_gs_particle.cpp
@@ -262,10 +262,37 @@ int main() {
         auto magic = gs_resolve_preset("magic_spiral");
         assert(magic.has_value());
 
+        auto fire = gs_resolve_preset("fire");
+        assert(fire.has_value());
+        assert(fire->emission == 1.5f);
+
+        auto smoke = gs_resolve_preset("smoke");
+        assert(smoke.has_value());
+
+        auto rain = gs_resolve_preset("rain");
+        assert(rain.has_value());
+        assert(rain->spawn_rate == 200.0f);
+
+        auto snow = gs_resolve_preset("snow");
+        assert(snow.has_value());
+
+        auto leaves = gs_resolve_preset("leaves");
+        assert(leaves.has_value());
+
+        auto fireflies = gs_resolve_preset("fireflies");
+        assert(fireflies.has_value());
+        assert(fireflies->emission == 1.0f);
+
+        auto steam = gs_resolve_preset("steam");
+        assert(steam.has_value());
+
+        auto mist = gs_resolve_preset("waterfall_mist");
+        assert(mist.has_value());
+
         auto unknown = gs_resolve_preset("nonexistent");
         assert(!unknown.has_value());
 
-        std::printf("PASS: gs_resolve_preset known/unknown\n");
+        std::printf("PASS: gs_resolve_preset known/unknown (11 presets)\n");
     }
 
     // --- Test: Scene JSON round-trip for gs_particle_emitters ---

--- a/tools/apps/bricklayer/src/panels/GsEmittersTab.tsx
+++ b/tools/apps/bricklayer/src/panels/GsEmittersTab.tsx
@@ -31,6 +31,78 @@ const PRESETS: Record<string, Partial<GsParticleEmitterData>> = {
     scale_end_factor: 0.3, opacity_start: 0.9, opacity_end: 0, emission: 0,
     spawn_offset_min: [-1, -0.5, -1], spawn_offset_max: [1, 0.5, 1],
   },
+  fire: {
+    spawn_rate: 80, lifetime_min: 0.4, lifetime_max: 1.2,
+    velocity_min: [-1.5, 3, -1.5], velocity_max: [1.5, 8, 1.5],
+    acceleration: [0, 1, 0],
+    color_start: [1, 0.6, 0.1], color_end: [0.8, 0.1, 0],
+    scale_min: [0.2, 0.2, 0.2], scale_max: [0.5, 0.5, 0.5],
+    scale_end_factor: 0, opacity_start: 0.8, opacity_end: 0, emission: 1.5,
+    spawn_offset_min: [-0.5, 0, -0.5], spawn_offset_max: [0.5, 0.5, 0.5],
+  },
+  smoke: {
+    spawn_rate: 30, lifetime_min: 2, lifetime_max: 4,
+    velocity_min: [-0.5, 1, -0.5], velocity_max: [0.5, 3, 0.5],
+    acceleration: [0, 0.3, 0],
+    color_start: [0.4, 0.4, 0.42], color_end: [0.3, 0.3, 0.32],
+    scale_min: [0.3, 0.3, 0.3], scale_max: [0.8, 0.8, 0.8],
+    scale_end_factor: 2, opacity_start: 0.5, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-1, 0, -1], spawn_offset_max: [1, 0.5, 1],
+  },
+  rain: {
+    spawn_rate: 200, lifetime_min: 0.5, lifetime_max: 1,
+    velocity_min: [-0.5, -20, -0.5], velocity_max: [0.5, -15, 0.5],
+    acceleration: [0, 0, 0],
+    color_start: [0.7, 0.75, 0.9], color_end: [0.5, 0.55, 0.8],
+    scale_min: [0.02, 0.15, 0.02], scale_max: [0.03, 0.25, 0.03],
+    scale_end_factor: 1, opacity_start: 0.4, opacity_end: 0.1, emission: 0,
+    spawn_offset_min: [-15, 10, -15], spawn_offset_max: [15, 15, 15],
+  },
+  snow: {
+    spawn_rate: 60, lifetime_min: 3, lifetime_max: 6,
+    velocity_min: [-1, -2, -1], velocity_max: [1, -0.5, 1],
+    acceleration: [0, -0.1, 0],
+    color_start: [0.95, 0.95, 1], color_end: [0.9, 0.9, 0.95],
+    scale_min: [0.05, 0.05, 0.05], scale_max: [0.15, 0.15, 0.15],
+    scale_end_factor: 0.5, opacity_start: 0.7, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-12, 8, -12], spawn_offset_max: [12, 12, 12],
+  },
+  leaves: {
+    spawn_rate: 15, lifetime_min: 3, lifetime_max: 6,
+    velocity_min: [-2, -1.5, -2], velocity_max: [2, -0.5, 2],
+    acceleration: [0, -0.3, 0],
+    color_start: [0.4, 0.6, 0.15], color_end: [0.5, 0.35, 0.1],
+    scale_min: [0.1, 0.02, 0.1], scale_max: [0.2, 0.04, 0.2],
+    scale_end_factor: 0.8, opacity_start: 0.9, opacity_end: 0.2, emission: 0,
+    spawn_offset_min: [-8, 5, -8], spawn_offset_max: [8, 10, 8],
+  },
+  fireflies: {
+    spawn_rate: 8, lifetime_min: 3, lifetime_max: 7,
+    velocity_min: [-0.5, -0.3, -0.5], velocity_max: [0.5, 0.5, 0.5],
+    acceleration: [0, 0, 0],
+    color_start: [0.8, 1, 0.3], color_end: [0.6, 0.9, 0.2],
+    scale_min: [0.03, 0.03, 0.03], scale_max: [0.06, 0.06, 0.06],
+    scale_end_factor: 0.5, opacity_start: 0.8, opacity_end: 0, emission: 1,
+    spawn_offset_min: [-6, 0.5, -6], spawn_offset_max: [6, 4, 6],
+  },
+  steam: {
+    spawn_rate: 40, lifetime_min: 0.5, lifetime_max: 1.5,
+    velocity_min: [-0.8, 2, -0.8], velocity_max: [0.8, 5, 0.8],
+    acceleration: [0, 0.5, 0],
+    color_start: [0.9, 0.9, 0.92], color_end: [0.85, 0.85, 0.88],
+    scale_min: [0.15, 0.15, 0.15], scale_max: [0.4, 0.4, 0.4],
+    scale_end_factor: 2.5, opacity_start: 0.4, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-0.5, 0, -0.5], spawn_offset_max: [0.5, 0.3, 0.5],
+  },
+  waterfall_mist: {
+    spawn_rate: 100, lifetime_min: 1, lifetime_max: 2.5,
+    velocity_min: [-4, 0.5, -4], velocity_max: [4, 3, 4],
+    acceleration: [0, -1, 0],
+    color_start: [0.75, 0.8, 0.95], color_end: [0.7, 0.75, 0.9],
+    scale_min: [0.1, 0.1, 0.1], scale_max: [0.3, 0.3, 0.3],
+    scale_end_factor: 1.5, opacity_start: 0.35, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-3, -0.5, -3], spawn_offset_max: [3, 1, 3],
+  },
 };
 
 const styles: Record<string, React.CSSProperties> = {
@@ -124,6 +196,14 @@ function EmitterEditor({ emitter }: { emitter: GsParticleEmitterData }) {
           <option value="dust_puff">Dust Puff</option>
           <option value="spark_shower">Spark Shower</option>
           <option value="magic_spiral">Magic Spiral</option>
+          <option value="fire">Fire</option>
+          <option value="smoke">Smoke</option>
+          <option value="rain">Rain</option>
+          <option value="snow">Snow</option>
+          <option value="leaves">Leaves</option>
+          <option value="fireflies">Fireflies</option>
+          <option value="steam">Steam</option>
+          <option value="waterfall_mist">Waterfall Mist</option>
         </select>
       </div>
 

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -614,6 +614,70 @@ const GS_PRESETS: Record<string, Partial<GsParticleEmitterData>> = {
     scale_end_factor: 0.3, opacity_start: 0.9, opacity_end: 0, emission: 0,
     spawn_offset_min: [-1, -0.5, -1], spawn_offset_max: [1, 0.5, 1],
   },
+  fire: {
+    spawn_rate: 80, lifetime_min: 0.4, lifetime_max: 1.2,
+    velocity_min: [-1.5, 3, -1.5], velocity_max: [1.5, 8, 1.5], acceleration: [0, 1, 0],
+    color_start: [1, 0.6, 0.1], color_end: [0.8, 0.1, 0],
+    scale_min: [0.2, 0.2, 0.2], scale_max: [0.5, 0.5, 0.5],
+    scale_end_factor: 0, opacity_start: 0.8, opacity_end: 0, emission: 1.5,
+    spawn_offset_min: [-0.5, 0, -0.5], spawn_offset_max: [0.5, 0.5, 0.5],
+  },
+  smoke: {
+    spawn_rate: 30, lifetime_min: 2, lifetime_max: 4,
+    velocity_min: [-0.5, 1, -0.5], velocity_max: [0.5, 3, 0.5], acceleration: [0, 0.3, 0],
+    color_start: [0.4, 0.4, 0.42], color_end: [0.3, 0.3, 0.32],
+    scale_min: [0.3, 0.3, 0.3], scale_max: [0.8, 0.8, 0.8],
+    scale_end_factor: 2, opacity_start: 0.5, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-1, 0, -1], spawn_offset_max: [1, 0.5, 1],
+  },
+  rain: {
+    spawn_rate: 200, lifetime_min: 0.5, lifetime_max: 1,
+    velocity_min: [-0.5, -20, -0.5], velocity_max: [0.5, -15, 0.5], acceleration: [0, 0, 0],
+    color_start: [0.7, 0.75, 0.9], color_end: [0.5, 0.55, 0.8],
+    scale_min: [0.02, 0.15, 0.02], scale_max: [0.03, 0.25, 0.03],
+    scale_end_factor: 1, opacity_start: 0.4, opacity_end: 0.1, emission: 0,
+    spawn_offset_min: [-15, 10, -15], spawn_offset_max: [15, 15, 15],
+  },
+  snow: {
+    spawn_rate: 60, lifetime_min: 3, lifetime_max: 6,
+    velocity_min: [-1, -2, -1], velocity_max: [1, -0.5, 1], acceleration: [0, -0.1, 0],
+    color_start: [0.95, 0.95, 1], color_end: [0.9, 0.9, 0.95],
+    scale_min: [0.05, 0.05, 0.05], scale_max: [0.15, 0.15, 0.15],
+    scale_end_factor: 0.5, opacity_start: 0.7, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-12, 8, -12], spawn_offset_max: [12, 12, 12],
+  },
+  leaves: {
+    spawn_rate: 15, lifetime_min: 3, lifetime_max: 6,
+    velocity_min: [-2, -1.5, -2], velocity_max: [2, -0.5, 2], acceleration: [0, -0.3, 0],
+    color_start: [0.4, 0.6, 0.15], color_end: [0.5, 0.35, 0.1],
+    scale_min: [0.1, 0.02, 0.1], scale_max: [0.2, 0.04, 0.2],
+    scale_end_factor: 0.8, opacity_start: 0.9, opacity_end: 0.2, emission: 0,
+    spawn_offset_min: [-8, 5, -8], spawn_offset_max: [8, 10, 8],
+  },
+  fireflies: {
+    spawn_rate: 8, lifetime_min: 3, lifetime_max: 7,
+    velocity_min: [-0.5, -0.3, -0.5], velocity_max: [0.5, 0.5, 0.5], acceleration: [0, 0, 0],
+    color_start: [0.8, 1, 0.3], color_end: [0.6, 0.9, 0.2],
+    scale_min: [0.03, 0.03, 0.03], scale_max: [0.06, 0.06, 0.06],
+    scale_end_factor: 0.5, opacity_start: 0.8, opacity_end: 0, emission: 1,
+    spawn_offset_min: [-6, 0.5, -6], spawn_offset_max: [6, 4, 6],
+  },
+  steam: {
+    spawn_rate: 40, lifetime_min: 0.5, lifetime_max: 1.5,
+    velocity_min: [-0.8, 2, -0.8], velocity_max: [0.8, 5, 0.8], acceleration: [0, 0.5, 0],
+    color_start: [0.9, 0.9, 0.92], color_end: [0.85, 0.85, 0.88],
+    scale_min: [0.15, 0.15, 0.15], scale_max: [0.4, 0.4, 0.4],
+    scale_end_factor: 2.5, opacity_start: 0.4, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-0.5, 0, -0.5], spawn_offset_max: [0.5, 0.3, 0.5],
+  },
+  waterfall_mist: {
+    spawn_rate: 100, lifetime_min: 1, lifetime_max: 2.5,
+    velocity_min: [-4, 0.5, -4], velocity_max: [4, 3, 4], acceleration: [0, -1, 0],
+    color_start: [0.75, 0.8, 0.95], color_end: [0.7, 0.75, 0.9],
+    scale_min: [0.1, 0.1, 0.1], scale_max: [0.3, 0.3, 0.3],
+    scale_end_factor: 1.5, opacity_start: 0.35, opacity_end: 0, emission: 0,
+    spawn_offset_min: [-3, -0.5, -3], spawn_offset_max: [3, 1, 3],
+  },
 };
 
 function rgbToHex(c: [number, number, number]): string {
@@ -659,6 +723,14 @@ function GsEmitterProperties({ emitter }: { emitter: GsParticleEmitterData }) {
           <option value="dust_puff">Dust Puff</option>
           <option value="spark_shower">Spark Shower</option>
           <option value="magic_spiral">Magic Spiral</option>
+          <option value="fire">Fire</option>
+          <option value="smoke">Smoke</option>
+          <option value="rain">Rain</option>
+          <option value="snow">Snow</option>
+          <option value="leaves">Leaves</option>
+          <option value="fireflies">Fireflies</option>
+          <option value="steam">Steam</option>
+          <option value="waterfall_mist">Waterfall Mist</option>
         </select>
       </div>
 

--- a/tools/tests/src/bricklayer-gs-emitters.test.ts
+++ b/tools/tests/src/bricklayer-gs-emitters.test.ts
@@ -87,13 +87,16 @@ const PRESETS: Record<string, Partial<GsParticleEmitterData>> = {
     scale_end_factor: 0.1, opacity_start: 0.4, opacity_end: 0, emission: 0,
     spawn_offset_min: [-2, 0, -2], spawn_offset_max: [2, 1, 2],
   },
-  spark_shower: {
-    spawn_rate: 40, lifetime_min: 0.3, lifetime_max: 0.8,
-    emission: 0.8,
-  },
-  magic_spiral: {
-    spawn_rate: 50, lifetime_min: 1.5, lifetime_max: 3,
-  },
+  spark_shower: { spawn_rate: 40, emission: 0.8 },
+  magic_spiral: { spawn_rate: 50 },
+  fire: { spawn_rate: 80, emission: 1.5 },
+  smoke: { spawn_rate: 30 },
+  rain: { spawn_rate: 200 },
+  snow: { spawn_rate: 60 },
+  leaves: { spawn_rate: 15 },
+  fireflies: { spawn_rate: 8, emission: 1 },
+  steam: { spawn_rate: 40 },
+  waterfall_mist: { spawn_rate: 100 },
 };
 
 function applyPreset(emitter: GsParticleEmitterData, presetName: string): GsParticleEmitterData {
@@ -276,7 +279,29 @@ console.log('\n--- Preset application ---\n');
 }
 
 {
-  console.log('Test 2.3: Apply unknown preset -> clears preset name');
+  console.log('Test 2.3: Apply fire preset -> self-lit');
+  let list: GsParticleEmitterData[] = [];
+  list = addEmitter(list);
+  const updated = applyPreset(list[0], 'fire');
+  assert(updated.preset === 'fire', 'preset name set');
+  assert(updated.spawn_rate === 80, 'spawn_rate from fire preset');
+  assert(updated.emission === 1.5, 'emission from fire preset');
+}
+
+{
+  console.log('Test 2.4: Apply all presets -> each has valid spawn_rate');
+  const names = ['dust_puff', 'spark_shower', 'magic_spiral', 'fire', 'smoke', 'rain', 'snow', 'leaves', 'fireflies', 'steam', 'waterfall_mist'];
+  for (const name of names) {
+    let list: GsParticleEmitterData[] = [];
+    list = addEmitter(list);
+    const updated = applyPreset(list[0], name);
+    assert(updated.preset === name, `preset '${name}' name set`);
+    assert(updated.spawn_rate > 0, `preset '${name}' has positive spawn_rate`);
+  }
+}
+
+{
+  console.log('Test 2.5: Apply unknown preset -> clears preset name');
   let list: GsParticleEmitterData[] = [];
   list = addEmitter(list);
   const withPreset = applyPreset(list[0], 'dust_puff');
@@ -285,7 +310,7 @@ console.log('\n--- Preset application ---\n');
 }
 
 {
-  console.log('Test 2.4: Preset preserves position');
+  console.log('Test 2.6: Preset preserves position');
   let list: GsParticleEmitterData[] = [];
   list = addEmitter(list, [99, 88, 77]);
   const updated = applyPreset(list[0], 'dust_puff');


### PR DESCRIPTION
## Summary
- 8 new presets: fire, smoke, rain, snow, leaves, fireflies, steam, waterfall_mist
- Available in C++ engine (`gs_resolve_preset`), Bricklayer dropdowns, and scene.json
- Self-lit effects: fire (emission=1.5), fireflies (emission=1.0)
- Weather effects: rain (200/s wide area), snow (gentle drift), leaves (slow fall)
- Ambient effects: smoke (expanding), steam (fast fade), waterfall_mist (spray)

## Test plan
- [x] C++ tests: all 11 presets resolve correctly (13/13 pass)
- [x] TS tests: preset application for all 11 names (70/70 pass)
- [x] Visual: Select each preset in Bricklayer dropdown → fields auto-populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)