### PR TITLE
Remove phase system from Méliès VFX editor

### DIFF
--- a/schemas/vfx.schema.json
+++ b/schemas/vfx.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/eccyan/GSeurat/schemas/vfx.schema.json",
   "title": "GSeurat VFX Preset",
-  "description": "Visual effect preset composing emitters, animations, and lights with timeline and phases",
+  "description": "Visual effect preset composing emitters, animations, and lights with timeline",
   "type": "object",
   "required": ["name", "duration", "layers"],
   "properties": {
@@ -15,10 +15,6 @@
       "minimum": 0.1,
       "description": "Total duration in seconds"
     },
-    "phases": {
-      "$ref": "#/definitions/phases",
-      "description": "Three-phase timing: anticipation, impact, residual"
-    },
     "layers": {
       "type": "array",
       "items": { "$ref": "#/definitions/layer" },
@@ -27,23 +23,6 @@
   },
   "additionalProperties": false,
   "definitions": {
-    "phases": {
-      "type": "object",
-      "required": ["anticipation", "impact"],
-      "properties": {
-        "anticipation": {
-          "type": "number",
-          "minimum": 0,
-          "description": "End time of anticipation phase (seconds). Residual runs from impact to duration."
-        },
-        "impact": {
-          "type": "number",
-          "minimum": 0,
-          "description": "End time of impact phase (seconds). Must be >= anticipation."
-        }
-      },
-      "additionalProperties": false
-    },
     "layer": {
       "type": "object",
       "required": ["name", "type", "start", "duration"],
@@ -57,10 +36,10 @@
           "enum": ["emitter", "animation", "light"],
           "description": "Layer type"
         },
-        "phase": {
-          "type": "string",
-          "enum": ["anticipation", "impact", "residual", "custom"],
-          "description": "Which phase this layer belongs to"
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Free-form tags for organization"
         },
         "start": {
           "type": "number",

--- a/tools/apps/vfx-editor/src/App.tsx
+++ b/tools/apps/vfx-editor/src/App.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { useVfxStore, playbackTimeRef } from './store/useVfxStore.js';
-import type { VfxPreset, VfxLayer, LayerType, Phase } from './store/types.js';
+import type { VfxPreset, VfxLayer, LayerType } from './store/types.js';
 import { serializeVfx } from './lib/vfxExport.js';
 import { parseVfx } from './lib/vfxImport.js';
 import { hasFileSystemAccess, openProjectDirectory, saveProject, loadProject, downloadProject, uploadProject } from './lib/projectIO.js';
 import { loadPly, type PlyPoint } from './lib/plyLoader.js';
 import { Preview } from './viewport/Preview.js';
 import { LayerProperties } from './panels/LayerProperties.js';
-import { T, inputStyle, selectStyle, layerColor, phaseColor } from './styles/theme.js';
+import { T, inputStyle, selectStyle, layerColor } from './styles/theme.js';
 
 // ═══════════════════════════════════════════════════════════════
 // MenuBar
@@ -258,11 +258,11 @@ function VfxTree() {
                     })}
                     {/* Add layer buttons */}
                     <div style={{ display: 'flex', gap: 2, padding: '2px 4px' }}>
-                      <button onClick={() => addLayer(preset.id, 'emitter', 'Emitter', 0, 1, 'custom')}
+                      <button onClick={() => addLayer(preset.id, 'emitter', 'Emitter', 0, 1)}
                         style={{ ...treeStyles.addBtn, color: T.layerEmitter, fontSize: 9 }}>+✦</button>
-                      <button onClick={() => addLayer(preset.id, 'animation', 'Animation', 0, 1, 'custom')}
+                      <button onClick={() => addLayer(preset.id, 'animation', 'Animation', 0, 1)}
                         style={{ ...treeStyles.addBtn, color: T.layerAnimation, fontSize: 9 }}>+↻</button>
-                      <button onClick={() => addLayer(preset.id, 'light', 'Light', 0, 0.2, 'custom')}
+                      <button onClick={() => addLayer(preset.id, 'light', 'Light', 0, 0.2)}
                         style={{ ...treeStyles.addBtn, color: T.layerLight, fontSize: 9 }}>+☀</button>
                     </div>
                   </div>
@@ -353,9 +353,6 @@ function Timeline() {
   }
 
   const dur = preset.duration;
