### PR TITLE
Add full easing library: 31 curves from easings.net

### DIFF
--- a/docs/bricklayer.md
+++ b/docs/bricklayer.md
@@ -406,12 +406,24 @@ All params describe **targets** at the end of the lifetime. Each can have an ind
 
 ### Easing Curves
 
-| Easing | Formula | Description |
-|--------|---------|-------------|
-| `"linear"` | t | Constant rate (default) |
-| `"ease_in"` | t² | Slow start, fast end |
-| `"ease_out"` | 1-(1-t)² | Fast start, slow end |
-| `"ease_in_out"` | 3t²-2t³ | Smooth start and end |
+31 easing functions from [easings.net](https://easings.net/). Format: `{direction}_{type}`.
+
+| Type | In | Out | In Out |
+|------|----|----|--------|
+| Quad | `in_quad` | `out_quad` | `in_out_quad` |
+| Cubic | `in_cubic` | `out_cubic` | `in_out_cubic` |
+| Quart | `in_quart` | `out_quart` | `in_out_quart` |
+| Quint | `in_quint` | `out_quint` | `in_out_quint` |
+| Sine | `in_sine` | `out_sine` | `in_out_sine` |
+| Expo | `in_expo` | `out_expo` | `in_out_expo` |
+| Circ | `in_circ` | `out_circ` | `in_out_circ` |
+| Back | `in_back` | `out_back` | `in_out_back` |
+| Elastic | `in_elastic` | `out_elastic` | `in_out_elastic` |
+| Bounce | `in_bounce` | `out_bounce` | `in_out_bounce` |
+
+Plus `"linear"` (constant rate). Aliases: `ease_in` = `in_quad`, `ease_out` = `out_quad`, `ease_in_out` = `in_out_quad`.
+
+In Bricklayer, each easing is selected via two dropdowns: **[Type]** + **[Direction]**.
 
 ### Scene JSON Format
 

--- a/include/gseurat/engine/gs_animator.hpp
+++ b/include/gseurat/engine/gs_animator.hpp
@@ -28,7 +28,19 @@ struct GsAnimRegion {
     glm::vec3 half_extents{5.0f};    // for Box
 };
 
-enum class GsEasing { Linear, EaseIn, EaseOut, EaseInOut };
+enum class GsEasing {
+    Linear,
+    InQuad, OutQuad, InOutQuad,
+    InCubic, OutCubic, InOutCubic,
+    InQuart, OutQuart, InOutQuart,
+    InQuint, OutQuint, InOutQuint,
+    InSine, OutSine, InOutSine,
+    InExpo, OutExpo, InOutExpo,
+    InCirc, OutCirc, InOutCirc,
+    InBack, OutBack, InOutBack,
+    InElastic, OutElastic, InOutElastic,
+    InBounce, OutBounce, InOutBounce,
+};
 
 float apply_easing(float t, GsEasing easing);
 

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -223,8 +223,21 @@
     },
     "easing": {
       "type": "string",
-      "enum": ["linear", "ease_in", "ease_out", "ease_in_out"],
-      "description": "Easing curve: linear (default), ease_in (t²), ease_out (1-(1-t)²), ease_in_out (smoothstep)"
+      "enum": [
+        "linear",
+        "in_quad", "out_quad", "in_out_quad",
+        "in_cubic", "out_cubic", "in_out_cubic",
+        "in_quart", "out_quart", "in_out_quart",
+        "in_quint", "out_quint", "in_out_quint",
+        "in_sine", "out_sine", "in_out_sine",
+        "in_expo", "out_expo", "in_out_expo",
+        "in_circ", "out_circ", "in_out_circ",
+        "in_back", "out_back", "in_out_back",
+        "in_elastic", "out_elastic", "in_out_elastic",
+        "in_bounce", "out_bounce", "in_out_bounce",
+        "ease_in", "ease_out", "ease_in_out"
+      ],
+      "description": "Easing curve (see easings.net). Format: {direction}_{type}. Aliases: ease_in=in_quad, ease_out=out_quad, ease_in_out=in_out_quad"
     },
     "animation_params": {
       "type": "object",

--- a/src/engine/gs_animator.cpp
+++ b/src/engine/gs_animator.cpp
@@ -5,14 +5,81 @@
 
 namespace gseurat {
 
+static constexpr float kPI = 3.14159265358979323846f;
+static constexpr float kC1 = 1.70158f;
+static constexpr float kC2 = kC1 * 1.525f;
+static constexpr float kC3 = kC1 + 1.0f;
+static constexpr float kC4 = (2.0f * kPI) / 3.0f;
+static constexpr float kC5 = (2.0f * kPI) / 4.5f;
+
+static float bounce_out(float t) {
+    constexpr float n1 = 7.5625f, d1 = 2.75f;
+    if (t < 1.0f / d1)          return n1 * t * t;
+    if (t < 2.0f / d1) { t -= 1.5f / d1;   return n1 * t * t + 0.75f; }
+    if (t < 2.5f / d1) { t -= 2.25f / d1;  return n1 * t * t + 0.9375f; }
+    t -= 2.625f / d1; return n1 * t * t + 0.984375f;
+}
+
 float apply_easing(float t, GsEasing easing) {
     t = std::clamp(t, 0.0f, 1.0f);
     switch (easing) {
-        case GsEasing::EaseIn:    return t * t;
-        case GsEasing::EaseOut:   return 1.0f - (1.0f - t) * (1.0f - t);
-        case GsEasing::EaseInOut: return t * t * (3.0f - 2.0f * t);
-        default:                  return t;
+        case GsEasing::Linear:      return t;
+        // Quad
+        case GsEasing::InQuad:      return t * t;
+        case GsEasing::OutQuad:     return 1.0f - (1.0f - t) * (1.0f - t);
+        case GsEasing::InOutQuad:   return t < 0.5f ? 2.0f * t * t : 1.0f - std::pow(-2.0f * t + 2.0f, 2.0f) / 2.0f;
+        // Cubic
+        case GsEasing::InCubic:     return t * t * t;
+        case GsEasing::OutCubic:    return 1.0f - std::pow(1.0f - t, 3.0f);
+        case GsEasing::InOutCubic:  return t < 0.5f ? 4.0f * t * t * t : 1.0f - std::pow(-2.0f * t + 2.0f, 3.0f) / 2.0f;
+        // Quart
+        case GsEasing::InQuart:     return t * t * t * t;
+        case GsEasing::OutQuart:    return 1.0f - std::pow(1.0f - t, 4.0f);
+        case GsEasing::InOutQuart:  return t < 0.5f ? 8.0f * t * t * t * t : 1.0f - std::pow(-2.0f * t + 2.0f, 4.0f) / 2.0f;
+        // Quint
+        case GsEasing::InQuint:     return t * t * t * t * t;
+        case GsEasing::OutQuint:    return 1.0f - std::pow(1.0f - t, 5.0f);
+        case GsEasing::InOutQuint:  return t < 0.5f ? 16.0f * t * t * t * t * t : 1.0f - std::pow(-2.0f * t + 2.0f, 5.0f) / 2.0f;
+        // Sine
+        case GsEasing::InSine:      return 1.0f - std::cos(t * kPI / 2.0f);
+        case GsEasing::OutSine:     return std::sin(t * kPI / 2.0f);
+        case GsEasing::InOutSine:   return -(std::cos(kPI * t) - 1.0f) / 2.0f;
+        // Expo
+        case GsEasing::InExpo:      return t == 0.0f ? 0.0f : std::pow(2.0f, 10.0f * t - 10.0f);
+        case GsEasing::OutExpo:     return t == 1.0f ? 1.0f : 1.0f - std::pow(2.0f, -10.0f * t);
+        case GsEasing::InOutExpo:
+            if (t == 0.0f || t == 1.0f) return t;
+            return t < 0.5f ? std::pow(2.0f, 20.0f * t - 10.0f) / 2.0f
+                            : (2.0f - std::pow(2.0f, -20.0f * t + 10.0f)) / 2.0f;
+        // Circ
+        case GsEasing::InCirc:      return 1.0f - std::sqrt(1.0f - t * t);
+        case GsEasing::OutCirc:     return std::sqrt(1.0f - (t - 1.0f) * (t - 1.0f));
+        case GsEasing::InOutCirc:
+            return t < 0.5f ? (1.0f - std::sqrt(1.0f - std::pow(2.0f * t, 2.0f))) / 2.0f
+                            : (std::sqrt(1.0f - std::pow(-2.0f * t + 2.0f, 2.0f)) + 1.0f) / 2.0f;
+        // Back
+        case GsEasing::InBack:      return kC3 * t * t * t - kC1 * t * t;
+        case GsEasing::OutBack:     { float u = t - 1.0f; return 1.0f + kC3 * u * u * u + kC1 * u * u; }
+        case GsEasing::InOutBack:
+            return t < 0.5f ? (std::pow(2.0f * t, 2.0f) * ((kC2 + 1.0f) * 2.0f * t - kC2)) / 2.0f
+                            : (std::pow(2.0f * t - 2.0f, 2.0f) * ((kC2 + 1.0f) * (t * 2.0f - 2.0f) + kC2) + 2.0f) / 2.0f;
+        // Elastic
+        case GsEasing::InElastic:
+            return t == 0.0f || t == 1.0f ? t : -std::pow(2.0f, 10.0f * t - 10.0f) * std::sin((10.0f * t - 10.75f) * kC4);
+        case GsEasing::OutElastic:
+            return t == 0.0f || t == 1.0f ? t : std::pow(2.0f, -10.0f * t) * std::sin((10.0f * t - 0.75f) * kC4) + 1.0f;
+        case GsEasing::InOutElastic:
+            if (t == 0.0f || t == 1.0f) return t;
+            return t < 0.5f ? -(std::pow(2.0f, 20.0f * t - 10.0f) * std::sin((20.0f * t - 11.125f) * kC5)) / 2.0f
+                            : (std::pow(2.0f, -20.0f * t + 10.0f) * std::sin((20.0f * t - 11.125f) * kC5)) / 2.0f + 1.0f;
+        // Bounce
+        case GsEasing::InBounce:    return 1.0f - bounce_out(1.0f - t);
+        case GsEasing::OutBounce:   return bounce_out(t);
+        case GsEasing::InOutBounce:
+            return t < 0.5f ? (1.0f - bounce_out(1.0f - 2.0f * t)) / 2.0f
+                            : (1.0f + bounce_out(2.0f * t - 1.0f)) / 2.0f;
     }
+    return t;
 }
 
 static uint32_t xorshift(uint32_t& state) {

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -531,9 +531,36 @@ GsAnimationData SceneLoader::parse_gs_animation(const nlohmann::json& j) {
 
     // Animation parameters — lifetime-centric with per-parameter easing
     auto parse_easing = [](const std::string& s) -> GsEasing {
-        if (s == "ease_in")     return GsEasing::EaseIn;
-        if (s == "ease_out")    return GsEasing::EaseOut;
-        if (s == "ease_in_out") return GsEasing::EaseInOut;
+        if (s == "in_quad"      || s == "ease_in")     return GsEasing::InQuad;
+        if (s == "out_quad"     || s == "ease_out")    return GsEasing::OutQuad;
+        if (s == "in_out_quad"  || s == "ease_in_out") return GsEasing::InOutQuad;
+        if (s == "in_cubic")     return GsEasing::InCubic;
+        if (s == "out_cubic")    return GsEasing::OutCubic;
+        if (s == "in_out_cubic") return GsEasing::InOutCubic;
+        if (s == "in_quart")     return GsEasing::InQuart;
+        if (s == "out_quart")    return GsEasing::OutQuart;
+        if (s == "in_out_quart") return GsEasing::InOutQuart;
+        if (s == "in_quint")     return GsEasing::InQuint;
+        if (s == "out_quint")    return GsEasing::OutQuint;
+        if (s == "in_out_quint") return GsEasing::InOutQuint;
+        if (s == "in_sine")      return GsEasing::InSine;
+        if (s == "out_sine")     return GsEasing::OutSine;
+        if (s == "in_out_sine")  return GsEasing::InOutSine;
+        if (s == "in_expo")      return GsEasing::InExpo;
+        if (s == "out_expo")     return GsEasing::OutExpo;
+        if (s == "in_out_expo")  return GsEasing::InOutExpo;
+        if (s == "in_circ")      return GsEasing::InCirc;
+        if (s == "out_circ")     return GsEasing::OutCirc;
+        if (s == "in_out_circ")  return GsEasing::InOutCirc;
+        if (s == "in_back")      return GsEasing::InBack;
+        if (s == "out_back")     return GsEasing::OutBack;
+        if (s == "in_out_back")  return GsEasing::InOutBack;
+        if (s == "in_elastic")      return GsEasing::InElastic;
+        if (s == "out_elastic")     return GsEasing::OutElastic;
+        if (s == "in_out_elastic")  return GsEasing::InOutElastic;
+        if (s == "in_bounce")       return GsEasing::InBounce;
+        if (s == "out_bounce")      return GsEasing::OutBounce;
+        if (s == "in_out_bounce")   return GsEasing::InOutBounce;
         return GsEasing::Linear;
     };
     if (j.contains("params")) {
@@ -585,10 +612,37 @@ nlohmann::json SceneLoader::gs_animation_json(const GsAnimationData& anim) {
     // Only write params if any differ from defaults
     auto easing_str = [](GsEasing e) -> std::string {
         switch (e) {
-            case GsEasing::EaseIn:    return "ease_in";
-            case GsEasing::EaseOut:   return "ease_out";
-            case GsEasing::EaseInOut: return "ease_in_out";
-            default:                  return "linear";
+            case GsEasing::InQuad:      return "in_quad";
+            case GsEasing::OutQuad:     return "out_quad";
+            case GsEasing::InOutQuad:   return "in_out_quad";
+            case GsEasing::InCubic:     return "in_cubic";
+            case GsEasing::OutCubic:    return "out_cubic";
+            case GsEasing::InOutCubic:  return "in_out_cubic";
+            case GsEasing::InQuart:     return "in_quart";
+            case GsEasing::OutQuart:    return "out_quart";
+            case GsEasing::InOutQuart:  return "in_out_quart";
+            case GsEasing::InQuint:     return "in_quint";
+            case GsEasing::OutQuint:    return "out_quint";
+            case GsEasing::InOutQuint:  return "in_out_quint";
+            case GsEasing::InSine:      return "in_sine";
+            case GsEasing::OutSine:     return "out_sine";
+            case GsEasing::InOutSine:   return "in_out_sine";
+            case GsEasing::InExpo:      return "in_expo";
+            case GsEasing::OutExpo:     return "out_expo";
+            case GsEasing::InOutExpo:   return "in_out_expo";
+            case GsEasing::InCirc:      return "in_circ";
+            case GsEasing::OutCirc:     return "out_circ";
+            case GsEasing::InOutCirc:   return "in_out_circ";
+            case GsEasing::InBack:      return "in_back";
+            case GsEasing::OutBack:     return "out_back";
+            case GsEasing::InOutBack:   return "in_out_back";
+            case GsEasing::InElastic:   return "in_elastic";
+            case GsEasing::OutElastic:  return "out_elastic";
+            case GsEasing::InOutElastic:return "in_out_elastic";
+            case GsEasing::InBounce:    return "in_bounce";
+            case GsEasing::OutBounce:   return "out_bounce";
+            case GsEasing::InOutBounce: return "in_out_bounce";
+            default:                    return "linear";
         }
     };
     const auto& p = anim.params;

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -830,10 +830,50 @@ const defaultAnimParams = {
   noise: 1, wave_speed: 5, pulse_frequency: 4,
 };
 
-const easingOptions = ['linear', 'ease_in', 'ease_out', 'ease_in_out'];
-const easingLabels: Record<string, string> = {
-  linear: 'Linear', ease_in: 'Ease In', ease_out: 'Ease Out', ease_in_out: 'Ease In/Out',
-};
+const easingTypes = ['linear', 'quad', 'cubic', 'quart', 'quint', 'sine', 'expo', 'circ', 'back', 'elastic', 'bounce'];
+const easingDirs = ['in', 'out', 'in_out'];
+const easingDirLabels: Record<string, string> = { in: 'In', out: 'Out', in_out: 'In Out' };
+
+function parseEasing(value: string): { type: string; dir: string } {
+  if (value === 'linear') return { type: 'linear', dir: 'in' };
+  for (const dir of ['in_out', 'out', 'in']) {
+    if (value.startsWith(dir + '_')) return { type: value.slice(dir.length + 1), dir };
+  }
+  return { type: 'linear', dir: 'in' };
+}
+
+function composeEasing(type: string, dir: string): string {
+  if (type === 'linear') return 'linear';
+  return `${dir}_${type}`;
+}
+
+function EasingPicker({ value, onChange, style }: {
+  value: string;
+  onChange: (v: string) => void;
+  style?: React.CSSProperties;
+}) {
+  const { type, dir } = parseEasing(value);
+  return (
+    <div style={{ display: 'flex', gap: 4, ...style }}>
+      <select
+        style={{ flex: 1, padding: '3px 4px', background: '#2a2a4a', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 11 }}
+        value={type}
+        onChange={(e) => onChange(composeEasing(e.target.value, dir))}
+      >
+        {easingTypes.map((t) => <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>)}
+      </select>
+      {type !== 'linear' && (
+        <select
+          style={{ width: 60, padding: '3px 4px', background: '#2a2a4a', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 11 }}
+          value={dir}
+          onChange={(e) => onChange(composeEasing(type, e.target.value))}
+        >
+          {easingDirs.map((d) => <option key={d} value={d}>{easingDirLabels[d]}</option>)}
+        </select>
+      )}
+    </div>
+  );
+}
 
 function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
   const update = useSceneStore((s) => s.updateGsAnimation);
@@ -945,10 +985,8 @@ function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
           <span style={{ fontSize: 12, minWidth: 80 }}>Rotations</span>
           <NumberInput value={params.rotations} min={0} step={0.5}
             onChange={(v) => update(anim.id, { params: { ...params, rotations: v } })} style={styles.input} />
-          <select style={{ ...styles.select, maxWidth: 90 }} value={params.rotations_easing}
-            onChange={(e) => update(anim.id, { params: { ...params, rotations_easing: e.target.value as any } })}>
-            {easingOptions.map((e) => <option key={e} value={e}>{easingLabels[e]}</option>)}
-          </select>
+          <EasingPicker value={params.rotations_easing}
+            onChange={(v) => update(anim.id, { params: { ...params, rotations_easing: v as any } })} />
         </div>
       </div>
 
@@ -957,10 +995,8 @@ function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
           <span style={{ fontSize: 12, minWidth: 80 }}>Expansion</span>
           <NumberInput value={params.expansion} min={0} step={0.1}
             onChange={(v) => update(anim.id, { params: { ...params, expansion: v } })} style={styles.input} />
-          <select style={{ ...styles.select, maxWidth: 90 }} value={params.expansion_easing}
-            onChange={(e) => update(anim.id, { params: { ...params, expansion_easing: e.target.value as any } })}>
-            {easingOptions.map((e) => <option key={e} value={e}>{easingLabels[e]}</option>)}
-          </select>
+          <EasingPicker value={params.expansion_easing}
+            onChange={(v) => update(anim.id, { params: { ...params, expansion_easing: v as any } })} />
         </div>
         <span style={{ fontSize: 10, color: '#666' }}>1 = no change, 2 = double radius at end</span>
       </div>
@@ -970,10 +1006,8 @@ function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
           <span style={{ fontSize: 12, minWidth: 80 }}>Height Rise</span>
           <NumberInput value={params.height_rise} step={0.5}
             onChange={(v) => update(anim.id, { params: { ...params, height_rise: v } })} style={styles.input} />
-          <select style={{ ...styles.select, maxWidth: 90 }} value={params.height_easing}
-            onChange={(e) => update(anim.id, { params: { ...params, height_easing: e.target.value as any } })}>
-            {easingOptions.map((e) => <option key={e} value={e}>{easingLabels[e]}</option>)}
-          </select>
+          <EasingPicker value={params.height_easing}
+            onChange={(v) => update(anim.id, { params: { ...params, height_easing: v as any } })} />
         </div>
         <span style={{ fontSize: 10, color: '#666' }}>Total Y offset at end (units)</span>
       </div>
@@ -983,10 +1017,8 @@ function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
           <span style={{ fontSize: 12, minWidth: 80 }}>Opacity End</span>
           <NumberInput value={params.opacity_end} min={0} max={1} step={0.05}
             onChange={(v) => update(anim.id, { params: { ...params, opacity_end: v } })} style={styles.input} />
-          <select style={{ ...styles.select, maxWidth: 90 }} value={params.opacity_easing}
-            onChange={(e) => update(anim.id, { params: { ...params, opacity_easing: e.target.value as any } })}>
-            {easingOptions.map((e) => <option key={e} value={e}>{easingLabels[e]}</option>)}
-          </select>
+          <EasingPicker value={params.opacity_easing}
+            onChange={(v) => update(anim.id, { params: { ...params, opacity_easing: v as any } })} />
         </div>
         <span style={{ fontSize: 10, color: '#666' }}>0 = fully transparent, 1 = unchanged</span>
       </div>
@@ -996,10 +1028,8 @@ function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
           <span style={{ fontSize: 12, minWidth: 80 }}>Scale End</span>
           <NumberInput value={params.scale_end} min={0} max={1} step={0.05}
             onChange={(v) => update(anim.id, { params: { ...params, scale_end: v } })} style={styles.input} />
-          <select style={{ ...styles.select, maxWidth: 90 }} value={params.scale_easing}
-            onChange={(e) => update(anim.id, { params: { ...params, scale_easing: e.target.value as any } })}>
-            {easingOptions.map((e) => <option key={e} value={e}>{easingLabels[e]}</option>)}
-          </select>
+          <EasingPicker value={params.scale_easing}
+            onChange={(v) => update(anim.id, { params: { ...params, scale_easing: v as any } })} />
         </div>
         <span style={{ fontSize: 10, color: '#666' }}>0 = vanish, 1 = unchanged</span>
       </div>

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -163,7 +163,18 @@ export type SettingsCategory =
   | 'vfx'
   | 'backgrounds';
 
-export type GsEasing = 'linear' | 'ease_in' | 'ease_out' | 'ease_in_out';
+export type GsEasing =
+  | 'linear'
+  | 'in_quad' | 'out_quad' | 'in_out_quad'
+  | 'in_cubic' | 'out_cubic' | 'in_out_cubic'
+  | 'in_quart' | 'out_quart' | 'in_out_quart'
+  | 'in_quint' | 'out_quint' | 'in_out_quint'
+  | 'in_sine' | 'out_sine' | 'in_out_sine'
+  | 'in_expo' | 'out_expo' | 'in_out_expo'
+  | 'in_circ' | 'out_circ' | 'in_out_circ'
+  | 'in_back' | 'out_back' | 'in_out_back'
+  | 'in_elastic' | 'out_elastic' | 'in_out_elastic'
+  | 'in_bounce' | 'out_bounce' | 'in_out_bounce';
 
 export interface GsAnimParams {
   rotations: number;


### PR DESCRIPTION
## Summary
Expands the easing system from 4 basic curves to the full 31 from [easings.net](https://easings.net/):
- **10 types**: Quad, Cubic, Quart, Quint, Sine, Expo, Circ, Back, Elastic, Bounce
- **3 directions each**: In, Out, InOut
- Plus Linear = 31 total

Format: `"in_bounce"`, `"out_elastic"`, `"in_out_cubic"`, `"linear"`

Backward compat: `ease_in` → `in_quad`, `ease_out` → `out_quad`, `ease_in_out` → `in_out_quad`

Bricklayer: **[Type ▼] [Direction ▼]** picker replaces the old flat dropdown.

## Test plan
- [x] C++ build + 13/13 tests pass
- [x] TS typecheck: clean
- [x] Schema updated first as source of truth
- [x] Docs updated with full easing table
- [x] Visual: orbit with `in_out_bounce` → bouncy rotation start and end

🤖 Generated with [Claude Code](https://claude.com/claude-code)