### PR TITLE
Add nested reform: auto-restore after animation effect

### DIFF
--- a/assets/scenes/test_brickslayer.json
+++ b/assets/scenes/test_brickslayer.json
@@ -295,8 +295,9 @@
         "radius": 50
       },
       "speed": 1,
-      "lifetime": 100,
-      "loop": false
+      "lifetime": 5,
+      "loop": false,
+      "reform": { "lifetime": 5, "speed": 1 }                                                                                                                                                                          
     },
     {
       "effect": "orbit",
@@ -309,11 +310,11 @@
         ],
         "radius": 50
       },
-      "speed": 0.1,
+      "speed": 0.5,
       "expansion": 30,
-      "orbit_acceleration": 0.1,
-      "lifetime": 5,
-      "loop": false
+      "lifetime": 2.5,
+      "loop": false,
+      "reform": { "lifetime": 5, "speed": 1 }                                                                                                                                                                          
     }
   ]
 }

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -24,6 +24,7 @@
 #include "gseurat/engine/vk_context.hpp"
 
 #include <array>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -87,16 +88,25 @@ public:
     const std::vector<Gaussian>& gs_active_buffer() const { return gs_active_buffer_; }
 
     // Scene-placed animations (with loop support)
+    struct ReformConfig {
+        float lifetime = 2.0f;
+        float speed = 1.0f;
+    };
     struct SceneAnimation {
         std::string effect;
         GsAnimRegion region;
         float lifetime = 3.0f;
         bool loop = false;
         GsAnimParams params;
+        std::optional<ReformConfig> reform;
+        enum class Phase { Effect, Reforming, Idle };
+        Phase phase = Phase::Effect;
         uint32_t group_id = 0;
+        uint32_t reform_group_id = 0;
     };
     void add_gs_animation(const std::string& effect, const GsAnimRegion& region,
-                          float lifetime, bool loop, const GsAnimParams& params = {});
+                          float lifetime, bool loop, const GsAnimParams& params = {},
+                          const std::optional<ReformConfig>& reform = std::nullopt);
     void clear_gs_animations();
     const std::vector<SceneAnimation>& gs_scene_animations() const { return gs_scene_animations_; }
 

--- a/include/gseurat/engine/scene_loader.hpp
+++ b/include/gseurat/engine/scene_loader.hpp
@@ -98,12 +98,18 @@ struct GsEmitterData {
     GsEmitterConfig config;      // full config (preset values overridden by explicit fields)
 };
 
