### PR TITLE
Blender-style grab: screen-aligned plane + axis lock

### DIFF
--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -120,6 +120,7 @@ function GrabOverlay() {
       const store = useSceneStore.getState();
       store.setGrabMode(false);
       store.setGrabOriginalPosition(null);
+      store.setGrabAxisLock('free');
     };
 
     // Use capture phase to guarantee we get the event first
@@ -316,7 +317,18 @@ export function App() {
         }
         store.setGrabMode(false);
         store.setGrabOriginalPosition(null);
+        store.setGrabAxisLock('free');
         return;
+      }
+
+      // X/Y/Z keys during grab: toggle axis lock
+      if (store.grabMode && !meta) {
+        const key = e.key.toLowerCase();
+        if (key === 'x' || key === 'y' || key === 'z') {
+          e.preventDefault();
+          store.setGrabAxisLock(store.grabAxisLock === key ? 'free' : key as 'x' | 'y' | 'z');
+          return;
+        }
       }
 
       // G key: grab in scene mode, fill in terrain mode
@@ -349,6 +361,7 @@ export function App() {
           }
           if (pos) {
             store.setGrabOriginalPosition(pos);
+            store.setGrabAxisLock('free');
             store.setGrabMode(true);
           }
           return;
@@ -359,7 +372,7 @@ export function App() {
       }
 
       const tool = toolKeys[e.key.toLowerCase()];
-      if (tool) {
+      if (tool && !store.grabMode) {
         store.setTool(tool);
         return;
       }

--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -321,8 +321,8 @@ export function App() {
         return;
       }
 
-      // X/Y/Z keys during grab: toggle axis lock
-      if (store.grabMode && !meta) {
+      // X/Y/Z keys during grab: toggle axis lock (ignore key repeat)
+      if (store.grabMode && !meta && !e.repeat) {
         const key = e.key.toLowerCase();
         if (key === 'x' || key === 'y' || key === 'z') {
           e.preventDefault();

--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -155,7 +155,7 @@ function GrabOverlay() {
         fontSize: 12,
         pointerEvents: 'none',
       }}>
-        GRAB: Click to confirm, Esc to cancel, Shift = height
+        GRAB: Click to confirm, Esc to cancel, X/Y/Z = axis lock
       </div>
     </div>
   );

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -193,7 +193,11 @@ export function exportSceneJson(state: SceneStoreState): object {
       };
       if (a.loop) out.loop = true;
       // Only write params that differ from defaults
-      const p = a.params;
+      const p = a.params ?? {
+        speed: 1, gravity: [0, -9.8, 0], velocity_scale: 1,
+        noise_amplitude: 1, orbit_speed: 1, orbit_acceleration: 0,
+        expansion: 1, height_rise: 1, opacity_fade: 1, scale_shrink: 1,
+      };
       const params: Record<string, unknown> = {};
       if (p.speed !== 1) params.speed = p.speed;
       if (p.gravity[0] !== 0 || p.gravity[1] !== -9.8 || p.gravity[2] !== 0) params.gravity = p.gravity;

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -850,9 +850,18 @@ const effectDescriptions: Record<string, string> = {
   scatter: 'Explosive outward burst (impacts, shattering)',
 };
 
+const defaultAnimParams = {
+  speed: 1, gravity: [0, -9.8, 0] as [number, number, number], velocity_scale: 1,
+  noise_amplitude: 1, orbit_speed: 1, orbit_acceleration: 0,
+  expansion: 1, height_rise: 1, opacity_fade: 1, scale_shrink: 1,
+};
+
 function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
   const update = useSceneStore((s) => s.updateGsAnimation);
   const remove = useSceneStore((s) => s.removeGsAnimation);
+
+  // Ensure params exists (backward compat with old saved data)
+  const params = anim.params ?? defaultAnimParams;
 
   return (
     <div>
@@ -959,65 +968,65 @@ function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
 
       <div style={styles.section}>
         <span style={styles.label}>Speed</span>
-        <NumberInput value={anim.params.speed} min={0.01} step={0.1}
-          onChange={(v) => update(anim.id, { params: { ...anim.params, speed: v } })} style={styles.input} />
+        <NumberInput value={params.speed} min={0.01} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...params, speed: v } })} style={styles.input} />
       </div>
 
       <div style={styles.section}>
         <span style={styles.label}>Gravity</span>
-        <Vec3Input value={anim.params.gravity}
-          onChange={(v) => update(anim.id, { params: { ...anim.params, gravity: v } })} />
+        <Vec3Input value={params.gravity}
+          onChange={(v) => update(anim.id, { params: { ...params, gravity: v } })} />
       </div>
 
       <div style={styles.section}>
         <span style={styles.label}>Velocity Scale</span>
