### PR TITLE
Add full easing library + compact UI

### DIFF
--- a/tools/apps/bricklayer/src/panels/BackgroundTab.tsx
+++ b/tools/apps/bricklayer/src/panels/BackgroundTab.tsx
@@ -7,10 +7,7 @@ const styles: Record<string, React.CSSProperties> = {
   section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
   row: { display: 'flex', alignItems: 'center', gap: 8 },
-  input: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
+  input: { flex: 1, padding: '3px 5px', fontSize: 12 },
   btn: {
     padding: '4px 10px', border: '1px solid #555', borderRadius: 4,
     background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 12,

--- a/tools/apps/bricklayer/src/panels/CollisionLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/CollisionLeftPanel.tsx
@@ -23,10 +23,7 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '4px 10px', border: '1px solid #555', borderRadius: 4,
     background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 11,
   },
-  input: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
+  input: { flex: 1, padding: '3px 5px', fontSize: 12 },
   info: { fontSize: 11, color: '#888', marginBottom: 4 },
   divider: { borderTop: '1px solid #333', margin: '12px 0' },
 };

--- a/tools/apps/bricklayer/src/panels/EntitiesTab.tsx
+++ b/tools/apps/bricklayer/src/panels/EntitiesTab.tsx
@@ -7,10 +7,7 @@ const styles: Record<string, React.CSSProperties> = {
   section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
   row: { display: 'flex', alignItems: 'center', gap: 8 },
-  input: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
+  input: { flex: 1, padding: '3px 5px', fontSize: 12 },
   select: {
     flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
     borderRadius: 4, color: '#ddd', fontSize: 13,

--- a/tools/apps/bricklayer/src/panels/GaussianTab.tsx
+++ b/tools/apps/bricklayer/src/panels/GaussianTab.tsx
@@ -6,10 +6,7 @@ const styles: Record<string, React.CSSProperties> = {
   section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
   row: { display: 'flex', alignItems: 'center', gap: 8 },
-  input: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
+  input: { flex: 1, padding: '3px 5px', fontSize: 12 },
   btn: {
     padding: '4px 10px', background: '#3a3a6a', border: '1px solid #555',
     borderRadius: 4, color: '#ddd', fontSize: 12, cursor: 'pointer',

--- a/tools/apps/bricklayer/src/panels/GsEmittersTab.tsx
+++ b/tools/apps/bricklayer/src/panels/GsEmittersTab.tsx
@@ -108,10 +108,7 @@ const PRESETS: Record<string, Partial<GsParticleEmitterData>> = {
 const styles: Record<string, React.CSSProperties> = {
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
   row: { display: 'flex', alignItems: 'center', gap: 8 },
-  input: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
+  input: { flex: 1, padding: '3px 5px', fontSize: 12 },
   btn: {
     padding: '4px 10px', border: '1px solid #555', borderRadius: 4,
     background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 12,

--- a/tools/apps/bricklayer/src/panels/LightsTab.tsx
+++ b/tools/apps/bricklayer/src/panels/LightsTab.tsx
@@ -7,10 +7,7 @@ const styles: Record<string, React.CSSProperties> = {
   section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
   row: { display: 'flex', alignItems: 'center', gap: 8 },
-  input: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
+  input: { flex: 1, padding: '3px 5px', fontSize: 12 },
   btn: {
     padding: '4px 10px', border: '1px solid #555', borderRadius: 4,
     background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 12,

--- a/tools/apps/bricklayer/src/panels/NavZoneTab.tsx
+++ b/tools/apps/bricklayer/src/panels/NavZoneTab.tsx
@@ -5,10 +5,7 @@ const styles: Record<string, React.CSSProperties> = {
   section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
   row: { display: 'flex', alignItems: 'center', gap: 8 },
-  input: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
+  input: { flex: 1, padding: '3px 5px', fontSize: 12 },
   btn: {
     padding: '4px 10px', background: '#3a3a6a', border: '1px solid #555',
     borderRadius: 4, color: '#ddd', fontSize: 12, cursor: 'pointer',

--- a/tools/apps/bricklayer/src/panels/ObjectsTab.tsx
+++ b/tools/apps/bricklayer/src/panels/ObjectsTab.tsx
@@ -7,10 +7,7 @@ const styles: Record<string, React.CSSProperties> = {
   section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
   row: { display: 'flex', alignItems: 'center', gap: 8 },
-  input: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
+  input: { flex: 1, padding: '3px 5px', fontSize: 12 },
   btn: {
     padding: '4px 10px', border: '1px solid #555', borderRadius: 4,
     background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 12,

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -863,6 +863,13 @@ function ParamRow({ label, value, onChange, min, max, step, easing, onEasingChan
     <div style={{ marginBottom: 6 }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
         <span style={{ fontSize: 11, minWidth: 60, color: '#aaa' }}>{label}</span>
+        {hint && (
+          <span title={hint} style={{
+            fontSize: 9, color: '#666', cursor: 'help', width: 12, height: 12,
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+            border: '1px solid #555', borderRadius: '50%', flexShrink: 0,
+          }}>?</span>
+        )}
         <NumberInput value={value} min={min} max={max} step={step ?? 0.1}
           onChange={onChange} style={{ flex: 1, maxWidth: 80, padding: '3px 5px', background: '#2a2a4a', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 12 }} />
         {easingParts && onEasingChange && (
@@ -886,7 +893,6 @@ function ParamRow({ label, value, onChange, min, max, step, easing, onEasingChan
           </>
         )}
       </div>
-      {hint && <span style={{ fontSize: 9, color: '#555', marginLeft: 64 }}>{hint}</span>}
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -847,30 +847,46 @@ function composeEasing(type: string, dir: string): string {
   return `${dir}_${type}`;
 }
 
-function EasingPicker({ value, onChange, style }: {
-  value: string;
-  onChange: (v: string) => void;
-  style?: React.CSSProperties;
+function ParamRow({ label, value, onChange, min, max, step, easing, onEasingChange, hint }: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  easing?: string;
+  onEasingChange?: (v: string) => void;
+  hint?: string;
 }) {
-  const { type, dir } = parseEasing(value);
+  const easingParts = easing ? parseEasing(easing) : null;
   return (
-    <div style={{ display: 'flex', gap: 4, ...style }}>
-      <select
-        style={{ flex: 1, padding: '3px 4px', background: '#2a2a4a', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 11 }}
-        value={type}
-        onChange={(e) => onChange(composeEasing(e.target.value, dir))}
-      >
-        {easingTypes.map((t) => <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>)}
-      </select>
-      {type !== 'linear' && (
-        <select
-          style={{ width: 60, padding: '3px 4px', background: '#2a2a4a', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 11 }}
-          value={dir}
-          onChange={(e) => onChange(composeEasing(type, e.target.value))}
-        >
-          {easingDirs.map((d) => <option key={d} value={d}>{easingDirLabels[d]}</option>)}
-        </select>
-      )}
+    <div style={{ marginBottom: 6 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+        <span style={{ fontSize: 11, minWidth: 60, color: '#aaa' }}>{label}</span>
+        <NumberInput value={value} min={min} max={max} step={step ?? 0.1}
+          onChange={onChange} style={{ flex: 1, padding: '3px 5px', background: '#2a2a4a', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 12 }} />
+        {easingParts && onEasingChange && (
+          <>
+            <select
+              style={{ width: 62, padding: '2px 2px', background: '#2a2a4a', border: '1px solid #444', borderRadius: 4, color: '#999', fontSize: 10 }}
+              value={easingParts.type}
+              onChange={(e) => onEasingChange(composeEasing(e.target.value, easingParts.dir))}
+            >
+              {easingTypes.map((t) => <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>)}
+            </select>
+            {easingParts.type !== 'linear' && (
+              <select
+                style={{ width: 46, padding: '2px 2px', background: '#2a2a4a', border: '1px solid #444', borderRadius: 4, color: '#999', fontSize: 10 }}
+                value={easingParts.dir}
+                onChange={(e) => onEasingChange(composeEasing(easingParts.type, e.target.value))}
+              >
+                {easingDirs.map((d) => <option key={d} value={d}>{easingDirLabels[d]}</option>)}
+              </select>
+            )}
+          </>
+        )}
+      </div>
+      {hint && <span style={{ fontSize: 9, color: '#555', marginLeft: 64 }}>{hint}</span>}
     </div>
   );
 }
@@ -976,93 +992,48 @@ function GsAnimationProperties({ anim }: { anim: GsAnimationGroupData }) {
         </>
       )}
 
-      <div style={styles.section}>
-        <span style={{ ...styles.label, marginTop: 8 }}>Parameters</span>
+      <div style={{ marginTop: 8, marginBottom: 4 }}>
+        <span style={styles.label}>Parameters</span>
       </div>
 
-      <div style={styles.section}>
-        <div style={styles.row}>
-          <span style={{ fontSize: 12, minWidth: 80 }}>Rotations</span>
-          <NumberInput value={params.rotations} min={0} step={0.5}
-            onChange={(v) => update(anim.id, { params: { ...params, rotations: v } })} style={styles.input} />
-          <EasingPicker value={params.rotations_easing}
-            onChange={(v) => update(anim.id, { params: { ...params, rotations_easing: v as any } })} />
-        </div>
-      </div>
+      <ParamRow label="Rotations" value={params.rotations} min={0} step={0.5}
+        onChange={(v) => update(anim.id, { params: { ...params, rotations: v } })}
+        easing={params.rotations_easing}
+        onEasingChange={(v) => update(anim.id, { params: { ...params, rotations_easing: v as any } })} />
+      <ParamRow label="Expansion" value={params.expansion} min={0} step={0.1}
+        onChange={(v) => update(anim.id, { params: { ...params, expansion: v } })}
+        easing={params.expansion_easing}
+        onEasingChange={(v) => update(anim.id, { params: { ...params, expansion_easing: v as any } })}
+        hint="1=none 2=double" />
+      <ParamRow label="Height" value={params.height_rise} step={0.5}
+        onChange={(v) => update(anim.id, { params: { ...params, height_rise: v } })}
+        easing={params.height_easing}
+        onEasingChange={(v) => update(anim.id, { params: { ...params, height_easing: v as any } })}
+        hint="Y offset (units)" />
+      <ParamRow label="Opacity" value={params.opacity_end} min={0} max={1} step={0.05}
+        onChange={(v) => update(anim.id, { params: { ...params, opacity_end: v } })}
+        easing={params.opacity_easing}
+        onEasingChange={(v) => update(anim.id, { params: { ...params, opacity_easing: v as any } })}
+        hint="0=gone 1=keep" />
+      <ParamRow label="Scale" value={params.scale_end} min={0} max={1} step={0.05}
+        onChange={(v) => update(anim.id, { params: { ...params, scale_end: v } })}
+        easing={params.scale_easing}
+        onEasingChange={(v) => update(anim.id, { params: { ...params, scale_easing: v as any } })}
+        hint="0=vanish 1=keep" />
+      <ParamRow label="Velocity" value={params.velocity} min={0} step={0.1}
+        onChange={(v) => update(anim.id, { params: { ...params, velocity: v } })} />
+      <ParamRow label="Noise" value={params.noise} min={0} step={0.1}
+        onChange={(v) => update(anim.id, { params: { ...params, noise: v } })} />
+      <ParamRow label="Wave Spd" value={params.wave_speed} min={0} step={0.5}
+        onChange={(v) => update(anim.id, { params: { ...params, wave_speed: v } })} />
+      <ParamRow label="Pulse Hz" value={params.pulse_frequency} min={0.1} step={0.5}
+        onChange={(v) => update(anim.id, { params: { ...params, pulse_frequency: v } })} />
 
-      <div style={styles.section}>
-        <div style={styles.row}>
-          <span style={{ fontSize: 12, minWidth: 80 }}>Expansion</span>
-          <NumberInput value={params.expansion} min={0} step={0.1}
-            onChange={(v) => update(anim.id, { params: { ...params, expansion: v } })} style={styles.input} />
-          <EasingPicker value={params.expansion_easing}
-            onChange={(v) => update(anim.id, { params: { ...params, expansion_easing: v as any } })} />
-        </div>
-        <span style={{ fontSize: 10, color: '#666' }}>1 = no change, 2 = double radius at end</span>
+      <div style={{ marginTop: 4, marginBottom: 4 }}>
+        <span style={{ fontSize: 11, color: '#555' }}>Gravity</span>
       </div>
-
-      <div style={styles.section}>
-        <div style={styles.row}>
-          <span style={{ fontSize: 12, minWidth: 80 }}>Height Rise</span>
-          <NumberInput value={params.height_rise} step={0.5}
-            onChange={(v) => update(anim.id, { params: { ...params, height_rise: v } })} style={styles.input} />
-          <EasingPicker value={params.height_easing}
-            onChange={(v) => update(anim.id, { params: { ...params, height_easing: v as any } })} />
-        </div>
-        <span style={{ fontSize: 10, color: '#666' }}>Total Y offset at end (units)</span>
-      </div>
-
-      <div style={styles.section}>
-        <div style={styles.row}>
-          <span style={{ fontSize: 12, minWidth: 80 }}>Opacity End</span>
-          <NumberInput value={params.opacity_end} min={0} max={1} step={0.05}
-            onChange={(v) => update(anim.id, { params: { ...params, opacity_end: v } })} style={styles.input} />
-          <EasingPicker value={params.opacity_easing}
-            onChange={(v) => update(anim.id, { params: { ...params, opacity_easing: v as any } })} />
-        </div>
-        <span style={{ fontSize: 10, color: '#666' }}>0 = fully transparent, 1 = unchanged</span>
-      </div>
-
-      <div style={styles.section}>
-        <div style={styles.row}>
-          <span style={{ fontSize: 12, minWidth: 80 }}>Scale End</span>
-          <NumberInput value={params.scale_end} min={0} max={1} step={0.05}
-            onChange={(v) => update(anim.id, { params: { ...params, scale_end: v } })} style={styles.input} />
-          <EasingPicker value={params.scale_easing}
-            onChange={(v) => update(anim.id, { params: { ...params, scale_easing: v as any } })} />
-        </div>
-        <span style={{ fontSize: 10, color: '#666' }}>0 = vanish, 1 = unchanged</span>
-      </div>
-
-      <div style={styles.section}>
-        <span style={styles.label}>Velocity</span>
-        <NumberInput value={params.velocity} min={0} step={0.1}
-          onChange={(v) => update(anim.id, { params: { ...params, velocity: v } })} style={styles.input} />
-      </div>
-
-      <div style={styles.section}>
-        <span style={styles.label}>Gravity</span>
-        <Vec3Input value={params.gravity}
-          onChange={(v) => update(anim.id, { params: { ...params, gravity: v } })} />
-      </div>
-
-      <div style={styles.section}>
-        <span style={styles.label}>Noise</span>
-        <NumberInput value={params.noise} min={0} step={0.1}
-          onChange={(v) => update(anim.id, { params: { ...params, noise: v } })} style={styles.input} />
-      </div>
-
-      <div style={styles.section}>
-        <span style={styles.label}>Wave Speed</span>
-        <NumberInput value={params.wave_speed} min={0} step={0.5}
-          onChange={(v) => update(anim.id, { params: { ...params, wave_speed: v } })} style={styles.input} />
-      </div>
-
-      <div style={styles.section}>
-        <span style={styles.label}>Pulse Frequency</span>
-        <NumberInput value={params.pulse_frequency} min={0.1} step={0.5}
-          onChange={(v) => update(anim.id, { params: { ...params, pulse_frequency: v } })} style={styles.input} />
-      </div>
+      <Vec3Input value={params.gravity}
+        onChange={(v) => update(anim.id, { params: { ...params, gravity: v } })} />
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -12,20 +12,20 @@ import type {
 } from '../store/types.js';
 
 const styles: Record<string, React.CSSProperties> = {
-  section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
+  section: { display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 12 },
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
-  row: { display: 'flex', alignItems: 'center', gap: 8 },
+  row: { display: 'flex', alignItems: 'center', gap: 6 },
   input: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
+    flex: 1, maxWidth: 80, padding: '3px 5px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 12,
   },
   select: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
+    flex: 1, padding: '3px 5px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 12,
   },
   btnDanger: {
-    padding: '4px 10px', border: '1px solid #c33', borderRadius: 4,
-    background: '#4a2020', color: '#faa', cursor: 'pointer', fontSize: 12,
+    padding: '3px 8px', border: '1px solid #c33', borderRadius: 4,
+    background: '#4a2020', color: '#faa', cursor: 'pointer', fontSize: 11,
   },
   empty: { fontSize: 12, color: '#666', textAlign: 'center' as const, paddingTop: 40 },
   checkbox: { marginRight: 4 },

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -16,8 +16,7 @@ const styles: Record<string, React.CSSProperties> = {
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
   row: { display: 'flex', alignItems: 'center', gap: 6 },
   input: {
-    flex: 1, maxWidth: 80, padding: '3px 5px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 12,
+    flex: 1, maxWidth: 80, padding: '3px 5px', fontSize: 12,
   },
   select: {
     flex: 1, padding: '3px 5px', background: '#2a2a4a', border: '1px solid #444',
@@ -888,7 +887,7 @@ function ParamRow({ label, value, onChange, min, max, step, easing, onEasingChan
           </span>
         )}
         <NumberInput value={value} min={min} max={max} step={step ?? 0.1}
-          onChange={onChange} style={{ flex: 1, maxWidth: 80, padding: '3px 5px', background: '#2a2a4a', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 12 }} />
+          onChange={onChange} style={{ flex: 1, maxWidth: 80, padding: '3px 5px', fontSize: 12 }} />
         {easingParts && onEasingChange && (
           <>
             <select

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -864,11 +864,28 @@ function ParamRow({ label, value, onChange, min, max, step, easing, onEasingChan
       <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
         <span style={{ fontSize: 11, minWidth: 60, color: '#aaa' }}>{label}</span>
         {hint && (
-          <span title={hint} style={{
-            fontSize: 9, color: '#666', cursor: 'help', width: 12, height: 12,
+          <span style={{
+            position: 'relative', fontSize: 9, color: '#666', cursor: 'help', width: 12, height: 12,
             display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
             border: '1px solid #555', borderRadius: '50%', flexShrink: 0,
-          }}>?</span>
+          }}
+            onMouseEnter={(e) => {
+              const tip = e.currentTarget.querySelector('[data-tip]') as HTMLElement;
+              if (tip) tip.style.display = 'block';
+            }}
+            onMouseLeave={(e) => {
+              const tip = e.currentTarget.querySelector('[data-tip]') as HTMLElement;
+              if (tip) tip.style.display = 'none';
+            }}
+          >
+            ?
+            <span data-tip="" style={{
+              display: 'none', position: 'absolute', bottom: '100%', left: '50%', transform: 'translateX(-50%)',
+              marginBottom: 4, padding: '4px 8px', background: '#111', color: '#ccc', fontSize: 10,
+              borderRadius: 4, whiteSpace: 'nowrap', zIndex: 100, boxShadow: '0 2px 8px rgba(0,0,0,0.5)',
+              pointerEvents: 'none',
+            }}>{hint}</span>
+          </span>
         )}
         <NumberInput value={value} min={min} max={max} step={step ?? 0.1}
           onChange={onChange} style={{ flex: 1, maxWidth: 80, padding: '3px 5px', background: '#2a2a4a', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 12 }} />

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -864,7 +864,7 @@ function ParamRow({ label, value, onChange, min, max, step, easing, onEasingChan
       <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
         <span style={{ fontSize: 11, minWidth: 60, color: '#aaa' }}>{label}</span>
         <NumberInput value={value} min={min} max={max} step={step ?? 0.1}
-          onChange={onChange} style={{ flex: 1, padding: '3px 5px', background: '#2a2a4a', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 12 }} />
+          onChange={onChange} style={{ flex: 1, maxWidth: 80, padding: '3px 5px', background: '#2a2a4a', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 12 }} />
         {easingParts && onEasingChange && (
           <>
             <select

--- a/tools/apps/bricklayer/src/panels/SceneTab.tsx
+++ b/tools/apps/bricklayer/src/panels/SceneTab.tsx
@@ -6,10 +6,7 @@ const styles: Record<string, React.CSSProperties> = {
   section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
   row: { display: 'flex', alignItems: 'center', gap: 8 },
-  input: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
+  input: { flex: 1, padding: '3px 5px', fontSize: 12 },
   btn: {
     padding: '4px 10px', border: '1px solid #555', borderRadius: 4,
     background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 12,

--- a/tools/apps/bricklayer/src/panels/SettingsRightPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/SettingsRightPanel.tsx
@@ -74,10 +74,7 @@ function DayNightSettings() {
   const dayNight = useSceneStore((s) => s.dayNight);
   const setDayNight = useSceneStore((s) => s.setDayNight);
 
-  const inputStyle: React.CSSProperties = {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  };
+  const inputStyle: React.CSSProperties = { flex: 1, padding: '3px 5px', fontSize: 12 };
   const row: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8 };
   const section: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 };
 

--- a/tools/apps/bricklayer/src/panels/TerrainRightPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/TerrainRightPanel.tsx
@@ -10,10 +10,7 @@ const styles: Record<string, React.CSSProperties> = {
   colorSwatch: {
     width: 20, height: 20, borderRadius: 3, border: '1px solid #666', flexShrink: 0,
   },
-  input: {
-    width: 60, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
+  input: { width: 60, padding: '3px 5px', fontSize: 12 },
 };
 
 export function TerrainRightPanel() {

--- a/tools/apps/bricklayer/src/panels/VfxTab.tsx
+++ b/tools/apps/bricklayer/src/panels/VfxTab.tsx
@@ -7,10 +7,7 @@ const styles: Record<string, React.CSSProperties> = {
   section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
   row: { display: 'flex', alignItems: 'center', gap: 8 },
-  input: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
+  input: { flex: 1, padding: '3px 5px', fontSize: 12 },
   btn: {
     padding: '4px 10px', border: '1px solid #555', borderRadius: 4,
     background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 12,

--- a/tools/apps/bricklayer/src/panels/WeatherTab.tsx
+++ b/tools/apps/bricklayer/src/panels/WeatherTab.tsx
@@ -6,10 +6,7 @@ const styles: Record<string, React.CSSProperties> = {
   section: { display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 },
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
   row: { display: 'flex', alignItems: 'center', gap: 8 },
-  input: {
-    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
+  input: { flex: 1, padding: '3px 5px', fontSize: 12 },
   select: {
     flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
     borderRadius: 4, color: '#ddd', fontSize: 13,


### PR DESCRIPTION
## Summary
- **31 easing curves** from easings.net: Quad, Cubic, Quart, Quint, Sine, Expo, Circ, Back, Elastic, Bounce (each with In/Out/InOut) + Linear
- **Type + Direction picker** in Bricklayer: [Type ▼] [Direction ▼] dropdown pair
- **Compact ParamRow** component: label + value + easing all on one line
- **(?) tooltip** icons for parameter hints (hover to see)
- **maxWidth 80px** on all number inputs
- **Drag-to-scrub border** fixed across all 13 panel files
- Backward compat: `ease_in` = `in_quad`, `ease_out` = `out_quad`

## Test plan
- [x] C++ build + 13/13 tests pass
- [x] TS typecheck: clean
- [x] Schema updated with all 31 easing values
- [x] Docs updated with easing table
- [x] Visual: animation with `in_out_bounce` easing, drag-to-scrub on all inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)