### PR TITLE
Add GS animations to scene.json and Bricklayer

### DIFF
--- a/assets/scenes/test_brickslayer.json
+++ b/assets/scenes/test_brickslayer.json
@@ -306,9 +306,11 @@
           60,
           0
         ],
-        "radius": 15
+        "radius": 100
       },
-      "lifetime": 4,
+      "speed": 0.01,
+      "expansion": 20,
+      "lifetime": 10,
       "loop": true
     }
   ]

--- a/assets/scenes/test_brickslayer.json
+++ b/assets/scenes/test_brickslayer.json
@@ -294,8 +294,9 @@
         ],
         "radius": 50
       },
-      "lifetime": 4,
-      "loop": true
+      "speed": 1,
+      "lifetime": 100,
+      "loop": false
     },
     {
       "effect": "orbit",
@@ -304,14 +305,15 @@
         "center": [
           128,
           60,
-          0
+          30
         ],
-        "radius": 100
+        "radius": 50
       },
-      "speed": 0.01,
-      "expansion": 20,
-      "lifetime": 10,
-      "loop": true
+      "speed": 0.1,
+      "expansion": 30,
+      "orbit_acceleration": 0.1,
+      "lifetime": 5,
+      "loop": false
     }
   ]
 }

--- a/include/gseurat/engine/gs_animator.hpp
+++ b/include/gseurat/engine/gs_animator.hpp
@@ -32,6 +32,7 @@ struct GsAnimParams {
     float orbit_speed = 1.0f;       // rotation speed multiplier (Orbit)
     float orbit_acceleration = 0.0f; // angular acceleration (Orbit): >0 speeds up, <0 slows down
     float expansion = 1.0f;         // radius growth scale (Orbit)
+    float height_rise = 1.0f;       // vertical rise scale (Orbit): 0=flat, 1=default rise
     float opacity_fade = 1.0f;      // 0=no fade, 1=full fade to 0
     float scale_shrink = 1.0f;      // 0=no shrink, 1=full shrink
 };

--- a/include/gseurat/engine/gs_animator.hpp
+++ b/include/gseurat/engine/gs_animator.hpp
@@ -24,6 +24,17 @@ struct GsAnimRegion {
     glm::vec3 half_extents{5.0f};    // for Box
 };
 
+struct GsAnimParams {
+    float speed = 1.0f;             // time multiplier (scales dt)
+    glm::vec3 gravity{0.0f, -9.8f, 0.0f};  // gravity vector (Detach)
+    float velocity_scale = 1.0f;    // scales initial velocity (Detach/Float)
+    float noise_amplitude = 1.0f;   // horizontal wander scale (Float/Dissolve)
+    float orbit_speed = 1.0f;       // rotation speed multiplier (Orbit)
+    float expansion = 1.0f;         // radius growth scale (Orbit)
+    float opacity_fade = 1.0f;      // 0=no fade, 1=full fade to 0
+    float scale_shrink = 1.0f;      // 0=no shrink, 1=full shrink
+};
+
 struct GsParticleState {
     glm::vec3 velocity{0.0f};
     glm::vec3 original_position{0.0f};
@@ -42,7 +53,8 @@ public:
     uint32_t tag_region(const std::vector<Gaussian>& gaussians,
                         const GsAnimRegion& region,
                         GsAnimEffect effect,
-                        float lifetime = 3.0f);
+                        float lifetime = 3.0f,
+                        const GsAnimParams& params = {});
 
     // Apply animations to the Gaussian buffer (modifies in place).
     // Indices refer to the active buffer provided.
@@ -61,6 +73,7 @@ private:
     struct AnimGroup {
         uint32_t id = 0;
         GsAnimEffect effect;
+        GsAnimParams params;
         std::vector<uint32_t> indices;       // indices into the Gaussian array
         std::vector<GsParticleState> states;
         float global_time = 0.0f;

--- a/include/gseurat/engine/gs_animator.hpp
+++ b/include/gseurat/engine/gs_animator.hpp
@@ -30,6 +30,7 @@ struct GsAnimParams {
     float velocity_scale = 1.0f;    // scales initial velocity (Detach/Float)
     float noise_amplitude = 1.0f;   // horizontal wander scale (Float/Dissolve)
     float orbit_speed = 1.0f;       // rotation speed multiplier (Orbit)
+    float orbit_acceleration = 0.0f; // angular acceleration (Orbit): >0 speeds up, <0 slows down
     float expansion = 1.0f;         // radius growth scale (Orbit)
     float opacity_fade = 1.0f;      // 0=no fade, 1=full fade to 0
     float scale_shrink = 1.0f;      // 0=no shrink, 1=full shrink

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -92,10 +92,11 @@ public:
         GsAnimRegion region;
         float lifetime = 3.0f;
         bool loop = false;
+        GsAnimParams params;
         uint32_t group_id = 0;
     };
     void add_gs_animation(const std::string& effect, const GsAnimRegion& region,
-                          float lifetime, bool loop);
+                          float lifetime, bool loop, const GsAnimParams& params = {});
     void clear_gs_animations();
     const std::vector<SceneAnimation>& gs_scene_animations() const { return gs_scene_animations_; }
 

