### PR TITLE
WASM particle rendering: colors, opacity, scale, size fix

### DIFF
--- a/docs/vfx-editor.md
+++ b/docs/vfx-editor.md
@@ -53,9 +53,17 @@ Each effect is composed of parallel layers:
 | Input | Action |
 |-------|--------|
 | File > New VFX | Create new preset |
+| File > Open Project / Cmd+O | Open project directory |
+| File > Save Project / Cmd+S | Save project to directory |
+| File > Import .vfx.json | Load single VFX file |
+| File > Export .vfx.json | Download selected preset |
+| File > Import Scene PLY | Load PLY for 3D preview |
 | + Emitter / + Anim / + Light | Add layer to timeline |
 | Click layer bar | Select for editing |
-| ▶ Play / ■ Pause | Preview playback |
+| Drag layer bar | Move layer in time |
+| Drag layer edges | Resize layer duration |
+| Click scrubber | Seek to time |
+| ▶ Play / ■ Pause | Preview playback with real particles |
 | ↺ Reset | Return to start |
 
 ## File Format: `.vfx.json`
@@ -121,6 +129,32 @@ See [Bricklayer docs](bricklayer.md#gaussian-animations).
 Instantaneous or brief light flash. Color, intensity, and radius.
 Useful for impact moments (explosions, magic hits).
 
+## Real-time Preview (WASM-powered)
+
+The 3D viewport renders actual particles during playback using the
+`@gseurat/simulation-wasm` module — the exact same C++ simulation code
+as the engine, compiled to WebAssembly.
+
+### What renders during playback
+- **Emitter layers**: Real particles with per-particle color, opacity, and scale
+- **Light layers**: Dynamic point light flash
+- **Animation layers**: Region gizmos (animation preview on geometry planned)
+- **Imported PLY**: Scene geometry as colored point cloud
+
+### Particle rendering
+- Custom `ShaderMaterial` with per-vertex RGBA colors (opacity fade) and per-vertex
+  point sizes (scale_min/max)
+- Soft circle fragment shader with smoothstep edges
+- Additive blending for emissive particles (fire, sparks)
+- All 11 presets work with custom overrides
+
+### Import scene geometry
+**File > Import Scene PLY** loads a `.ply` file into the viewport for context.
+Particles render on top of the imported scene.
+
+### Prerequisites
+Build WASM module: `cd tools/packages/simulation-wasm && bash build.sh`
+
 ## Scene Integration
 
 Scenes reference VFX presets via `vfx_instances`:
@@ -143,18 +177,34 @@ Scenes reference VFX presets via `vfx_instances`:
 ```
 tools/apps/vfx-editor/
 ├── src/
-│   ├── App.tsx              — Main layout
+│   ├── App.tsx                    — Layout, MenuBar, VfxTree, Timeline
 │   ├── store/
-│   │   ├── types.ts         — VfxPreset, VfxLayer types
-│   │   └── useVfxStore.ts   — Zustand state management
-│   ├── panels/              — (future) Extracted panel components
-│   ├── timeline/            — (future) Timeline sub-components
-│   ├── viewport/            — (future) 3D preview
-│   └── lib/                 — (future) Export, PLY loader
+│   │   ├── types.ts               — VfxPreset, VfxLayer, VfxProject
+│   │   └── useVfxStore.ts         — Zustand (presets, layers, playback, project)
+│   ├── panels/
+│   │   └── LayerProperties.tsx    — Full type-specific editors (578 lines)
+│   ├── viewport/
+│   │   ├── Preview.tsx            — R3F Canvas, PLY point cloud, gizmos
+│   │   └── ParticleSystem.tsx     — WASM-powered particle rendering
+│   ├── components/
+│   │   ├── NumberInput.tsx         — Drag-to-scrub number input
+│   │   └── Vec3Input.tsx           — 3-axis vector input
+│   ├── data/
+│   │   └── emitterPresets.ts       — 11 particle presets
+│   ├── styles/
+│   │   └── panel.ts                — Shared panel styles
+│   └── lib/
+│       ├── vfxExport.ts            — Serialize preset to JSON
+│       ├── vfxImport.ts            — Parse JSON to preset
+│       ├── plyLoader.ts            — Binary PLY parser
+│       └── projectIO.ts            — Project directory save/load
 ├── index.html
 ├── package.json
 ├── vite.config.ts
 └── tsconfig.json
 ```
 
-Schema: `schemas/vfx.schema.json`
+Related:
+- `schemas/vfx.schema.json` — VFX preset format
+- `tools/packages/simulation-wasm/` — C++ simulation compiled to WASM
+- `docs/simulation-wasm.md` — WASM module documentation

--- a/tools/apps/vfx-editor/src/viewport/ParticleSystem.tsx
+++ b/tools/apps/vfx-editor/src/viewport/ParticleSystem.tsx
@@ -45,6 +45,7 @@ function EmitterRenderer({ layer, active }: { layer: VfxLayer; active: boolean }
   // Pre-allocate buffers
   const positionBuffer = useMemo(() => new Float32Array(MAX_PARTICLES * 3), []);
   const colorBuffer = useMemo(() => new Float32Array(MAX_PARTICLES * 4), []); // RGBA for per-particle opacity
+  const sizeBuffer = useMemo(() => new Float32Array(MAX_PARTICLES), []);
   const [particleCount, setParticleCount] = useState(0);
 
   // Create/destroy emitter
@@ -102,7 +103,8 @@ function EmitterRenderer({ layer, active }: { layer: VfxLayer; active: boolean }
     // Lazy init geometry attributes (can't use useEffect — component may remount)
     if (!geoInitialized.current) {
       geo.setAttribute('position', new THREE.BufferAttribute(positionBuffer, 3).setUsage(THREE.DynamicDrawUsage));
-      geo.setAttribute('color', new THREE.BufferAttribute(colorBuffer, 4).setUsage(THREE.DynamicDrawUsage)); // RGBA
+      geo.setAttribute('color', new THREE.BufferAttribute(colorBuffer, 4).setUsage(THREE.DynamicDrawUsage));
+      geo.setAttribute('aSize', new THREE.BufferAttribute(sizeBuffer, 1).setUsage(THREE.DynamicDrawUsage));
       geo.setDrawRange(0, 0);
       geoInitialized.current = true;
     }
@@ -120,38 +122,59 @@ function EmitterRenderer({ layer, active }: { layer: VfxLayer; active: boolean }
       const count = Math.min(data.count, MAX_PARTICLES);
       positionBuffer.set(data.positions.subarray(0, count * 3));
 
-      // Write RGBA colors with per-particle opacity
+      // Write RGBA colors with per-particle opacity + per-particle scale
       for (let i = 0; i < count; i++) {
         colorBuffer[i * 4] = data.colors[i * 3];
         colorBuffer[i * 4 + 1] = data.colors[i * 3 + 1];
         colorBuffer[i * 4 + 2] = data.colors[i * 3 + 2];
         colorBuffer[i * 4 + 3] = data.opacities[i];
+        sizeBuffer[i] = data.scales[i];
       }
 
       (geo.getAttribute('position') as THREE.BufferAttribute).needsUpdate = true;
       (geo.getAttribute('color') as THREE.BufferAttribute).needsUpdate = true;
+      (geo.getAttribute('aSize') as THREE.BufferAttribute).needsUpdate = true;
       geo.setDrawRange(0, count);
     } else {
       geo.setDrawRange(0, 0);
     }
   });
 
+  const shaderMaterial = useMemo(() => {
+    const cfg = layer.emitter as Record<string, unknown> | undefined;
+    const hasEmission = ((cfg?.emission as number) ?? 0) > 0;
+    return new THREE.ShaderMaterial({
+      vertexShader: `
+        attribute float aSize;
+        varying vec4 vColor;
+        void main() {
+          vColor = color;
+          vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+          gl_PointSize = aSize * 80.0 * (300.0 / -mvPosition.z);
+          gl_Position = projectionMatrix * mvPosition;
+        }
+      `,
+      fragmentShader: `
+        varying vec4 vColor;
+        void main() {
+          float d = length(gl_PointCoord - vec2(0.5));
+          if (d > 0.5) discard;
+          float alpha = vColor.a * smoothstep(0.5, 0.2, d);
+          gl_FragColor = vec4(vColor.rgb, alpha);
+        }
+      `,
+      vertexColors: true,
+      transparent: true,
+      blending: hasEmission ? THREE.AdditiveBlending : THREE.NormalBlending,
+      depthWrite: false,
+    });
+  }, [layer.emitter]);
+
   if (!wasmModule) return null;
 
-  const cfg = layer.emitter as Record<string, unknown> | undefined;
-  const hasEmission = ((cfg?.emission as number) ?? 0) > 0;
-
   return (
-    <points ref={pointsRef} visible={active}>
+    <points ref={pointsRef} visible={active} material={shaderMaterial}>
       <bufferGeometry ref={geoRef} />
-      <pointsMaterial
-        size={hasEmission ? 0.3 : 0.2}
-        vertexColors
-        sizeAttenuation
-        transparent
-        blending={hasEmission ? THREE.AdditiveBlending : THREE.NormalBlending}
-        depthWrite={false}
-      />
     </points>
   );
 }