-  const antPct = (preset.phases.anticipation / dur) * 100;
-  const impPct = ((preset.phases.impact - preset.phases.anticipation) / dur) * 100;
-  const resPct = 100 - antPct - impPct;
 
   return (
     <div style={{
@@ -379,15 +376,15 @@ function Timeline() {
           {playbackTime.toFixed(2)}s / {dur.toFixed(1)}s
         </span>
         <div style={{ flex: 1 }} />
-        <button onClick={() => addLayer(preset.id, 'emitter', 'New Emitter', 0, 1, 'custom')} style={{
+        <button onClick={() => addLayer(preset.id, 'emitter', 'New Emitter', 0, 1)} style={{
           background: 'none', border: `1px solid ${T.layerEmitter}40`, borderRadius: 3,
           color: T.layerEmitter, padding: '2px 8px', cursor: 'pointer', fontSize: 10,
         }}>+ Emitter</button>
-        <button onClick={() => addLayer(preset.id, 'animation', 'New Animation', 0, 1, 'custom')} style={{
+        <button onClick={() => addLayer(preset.id, 'animation', 'New Animation', 0, 1)} style={{
           background: 'none', border: `1px solid ${T.layerAnimation}40`, borderRadius: 3,
           color: T.layerAnimation, padding: '2px 8px', cursor: 'pointer', fontSize: 10,
         }}>+ Anim</button>
-        <button onClick={() => addLayer(preset.id, 'light', 'New Light', 0, 0.2, 'custom')} style={{
+        <button onClick={() => addLayer(preset.id, 'light', 'New Light', 0, 0.2)} style={{
           background: 'none', border: `1px solid ${T.layerLight}40`, borderRadius: 3,
           color: T.layerLight, padding: '2px 8px', cursor: 'pointer', fontSize: 10,
         }}>+ Light</button>
@@ -418,12 +415,6 @@ function Timeline() {
           move(e.nativeEvent);
         }}
       >
-        {/* Phase colors in scrubber */}
-        <div style={{ display: 'flex', height: '100%' }}>
-          <div style={{ width: `${antPct}%`, background: `${T.phaseAnticipation}30` }} />
-          <div style={{ width: `${impPct}%`, background: `${T.phaseImpact}30` }} />
-          <div style={{ width: `${resPct}%`, background: `${T.phaseResidual}30` }} />
-        </div>
         {/* Scrubber playhead */}
         <div style={{
           position: 'absolute', top: 0, bottom: 0, width: 2, background: '#fff',
@@ -433,26 +424,6 @@ function Timeline() {
 
       {/* Timeline area */}
       <div style={{ flex: 1, overflowY: 'auto', position: 'relative' }}>
-        {/* Phase background — use 100% width, not fixed px */}
-        <div style={{ display: 'flex', height: '100%', position: 'absolute', top: 0, left: 0, width: '100%', zIndex: 0 }}>
-          <div style={{ width: `${antPct}%`, background: `${T.phaseAnticipation}08`, borderRight: `1px dashed ${T.phaseAnticipation}30` }} />
-          <div style={{ width: `${impPct}%`, background: `${T.phaseImpact}08`, borderRight: `1px dashed ${T.phaseImpact}30` }} />
-          <div style={{ width: `${resPct}%`, background: `${T.phaseResidual}08` }} />
-        </div>
-
-        {/* Phase labels */}
-        <div style={{ display: 'flex', height: 16, position: 'relative', zIndex: 1 }}>
-          <div style={{ width: `${antPct}%`, textAlign: 'center', fontSize: 8, color: T.phaseAnticipation, lineHeight: '16px', letterSpacing: 1, textTransform: 'uppercase' }}>
-            Anticipation
-          </div>
-          <div style={{ width: `${impPct}%`, textAlign: 'center', fontSize: 8, color: T.phaseImpact, lineHeight: '16px', letterSpacing: 1, textTransform: 'uppercase' }}>
-            Impact
-          </div>
-          <div style={{ width: `${resPct}%`, textAlign: 'center', fontSize: 8, color: T.phaseResidual, lineHeight: '16px', letterSpacing: 1, textTransform: 'uppercase' }}>
-            Residual
-          </div>
-        </div>
-
         {/* Layer tracks with drag handles */}
         <div ref={tracksRef} style={{ position: 'relative', zIndex: 1, padding: '2px 0' }}>
           {preset.layers.map((layer) => {

--- a/tools/apps/vfx-editor/src/lib/projectIO.ts
+++ b/tools/apps/vfx-editor/src/lib/projectIO.ts
@@ -65,7 +65,8 @@ export async function loadProject(handle: FileSystemDirectoryHandle): Promise<bo
     const fileHandle = await handle.getFileHandle('project.json');
     const file = await fileHandle.getFile();
     const text = await file.text();
-    const data = JSON.parse(text) as VfxProject;
+    const raw = JSON.parse(text);
+    const data = migrateProject(raw) as VfxProject;
     useVfxStore.getState().loadProjectData(data);
     return true;
   } catch (err) {
@@ -96,10 +97,39 @@ export function downloadProject(): void {
 export async function uploadProject(file: File): Promise<boolean> {
   try {
     const text = await file.text();
-    const data = JSON.parse(text) as VfxProject;
+    const raw = JSON.parse(text);
+    const data = migrateProject(raw);
     useVfxStore.getState().loadProjectData(data);
     return true;
   } catch {
     return false;
   }
+}
+
+/**
+ * Migrate project data from older versions.
+ * v1 → v2: remove phases from presets, convert layer.phase to tags.
+ */
+function migrateProject(data: Record<string, unknown>): VfxProject {
+  const version = (data.version as number) ?? 1;
+  if (version >= 2) return data as unknown as VfxProject;
+
+  // v1 → v2 migration
+  const presets = (data.presets as Record<string, unknown>[]) ?? [];
+  return {
+    version: 2,
+    presets: presets.map((p) => {
+      const layers = (p.layers as Record<string, unknown>[]) ?? [];
+      const { phases: _, ...rest } = p;
+      return {
+        ...rest,
+        layers: layers.map((l) => {
+          const phase = l.phase as string | undefined;
+          const tags = phase && phase !== 'custom' ? [phase] : undefined;
+          const { phase: __, ...layerRest } = l;
+          return { ...layerRest, ...(tags ? { tags } : {}) };
+        }),
+      };
+    }),
+  } as unknown as VfxProject;
 }

--- a/tools/apps/vfx-editor/src/lib/vfxExport.ts
+++ b/tools/apps/vfx-editor/src/lib/vfxExport.ts
@@ -4,10 +4,10 @@ function exportLayer(layer: VfxLayer): Record<string, unknown> {
   const out: Record<string, unknown> = {
     name: layer.name,
     type: layer.type,
-    phase: layer.phase,
     start: layer.start,
     duration: layer.duration,
   };
+  if (layer.tags && layer.tags.length > 0) out.tags = layer.tags;
   if (layer.emitter && Object.keys(layer.emitter).length > 0) out.emitter = layer.emitter;
   if (layer.animation && Object.keys(layer.animation).length > 0) out.animation = layer.animation;
   if (layer.light) out.light = layer.light;
@@ -18,7 +18,6 @@ export function exportVfx(preset: VfxPreset): Record<string, unknown> {
   return {
     name: preset.name,
     duration: preset.duration,
-    phases: preset.phases,
     layers: preset.layers.map(exportLayer),
   };
 }

--- a/tools/apps/vfx-editor/src/lib/vfxImport.ts
+++ b/tools/apps/vfx-editor/src/lib/vfxImport.ts
@@ -1,4 +1,4 @@
-import type { VfxPreset, VfxLayer, LayerType, Phase } from '../store/types.js';
+import type { VfxPreset, VfxLayer, LayerType } from '../store/types.js';
 
 let importIdCounter = 0;
 function genId(prefix: string): string {
@@ -9,28 +9,31 @@ export function parseVfx(json: string): VfxPreset {
   const data = JSON.parse(json);
 
   const duration = data.duration ?? 3.0;
-  const phases = data.phases ?? {
-    anticipation: duration * 0.3,
-    impact: duration * 0.5,
-  };
 
-  const layers: VfxLayer[] = (data.layers ?? []).map((l: Record<string, unknown>) => ({
-    id: genId('layer'),
-    name: (l.name as string) ?? 'Unnamed',
-    type: (l.type as LayerType) ?? 'emitter',
-    phase: (l.phase as Phase) ?? 'custom',
-    start: (l.start as number) ?? 0,
-    duration: (l.duration as number) ?? 1,
-    emitter: l.emitter as Record<string, unknown> | undefined,
-    animation: l.animation as Record<string, unknown> | undefined,
-    light: l.light as { color: [number, number, number]; intensity: number; radius: number } | undefined,
-  }));
+  const layers: VfxLayer[] = (data.layers ?? []).map((l: Record<string, unknown>) => {
+    // Migrate v1 phase field to tags
+    const tags: string[] = l.tags as string[] ?? [];
+    if (l.phase && l.phase !== 'custom' && tags.length === 0) {
+      tags.push(l.phase as string);
+    }
+
+    return {
+      id: genId('layer'),
+      name: (l.name as string) ?? 'Unnamed',
+      type: (l.type as LayerType) ?? 'emitter',
+      tags: tags.length > 0 ? tags : undefined,
+      start: (l.start as number) ?? 0,
+      duration: (l.duration as number) ?? 1,
+      emitter: l.emitter as Record<string, unknown> | undefined,
+      animation: l.animation as Record<string, unknown> | undefined,
+      light: l.light as { color: [number, number, number]; intensity: number; radius: number } | undefined,
+    };
+  });
 
   return {
     id: genId('vfx'),
     name: data.name ?? 'Imported VFX',
     duration,
-    phases,
     layers,
   };
 }

--- a/tools/apps/vfx-editor/src/panels/LayerProperties.tsx
+++ b/tools/apps/vfx-editor/src/panels/LayerProperties.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useVfxStore } from '../store/useVfxStore.js';
-import type { VfxLayer, LayerType, Phase } from '../store/types.js';
+import type { VfxLayer, LayerType } from '../store/types.js';
 import { NumberInput } from '../components/NumberInput.js';
 import { Vec3Input } from '../components/Vec3Input.js';
 import { emitterPresets, defaultEmitterConfig } from '../data/emitterPresets.js';
 import type { EmitterConfig } from '../data/emitterPresets.js';
-import { T, inputStyle, selectStyle, sectionLabel, layerColor, phaseColor } from '../styles/theme.js';
+import { T, inputStyle, selectStyle, sectionLabel, layerColor } from '../styles/theme.js';
 
 // ── Easing helpers ──
 
@@ -512,23 +512,6 @@ export function LayerProperties() {
           <option value="animation">Animation</option>
           <option value="light">Light</option>
         </select>
-      </div>
-
-      {/* Phase */}
-      <div>
-        <label style={sectionLabel}>Phase</label>
-        <select value={layer.phase} onChange={(e) => update({ phase: e.target.value as Phase })} style={selectStyle}>
-          <option value="anticipation">Anticipation</option>
-          <option value="impact">Impact</option>
-          <option value="residual">Residual</option>
-          <option value="custom">Custom</option>
-        </select>
-        <div style={{ marginTop: 2, fontSize: 9, color: phaseColor(layer.phase) }}>
-          {layer.phase === 'anticipation' ? 'Buildup — signals something is coming'
-            : layer.phase === 'impact' ? 'Peak energy — the main event'
-            : layer.phase === 'residual' ? 'Dissipation and aftermath'
-            : 'Manual timing'}
-        </div>
       </div>
 
       {/* Timing */}

--- a/tools/apps/vfx-editor/src/store/types.ts
+++ b/tools/apps/vfx-editor/src/store/types.ts
@@ -1,11 +1,10 @@
 export type LayerType = 'emitter' | 'animation' | 'light';
-export type Phase = 'anticipation' | 'impact' | 'residual' | 'custom';
 
 export interface VfxLayer {
   id: string;
   name: string;
   type: LayerType;
-  phase: Phase;
+  tags?: string[];
   start: number;
   duration: number;
   emitter?: Record<string, unknown>;
@@ -13,20 +12,14 @@ export interface VfxLayer {
   light?: { color: [number, number, number]; intensity: number; radius: number };
 }
 
-export interface VfxPhases {
-  anticipation: number;
-  impact: number;
-}
-
 export interface VfxPreset {
   id: string;
   name: string;
   duration: number;
-  phases: VfxPhases;
   layers: VfxLayer[];
 }
 
 export interface VfxProject {
-  version: 1;
+  version: 2;
   presets: VfxPreset[];
 }

--- a/tools/apps/vfx-editor/src/store/useVfxStore.ts
+++ b/tools/apps/vfx-editor/src/store/useVfxStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { VfxPreset, VfxLayer, VfxPhases, VfxProject, LayerType, Phase } from './types.js';
+import type { VfxPreset, VfxLayer, VfxProject, LayerType } from './types.js';
 
 let idCounter = 0;
 function genId(prefix: string): string {
@@ -41,7 +41,7 @@ export interface VfxStoreState {
   selectPreset: (id: string | null) => void;
 
   // Actions — layers
-  addLayer: (presetId: string, type: LayerType, name: string, start: number, duration: number, phase?: Phase) => void;
+  addLayer: (presetId: string, type: LayerType, name: string, start: number, duration: number) => void;
   updateLayer: (presetId: string, layerId: string, patch: Partial<VfxLayer>) => void;
   removeLayer: (presetId: string, layerId: string) => void;
   selectLayer: (id: string | null) => void;
@@ -71,7 +71,7 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
   setProjectName: (name) => set({ projectName: name }),
 
   saveProjectData: () => ({
-    version: 1 as const,
+    version: 2 as const,
     presets: get().presets,
   }),
 
@@ -89,7 +89,6 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
       id: genId('vfx'),
       name: name ?? 'New VFX',
       duration: 3.0,
-      phases: { anticipation: 0.9, impact: 1.5 },
       layers: [],
     };
     set({ presets: [...get().presets, preset], selectedPresetId: preset.id });
@@ -109,12 +108,11 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
 
   selectPreset: (id) => set({ selectedPresetId: id, selectedLayerId: null }),
 
-  addLayer: (presetId, type, name, start, duration, phase = 'custom') => {
+  addLayer: (presetId, type, name, start, duration) => {
     const layer: VfxLayer = {
       id: genId('layer'),
       name,
       type,
-      phase,
       start,
       duration,
     };

--- a/tools/apps/vfx-editor/src/styles/theme.ts
+++ b/tools/apps/vfx-editor/src/styles/theme.ts
@@ -1,4 +1,4 @@
-import type { LayerType, Phase } from '../store/types.js';
+import type { LayerType } from '../store/types.js';
 
 // ── Shared theme — single source of truth for Méliès UI ──
 
@@ -48,7 +48,3 @@ export const labelStyle: React.CSSProperties = {
 export const layerColor = (type: LayerType) =>
   type === 'emitter' ? T.layerEmitter : type === 'animation' ? T.layerAnimation : T.layerLight;
 
-export const phaseColor = (phase: Phase) =>
-  phase === 'anticipation' ? T.phaseAnticipation
-    : phase === 'impact' ? T.phaseImpact
-    : phase === 'residual' ? T.phaseResidual : T.textMuted;

--- a/tools/apps/vfx-editor/src/viewport/Preview.tsx
+++ b/tools/apps/vfx-editor/src/viewport/Preview.tsx
@@ -242,22 +242,6 @@ export function Preview({ scenePoints }: { scenePoints: PlyPoint[] }) {
     }
   }, []);
 
-  // Determine current phase for overlay
-  let phaseName = '';
-  let phaseColor = '#666';
-  if (preset) {
-    if (playbackTime < preset.phases.anticipation) {
-      phaseName = 'Anticipation';
-      phaseColor = '#f59e0b';
-    } else if (playbackTime < preset.phases.impact) {
-      phaseName = 'Impact';
-      phaseColor = '#ef4444';
-    } else if (playbackTime < preset.duration) {
-      phaseName = 'Residual';
-      phaseColor = '#3b82f6';
-    }
-  }
-
   return (
     <div style={{ flex: 1, position: 'relative' }}>
       <Canvas camera={{ position: [10, 10, 10], fov: 50 }} style={{ background: '#0f0f1e' }}>
@@ -270,19 +254,6 @@ export function Preview({ scenePoints }: { scenePoints: PlyPoint[] }) {
         <AnimationSystem scenePoints={scenePoints} onUpdateGeometry={handleUpdateGeometry} />
         <OrbitControls />
       </Canvas>
-
-      {/* Phase overlay */}
-      {phaseName && (
-        <div style={{
-          position: 'absolute', top: 8, left: 8,
-          padding: '2px 8px', borderRadius: 3,
-          background: `${phaseColor}20`, border: `1px solid ${phaseColor}40`,
-          color: phaseColor, fontSize: 10, letterSpacing: 1,
-          textTransform: 'uppercase', pointerEvents: 'none',
-        }}>
-          {phaseName}
-        </div>
-      )}
 
       {/* Scene info */}
       <div style={{


### PR DESCRIPTION
## Summary
- Remove ANTICIPATION/IMPACT/RESIDUAL phase system — designer conventions, not tool concerns
- Schema: remove `Phase` type, `VfxPhases`, `phase` from layer, `phases` from preset
- Add `tags?: string[]` to VfxLayer for future free-form tagging
- Bump VfxProject version 1 → 2 with migration in projectIO.ts
- Timeline: remove phase background bands, labels, calculations
- LayerProperties: remove Phase dropdown
- Preview: remove phase overlay
- vfx.schema.json updated (schema-first)

PR 2 of 7 in the Méliès UI improvement series. Depends on PR 1 (merged).

## Test plan
- [x] TypeScript compiles with no errors
- [x] Visual: open Méliès, timeline is clean without phase bands
- [x] Create new preset → no phase fields, layers work normally
- [x] Import v1 .vfx.json → migrates phase to tags silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)