### PR TITLE
Add VFX Editor: timeline-based visual effect composition tool

### DIFF
--- a/tools/apps/vfx-editor/src/App.tsx
+++ b/tools/apps/vfx-editor/src/App.tsx
@@ -307,8 +307,6 @@ function Timeline() {
   }
 
   const dur = preset.duration;
-  const pxPerSec = 120;
-  const totalWidth = dur * pxPerSec;
   const antPct = (preset.phases.anticipation / dur) * 100;
   const impPct = ((preset.phases.impact - preset.phases.anticipation) / dur) * 100;
   const resPct = 100 - antPct - impPct;
@@ -349,17 +347,55 @@ function Timeline() {
         }}>+ Light</button>
       </div>
 
+      {/* Scrubber bar — click to seek */}
+      <div
+        style={{ height: 12, background: T.bg, cursor: 'pointer', position: 'relative', borderBottom: `1px solid ${T.border}` }}
+        onClick={(e) => {
+          const rect = e.currentTarget.getBoundingClientRect();
+          const t = ((e.clientX - rect.left) / rect.width) * dur;
+          setPlaybackTime(Math.max(0, Math.min(dur, t)));
+        }}
+        onPointerDown={(e) => {
+          e.preventDefault();
+          const el = e.currentTarget;
+          const rect = el.getBoundingClientRect();
+          const move = (ev: PointerEvent) => {
+            const t = ((ev.clientX - rect.left) / rect.width) * dur;
+            setPlaybackTime(Math.max(0, Math.min(dur, t)));
+          };
+          const up = () => {
+            window.removeEventListener('pointermove', move);
+            window.removeEventListener('pointerup', up);
+          };
+          window.addEventListener('pointermove', move);
+          window.addEventListener('pointerup', up);
+          move(e.nativeEvent);
+        }}
+      >
+        {/* Phase colors in scrubber */}
+        <div style={{ display: 'flex', height: '100%' }}>
+          <div style={{ width: `${antPct}%`, background: `${T.phaseAnticipation}30` }} />
+          <div style={{ width: `${impPct}%`, background: `${T.phaseImpact}30` }} />
+          <div style={{ width: `${resPct}%`, background: `${T.phaseResidual}30` }} />
+        </div>
+        {/* Scrubber playhead */}
+        <div style={{
+          position: 'absolute', top: 0, bottom: 0, width: 2, background: '#fff',
+          left: `${(playbackTime / dur) * 100}%`, pointerEvents: 'none',
+        }} />
+      </div>
+
       {/* Timeline area */}
-      <div style={{ flex: 1, overflowX: 'auto', overflowY: 'auto', position: 'relative' }}>
-        {/* Phase background */}
-        <div style={{ display: 'flex', height: '100%', position: 'absolute', top: 0, left: 0, width: totalWidth, zIndex: 0 }}>
+      <div style={{ flex: 1, overflowY: 'auto', position: 'relative' }}>
+        {/* Phase background — use 100% width, not fixed px */}
+        <div style={{ display: 'flex', height: '100%', position: 'absolute', top: 0, left: 0, width: '100%', zIndex: 0 }}>
           <div style={{ width: `${antPct}%`, background: `${T.phaseAnticipation}08`, borderRight: `1px dashed ${T.phaseAnticipation}30` }} />
           <div style={{ width: `${impPct}%`, background: `${T.phaseImpact}08`, borderRight: `1px dashed ${T.phaseImpact}30` }} />
           <div style={{ width: `${resPct}%`, background: `${T.phaseResidual}08` }} />
         </div>
 
         {/* Phase labels */}
-        <div style={{ display: 'flex', height: 16, position: 'relative', zIndex: 1, width: totalWidth }}>
+        <div style={{ display: 'flex', height: 16, position: 'relative', zIndex: 1 }}>
           <div style={{ width: `${antPct}%`, textAlign: 'center', fontSize: 8, color: T.phaseAnticipation, lineHeight: '16px', letterSpacing: 1, textTransform: 'uppercase' }}>
             Anticipation
           </div>