--- a/include/gseurat/engine/scene_loader.hpp
+++ b/include/gseurat/engine/scene_loader.hpp
@@ -103,6 +103,7 @@ struct GsAnimationData {
     GsAnimRegion region;
     float lifetime = 3.0f;
     bool loop = false;
+    GsAnimParams params;
 };
 
 struct PortalData {

--- a/src/demo/demo_app.cpp
+++ b/src/demo/demo_app.cpp
@@ -218,7 +218,7 @@ void DemoApp::init_scene(const std::string& scene_path) {
                 auto region = anim.region;
                 region.center.x += aabb.min.x;
                 region.center.y += aabb.min.y;
-                renderer_.add_gs_animation(anim.effect, region, anim.lifetime, anim.loop);
+                renderer_.add_gs_animation(anim.effect, region, anim.lifetime, anim.loop, anim.params);
             }
         }
 

--- a/src/engine/gs_animator.cpp
+++ b/src/engine/gs_animator.cpp
@@ -176,7 +176,9 @@ void GaussianAnimator::apply_orbit(AnimGroup& group, std::vector<Gaussian>& gaus
         // Rotate around center — use age directly for orbit dynamics
         // so expansion/height aren't coupled to lifetime
         glm::vec3 rel = s.original_position - center;
-        float angle = group.global_time * (2.0f * p.orbit_speed + s.phase * 0.5f);
+        float base_speed = 2.0f * p.orbit_speed + s.phase * 0.5f;
+        float gt = group.global_time;
+        float angle = gt * base_speed + 0.5f * p.orbit_acceleration * gt * gt;
         float cs = std::cos(angle), sn = std::sin(angle);
         float age_factor = std::min(s.age * 0.2f, 1.0f);  // ramp over ~5 seconds, then plateau
         glm::vec3 rotated{rel.x * cs - rel.z * sn, rel.y + age_factor * 5.0f * p.expansion, rel.x * sn + rel.z * cs};

--- a/src/engine/gs_animator.cpp
+++ b/src/engine/gs_animator.cpp
@@ -29,10 +29,12 @@ static bool in_box(const glm::vec3& pos, const glm::vec3& center, const glm::vec
 uint32_t GaussianAnimator::tag_region(const std::vector<Gaussian>& gaussians,
                                        const GsAnimRegion& region,
                                        GsAnimEffect effect,
-                                       float lifetime) {
+                                       float lifetime,
+                                       const GsAnimParams& params) {
     AnimGroup group;
     group.id = next_group_id_++;
     group.effect = effect;
+    group.params = params;
     group.global_time = 0.0f;
 
     for (uint32_t i = 0; i < static_cast<uint32_t>(gaussians.size()); ++i) {
@@ -58,14 +60,15 @@ uint32_t GaussianAnimator::tag_region(const std::vector<Gaussian>& gaussians,
         if (len > 0.001f) dir /= len;
         else dir = glm::vec3(0.0f, 1.0f, 0.0f);
 
+        float vs = params.velocity_scale;
         if (effect == GsAnimEffect::Detach) {
-            state.velocity = dir * rand_float(rng_, 3.0f, 8.0f);
-            state.velocity.y += rand_float(rng_, 2.0f, 5.0f);
+            state.velocity = dir * rand_float(rng_, 3.0f * vs, 8.0f * vs);
+            state.velocity.y += rand_float(rng_, 2.0f * vs, 5.0f * vs);
         } else if (effect == GsAnimEffect::Float) {
             state.velocity = glm::vec3(
-                rand_float(rng_, -0.5f, 0.5f),
-                rand_float(rng_, 1.0f, 3.0f),
-                rand_float(rng_, -0.5f, 0.5f));
+                rand_float(rng_, -0.5f * vs, 0.5f * vs),
+                rand_float(rng_, 1.0f * vs, 3.0f * vs),
+                rand_float(rng_, -0.5f * vs, 0.5f * vs));
         } else {
             state.velocity = glm::vec3(0.0f);
         }
@@ -110,7 +113,8 @@ void GaussianAnimator::update(float dt, std::vector<Gaussian>& gaussians) {
 }
 
 void GaussianAnimator::apply_detach(AnimGroup& group, std::vector<Gaussian>& gaussians, float dt) {
-    const glm::vec3 gravity{0.0f, -9.8f, 0.0f};
+    const auto& p = group.params;
+    dt *= p.speed;
     for (size_t i = 0; i < group.indices.size(); ++i) {
         auto& s = group.states[i];
         if (!s.active || s.age >= s.lifetime) continue;
@@ -118,18 +122,20 @@ void GaussianAnimator::apply_detach(AnimGroup& group, std::vector<Gaussian>& gau
         if (idx >= gaussians.size()) continue;
 
         s.age += dt;
-        s.velocity += gravity * dt;
+        s.velocity += p.gravity * dt;
         float t = std::clamp(s.age / s.lifetime, 0.0f, 1.0f);
 
         auto& g = gaussians[idx];
         g.position = s.original_position + s.velocity * s.age;
-        g.opacity = s.original_opacity * (1.0f - t);
-        g.scale = s.original_scale * (1.0f - t * 0.5f);
-        g.emission = 0.01f;  // self-lit: prevent scene lights from amplifying scattered Gaussians
+        g.opacity = s.original_opacity * (1.0f - t * p.opacity_fade);
+        g.scale = s.original_scale * (1.0f - t * 0.5f * p.scale_shrink);
+        g.emission = 0.01f;
     }
 }
 
 void GaussianAnimator::apply_float(AnimGroup& group, std::vector<Gaussian>& gaussians, float dt) {
+    const auto& p = group.params;
+    dt *= p.speed;
     for (size_t i = 0; i < group.indices.size(); ++i) {
         auto& s = group.states[i];
         if (!s.active || s.age >= s.lifetime) continue;
@@ -141,16 +147,18 @@ void GaussianAnimator::apply_float(AnimGroup& group, std::vector<Gaussian>& gaus
 
         auto& g = gaussians[idx];
         g.position = s.original_position + s.velocity * s.age;
-        // Add gentle horizontal noise
-        g.position.x += std::sin(s.age * 2.0f + s.phase) * 0.5f;
-        g.position.z += std::cos(s.age * 1.5f + s.phase) * 0.5f;
-        g.opacity = s.original_opacity * (1.0f - t);
-        g.scale = s.original_scale * (1.0f - t * 0.7f);
+        float na = 0.5f * p.noise_amplitude;
+        g.position.x += std::sin(s.age * 2.0f + s.phase) * na;
+        g.position.z += std::cos(s.age * 1.5f + s.phase) * na;
+        g.opacity = s.original_opacity * (1.0f - t * p.opacity_fade);
+        g.scale = s.original_scale * (1.0f - t * 0.7f * p.scale_shrink);
         g.emission = 0.01f;
     }
 }
 
 void GaussianAnimator::apply_orbit(AnimGroup& group, std::vector<Gaussian>& gaussians, float dt) {
+    const auto& p = group.params;
+    dt *= p.speed;
     // Find region center from first Gaussian's original position average
     glm::vec3 center{0.0f};
     for (const auto& s : group.states) center += s.original_position;
@@ -167,18 +175,20 @@ void GaussianAnimator::apply_orbit(AnimGroup& group, std::vector<Gaussian>& gaus
 
         // Rotate around center
         glm::vec3 rel = s.original_position - center;
-        float angle = group.global_time * (2.0f + s.phase * 0.5f);
+        float angle = group.global_time * (2.0f * p.orbit_speed + s.phase * 0.5f);
         float cs = std::cos(angle), sn = std::sin(angle);
-        glm::vec3 rotated{rel.x * cs - rel.z * sn, rel.y + t * 5.0f, rel.x * sn + rel.z * cs};
+        glm::vec3 rotated{rel.x * cs - rel.z * sn, rel.y + t * 5.0f * p.expansion, rel.x * sn + rel.z * cs};
 
         auto& g = gaussians[idx];
-        g.position = center + rotated * (1.0f + t * 0.5f);
-        g.opacity = s.original_opacity * (1.0f - t * 0.3f);
+        g.position = center + rotated * (1.0f + t * 0.5f * p.expansion);
+        g.opacity = s.original_opacity * (1.0f - t * 0.3f * p.opacity_fade);
         g.emission = 0.01f;
     }
 }
 
 void GaussianAnimator::apply_dissolve(AnimGroup& group, std::vector<Gaussian>& gaussians, float dt) {
+    const auto& p = group.params;
+    dt *= p.speed;
     for (size_t i = 0; i < group.indices.size(); ++i) {
         auto& s = group.states[i];
         if (!s.active || s.age >= s.lifetime) continue;
@@ -189,18 +199,20 @@ void GaussianAnimator::apply_dissolve(AnimGroup& group, std::vector<Gaussian>& g
         float t = std::clamp(s.age / s.lifetime, 0.0f, 1.0f);
 
         auto& g = gaussians[idx];
-        // Slight drift
+        float na = p.noise_amplitude;
         g.position = s.original_position + glm::vec3(
-            std::sin(s.phase + s.age) * t * 2.0f,
-            t * 1.0f,
-            std::cos(s.phase + s.age) * t * 2.0f);
-        g.scale = s.original_scale * (1.0f - t);
-        g.opacity = s.original_opacity * (1.0f - t);
+            std::sin(s.phase + s.age) * t * 2.0f * na,
+            t * 1.0f * na,
+            std::cos(s.phase + s.age) * t * 2.0f * na);
+        g.scale = s.original_scale * (1.0f - t * p.scale_shrink);
+        g.opacity = s.original_opacity * (1.0f - t * p.opacity_fade);
         g.emission = 0.01f;
     }
 }
 
 void GaussianAnimator::apply_reform(AnimGroup& group, std::vector<Gaussian>& gaussians, float dt) {
+    const auto& p = group.params;
+    dt *= p.speed;
     for (size_t i = 0; i < group.indices.size(); ++i) {
         auto& s = group.states[i];
         if (!s.active || s.age >= s.lifetime) continue;
@@ -209,15 +221,14 @@ void GaussianAnimator::apply_reform(AnimGroup& group, std::vector<Gaussian>& gau
 
         s.age += dt;
         float t = std::clamp(s.age / s.lifetime, 0.0f, 1.0f);
-        // Smooth ease-in-out
         float smooth_t = t * t * (3.0f - 2.0f * t);
 
         auto& g = gaussians[idx];
-        g.position = glm::mix(g.position, s.original_position, smooth_t * dt * 3.0f);
-        g.scale = glm::mix(g.scale, s.original_scale, smooth_t * dt * 3.0f);
+        float lerp_rate = smooth_t * dt * 3.0f * p.velocity_scale;
+        g.position = glm::mix(g.position, s.original_position, lerp_rate);
+        g.scale = glm::mix(g.scale, s.original_scale, lerp_rate);
         g.opacity = s.original_opacity * std::min(1.0f, t * 2.0f);
         g.color = glm::mix(g.color, s.original_color, smooth_t);
-        // Reform restores emission to 0 gradually (back to scene-lit)
         g.emission = 0.01f * (1.0f - smooth_t);
     }
 }

--- a/src/engine/gs_animator.cpp
+++ b/src/engine/gs_animator.cpp
@@ -181,7 +181,7 @@ void GaussianAnimator::apply_orbit(AnimGroup& group, std::vector<Gaussian>& gaus
         float angle = gt * base_speed + 0.5f * p.orbit_acceleration * gt * gt;
         float cs = std::cos(angle), sn = std::sin(angle);
         float age_factor = std::min(s.age * 0.2f, 1.0f);  // ramp over ~5 seconds, then plateau
-        glm::vec3 rotated{rel.x * cs - rel.z * sn, rel.y + age_factor * 5.0f * p.expansion, rel.x * sn + rel.z * cs};
+        glm::vec3 rotated{rel.x * cs - rel.z * sn, rel.y + age_factor * 5.0f * p.height_rise, rel.x * sn + rel.z * cs};
 
         auto& g = gaussians[idx];
         g.position = center + rotated * (1.0f + age_factor * 0.5f * p.expansion);

--- a/src/engine/gs_animator.cpp
+++ b/src/engine/gs_animator.cpp
@@ -87,7 +87,7 @@ uint32_t GaussianAnimator::tag_region(const std::vector<Gaussian>& gaussians,
 void GaussianAnimator::update(float dt, std::vector<Gaussian>& gaussians) {
     for (auto& group : groups_) {
         if (group.finished) continue;
-        group.global_time += dt;
+        group.global_time += dt * group.params.speed;
 
         switch (group.effect) {
             case GsAnimEffect::Detach:  apply_detach(group, gaussians, dt); break;

--- a/src/engine/gs_animator.cpp
+++ b/src/engine/gs_animator.cpp
@@ -173,14 +173,16 @@ void GaussianAnimator::apply_orbit(AnimGroup& group, std::vector<Gaussian>& gaus
         s.age += dt;
         float t = std::clamp(s.age / s.lifetime, 0.0f, 1.0f);
 
-        // Rotate around center
+        // Rotate around center — use age directly for orbit dynamics
+        // so expansion/height aren't coupled to lifetime
         glm::vec3 rel = s.original_position - center;
         float angle = group.global_time * (2.0f * p.orbit_speed + s.phase * 0.5f);
         float cs = std::cos(angle), sn = std::sin(angle);
-        glm::vec3 rotated{rel.x * cs - rel.z * sn, rel.y + t * 5.0f * p.expansion, rel.x * sn + rel.z * cs};
+        float age_factor = std::min(s.age * 0.2f, 1.0f);  // ramp over ~5 seconds, then plateau
+        glm::vec3 rotated{rel.x * cs - rel.z * sn, rel.y + age_factor * 5.0f * p.expansion, rel.x * sn + rel.z * cs};
 
         auto& g = gaussians[idx];
-        g.position = center + rotated * (1.0f + t * 0.5f * p.expansion);
+        g.position = center + rotated * (1.0f + age_factor * 0.5f * p.expansion);
         g.opacity = s.original_opacity * (1.0f - t * 0.3f * p.opacity_fade);
         g.emission = 0.01f;
     }

--- a/src/engine/gs_animator.cpp
+++ b/src/engine/gs_animator.cpp
@@ -184,7 +184,8 @@ void GaussianAnimator::apply_orbit(AnimGroup& group, std::vector<Gaussian>& gaus
         glm::vec3 rotated{rel.x * cs - rel.z * sn, rel.y + age_factor * 5.0f * p.height_rise, rel.x * sn + rel.z * cs};
 
         auto& g = gaussians[idx];
-        g.position = center + rotated * (1.0f + age_factor * 0.5f * p.expansion);
+        float radius_scale = 1.0f + age_factor * 0.5f * p.expansion;
+        g.position = center + glm::vec3(rotated.x * radius_scale, rotated.y, rotated.z * radius_scale);
         g.opacity = s.original_opacity * (1.0f - t * 0.3f * p.opacity_fade);
         g.emission = 0.01f;
     }

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -795,7 +795,7 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                     if (sa.group_id == 0 || (sa.loop && !gs_animator_.has_group(sa.group_id))) {
                         sa.group_id = gs_animator_.tag_region(
                             gs_scene_buffer_, sa.region,
-                            parse_effect_name(sa.effect), sa.lifetime);
+                            parse_effect_name(sa.effect), sa.lifetime, sa.params);
                     }
                 }
 
@@ -951,16 +951,16 @@ void Renderer::clear_gs_particle_emitters() {
 }
 
 void Renderer::add_gs_animation(const std::string& effect, const GsAnimRegion& region,
-                                 float lifetime, bool loop) {
+                                 float lifetime, bool loop, const GsAnimParams& params) {
     SceneAnimation sa;
     sa.effect = effect;
     sa.region = region;
     sa.lifetime = lifetime;
     sa.loop = loop;
-    // Tag immediately if we have a scene buffer
+    sa.params = params;
     if (!gs_scene_buffer_.empty()) {
         sa.group_id = gs_animator_.tag_region(
-            gs_scene_buffer_, region, parse_effect_name(effect), lifetime);
+            gs_scene_buffer_, region, parse_effect_name(effect), lifetime, params);
     }
     gs_scene_animations_.push_back(std::move(sa));
 }

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -532,6 +532,7 @@ GsAnimationData SceneLoader::parse_gs_animation(const nlohmann::json& j) {
         anim.params.velocity_scale = p.value("velocity_scale", anim.params.velocity_scale);
         anim.params.noise_amplitude = p.value("noise_amplitude", anim.params.noise_amplitude);
         anim.params.orbit_speed = p.value("orbit_speed", anim.params.orbit_speed);
+        anim.params.orbit_acceleration = p.value("orbit_acceleration", anim.params.orbit_acceleration);
         anim.params.expansion = p.value("expansion", anim.params.expansion);
         anim.params.opacity_fade = p.value("opacity_fade", anim.params.opacity_fade);
         anim.params.scale_shrink = p.value("scale_shrink", anim.params.scale_shrink);
@@ -569,6 +570,7 @@ nlohmann::json SceneLoader::gs_animation_json(const GsAnimationData& anim) {
     if (p.velocity_scale != def.velocity_scale) params["velocity_scale"] = p.velocity_scale;
     if (p.noise_amplitude != def.noise_amplitude) params["noise_amplitude"] = p.noise_amplitude;
     if (p.orbit_speed != def.orbit_speed) params["orbit_speed"] = p.orbit_speed;
+    if (p.orbit_acceleration != def.orbit_acceleration) params["orbit_acceleration"] = p.orbit_acceleration;
     if (p.expansion != def.expansion) params["expansion"] = p.expansion;
     if (p.opacity_fade != def.opacity_fade) params["opacity_fade"] = p.opacity_fade;
     if (p.scale_shrink != def.scale_shrink) params["scale_shrink"] = p.scale_shrink;

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -525,6 +525,19 @@ GsAnimationData SceneLoader::parse_gs_animation(const nlohmann::json& j) {
         if (r.contains("half_extents")) anim.region.half_extents = parse_vec3(r["half_extents"]);
     }
 
+    // Animation parameters
+    if (j.contains("params")) {
+        const auto& p = j["params"];
+        anim.params.speed = p.value("speed", 1.0f);
+        if (p.contains("gravity")) anim.params.gravity = parse_vec3(p["gravity"]);
+        anim.params.velocity_scale = p.value("velocity_scale", 1.0f);
+        anim.params.noise_amplitude = p.value("noise_amplitude", 1.0f);
+        anim.params.orbit_speed = p.value("orbit_speed", 1.0f);
+        anim.params.expansion = p.value("expansion", 1.0f);
+        anim.params.opacity_fade = p.value("opacity_fade", 1.0f);
+        anim.params.scale_shrink = p.value("scale_shrink", 1.0f);
+    }
+
     return anim;
 }
 
@@ -543,6 +556,20 @@ nlohmann::json SceneLoader::gs_animation_json(const GsAnimationData& anim) {
         region["half_extents"] = vec3_json(anim.region.half_extents);
     }
     j["region"] = region;
+
+    // Only write params if any differ from defaults
+    const auto& p = anim.params;
+    GsAnimParams def;
+    nlohmann::json params;
+    if (p.speed != def.speed) params["speed"] = p.speed;
+    if (p.gravity != def.gravity) params["gravity"] = vec3_json(p.gravity);
+    if (p.velocity_scale != def.velocity_scale) params["velocity_scale"] = p.velocity_scale;
+    if (p.noise_amplitude != def.noise_amplitude) params["noise_amplitude"] = p.noise_amplitude;
+    if (p.orbit_speed != def.orbit_speed) params["orbit_speed"] = p.orbit_speed;
+    if (p.expansion != def.expansion) params["expansion"] = p.expansion;
+    if (p.opacity_fade != def.opacity_fade) params["opacity_fade"] = p.opacity_fade;
+    if (p.scale_shrink != def.scale_shrink) params["scale_shrink"] = p.scale_shrink;
+    if (!params.empty()) j["params"] = params;
 
     return j;
 }

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -534,6 +534,7 @@ GsAnimationData SceneLoader::parse_gs_animation(const nlohmann::json& j) {
         anim.params.orbit_speed = p.value("orbit_speed", anim.params.orbit_speed);
         anim.params.orbit_acceleration = p.value("orbit_acceleration", anim.params.orbit_acceleration);
         anim.params.expansion = p.value("expansion", anim.params.expansion);
+        anim.params.height_rise = p.value("height_rise", anim.params.height_rise);
         anim.params.opacity_fade = p.value("opacity_fade", anim.params.opacity_fade);
         anim.params.scale_shrink = p.value("scale_shrink", anim.params.scale_shrink);
     };
@@ -572,6 +573,7 @@ nlohmann::json SceneLoader::gs_animation_json(const GsAnimationData& anim) {
     if (p.orbit_speed != def.orbit_speed) params["orbit_speed"] = p.orbit_speed;
     if (p.orbit_acceleration != def.orbit_acceleration) params["orbit_acceleration"] = p.orbit_acceleration;
     if (p.expansion != def.expansion) params["expansion"] = p.expansion;
+    if (p.height_rise != def.height_rise) params["height_rise"] = p.height_rise;
     if (p.opacity_fade != def.opacity_fade) params["opacity_fade"] = p.opacity_fade;
     if (p.scale_shrink != def.scale_shrink) params["scale_shrink"] = p.scale_shrink;
     if (!params.empty()) j["params"] = params;

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -525,18 +525,21 @@ GsAnimationData SceneLoader::parse_gs_animation(const nlohmann::json& j) {
         if (r.contains("half_extents")) anim.region.half_extents = parse_vec3(r["half_extents"]);
     }
 
-    // Animation parameters
-    if (j.contains("params")) {
-        const auto& p = j["params"];
-        anim.params.speed = p.value("speed", 1.0f);
+    // Animation parameters — check both nested "params" block and top-level fields
+    auto read_params = [&](const nlohmann::json& p) {
+        anim.params.speed = p.value("speed", anim.params.speed);
         if (p.contains("gravity")) anim.params.gravity = parse_vec3(p["gravity"]);
-        anim.params.velocity_scale = p.value("velocity_scale", 1.0f);
-        anim.params.noise_amplitude = p.value("noise_amplitude", 1.0f);
-        anim.params.orbit_speed = p.value("orbit_speed", 1.0f);
-        anim.params.expansion = p.value("expansion", 1.0f);
-        anim.params.opacity_fade = p.value("opacity_fade", 1.0f);
-        anim.params.scale_shrink = p.value("scale_shrink", 1.0f);
-    }
+        anim.params.velocity_scale = p.value("velocity_scale", anim.params.velocity_scale);
+        anim.params.noise_amplitude = p.value("noise_amplitude", anim.params.noise_amplitude);
+        anim.params.orbit_speed = p.value("orbit_speed", anim.params.orbit_speed);
+        anim.params.expansion = p.value("expansion", anim.params.expansion);
+        anim.params.opacity_fade = p.value("opacity_fade", anim.params.opacity_fade);
+        anim.params.scale_shrink = p.value("scale_shrink", anim.params.scale_shrink);
+    };
+    // Top-level fields (flat format)
+    read_params(j);
+    // Nested "params" block overrides top-level
+    if (j.contains("params")) read_params(j["params"]);
 
     return anim;
 }

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -202,6 +202,7 @@ export function exportSceneJson(state: SceneStoreState): object {
       if (p.orbit_speed !== 1) params.orbit_speed = p.orbit_speed;
       if (p.orbit_acceleration !== 0) params.orbit_acceleration = p.orbit_acceleration;
       if (p.expansion !== 1) params.expansion = p.expansion;
+      if (p.height_rise !== 1) params.height_rise = p.height_rise;
       if (p.opacity_fade !== 1) params.opacity_fade = p.opacity_fade;
       if (p.scale_shrink !== 1) params.scale_shrink = p.scale_shrink;
       if (Object.keys(params).length > 0) out.params = params;

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -192,6 +192,18 @@ export function exportSceneJson(state: SceneStoreState): object {
         lifetime: a.lifetime,
       };
       if (a.loop) out.loop = true;
+      // Only write params that differ from defaults
+      const p = a.params;
+      const params: Record<string, unknown> = {};
+      if (p.speed !== 1) params.speed = p.speed;
+      if (p.gravity[0] !== 0 || p.gravity[1] !== -9.8 || p.gravity[2] !== 0) params.gravity = p.gravity;
+      if (p.velocity_scale !== 1) params.velocity_scale = p.velocity_scale;
+      if (p.noise_amplitude !== 1) params.noise_amplitude = p.noise_amplitude;
+      if (p.orbit_speed !== 1) params.orbit_speed = p.orbit_speed;
+      if (p.expansion !== 1) params.expansion = p.expansion;
+      if (p.opacity_fade !== 1) params.opacity_fade = p.opacity_fade;
+      if (p.scale_shrink !== 1) params.scale_shrink = p.scale_shrink;
+      if (Object.keys(params).length > 0) out.params = params;
       return out;
     });
   }

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -200,6 +200,7 @@ export function exportSceneJson(state: SceneStoreState): object {
       if (p.velocity_scale !== 1) params.velocity_scale = p.velocity_scale;
       if (p.noise_amplitude !== 1) params.noise_amplitude = p.noise_amplitude;
       if (p.orbit_speed !== 1) params.orbit_speed = p.orbit_speed;
+      if (p.orbit_acceleration !== 0) params.orbit_acceleration = p.orbit_acceleration;
       if (p.expansion !== 1) params.expansion = p.expansion;
       if (p.opacity_fade !== 1) params.opacity_fade = p.opacity_fade;
       if (p.scale_shrink !== 1) params.scale_shrink = p.scale_shrink;

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -957,6 +957,13 @@ function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
       </div>
 
       <div style={styles.section}>
+        <span style={styles.label}>Orbit Acceleration</span>
+        <NumberInput value={anim.params.orbit_acceleration} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...anim.params, orbit_acceleration: v } })} style={styles.input} />
+        <span style={{ fontSize: 10, color: '#666' }}>{'>'}0 = spin up, {'<'}0 = spin down</span>
+      </div>
+
+      <div style={styles.section}>
         <span style={styles.label}>Expansion</span>
         <NumberInput value={anim.params.expansion} min={0} step={0.1}
           onChange={(v) => update(anim.id, { params: { ...anim.params, expansion: v } })} style={styles.input} />

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -970,6 +970,13 @@ function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
       </div>
 
       <div style={styles.section}>
+        <span style={styles.label}>Height Rise</span>
+        <NumberInput value={anim.params.height_rise} min={0} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...anim.params, height_rise: v } })} style={styles.input} />
+        <span style={{ fontSize: 10, color: '#666' }}>0 = flat orbit, 1 = default rise</span>
+      </div>
+
+      <div style={styles.section}>
         <span style={styles.label}>Opacity Fade</span>
         <NumberInput value={anim.params.opacity_fade} min={0} max={1} step={0.05}
           onChange={(v) => update(anim.id, { params: { ...anim.params, opacity_fade: v } })} style={styles.input} />

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -921,6 +921,60 @@ function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
           Loop (restart when finished)
         </label>
       </div>