-        <NumberInput value={anim.params.velocity_scale} min={0} step={0.1}
-          onChange={(v) => update(anim.id, { params: { ...anim.params, velocity_scale: v } })} style={styles.input} />
+        <NumberInput value={params.velocity_scale} min={0} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...params, velocity_scale: v } })} style={styles.input} />
       </div>
 
       <div style={styles.section}>
         <span style={styles.label}>Noise Amplitude</span>
-        <NumberInput value={anim.params.noise_amplitude} min={0} step={0.1}
-          onChange={(v) => update(anim.id, { params: { ...anim.params, noise_amplitude: v } })} style={styles.input} />
+        <NumberInput value={params.noise_amplitude} min={0} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...params, noise_amplitude: v } })} style={styles.input} />
       </div>
 
       <div style={styles.section}>
         <span style={styles.label}>Orbit Speed</span>
-        <NumberInput value={anim.params.orbit_speed} min={0} step={0.1}
-          onChange={(v) => update(anim.id, { params: { ...anim.params, orbit_speed: v } })} style={styles.input} />
+        <NumberInput value={params.orbit_speed} min={0} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...params, orbit_speed: v } })} style={styles.input} />
       </div>
 
       <div style={styles.section}>
         <span style={styles.label}>Orbit Acceleration</span>
-        <NumberInput value={anim.params.orbit_acceleration} step={0.1}
-          onChange={(v) => update(anim.id, { params: { ...anim.params, orbit_acceleration: v } })} style={styles.input} />
+        <NumberInput value={params.orbit_acceleration} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...params, orbit_acceleration: v } })} style={styles.input} />
         <span style={{ fontSize: 10, color: '#666' }}>{'>'}0 = spin up, {'<'}0 = spin down</span>
       </div>
 
       <div style={styles.section}>
         <span style={styles.label}>Expansion</span>
-        <NumberInput value={anim.params.expansion} min={0} step={0.1}
-          onChange={(v) => update(anim.id, { params: { ...anim.params, expansion: v } })} style={styles.input} />
+        <NumberInput value={params.expansion} min={0} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...params, expansion: v } })} style={styles.input} />
       </div>
 
       <div style={styles.section}>
         <span style={styles.label}>Height Rise</span>
-        <NumberInput value={anim.params.height_rise} min={0} step={0.1}
-          onChange={(v) => update(anim.id, { params: { ...anim.params, height_rise: v } })} style={styles.input} />
+        <NumberInput value={params.height_rise} min={0} step={0.1}
+          onChange={(v) => update(anim.id, { params: { ...params, height_rise: v } })} style={styles.input} />
         <span style={{ fontSize: 10, color: '#666' }}>0 = flat orbit, 1 = default rise</span>
       </div>
 
       <div style={styles.section}>
         <span style={styles.label}>Opacity Fade</span>
-        <NumberInput value={anim.params.opacity_fade} min={0} max={1} step={0.05}
-          onChange={(v) => update(anim.id, { params: { ...anim.params, opacity_fade: v } })} style={styles.input} />
+        <NumberInput value={params.opacity_fade} min={0} max={1} step={0.05}
+          onChange={(v) => update(anim.id, { params: { ...params, opacity_fade: v } })} style={styles.input} />
         <span style={{ fontSize: 10, color: '#666' }}>0 = no fade, 1 = full fade to transparent</span>
       </div>
 
       <div style={styles.section}>
         <span style={styles.label}>Scale Shrink</span>