@@ -372,7 +408,7 @@ function Timeline() {
         </div>
 
         {/* Layer tracks with drag handles */}
-        <div ref={tracksRef} style={{ position: 'relative', zIndex: 1, padding: '2px 0', width: totalWidth }}>
+        <div ref={tracksRef} style={{ position: 'relative', zIndex: 1, padding: '2px 0' }}>
           {preset.layers.map((layer) => {
             const left = (layer.start / dur) * 100;
             const width = (layer.duration / dur) * 100;
@@ -477,7 +513,7 @@ function Timeline() {
         </div>
 
         {/* Time ruler ticks */}
-        <div style={{ position: 'absolute', top: 0, left: 0, width: totalWidth, height: '100%', pointerEvents: 'none', zIndex: 0 }}>
+        <div style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', pointerEvents: 'none', zIndex: 0 }}>
           {Array.from({ length: Math.ceil(dur) + 1 }, (_, i) => (
             <div key={i} style={{
               position: 'absolute', left: `${(i / dur) * 100}%`, top: 0, bottom: 0,

--- a/tools/apps/vfx-editor/src/App.tsx
+++ b/tools/apps/vfx-editor/src/App.tsx
@@ -191,49 +191,132 @@ function MenuBar({ onImportScene }: { onImportScene?: () => void }) {
 }
 
 // ═══════════════════════════════════════════════════════════════
-// VfxList (left panel)
+// Navigation Tree (left panel)
 // ═══════════════════════════════════════════════════════════════
 
-function VfxList() {
+const treeStyles = {
+  node: {
+    padding: '4px 8px', cursor: 'pointer', borderRadius: 3, color: T.textDim,
+    display: 'flex', alignItems: 'center', gap: 5, overflow: 'hidden',
+    marginBottom: 1, fontSize: 12, transition: 'background 0.1s',
+  } as React.CSSProperties,
+  nodeActive: { background: T.surface, color: T.text, boxShadow: `inset 3px 0 0 ${T.accent}` },
+  indent: { marginLeft: 10, paddingLeft: 8, borderLeft: `1px solid ${T.border}` },
+  arrow: { fontSize: 9, width: 10, textAlign: 'center' as const, color: T.textMuted, flexShrink: 0 },
+  icon: { fontSize: 11, width: 14, textAlign: 'center' as const, opacity: 0.7, flexShrink: 0 },
+  label: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const, flex: 1 },
+  count: { fontSize: 10, color: T.textMuted, marginLeft: 2 },
+  addBtn: {
+    marginLeft: 'auto', padding: '0 3px', border: 'none', background: 'transparent',
+    color: T.accent, cursor: 'pointer', fontSize: 13, lineHeight: '1', flexShrink: 0,
+  } as React.CSSProperties,
+  removeBtn: {
+    padding: '0 3px', border: 'none', background: 'transparent',
+    color: '#844', cursor: 'pointer', fontSize: 11, lineHeight: '1', flexShrink: 0,
+  } as React.CSSProperties,
+};
+
+const layerIcons: Record<string, string> = {
+  emitter: '✦', animation: '↻', light: '☀',
+};
+
+function VfxTree() {
   const presets = useVfxStore((s) => s.presets);
-  const selectedId = useVfxStore((s) => s.selectedPresetId);
+  const selectedPresetId = useVfxStore((s) => s.selectedPresetId);
+  const selectedLayerId = useVfxStore((s) => s.selectedLayerId);
   const selectPreset = useVfxStore((s) => s.selectPreset);
+  const selectLayer = useVfxStore((s) => s.selectLayer);
   const addPreset = useVfxStore((s) => s.addPreset);
   const removePreset = useVfxStore((s) => s.removePreset);
+  const addLayer = useVfxStore((s) => s.addLayer);
+  const removeLayer = useVfxStore((s) => s.removeLayer);
+  const [openPresets, setOpenPresets] = useState<Set<string>>(new Set());
+
+  const toggleOpen = (id: string) => {
+    setOpenPresets((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
 
   return (
     <div style={{
       width: 200, background: T.panel, borderRight: `1px solid ${T.border}`,
       display: 'flex', flexDirection: 'column', overflow: 'hidden',
     }}>
+      {/* Header */}
       <div style={{
-        padding: '8px 12px', borderBottom: `1px solid ${T.border}`,
-        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '6px 8px', borderBottom: `1px solid ${T.border}`,
+        fontSize: 10, color: T.textMuted, letterSpacing: 1.5, textTransform: 'uppercase',
       }}>
-        <span style={{ fontSize: 10, color: T.textMuted, textTransform: 'uppercase', letterSpacing: 1.5 }}>
-          VFX Presets
-        </span>
-        <button onClick={() => addPreset()} style={{
-          background: 'none', border: 'none', color: T.accent, cursor: 'pointer',
-          fontSize: 16, lineHeight: 1, padding: '0 4px',
-        }}>+</button>
+        VFX Editor
       </div>
+
+      {/* Tree */}
       <div style={{ flex: 1, overflowY: 'auto', padding: '4px 0' }}>
-        {presets.map((p) => (
-          <div key={p.id} onClick={() => selectPreset(p.id)} style={{
-            padding: '6px 12px', cursor: 'pointer', fontSize: 12,
-            color: selectedId === p.id ? T.text : T.textDim,
-            background: selectedId === p.id ? T.surface : 'transparent',
-            borderLeft: selectedId === p.id ? `3px solid ${T.accent}` : '3px solid transparent',
-            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-          }}>
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</span>
-            <button onClick={(e) => { e.stopPropagation(); removePreset(p.id); }} style={{
-              background: 'none', border: 'none', color: T.textMuted, cursor: 'pointer',
-              fontSize: 11, padding: '0 2px', opacity: 0.5,
-            }}>&times;</button>
-          </div>
-        ))}
+        {/* VFX Presets section */}
+        <div style={{ ...treeStyles.node, color: T.textDim }}
+          onClick={() => {}}>
+          <span style={treeStyles.icon}>◆</span>
+          <span style={treeStyles.label}>VFX Presets</span>
+          <span style={treeStyles.count}>({presets.length})</span>
+          <button style={treeStyles.addBtn} onClick={(e) => { e.stopPropagation(); addPreset(); }}>+</button>
+        </div>
+
+        <div style={treeStyles.indent}>
+          {presets.map((preset) => {
+            const isOpen = openPresets.has(preset.id) || selectedPresetId === preset.id;
+            const isActive = selectedPresetId === preset.id && !selectedLayerId;
+            return (
+              <React.Fragment key={preset.id}>
+                {/* Preset node */}
+                <div
+                  style={{ ...treeStyles.node, ...(isActive ? treeStyles.nodeActive : {}) }}
+                  onClick={() => { selectPreset(preset.id); selectLayer(null); toggleOpen(preset.id); }}
+                >
+                  <span style={treeStyles.arrow}>{isOpen ? '▾' : '▸'}</span>
+                  <span style={treeStyles.icon}>◇</span>
+                  <span style={treeStyles.label}>{preset.name}</span>
+                  <span style={treeStyles.count}>({preset.layers.length})</span>
+                  <button style={treeStyles.removeBtn}
+                    onClick={(e) => { e.stopPropagation(); removePreset(preset.id); }}>&times;</button>
+                </div>
+
+                {/* Layers (when expanded) */}
+                {isOpen && (
+                  <div style={treeStyles.indent}>
+                    {preset.layers.map((layer, i) => {
+                      const layerActive = selectedLayerId === layer.id;
+                      const color = layerColor(layer.type);
+                      return (
+                        <div key={layer.id}
+                          style={{ ...treeStyles.node, ...(layerActive ? treeStyles.nodeActive : {}) }}
+                          onClick={() => { selectPreset(preset.id); selectLayer(layer.id); }}
+                        >
+                          <span style={{ ...treeStyles.icon, color }}>{layerIcons[layer.type] ?? '?'}</span>
+                          <span style={treeStyles.label}>{layer.name}</span>
+                          <button style={treeStyles.removeBtn}
+                            onClick={(e) => { e.stopPropagation(); removeLayer(preset.id, layer.id); }}>&times;</button>
+                        </div>
+                      );
+                    })}
+                    {/* Add layer buttons */}
+                    <div style={{ display: 'flex', gap: 2, padding: '2px 4px' }}>
+                      <button onClick={() => addLayer(preset.id, 'emitter', 'Emitter', 0, 1, 'custom')}
+                        style={{ ...treeStyles.addBtn, color: T.layerEmitter, fontSize: 9 }}>+✦</button>
+                      <button onClick={() => addLayer(preset.id, 'animation', 'Animation', 0, 1, 'custom')}
+                        style={{ ...treeStyles.addBtn, color: T.layerAnimation, fontSize: 9 }}>+↻</button>
+                      <button onClick={() => addLayer(preset.id, 'light', 'Light', 0, 0.2, 'custom')}
+                        style={{ ...treeStyles.addBtn, color: T.layerLight, fontSize: 9 }}>+☀</button>
+                    </div>
+                  </div>
+                )}
+              </React.Fragment>
+            );
+          })}
+        </div>
+
         {presets.length === 0 && (
           <div style={{ padding: 16, textAlign: 'center', color: T.textMuted, fontSize: 11 }}>
             No VFX presets.<br />Click + to create one.
@@ -596,7 +679,7 @@ export function App() {
     <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', background: T.bg }}>
       <MenuBar onImportScene={handleImportScene} />
       <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
-        <VfxList />
+        <VfxTree />
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           <Preview scenePoints={scenePoints} />
           <Timeline />

--- a/tools/apps/vfx-editor/src/viewport/Preview.tsx
+++ b/tools/apps/vfx-editor/src/viewport/Preview.tsx
@@ -3,6 +3,7 @@ import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { OrbitControls, Grid } from '@react-three/drei';
 import * as THREE from 'three';
 import { useVfxStore } from '../store/useVfxStore.js';
+import type { VfxLayer } from '../store/types.js';
 import type { PlyPoint } from '../lib/plyLoader.js';
 
 // ── Gaussian Point Cloud (imported PLY data) ──
@@ -32,90 +33,144 @@ function GaussianPointCloud({ points }: { points: PlyPoint[] }) {
   );
 }
 
-// ── Active Layer Indicators ──
+// ── Layer Gizmos ──
 
-function ActiveLayers() {
+function EmitterGizmo({ layer, active, selected }: { layer: VfxLayer; active: boolean; selected: boolean }) {
+  const cfg = layer.emitter as Record<string, unknown> | undefined;
+  const pos: [number, number, number] = (cfg?.position as [number, number, number]) ?? [0, 1, 0];
+  const offsetMin = (cfg?.spawn_offset_min as [number, number, number]) ?? [0, 0, 0];
+  const offsetMax = (cfg?.spawn_offset_max as [number, number, number]) ?? [0, 0, 0];
+  const hasOffset = offsetMin.some((v) => v !== 0) || offsetMax.some((v) => v !== 0);
+  const boxSize: [number, number, number] = [
+    offsetMax[0] - offsetMin[0] || 0.5,
+    offsetMax[1] - offsetMin[1] || 0.5,
+    offsetMax[2] - offsetMin[2] || 0.5,
+  ];
+  const boxCenter: [number, number, number] = [
+    pos[0] + (offsetMin[0] + offsetMax[0]) / 2,
+    pos[1] + (offsetMin[1] + offsetMax[1]) / 2,
+    pos[2] + (offsetMin[2] + offsetMax[2]) / 2,
+  ];
+  const opacity = active ? 0.7 : 0.2;
+  const color = selected ? '#ffffff' : '#ec4899';
+
+  return (
+    <group>
+      {/* Center sphere */}
+      <mesh position={pos}>
+        <sphereGeometry args={[0.3, 12, 12]} />
+        <meshBasicMaterial color={color} transparent opacity={active ? 0.8 : 0.3} />
+      </mesh>
+      {/* Outer glow when active */}
+      {active && (
+        <mesh position={pos}>
+          <sphereGeometry args={[0.5, 12, 12]} />
+          <meshBasicMaterial color="#ec4899" transparent opacity={0.2} />
+        </mesh>
+      )}
+      {/* Spawn offset box */}
+      {hasOffset && (
+        <mesh position={boxCenter}>
+          <boxGeometry args={boxSize} />
+          <meshBasicMaterial color="#ec4899" wireframe transparent opacity={opacity * 0.5} />
+        </mesh>
+      )}
+    </group>
+  );
+}
+
+function AnimationGizmo({ layer, active, selected }: { layer: VfxLayer; active: boolean; selected: boolean }) {
+  const anim = layer.animation as Record<string, unknown> | undefined;
+  const effect = (anim?.effect as string) ?? 'detach';
+  const opacity = active ? 0.5 : 0.15;
+  const color = selected ? '#ffffff' : '#06b6d4';
+
+  return (
+    <group position={[0, 1, 0]}>
+      {/* Region sphere */}
+      <mesh>
+        <sphereGeometry args={[2, 16, 12]} />
+        <meshBasicMaterial color={color} wireframe transparent opacity={opacity} />
+      </mesh>
+      {/* Center dot */}
+      <mesh>
+        <sphereGeometry args={[0.15, 8, 8]} />
+        <meshBasicMaterial color="#06b6d4" transparent opacity={active ? 1 : 0.4} />
+      </mesh>
+    </group>
+  );
+}
+
+function LightGizmo({ layer, active, selected }: { layer: VfxLayer; active: boolean; selected: boolean }) {
+  const light = layer.light;
+  const radius = light?.radius ?? 50;
+  const color = light ? `rgb(${Math.round(light.color[0] * 255)},${Math.round(light.color[1] * 255)},${Math.round(light.color[2] * 255)})` : '#ffff00';
+  const displayRadius = Math.min(radius * 0.1, 5); // Scale down for viewport
+  const opacity = active ? 0.7 : 0.2;
+
+  return (
+    <group position={[0, 2, 0]}>
+      {/* Center sphere */}
+      <mesh>
+        <sphereGeometry args={[0.3, 12, 12]} />
+        <meshBasicMaterial color={selected ? '#ffffff' : color} transparent opacity={active ? 0.9 : 0.4} />
+      </mesh>
+      {/* Radius ring */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[displayRadius - 0.05, displayRadius + 0.05, 32]} />
+        <meshBasicMaterial color={color} transparent opacity={opacity} side={2} />
+      </mesh>
+      {/* Flash burst when active */}
+      {active && (
+        <mesh>
+          <sphereGeometry args={[displayRadius * 0.5, 12, 12]} />
+          <meshBasicMaterial color={color} transparent opacity={0.15} />
+        </mesh>
+      )}
+    </group>
+  );
+}
+
+function LayerGizmos() {
   const preset = useVfxStore((s) => {
-    const p = s.presets.find((p) => p.id === s.selectedPresetId);
-    return p;
+    return s.presets.find((p) => p.id === s.selectedPresetId);
   });
   const playbackTime = useVfxStore((s) => s.playbackTime);
+  const selectedLayerId = useVfxStore((s) => s.selectedLayerId);
   const lightRef = useRef<THREE.PointLight>(null);
 
-  // Find active layers at current playback time
-  const activeLayers = useMemo(() => {
-    if (!preset) return [];
-    return preset.layers.filter((l) =>
+  // Update dynamic point light for light layers
+  useFrame(() => {
+    if (!lightRef.current || !preset) return;
+    const activeLight = preset.layers.find((l) =>
+      l.type === 'light' && l.light &&
       playbackTime >= l.start && playbackTime < l.start + l.duration
     );
-  }, [preset, playbackTime]);
-
-  // Update light flash
-  useFrame(() => {
-    if (!lightRef.current) return;
-    const lightLayer = activeLayers.find((l) => l.type === 'light');
-    if (lightLayer?.light) {
+    if (activeLight?.light) {
       lightRef.current.visible = true;
-      lightRef.current.intensity = lightLayer.light.intensity;
-      lightRef.current.color.setRGB(
-        lightLayer.light.color[0],
-        lightLayer.light.color[1],
-        lightLayer.light.color[2]
-      );
-      lightRef.current.distance = lightLayer.light.radius;
+      lightRef.current.intensity = activeLight.light.intensity;
+      lightRef.current.color.setRGB(activeLight.light.color[0], activeLight.light.color[1], activeLight.light.color[2]);
+      lightRef.current.distance = activeLight.light.radius;
     } else {
       lightRef.current.visible = false;
     }
   });
 
-  // Emitter particle indicators (simple spheres at origin)
-  const emitterLayers = activeLayers.filter((l) => l.type === 'emitter');
-  const animLayers = activeLayers.filter((l) => l.type === 'animation');
+  if (!preset) return null;
 
   return (
     <group>
       <pointLight ref={lightRef} position={[0, 2, 0]} visible={false} />
-      {emitterLayers.map((l) => (
-        <mesh key={l.id} position={[0, 1, 0]}>
-          <sphereGeometry args={[0.3, 8, 8]} />
-          <meshBasicMaterial color="#ec4899" transparent opacity={0.5} wireframe />
-        </mesh>
-      ))}
-      {animLayers.map((l) => (
-        <mesh key={l.id} position={[0, 1, 0]}>
-          <sphereGeometry args={[0.5, 12, 12]} />
-          <meshBasicMaterial color="#06b6d4" transparent opacity={0.3} wireframe />
-        </mesh>
-      ))}
+      {preset.layers.map((layer) => {
+        const active = playbackTime >= layer.start && playbackTime < layer.start + layer.duration;
+        const selected = selectedLayerId === layer.id;
+        if (layer.type === 'emitter') return <EmitterGizmo key={layer.id} layer={layer} active={active} selected={selected} />;
+        if (layer.type === 'animation') return <AnimationGizmo key={layer.id} layer={layer} active={active} selected={selected} />;
+        if (layer.type === 'light') return <LightGizmo key={layer.id} layer={layer} active={active} selected={selected} />;
+        return null;
+      })}
     </group>
   );
-}
-
-// ── Phase Indicator ──
-
-function PhaseIndicator() {
-  const preset = useVfxStore((s) => {
-    const p = s.presets.find((p) => p.id === s.selectedPresetId);
-    return p;
-  });
-  const playbackTime = useVfxStore((s) => s.playbackTime);
-
-  if (!preset) return null;
-
-  let phase = 'Idle';
-  let color = '#666';
-  if (playbackTime < preset.phases.anticipation) {
-    phase = 'Anticipation';
-    color = '#f59e0b';
-  } else if (playbackTime < preset.phases.impact) {
-    phase = 'Impact';
-    color = '#ef4444';
-  } else if (playbackTime < preset.duration) {
-    phase = 'Residual';
-    color = '#3b82f6';
-  }
-
-  return null; // Phase shown in HTML overlay instead
 }
 
 // ── Main Preview Component ──
@@ -150,7 +205,7 @@ export function Preview({ scenePoints }: { scenePoints: PlyPoint[] }) {
         <directionalLight position={[10, 20, 10]} intensity={0.6} />
         <Grid args={[40, 40]} cellSize={1} cellColor="#1a1a3a" sectionSize={5} sectionColor="#2a2a4a" fadeDistance={30} infiniteGrid={false} />
         {scenePoints.length > 0 && <GaussianPointCloud points={scenePoints} />}
-        <ActiveLayers />
+        <LayerGizmos />
         <OrbitControls />
       </Canvas>
 


### PR DESCRIPTION
## Summary
New VFX Editor tool (`tools/apps/vfx-editor/`, port 5181) for composing game visual effects following professional VFX workflow.

### Three-Phase Workflow
Effects structured as **Anticipation → Impact → Residual** with layered elements (Core, Glow, Debris, Distortion).

### Features
- **VFX Preset List** — create, select, delete presets
- **Timeline** — phase-colored sections, draggable layer bars (move + resize edges), clickable scrubber bar, play/pause/reset
- **Layer Properties** — full type-specific editors:
  - Emitter: 11 presets with auto-fill, all spawn/velocity/color/scale/opacity params
  - Animation: 9 effects with effect-filtered params + easing pickers + reform
  - Light: color, intensity, radius
- **3D Preview** — Three.js viewport with PLY import, colored point cloud, active layer indicators, light flash
- **Project Directory** — File System Access API for save/load (`project.json` + `effects/*.vfx.json`)
- **File I/O** — import/export individual `.vfx.json`, Cmd+S/Cmd+O shortcuts
- **JSON Schema** — `schemas/vfx.schema.json` as source of truth

### Architecture
```
vfx-editor/src/
├── App.tsx (layout + MenuBar + VfxList + Timeline)
├── panels/LayerProperties.tsx (578 lines, full editors)
├── viewport/Preview.tsx (R3F + point cloud)
├── store/ (Zustand: presets, layers, playback, project)
├── components/ (NumberInput, Vec3Input)
├── lib/ (vfxExport, vfxImport, plyLoader, projectIO)
└── data/emitterPresets.ts
```

## Test plan
- [x] 79 data model tests (preset CRUD, layers, phases, export, roundtrip)
- [x] TS typecheck: clean
- [x] pnpm-lock.yaml updated
- [x] Visual: create VFX → add layers → drag timeline → play → import PLY → save project

🤖 Generated with [Claude Code](https://claude.com/claude-code)