+
+      <div style={styles.section}>
+        <span style={{ ...styles.label, marginTop: 8 }}>Parameters</span>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Speed</span>
+        <NumberInput value={anim.params.speed} min={0.01} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...anim.params, speed: v } })} style={styles.input} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Gravity</span>
+        <Vec3Input value={anim.params.gravity}
+          onChange={(v) => update(anim.id, { params: { ...anim.params, gravity: v } })} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Velocity Scale</span>
+        <NumberInput value={anim.params.velocity_scale} min={0} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...anim.params, velocity_scale: v } })} style={styles.input} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Noise Amplitude</span>
+        <NumberInput value={anim.params.noise_amplitude} min={0} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...anim.params, noise_amplitude: v } })} style={styles.input} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Orbit Speed</span>
+        <NumberInput value={anim.params.orbit_speed} min={0} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...anim.params, orbit_speed: v } })} style={styles.input} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Expansion</span>
+        <NumberInput value={anim.params.expansion} min={0} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...anim.params, expansion: v } })} style={styles.input} />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Opacity Fade</span>
+        <NumberInput value={anim.params.opacity_fade} min={0} max={1} step={0.05}
+          onChange={(v) => update(anim.id, { params: { ...anim.params, opacity_fade: v } })} style={styles.input} />
+        <span style={{ fontSize: 10, color: '#666' }}>0 = no fade, 1 = full fade to transparent</span>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Scale Shrink</span>
+        <NumberInput value={anim.params.scale_shrink} min={0} max={1} step={0.05}
+          onChange={(v) => update(anim.id, { params: { ...anim.params, scale_shrink: v } })} style={styles.input} />
+        <span style={{ fontSize: 10, color: '#666' }}>0 = no shrink, 1 = full shrink to zero</span>
+      </div>
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -164,6 +164,17 @@ export type SettingsCategory =
   | 'vfx'
   | 'backgrounds';
 