+struct GsAnimReformConfig {
+    float lifetime = 2.0f;
+    float speed = 1.0f;
+};
+
 struct GsAnimationData {
-    std::string effect;          // "detach", "float", "orbit", "dissolve", "reform"
+    std::string effect;          // "detach", "float", "orbit", "dissolve", etc.
     GsAnimRegion region;
     float lifetime = 3.0f;
     bool loop = false;
     GsAnimParams params;
+    std::optional<GsAnimReformConfig> reform;  // auto-reform after effect finishes
 };
 
 struct PortalData {

--- a/src/demo/demo_app.cpp
+++ b/src/demo/demo_app.cpp
@@ -218,7 +218,11 @@ void DemoApp::init_scene(const std::string& scene_path) {
                 auto region = anim.region;
                 region.center.x += aabb.min.x;
                 region.center.y += aabb.min.y;
-                renderer_.add_gs_animation(anim.effect, region, anim.lifetime, anim.loop, anim.params);
+                std::optional<Renderer::ReformConfig> reform;
+                if (anim.reform) {
+                    reform = Renderer::ReformConfig{anim.reform->lifetime, anim.reform->speed};
+                }
+                renderer_.add_gs_animation(anim.effect, region, anim.lifetime, anim.loop, anim.params, reform);
             }
         }
 

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -791,8 +791,20 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 || gs_animator_.has_active_groups()
                 || !gs_scene_animations_.empty();
             if (has_particles) {
-                // Start from cached scene buffer
-                gs_active_buffer_ = gs_scene_buffer_;
+                // Check if any animation is in reforming phase
+                bool any_reforming = false;
+                for (const auto& sa : gs_scene_animations_) {
+                    if (sa.phase == SceneAnimation::Phase::Reforming) {
+                        any_reforming = true;
+                        break;
+                    }
+                }
+
+                // Only reset to scene buffer if no reform is in progress
+                // (reform needs displaced positions to lerp from)
+                if (!any_reforming) {
+                    gs_active_buffer_ = gs_scene_buffer_;
+                }
 
                 // Phase-based state machine for scene animations
                 for (auto& sa : gs_scene_animations_) {
@@ -806,7 +818,8 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                         } else if (!gs_animator_.has_group(sa.group_id)) {
                             // Effect finished
                             if (sa.reform) {
-                                // Transition to reforming phase
+                                // Tag reform from scene buffer (original positions)
+                                // but active buffer retains displaced positions
                                 GsAnimParams reform_params;
                                 reform_params.speed = sa.reform->speed;
                                 reform_params.velocity_scale = sa.reform->speed;
@@ -824,7 +837,8 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                         }
                     } else if (sa.phase == Phase::Reforming) {
                         if (!gs_animator_.has_group(sa.reform_group_id)) {
-                            // Reform finished
+                            // Reform finished — reset buffer to clean state
+                            gs_active_buffer_ = gs_scene_buffer_;
                             if (sa.loop) {
                                 sa.group_id = gs_animator_.tag_region(
                                     gs_scene_buffer_, sa.region,

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -791,35 +791,17 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 || gs_animator_.has_active_groups()
                 || !gs_scene_animations_.empty();
             if (has_particles) {
-                // Check if any animation is in reforming phase
-                bool any_reforming = false;
-                for (const auto& sa : gs_scene_animations_) {
-                    if (sa.phase == SceneAnimation::Phase::Reforming) {
-                        any_reforming = true;
-                        break;
-                    }
-                }
-
-                // Only reset to scene buffer if no reform is in progress
-                // (reform needs displaced positions to lerp from)
-                if (!any_reforming) {
-                    gs_active_buffer_ = gs_scene_buffer_;
-                }
-
                 // Phase-based state machine for scene animations
+                // Run BEFORE buffer reset so we can detect transitions to Reforming
                 for (auto& sa : gs_scene_animations_) {
                     using Phase = SceneAnimation::Phase;
                     if (sa.phase == Phase::Effect) {
                         if (sa.group_id == 0) {
-                            // First start
                             sa.group_id = gs_animator_.tag_region(
                                 gs_scene_buffer_, sa.region,
                                 parse_effect_name(sa.effect), sa.lifetime, sa.params);
                         } else if (!gs_animator_.has_group(sa.group_id)) {
-                            // Effect finished
                             if (sa.reform) {
-                                // Tag reform from scene buffer (original positions)
-                                // but active buffer retains displaced positions
                                 GsAnimParams reform_params;
                                 reform_params.speed = sa.reform->speed;
                                 reform_params.velocity_scale = sa.reform->speed;
@@ -837,8 +819,6 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                         }
                     } else if (sa.phase == Phase::Reforming) {
                         if (!gs_animator_.has_group(sa.reform_group_id)) {
-                            // Reform finished — reset buffer to clean state
-                            gs_active_buffer_ = gs_scene_buffer_;
                             if (sa.loop) {
                                 sa.group_id = gs_animator_.tag_region(
                                     gs_scene_buffer_, sa.region,
@@ -849,7 +829,20 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                             }
                         }
                     }
-                    // Phase::Idle — do nothing
+                }
+
+                // Check if any animation is reforming AFTER state transitions
+                bool any_reforming = false;
+                for (const auto& sa : gs_scene_animations_) {
+                    if (sa.phase == SceneAnimation::Phase::Reforming) {
+                        any_reforming = true;
+                        break;
+                    }
+                }
+
+                // Skip buffer reset during reform so displaced positions persist
+                if (!any_reforming) {
+                    gs_active_buffer_ = gs_scene_buffer_;
                 }
 
                 // Animate tagged scene Gaussians (Mode 2)

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -794,13 +794,48 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 // Start from cached scene buffer
                 gs_active_buffer_ = gs_scene_buffer_;
 
-                // Tag scene animations that haven't started yet, or re-tag looping ones
+                // Phase-based state machine for scene animations
                 for (auto& sa : gs_scene_animations_) {
-                    if (sa.group_id == 0 || (sa.loop && !gs_animator_.has_group(sa.group_id))) {
-                        sa.group_id = gs_animator_.tag_region(
-                            gs_scene_buffer_, sa.region,
-                            parse_effect_name(sa.effect), sa.lifetime, sa.params);
+                    using Phase = SceneAnimation::Phase;
+                    if (sa.phase == Phase::Effect) {
+                        if (sa.group_id == 0) {
+                            // First start
+                            sa.group_id = gs_animator_.tag_region(
+                                gs_scene_buffer_, sa.region,
+                                parse_effect_name(sa.effect), sa.lifetime, sa.params);
+                        } else if (!gs_animator_.has_group(sa.group_id)) {
+                            // Effect finished
+                            if (sa.reform) {
+                                // Transition to reforming phase
+                                GsAnimParams reform_params;
+                                reform_params.speed = sa.reform->speed;
+                                reform_params.velocity_scale = sa.reform->speed;
+                                sa.reform_group_id = gs_animator_.tag_region(
+                                    gs_scene_buffer_, sa.region,
+                                    GsAnimEffect::Reform, sa.reform->lifetime, reform_params);
+                                sa.phase = Phase::Reforming;
+                            } else if (sa.loop) {
+                                sa.group_id = gs_animator_.tag_region(
+                                    gs_scene_buffer_, sa.region,
+                                    parse_effect_name(sa.effect), sa.lifetime, sa.params);
+                            } else {
+                                sa.phase = Phase::Idle;
+                            }
+                        }
+                    } else if (sa.phase == Phase::Reforming) {
+                        if (!gs_animator_.has_group(sa.reform_group_id)) {
+                            // Reform finished
+                            if (sa.loop) {
+                                sa.group_id = gs_animator_.tag_region(
+                                    gs_scene_buffer_, sa.region,
+                                    parse_effect_name(sa.effect), sa.lifetime, sa.params);
+                                sa.phase = Phase::Effect;
+                            } else {
+                                sa.phase = Phase::Idle;
+                            }
+                        }
                     }
+                    // Phase::Idle — do nothing
                 }
 
                 // Animate tagged scene Gaussians (Mode 2)
@@ -955,13 +990,15 @@ void Renderer::clear_gs_particle_emitters() {
 }
 
 void Renderer::add_gs_animation(const std::string& effect, const GsAnimRegion& region,
-                                 float lifetime, bool loop, const GsAnimParams& params) {
+                                 float lifetime, bool loop, const GsAnimParams& params,
+                                 const std::optional<ReformConfig>& reform) {
     SceneAnimation sa;
     sa.effect = effect;
     sa.region = region;
     sa.lifetime = lifetime;
     sa.loop = loop;
     sa.params = params;
+    sa.reform = reform;
     if (!gs_scene_buffer_.empty()) {
         sa.group_id = gs_animator_.tag_region(
             gs_scene_buffer_, region, parse_effect_name(effect), lifetime, params);

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -543,6 +543,15 @@ GsAnimationData SceneLoader::parse_gs_animation(const nlohmann::json& j) {
     // Nested "params" block overrides top-level
     if (j.contains("params")) read_params(j["params"]);
 
+    // Optional reform config
+    if (j.contains("reform")) {
+        GsAnimReformConfig reform;
+        const auto& r = j["reform"];
+        reform.lifetime = r.value("lifetime", 2.0f);
+        reform.speed = r.value("speed", 1.0f);
+        anim.reform = reform;
+    }
+
     return anim;
 }
 
@@ -577,6 +586,13 @@ nlohmann::json SceneLoader::gs_animation_json(const GsAnimationData& anim) {
     if (p.opacity_fade != def.opacity_fade) params["opacity_fade"] = p.opacity_fade;
     if (p.scale_shrink != def.scale_shrink) params["scale_shrink"] = p.scale_shrink;
     if (!params.empty()) j["params"] = params;
+
+    if (anim.reform) {
+        nlohmann::json reform;
+        reform["lifetime"] = anim.reform->lifetime;
+        reform["speed"] = anim.reform->speed;
+        j["reform"] = reform;
+    }
 
     return j;
 }

--- a/tests/test_gs_particle.cpp
+++ b/tests/test_gs_particle.cpp
@@ -384,6 +384,36 @@ int main() {
         std::printf("PASS: Scene JSON round-trip for gs_animations\n");
     }
 
+    // --- Test: gs_animation reform config round-trip ---
+    {
+        SceneData data;
+        GsAnimationData anim;
+        anim.effect = "scatter";
+        anim.region.center = glm::vec3(5.0f, 3.0f, 7.0f);
+        anim.lifetime = 2.0f;
+        anim.loop = true;
+        anim.reform = GsAnimReformConfig{3.0f, 0.5f};
+        data.gs_animations.push_back(anim);
+
+        auto j = SceneLoader::to_json(data);
+        auto rt = SceneLoader::from_json(j);
+
+        assert(rt.gs_animations.size() == 1);
+        assert(rt.gs_animations[0].reform.has_value());
+        assert(std::fabs(rt.gs_animations[0].reform->lifetime - 3.0f) < 0.01f);
+        assert(std::fabs(rt.gs_animations[0].reform->speed - 0.5f) < 0.01f);
+
+        // Without reform
+        GsAnimationData anim2;
+        anim2.effect = "orbit";
+        data.gs_animations.push_back(anim2);
+        auto j2 = SceneLoader::to_json(data);
+        auto rt2 = SceneLoader::from_json(j2);
+        assert(!rt2.gs_animations[1].reform.has_value());
+
+        std::printf("PASS: gs_animation reform config round-trip\n");
+    }
+
     std::printf("\nAll GS particle/animator tests passed.\n");
     return 0;
 }

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -206,6 +206,9 @@ export function exportSceneJson(state: SceneStoreState): object {
       if (p.opacity_fade !== 1) params.opacity_fade = p.opacity_fade;
       if (p.scale_shrink !== 1) params.scale_shrink = p.scale_shrink;
       if (Object.keys(params).length > 0) out.params = params;
+      if (a.reform_enabled) {
+        out.reform = { lifetime: a.reform_lifetime, speed: a.reform_speed };
+      }
       return out;
     });
   }

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -927,6 +927,33 @@ function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
       </div>
 
       <div style={styles.section}>
+        <label style={{ fontSize: 12, color: '#ddd', display: 'flex', alignItems: 'center' }}>
+          <input
+            type="checkbox"
+            checked={anim.reform_enabled}
+            onChange={(e) => update(anim.id, { reform_enabled: e.target.checked })}
+            style={styles.checkbox}
+          />
+          Reform after effect (restore to original)
+        </label>
+      </div>
+
+      {anim.reform_enabled && (
+        <>
+          <div style={styles.section}>
+            <span style={styles.label}>Reform Lifetime</span>
+            <NumberInput value={anim.reform_lifetime} min={0.1} step={0.5}
+              onChange={(v) => update(anim.id, { reform_lifetime: v })} style={styles.input} />
+          </div>
+          <div style={styles.section}>
+            <span style={styles.label}>Reform Speed</span>
+            <NumberInput value={anim.reform_speed} min={0.01} step={0.1}
+              onChange={(v) => update(anim.id, { reform_speed: v })} style={styles.input} />
+          </div>
+        </>
+      )}
+
+      <div style={styles.section}>
         <span style={{ ...styles.label, marginTop: 8 }}>Parameters</span>
       </div>
 

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -187,6 +187,9 @@ export interface GsAnimationGroupData {
   lifetime: number;
   loop: boolean;
   params: GsAnimParams;
+  reform_enabled: boolean;
+  reform_lifetime: number;
+  reform_speed: number;
 }
 
 export interface GsParticleEmitterData {

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -745,6 +745,9 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
         noise_amplitude: 1, orbit_speed: 1, orbit_acceleration: 0,
         expansion: 1, height_rise: 1, opacity_fade: 1, scale_shrink: 1,
       },
+      reform_enabled: false,
+      reform_lifetime: 2,
+      reform_speed: 1,
     };
     set({ gsAnimations: [...get().gsAnimations, anim], isDirty: true });
   },


### PR DESCRIPTION
## Summary
- Animations can now include a `reform` block that automatically restores Gaussians to their original positions after the main effect finishes
- State machine per animation: **Effect → Reforming → Idle** (or loop back to Effect)
- Reform has its own `lifetime` and `speed` parameters
- Enables cycles like: scatter → reform → scatter → reform → ...

## JSON Example
```json
{
  "effect": "scatter",
  "region": { "shape": "sphere", "center": [32, 5, 32], "radius": 5 },
  "lifetime": 2,
  "loop": true,
  "reform": { "lifetime": 3, "speed": 1 }
}
```

## Bricklayer
"Reform after effect" checkbox with lifetime/speed inputs, shown when enabled.

## Test plan
- [x] C++ tests: reform config round-trip (with and without reform)
- [x] TS typecheck: clean
- [x] Visual: scatter + reform + loop → Gaussians scatter, reform back, repeat

🤖 Generated with [Claude Code](https://claude.com/claude-code)