### PR TITLE
Rename VFX Editor to Méliès

### DIFF
--- a/docs/simulation-wasm.md
+++ b/docs/simulation-wasm.md
@@ -2,7 +2,7 @@
 
 The simulation WASM module compiles the GSeurat particle emitter and animation
 engine to WebAssembly, providing the exact same simulation logic to web tools
-(VFX Editor, Bricklayer) with zero code divergence from the native engine.
+(Méliès, Bricklayer) with zero code divergence from the native engine.
 
 ## Quick Start
 

--- a/docs/vfx-editor.md
+++ b/docs/vfx-editor.md
@@ -1,6 +1,8 @@
-# VFX Editor — Visual Effect Composition Tool
+# Méliès — Visual Effect Composition Tool
 
-The VFX Editor composes particle emitters, animations, and light flashes into
+Méliès (named after [Georges Méliès](https://en.wikipedia.org/wiki/Georges_M%C3%A9li%C3%A8s),
+the pioneer of cinematic special effects) composes particle emitters, animations,
+and light flashes into
 reusable VFX presets with timeline-based authoring.
 
 ## Quick Start

--- a/tools/apps/vfx-editor/index.html
+++ b/tools/apps/vfx-editor/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>VFX Editor — GSeurat</title>
+    <title>Méliès — GSeurat</title>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #1a1a2e; color: #e0e0e0; overflow: hidden; }

--- a/tools/apps/vfx-editor/src/App.tsx
+++ b/tools/apps/vfx-editor/src/App.tsx
@@ -185,7 +185,7 @@ function MenuBar({ onImportScene }: { onImportScene?: () => void }) {
       <span style={{ cursor: 'pointer', padding: '4px 8px' }}>Edit</span>
       <span style={{ cursor: 'pointer', padding: '4px 8px' }}>View</span>
       <div style={{ flex: 1 }} />
-      <span style={{ fontSize: 11, color: T.textMuted, letterSpacing: 1 }}>VFX Editor</span>
+      <span style={{ fontSize: 11, color: T.textMuted, letterSpacing: 1 }}>Méliès</span>
     </div>
   );
 }
@@ -250,7 +250,7 @@ function VfxTree() {
         padding: '6px 8px', borderBottom: `1px solid ${T.border}`,
         fontSize: 10, color: T.textMuted, letterSpacing: 1.5, textTransform: 'uppercase',
       }}>
-        VFX Editor
+        Méliès
       </div>
 
       {/* Tree */}

--- a/tools/apps/vfx-editor/src/viewport/ParticleSystem.tsx
+++ b/tools/apps/vfx-editor/src/viewport/ParticleSystem.tsx
@@ -1,5 +1,5 @@
 /**
- * WASM-powered particle rendering for VFX Editor.
+ * WASM-powered particle rendering for Méliès (VFX Editor).
  *
  * Uses the exact same C++ simulation code as the engine,
  * compiled to WebAssembly. Each active emitter layer gets


### PR DESCRIPTION
Named after [Georges Méliès](https://en.wikipedia.org/wiki/Georges_M%C3%A9li%C3%A8s), the pioneer of cinematic special effects.

Display name "Méliès" in: browser title, menu bar, nav tree header, docs, code comments.

Package/directory stays `vfx-editor` (no accented chars in paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)