+export interface GsAnimParams {
+  speed: number;
+  gravity: [number, number, number];
+  velocity_scale: number;
+  noise_amplitude: number;
+  orbit_speed: number;
+  expansion: number;
+  opacity_fade: number;
+  scale_shrink: number;
+}
+
 export interface GsAnimationGroupData {
   id: string;
   effect: string;  // 'detach' | 'float' | 'orbit' | 'dissolve' | 'reform'
@@ -173,6 +184,7 @@ export interface GsAnimationGroupData {
   half_extents: [number, number, number];
   lifetime: number;
   loop: boolean;
+  params: GsAnimParams;
 }
 
 export interface GsParticleEmitterData {

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -172,6 +172,7 @@ export interface GsAnimParams {
   orbit_speed: number;
   orbit_acceleration: number;
   expansion: number;
+  height_rise: number;
   opacity_fade: number;
   scale_shrink: number;
 }

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -170,6 +170,7 @@ export interface GsAnimParams {
   velocity_scale: number;
   noise_amplitude: number;
   orbit_speed: number;
+  orbit_acceleration: number;
   expansion: number;
   opacity_fade: number;
   scale_shrink: number;

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -740,6 +740,11 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       half_extents: [5, 5, 5],
       lifetime: 4,
       loop: true,
+      params: {
+        speed: 1, gravity: [0, -9.8, 0], velocity_scale: 1,
+        noise_amplitude: 1, orbit_speed: 1, expansion: 1,
+        opacity_fade: 1, scale_shrink: 1,
+      },
     };
     set({ gsAnimations: [...get().gsAnimations, anim], isDirty: true });
   },

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -743,7 +743,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       params: {
         speed: 1, gravity: [0, -9.8, 0], velocity_scale: 1,
         noise_amplitude: 1, orbit_speed: 1, orbit_acceleration: 0,
-        expansion: 1, opacity_fade: 1, scale_shrink: 1,
+        expansion: 1, height_rise: 1, opacity_fade: 1, scale_shrink: 1,
       },
     };
     set({ gsAnimations: [...get().gsAnimations, anim], isDirty: true });

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -742,8 +742,8 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       loop: true,
       params: {
         speed: 1, gravity: [0, -9.8, 0], velocity_scale: 1,
-        noise_amplitude: 1, orbit_speed: 1, expansion: 1,
-        opacity_fade: 1, scale_shrink: 1,
+        noise_amplitude: 1, orbit_speed: 1, orbit_acceleration: 0,
+        expansion: 1, opacity_fade: 1, scale_shrink: 1,
       },
     };
     set({ gsAnimations: [...get().gsAnimations, anim], isDirty: true });