--- a/tools/apps/vfx-editor/src/viewport/ParticleSystem.tsx
+++ b/tools/apps/vfx-editor/src/viewport/ParticleSystem.tsx
@@ -150,7 +150,7 @@ function EmitterRenderer({ layer, active }: { layer: VfxLayer; active: boolean }
         void main() {
           vColor = color;
           vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
-          gl_PointSize = aSize * 80.0 * (300.0 / -mvPosition.z);
+          gl_PointSize = aSize * 20.0 * (300.0 / -mvPosition.z);
           gl_Position = projectionMatrix * mvPosition;
         }
       `,


### PR DESCRIPTION
## Summary
Integrates the WASM simulation module into the VFX Editor viewport for real-time particle rendering during playback.

### Features
- **Real particles** rendered via WASM (same C++ code as engine)
- **Per-particle colors** from preset or custom config, merged with layer overrides
- **Per-particle opacity** via RGBA vertex colors (opacity_start → opacity_end fade)
- **Per-particle scale** via custom ShaderMaterial with `aSize` attribute
- **Soft circle rendering** with smoothstep edge in fragment shader
- **Additive blending** for emissive particles (fire, sparks glow)
- **Emitter lifecycle** managed per layer (create on activate, destroy on deactivate)

### Fixes during development
- Color not applied: preset config now merged with layer overrides
- Geometry crash: lazy init in useFrame instead of useEffect
- Opacity not working: RGBA vertex colors instead of global opacity
- Particles too large: reduced size multiplier to 20x

## Test plan
- [x] TS typecheck: clean
- [x] Visual: Fire emitter → orange particles with fade
- [x] Visual: Custom blue snow → blue particles
- [x] Visual: Multiple emitters render independently
- [x] Visual: Scale min/max affects particle size
- [x] Visual: Opacity start/end fades particles

🤖 Generated with [Claude Code](https://claude.com/claude-code)