-        <NumberInput value={anim.params.scale_shrink} min={0} max={1} step={0.05}
-          onChange={(v) => update(anim.id, { params: { ...anim.params, scale_shrink: v } })} style={styles.input} />
+        <NumberInput value={params.scale_shrink} min={0} max={1} step={0.05}
+          onChange={(v) => update(anim.id, { params: { ...params, scale_shrink: v } })} style={styles.input} />
         <span style={{ fontSize: 10, color: '#666' }}>0 = no shrink, 1 = full shrink to zero</span>
       </div>
     </div>

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -161,6 +161,7 @@ export interface SceneStoreState {
   // Grab mode
   grabMode: boolean;
   grabOriginalPosition: [number, number, number] | null;
+  grabAxisLock: 'free' | 'x' | 'y' | 'z';
 
   // Orbit lock (Shift-held drawing lock)
   orbitLocked: boolean;
@@ -304,6 +305,7 @@ export interface SceneStoreState {
   // Actions – grab
   setGrabMode: (v: boolean) => void;
   setGrabOriginalPosition: (pos: [number, number, number] | null) => void;
+  setGrabAxisLock: (axis: 'free' | 'x' | 'y' | 'z') => void;
   setOrbitLocked: (v: boolean) => void;
 
   // Actions – palettes
@@ -410,6 +412,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
 
   grabMode: false,
   grabOriginalPosition: null,
+  grabAxisLock: 'free' as const,
   orbitLocked: false,
 
   colorPalettes: [defaultPalette],
@@ -948,6 +951,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   // ── Grab actions ──
   setGrabMode: (v) => set({ grabMode: v }),
   setGrabOriginalPosition: (pos) => set({ grabOriginalPosition: pos }),
+  setGrabAxisLock: (axis) => set({ grabAxisLock: axis }),
   setOrbitLocked: (v) => set({ orbitLocked: v }),
 
   // ── Palette actions ──

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -137,22 +137,10 @@ function GrabPlane() {
   const selectedEntity = useSceneStore((s) => s.selectedEntity);
   const axisLock = useSceneStore((s) => s.grabAxisLock);
   const { camera, gl } = useThree();
-  const [shiftHeld, setShiftHeld] = useState(false);
-  const lastClientY = useRef(0);
   const currentPos = useRef<[number, number, number]>([0, 0, 0]);
-  const grabOffset = useRef<THREE.Vector3 | null>(null);  // cursor-to-entity offset at grab start
+  const grabOffset = useRef<THREE.Vector3 | null>(null);
   const labelPos = useRef<[number, number, number]>([0, 0, 0]);
   const [labelText, setLabelText] = useState('');
-
-  // Track Shift key
-  useEffect(() => {
-    if (!grabMode) return;
-    const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Shift') setShiftHeld(true); };
-    const onKeyUp = (e: KeyboardEvent) => { if (e.key === 'Shift') setShiftHeld(false); };
-    window.addEventListener('keydown', onKeyDown);
-    window.addEventListener('keyup', onKeyUp);
-    return () => { window.removeEventListener('keydown', onKeyDown); window.removeEventListener('keyup', onKeyUp); };
-  }, [grabMode]);
 
   // Initialize position when grab starts
   useEffect(() => {
@@ -180,19 +168,6 @@ function GrabPlane() {
       const store = useSceneStore.getState();
       const lock = store.grabAxisLock;
 
-      if (shiftHeld && lock === 'free') {
-        // Shift mode: vertical mouse movement adjusts Y (backward compat)
-        const deltaY = (lastClientY.current - ev.clientY) * 0.05;
-        lastClientY.current = ev.clientY;
-        const newY = Math.round((currentPos.current[1] + deltaY) * 10) / 10;
-        currentPos.current[1] = newY;
-        updateGrabbedEntity(currentPos.current[0], newY, currentPos.current[2]);
-        labelPos.current = [currentPos.current[0], newY + 1.5, currentPos.current[2]];
-        setLabelText(`${currentPos.current[0].toFixed(1)}, Y:${newY.toFixed(1)}, ${currentPos.current[2].toFixed(1)}`);
-        return;
-      }
-
-      lastClientY.current = ev.clientY;
       const rect = el.getBoundingClientRect();
       const pointer = new THREE.Vector2(
         ((ev.clientX - rect.left) / rect.width) * 2 - 1,
@@ -220,7 +195,7 @@ function GrabPlane() {
           currentPos.current = [sx, sy, sz];
           updateGrabbedEntity(sx, sy, sz);
           labelPos.current = [sx, sy + 1.5, sz];
-          setLabelText(`${sx.toFixed(1)}, ${sy.toFixed(1)}, ${sz.toFixed(1)}`);
+          setLabelText(`X:${sx.toFixed(1)}  Y:${sy.toFixed(1)}  Z:${sz.toFixed(1)}`);
         }
       } else {
         // Axis-locked: plane containing the axis, facing the camera
@@ -251,7 +226,8 @@ function GrabPlane() {
           updateGrabbedEntity(sx, sy, sz);
           labelPos.current = [sx, sy + 1.5, sz];
           const axisLabel = lock.toUpperCase();
-          setLabelText(`[${axisLabel}] ${sx.toFixed(1)}, ${sy.toFixed(1)}, ${sz.toFixed(1)}`);
+          const val = lock === 'x' ? sx : lock === 'y' ? sy : sz;
+          setLabelText(`${axisLabel}: ${val.toFixed(1)}`);
         }
       }
     };
@@ -261,7 +237,7 @@ function GrabPlane() {
 
     window.addEventListener('pointermove', onMove);
     return () => { window.removeEventListener('pointermove', onMove); };
-  }, [grabMode, selectedEntity, shiftHeld, camera, gl, axisLock]);
+  }, [grabMode, selectedEntity, camera, gl, axisLock]);
 
   if (!grabMode || !labelText) return null;
 
@@ -271,7 +247,7 @@ function GrabPlane() {
     <Html position={labelPos.current} center>
       <div style={{
         background: 'rgba(0,0,0,0.8)',
-        color: shiftHeld ? '#88aaff' : (axisColors[axisLock] ?? '#ffcc00'),
+        color: axisColors[axisLock] ?? '#ffcc00',
         padding: '2px 6px',
         borderRadius: 4,
         fontSize: 11,

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -135,42 +135,36 @@ function updateGrabbedEntity(x: number, y: number, z: number) {
 function GrabPlane() {
   const grabMode = useSceneStore((s) => s.grabMode);
   const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const axisLock = useSceneStore((s) => s.grabAxisLock);
   const { camera, gl } = useThree();
   const [shiftHeld, setShiftHeld] = useState(false);
   const lastClientY = useRef(0);
-  const currentY = useRef(0);
+  const currentPos = useRef<[number, number, number]>([0, 0, 0]);
   const labelPos = useRef<[number, number, number]>([0, 0, 0]);
   const [labelText, setLabelText] = useState('');
 
   // Track Shift key
   useEffect(() => {
     if (!grabMode) return;
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Shift') setShiftHeld(true);
-    };
-    const onKeyUp = (e: KeyboardEvent) => {
-      if (e.key === 'Shift') setShiftHeld(false);
-    };
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Shift') setShiftHeld(true); };
+    const onKeyUp = (e: KeyboardEvent) => { if (e.key === 'Shift') setShiftHeld(false); };
     window.addEventListener('keydown', onKeyDown);
     window.addEventListener('keyup', onKeyUp);
-    return () => {
-      window.removeEventListener('keydown', onKeyDown);
-      window.removeEventListener('keyup', onKeyUp);
-    };
+    return () => { window.removeEventListener('keydown', onKeyDown); window.removeEventListener('keyup', onKeyUp); };
   }, [grabMode]);
 
-  // Initialize currentY when grab starts, clear label when grab ends
+  // Initialize position when grab starts
   useEffect(() => {
     if (grabMode) {
-      currentY.current = getGrabbedEntityY();
+      const store = useSceneStore.getState();
+      const pos = store.grabOriginalPosition;
+      if (pos) currentPos.current = [...pos];
     } else {
       setLabelText('');
     }
   }, [grabMode]);
 
-  // Pointer tracking via window events for smooth grab
-  // Uses window so the overlay div doesn't block pointermove
+  // Pointer tracking
   useEffect(() => {
     if (!grabMode || !selectedEntity) return;
 
@@ -180,76 +174,90 @@ function GrabPlane() {
     const intersection = new THREE.Vector3();
 
     const onMove = (ev: PointerEvent) => {
-      if (shiftHeld) {
-        // Shift mode: vertical mouse movement adjusts Y
+      const store = useSceneStore.getState();
+      const lock = store.grabAxisLock;
+
+      if (shiftHeld && lock === 'free') {
+        // Shift mode: vertical mouse movement adjusts Y (backward compat)
         const deltaY = (lastClientY.current - ev.clientY) * 0.05;
         lastClientY.current = ev.clientY;
-        currentY.current = Math.round((currentY.current + deltaY) * 10) / 10;
+        const newY = Math.round((currentPos.current[1] + deltaY) * 10) / 10;
+        currentPos.current[1] = newY;
+        updateGrabbedEntity(currentPos.current[0], newY, currentPos.current[2]);
+        labelPos.current = [currentPos.current[0], newY + 1.5, currentPos.current[2]];
+        setLabelText(`${currentPos.current[0].toFixed(1)}, Y:${newY.toFixed(1)}, ${currentPos.current[2].toFixed(1)}`);
+        return;
+      }
 
-        // Get current XZ from entity
-        const store = useSceneStore.getState();
-        const sel = store.selectedEntity;
-        if (!sel) return;
+      lastClientY.current = ev.clientY;
+      const rect = el.getBoundingClientRect();
+      const pointer = new THREE.Vector2(
+        ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+        -((ev.clientY - rect.top) / rect.height) * 2 + 1,
+      );
+      raycaster.setFromCamera(pointer, camera);
 
-        let cx = 0, cz = 0;
-        if (sel.type === 'object') {
-          const obj = store.placedObjects.find((o) => o.id === sel.id);
-          if (obj) { cx = obj.position[0]; cz = obj.position[2]; }
-        } else if (sel.type === 'npc') {
-          const npc = store.npcs.find((n) => n.id === sel.id);
-          if (npc) { cx = npc.position[0]; cz = npc.position[2]; }
-        } else if (sel.type === 'light') {
-          const light = store.staticLights.find((l) => l.id === sel.id);
-          if (light) { cx = light.position[0]; cz = light.position[1]; }
-        } else if (sel.type === 'portal') {
-          const portal = store.portals.find((p) => p.id === sel.id);
-          if (portal) { cx = portal.position[0]; cz = portal.position[1]; }
-        } else if (sel.type === 'gs_emitter') {
-          const em = store.gsParticleEmitters.find((e) => e.id === sel.id);
-          if (em) { cx = em.position[0]; cz = em.position[2]; }
-        } else if (sel.type === 'gs_animation') {
-          const anim = store.gsAnimations.find((a) => a.id === sel.id);
-          if (anim) { cx = anim.center[0]; cz = anim.center[2]; }
-        } else if (sel.type === 'player') {
-          cx = store.player.position[0]; cz = store.player.position[2];
-        }
+      if (lock === 'free') {
+        // Screen-aligned plane: perpendicular to camera view at entity distance
+        const entityPos = new THREE.Vector3(currentPos.current[0], currentPos.current[1], currentPos.current[2]);
+        const camDir = camera.getWorldDirection(new THREE.Vector3());
+        plane.setFromNormalAndCoplanarPoint(camDir, entityPos);
 
-        updateGrabbedEntity(cx, currentY.current, cz);
-        labelPos.current = [cx, currentY.current + 1.5, cz];
-        setLabelText(`${cx.toFixed(1)}, Y:${currentY.current.toFixed(1)}, ${cz.toFixed(1)}`);
-      } else {
-        // Normal mode: XZ plane follow
-        lastClientY.current = ev.clientY;
-        const rect = el.getBoundingClientRect();
-        const pointer = new THREE.Vector2(
-          ((ev.clientX - rect.left) / rect.width) * 2 - 1,
-          -((ev.clientY - rect.top) / rect.height) * 2 + 1,
-        );
-        plane.set(new THREE.Vector3(0, 1, 0), -currentY.current);
-        raycaster.setFromCamera(pointer, camera);
         if (raycaster.ray.intersectPlane(plane, intersection)) {
           const sx = Math.round(intersection.x * 10) / 10;
+          const sy = Math.round(intersection.y * 10) / 10;
           const sz = Math.round(intersection.z * 10) / 10;
-          updateGrabbedEntity(sx, currentY.current, sz);
-          labelPos.current = [sx, currentY.current + 1.5, sz];
-          setLabelText(`${sx.toFixed(1)}, ${currentY.current.toFixed(1)}, ${sz.toFixed(1)}`);
+          currentPos.current = [sx, sy, sz];
+          updateGrabbedEntity(sx, sy, sz);
+          labelPos.current = [sx, sy + 1.5, sz];
+          setLabelText(`${sx.toFixed(1)}, ${sy.toFixed(1)}, ${sz.toFixed(1)}`);
+        }
+      } else {
+        // Axis-locked: use camera-perpendicular plane containing the locked axis
+        const entityPos = new THREE.Vector3(currentPos.current[0], currentPos.current[1], currentPos.current[2]);
+        const camDir = camera.getWorldDirection(new THREE.Vector3());
+
+        // Create a plane that contains the axis direction and faces the camera
+        const axisDir = lock === 'x' ? new THREE.Vector3(1, 0, 0)
+                      : lock === 'y' ? new THREE.Vector3(0, 1, 0)
+                      : new THREE.Vector3(0, 0, 1);
+        const planeNormal = new THREE.Vector3().crossVectors(axisDir, camDir).cross(axisDir).normalize();
+        if (planeNormal.lengthSq() < 0.001) {
+          // Camera is looking along the axis — use a fallback plane
+          planeNormal.set(camDir.x, camDir.y, camDir.z);
+        }
+        plane.setFromNormalAndCoplanarPoint(planeNormal, entityPos);
+
+        if (raycaster.ray.intersectPlane(plane, intersection)) {
+          // Project intersection onto the axis through entity position
+          const delta = intersection.clone().sub(entityPos);
+          const projected = axisDir.clone().multiplyScalar(delta.dot(axisDir));
+          const result = entityPos.clone().add(projected);
+          const sx = Math.round(result.x * 10) / 10;
+          const sy = Math.round(result.y * 10) / 10;
+          const sz = Math.round(result.z * 10) / 10;
+          currentPos.current = [sx, sy, sz];
+          updateGrabbedEntity(sx, sy, sz);
+          labelPos.current = [sx, sy + 1.5, sz];
+          const axisLabel = lock.toUpperCase();
+          setLabelText(`[${axisLabel}] ${sx.toFixed(1)}, ${sy.toFixed(1)}, ${sz.toFixed(1)}`);
         }
       }
     };
 
     window.addEventListener('pointermove', onMove);
-    return () => {
-      window.removeEventListener('pointermove', onMove);
-    };
-  }, [grabMode, selectedEntity, shiftHeld, camera, gl]);
+    return () => { window.removeEventListener('pointermove', onMove); };
+  }, [grabMode, selectedEntity, shiftHeld, camera, gl, axisLock]);
 
   if (!grabMode || !labelText) return null;
+
+  const axisColors: Record<string, string> = { free: '#ffcc00', x: '#ff4444', y: '#44ff44', z: '#4488ff' };
 
   return (
     <Html position={labelPos.current} center>
       <div style={{
         background: 'rgba(0,0,0,0.8)',
-        color: shiftHeld ? '#88aaff' : '#ffcc00',
+        color: shiftHeld ? '#88aaff' : (axisColors[axisLock] ?? '#ffcc00'),
         padding: '2px 6px',
         borderRadius: 4,
         fontSize: 11,

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -140,6 +140,7 @@ function GrabPlane() {
   const [shiftHeld, setShiftHeld] = useState(false);
   const lastClientY = useRef(0);
   const currentPos = useRef<[number, number, number]>([0, 0, 0]);
+  const grabOffset = useRef<THREE.Vector3 | null>(null);  // cursor-to-entity offset at grab start
   const labelPos = useRef<[number, number, number]>([0, 0, 0]);
   const [labelText, setLabelText] = useState('');
 
@@ -159,8 +160,10 @@ function GrabPlane() {
       const store = useSceneStore.getState();
       const pos = store.grabOriginalPosition;
       if (pos) currentPos.current = [...pos];
+      grabOffset.current = null;  // will be computed on first move
     } else {
       setLabelText('');
+      grabOffset.current = null;
     }
   }, [grabMode]);
 
@@ -197,42 +200,50 @@ function GrabPlane() {
       );
       raycaster.setFromCamera(pointer, camera);
 
+      // Compute grab plane at entity position
+      const entityPos = new THREE.Vector3(currentPos.current[0], currentPos.current[1], currentPos.current[2]);
+      const camDir = camera.getWorldDirection(new THREE.Vector3());
+
       if (lock === 'free') {
-        // Screen-aligned plane: perpendicular to camera view at entity distance
-        const entityPos = new THREE.Vector3(currentPos.current[0], currentPos.current[1], currentPos.current[2]);
-        const camDir = camera.getWorldDirection(new THREE.Vector3());
+        // Screen-aligned plane at entity distance
         plane.setFromNormalAndCoplanarPoint(camDir, entityPos);
 
         if (raycaster.ray.intersectPlane(plane, intersection)) {
-          const sx = Math.round(intersection.x * 10) / 10;
-          const sy = Math.round(intersection.y * 10) / 10;
-          const sz = Math.round(intersection.z * 10) / 10;
+          // On first move, compute offset so entity doesn't jump to cursor
+          if (!grabOffset.current) {
+            grabOffset.current = intersection.clone().sub(entityPos);
+          }
+          const adjusted = intersection.clone().sub(grabOffset.current);
+          const sx = Math.round(adjusted.x * 10) / 10;
+          const sy = Math.round(adjusted.y * 10) / 10;
+          const sz = Math.round(adjusted.z * 10) / 10;
           currentPos.current = [sx, sy, sz];
           updateGrabbedEntity(sx, sy, sz);
           labelPos.current = [sx, sy + 1.5, sz];
           setLabelText(`${sx.toFixed(1)}, ${sy.toFixed(1)}, ${sz.toFixed(1)}`);
         }
       } else {
-        // Axis-locked: use camera-perpendicular plane containing the locked axis
-        const entityPos = new THREE.Vector3(currentPos.current[0], currentPos.current[1], currentPos.current[2]);
-        const camDir = camera.getWorldDirection(new THREE.Vector3());
-
-        // Create a plane that contains the axis direction and faces the camera
+        // Axis-locked: plane containing the axis, facing the camera
         const axisDir = lock === 'x' ? new THREE.Vector3(1, 0, 0)
                       : lock === 'y' ? new THREE.Vector3(0, 1, 0)
                       : new THREE.Vector3(0, 0, 1);
         const planeNormal = new THREE.Vector3().crossVectors(axisDir, camDir).cross(axisDir).normalize();
         if (planeNormal.lengthSq() < 0.001) {
-          // Camera is looking along the axis — use a fallback plane
           planeNormal.set(camDir.x, camDir.y, camDir.z);
         }
         plane.setFromNormalAndCoplanarPoint(planeNormal, entityPos);
 
         if (raycaster.ray.intersectPlane(plane, intersection)) {
-          // Project intersection onto the axis through entity position
-          const delta = intersection.clone().sub(entityPos);
+          // On first move, compute offset along axis
+          if (!grabOffset.current) {
+            grabOffset.current = intersection.clone().sub(entityPos);
+          }
+          const adjusted = intersection.clone().sub(grabOffset.current);
+          // Project onto axis through original entity position
+          const origPos = new THREE.Vector3(...(useSceneStore.getState().grabOriginalPosition ?? [0, 0, 0]));
+          const delta = adjusted.clone().sub(origPos);
           const projected = axisDir.clone().multiplyScalar(delta.dot(axisDir));
-          const result = entityPos.clone().add(projected);
+          const result = origPos.clone().add(projected);
           const sx = Math.round(result.x * 10) / 10;
           const sy = Math.round(result.y * 10) / 10;
           const sz = Math.round(result.z * 10) / 10;
@@ -244,6 +255,9 @@ function GrabPlane() {
         }
       }
     };
+
+    // Reset offset when axis lock changes so entity doesn't jump
+    grabOffset.current = null;
 
     window.addEventListener('pointermove', onMove);
     return () => { window.removeEventListener('pointermove', onMove); };

--- a/tools/tests/src/bricklayer-grab.test.ts
+++ b/tools/tests/src/bricklayer-grab.test.ts
@@ -43,9 +43,12 @@ interface PlayerData {
 
 // ── Minimal grab-mode state machine (mirrors store + GrabPlane logic) ──
 
+type AxisLock = 'free' | 'x' | 'y' | 'z';
+
 interface GrabState {
   grabMode: boolean;
   grabOriginalPosition: [number, number, number] | null;
+  grabAxisLock: AxisLock;
   selectedEntity: SelectedEntity | null;
   placedObjects: PlacedObject[];
   staticLights: StaticLight[];
@@ -59,6 +62,7 @@ function createInitialState(): GrabState {
   return {
     grabMode: false,
     grabOriginalPosition: null,
+    grabAxisLock: 'free' as AxisLock,
     selectedEntity: null,
     placedObjects: [
       { id: 'obj1', position: [10, 5, 20] },
@@ -107,7 +111,7 @@ function enterGrab(state: GrabState): GrabState | null {
   }
 
   if (!pos) return null;
-  return { ...state, grabMode: true, grabOriginalPosition: pos };
+  return { ...state, grabMode: true, grabOriginalPosition: pos, grabAxisLock: 'free' as AxisLock };
 }
 
 /** Update grabbed entity position (mirrors GrabPlane pointermove). */
@@ -155,17 +159,17 @@ function updateGrabbedEntity(state: GrabState, x: number, y: number, z: number):
 
 /** Confirm grab — clears grab mode, keeps new position. */
 function confirmGrab(state: GrabState): GrabState {
-  return { ...state, grabMode: false, grabOriginalPosition: null };
+  return { ...state, grabMode: false, grabOriginalPosition: null, grabAxisLock: 'free' as AxisLock };
 }
 
 /** Cancel grab — restores original position. */
 function cancelGrab(state: GrabState): GrabState {
   if (!state.grabOriginalPosition || !state.selectedEntity) {
-    return { ...state, grabMode: false, grabOriginalPosition: null };
+    return { ...state, grabMode: false, grabOriginalPosition: null, grabAxisLock: 'free' as AxisLock };
   }
   const pos = state.grabOriginalPosition;
   const restored = updateGrabbedEntity(state, pos[0], pos[1], pos[2]);
-  return { ...restored, grabMode: false, grabOriginalPosition: null };
+  return { ...restored, grabMode: false, grabOriginalPosition: null, grabAxisLock: 'free' as AxisLock };
 }
 
 /** Simulate XZ move during grab (non-shift). Snaps to 0.1. */
@@ -646,6 +650,114 @@ console.log('\n--- 7. Orbit lock ---\n');
   assert(state.orbitLocked === true, 'orbit still locked');
   state = confirmGrab(state);
   assert(state.orbitLocked === true, 'orbit lock persists through grab');
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 8. Axis lock (10 tests)
+// ═══════════════════════════════════════════════════════════════
+
+console.log('\n--- Axis lock ---\n');
+
+function toggleAxisLock(state: GrabState, axis: 'x' | 'y' | 'z'): GrabState {
+  if (!state.grabMode) return state;
+  return { ...state, grabAxisLock: state.grabAxisLock === axis ? 'free' : axis };
+}
+
+{
+  console.log('Test 8.1: Toggle X axis lock on');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  state = toggleAxisLock(state, 'x');
+  assert(state.grabAxisLock === 'x', 'axis lock is x');
+}
+
+{
+  console.log('Test 8.2: Toggle X again -> free');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  state = toggleAxisLock(state, 'x');
+  state = toggleAxisLock(state, 'x');
+  assert(state.grabAxisLock === 'free', 'axis lock back to free');
+}
+
+{
+  console.log('Test 8.3: Switch from X to Y');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  state = toggleAxisLock(state, 'x');
+  state = toggleAxisLock(state, 'y');
+  assert(state.grabAxisLock === 'y', 'axis lock switched to y');
+}
+
+{
+  console.log('Test 8.4: Z axis lock');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  state = toggleAxisLock(state, 'z');
+  assert(state.grabAxisLock === 'z', 'axis lock is z');
+}
+
+{
+  console.log('Test 8.5: Axis lock resets on grab start');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  state = toggleAxisLock(state, 'x');
+  assert(state.grabAxisLock === 'x', 'x locked');
+  state = confirmGrab(state);
+  state = enterGrab(state)!;
+  assert(state.grabAxisLock === 'free', 'axis lock reset on new grab');
+}
+
+{
+  console.log('Test 8.6: Axis lock resets on confirm');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  state = toggleAxisLock(state, 'y');
+  state = confirmGrab(state);
+  assert(state.grabAxisLock === 'free', 'axis lock reset after confirm');
+}
+
+{
+  console.log('Test 8.7: Axis lock resets on cancel');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  state = toggleAxisLock(state, 'z');
+  state = cancelGrab(state);
+  assert(state.grabAxisLock === 'free', 'axis lock reset after cancel');
+}
+
+{
+  console.log('Test 8.8: Toggle axis outside grab mode -> no effect');
+  let state = createInitialState();
+  state = toggleAxisLock(state, 'x');
+  assert(state.grabAxisLock === 'free', 'no axis lock outside grab');
+}
+
+{
+  console.log('Test 8.9: Default is free');
+  const state = createInitialState();
+  assert(state.grabAxisLock === 'free', 'default is free');
+}
+
+{
+  console.log('Test 8.10: Axis-locked movement constrains to axis');
+  let state = createInitialState();
+  state = selectEntity(state, { type: 'object', id: 'obj1' });
+  state = enterGrab(state)!;
+  state = toggleAxisLock(state, 'x');
+  // Simulate axis-locked move: only X changes, Y and Z stay at original
+  const orig = state.grabOriginalPosition!;
+  // In real code, axis lock constrains via projection. Here we test the store toggle works.
+  assert(state.grabAxisLock === 'x', 'axis locked to X before movement');
+  // The actual constraint is in the 3D raycast code (Viewport.tsx), not testable here.
+  // We verify the state machine is correct.
 }
 
 // --- Summary ---


### PR DESCRIPTION
## Summary
Redesigned grab mode for intuitive 3D placement:
- **Screen-aligned grab** (default): Objects move parallel to the screen — no more unexpected depth changes
- **Axis lock**: Press X/Y/Z during grab to constrain movement to a single world axis. Press again to toggle back to free mode.
- **Relative movement**: Object follows mouse delta from its starting position, not absolute cursor position
- **Color-coded labels**: Free (yellow), X (red), Y (green), Z (blue) — shows locked axis value only

## Changes from old behavior
- Shift-height mode removed (use Y key instead)
- Tool shortcuts (X=Extrude etc.) suppressed during grab to prevent conflicts
- `e.repeat` ignored to prevent rapid toggle on key hold

## Backward compat
- Old saved animations without `params` field now handled gracefully (defaulted)

## Test plan
- [x] Grab tests: 62 passed (10 new axis lock tests)
- [x] TS typecheck: clean
- [x] Visual: G to grab → screen-aligned. X/Y/Z to lock axis. Click to confirm, Esc to cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)