### PR DESCRIPTION
## Summary
- **Scene JSON**: New `gs_animations` array — apply Detach/Float/Orbit/Dissolve/Reform effects to existing scene Gaussians within sphere/box regions
- **10 tunable parameters**: speed, gravity, velocity_scale, noise_amplitude, orbit_speed, orbit_acceleration, expansion, height_rise, opacity_fade, scale_shrink
- **Loop support**: Animations auto-restart when finished
- **Bricklayer**: Animations section in project tree, full property editor, cyan wireframe gizmos with G-key grab
- **Demo**: Cyan markers (A0, A1...) in scene layer overlay

## Parameters
| Parameter | Default | Description |
|-----------|---------|-------------|
| speed | 1.0 | Time scale |
| gravity | [0,-9.8,0] | Gravity vector (Detach) |
| velocity_scale | 1.0 | Initial velocity (Detach/Float/Reform) |
| noise_amplitude | 1.0 | Horizontal wander (Float/Dissolve) |
| orbit_speed | 1.0 | Rotation speed (Orbit) |
| orbit_acceleration | 0.0 | Spin up/down (Orbit) |
| expansion | 1.0 | Radius growth (Orbit) |
| height_rise | 1.0 | Vertical rise (Orbit), 0=flat |
| opacity_fade | 1.0 | 0=no fade, 1=full fade |
| scale_shrink | 1.0 | 0=no shrink, 1=full shrink |

## Test plan
- [x] C++ tests: scene JSON round-trip for gs_animations (13/13 pass)
- [x] TS tests: 45 cases — store CRUD, export, roundtrip, grab, all effects
- [x] Visual: Orbit with expansion/height_rise/acceleration tuned in Bricklayer

🤖 Generated with [Claude Code](https://claude.com/claude-code)