### PR TITLE
Add per-VFX duration settings panel

### DIFF
--- a/tools/apps/vfx-editor/src/App.tsx
+++ b/tools/apps/vfx-editor/src/App.tsx
@@ -7,6 +7,7 @@ import { hasFileSystemAccess, openProjectDirectory, saveProject, loadProject, do
 import { loadPly, type PlyPoint } from './lib/plyLoader.js';
 import { Preview } from './viewport/Preview.js';
 import { LayerProperties } from './panels/LayerProperties.js';
+import { PresetSettings } from './panels/PresetSettings.js';
 import { T, inputStyle, selectStyle, layerColor } from './styles/theme.js';
 
 // ═══════════════════════════════════════════════════════════════
@@ -185,6 +186,8 @@ function VfxTree() {
   const removePreset = useVfxStore((s) => s.removePreset);
   const addLayer = useVfxStore((s) => s.addLayer);
   const removeLayer = useVfxStore((s) => s.removeLayer);
+  const selectedView = useVfxStore((s) => s.selectedView);
+  const setSelectedView = useVfxStore((s) => s.setSelectedView);
   const [openPresets, setOpenPresets] = useState<Set<string>>(new Set());
 
   const toggleOpen = (id: string) => {
@@ -238,9 +241,17 @@ function VfxTree() {
                     onClick={(e) => { e.stopPropagation(); removePreset(preset.id); }}>&times;</button>
                 </div>
 
-                {/* Layers (when expanded) */}
+                {/* Settings + Layers (when expanded) */}
                 {isOpen && (
                   <div style={treeStyles.indent}>
+                    {/* Settings node */}
+                    <div
+                      style={{ ...treeStyles.node, ...(selectedView === 'preset-settings' && selectedPresetId === preset.id && !selectedLayerId ? treeStyles.nodeActive : {}) }}
+                      onClick={() => { selectPreset(preset.id); selectLayer(null); setSelectedView('preset-settings'); }}
+                    >
+                      <span style={treeStyles.icon}>&#9881;</span>
+                      <span style={treeStyles.label}>Settings</span>
+                    </div>
                     {preset.layers.map((layer, i) => {
                       const layerActive = selectedLayerId === layer.id;
                       const color = layerColor(layer.type);
@@ -551,6 +562,12 @@ function Timeline() {
 // App
 // ═══════════════════════════════════════════════════════════════
 
+function RightPanel() {
+  const selectedView = useVfxStore((s) => s.selectedView);
+  if (selectedView === 'preset-settings') return <PresetSettings />;
+  return <LayerProperties />;
+}
+
 export function App() {
   const [scenePoints, setScenePoints] = useState<PlyPoint[]>([]);
 
@@ -618,7 +635,7 @@ export function App() {
           <Preview scenePoints={scenePoints} />
           <Timeline />
         </div>
-        <LayerProperties />
+        <RightPanel />
       </div>
     </div>
   );

--- a/tools/apps/vfx-editor/src/panels/PresetSettings.tsx
+++ b/tools/apps/vfx-editor/src/panels/PresetSettings.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { useVfxStore } from '../store/useVfxStore.js';
+import { NumberInput } from '../components/NumberInput.js';
+import { T, inputStyle, sectionLabel } from '../styles/theme.js';
+
+export function PresetSettings() {
+  const preset = useVfxStore((s) => {
+    return s.presets.find((p) => p.id === s.selectedPresetId);
+  });
+  const updatePreset = useVfxStore((s) => s.updatePreset);
+
+  if (!preset) {
+    return (
+      <div style={{
+        width: 280, background: T.panel, borderLeft: `1px solid ${T.border}`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: T.textMuted, fontSize: 12, padding: 16, textAlign: 'center',
+      }}>
+        Select a VFX preset to edit its settings
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      width: 280, background: T.panel, borderLeft: `1px solid ${T.border}`,
+      overflowY: 'auto', padding: 12,
+      display: 'flex', flexDirection: 'column', gap: 12,
+    }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        paddingBottom: 8, borderBottom: `1px solid ${T.border}`,
+      }}>
+        <span style={{ fontSize: 14 }}>&#9881;</span>
+        <span style={{ fontSize: 11, color: T.textMuted, textTransform: 'uppercase', letterSpacing: 1 }}>
+          Preset Settings
+        </span>
+      </div>
+
+      {/* Name */}
+      <div>
+        <label style={sectionLabel}>Name</label>
+        <input
+          type="text"
+          value={preset.name}
+          onChange={(e) => updatePreset(preset.id, { name: e.target.value })}
+          style={inputStyle}
+        />
+      </div>
+
+      {/* Duration */}
+      <div>
+        <label style={sectionLabel}>Duration (s)</label>
+        <NumberInput
+          value={preset.duration}
+          min={0.1}
+          step={0.5}
+          onChange={(v) => updatePreset(preset.id, { duration: v })}
+          style={{ ...inputStyle, width: 'auto' }}
+        />
+        <div style={{ marginTop: 4, fontSize: 9, color: T.textMuted }}>
+          Total playback length for this VFX preset
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tools/apps/vfx-editor/src/store/useVfxStore.ts
+++ b/tools/apps/vfx-editor/src/store/useVfxStore.ts
@@ -24,6 +24,9 @@ export interface VfxStoreState {
   projectName: string;
   isDirty: boolean;
 
+  // UI
+  selectedView: 'layer' | 'preset-settings';
+
   // Playback
   playing: boolean;
   playbackTime: number;
@@ -45,6 +48,7 @@ export interface VfxStoreState {
   updateLayer: (presetId: string, layerId: string, patch: Partial<VfxLayer>) => void;
   removeLayer: (presetId: string, layerId: string) => void;
   selectLayer: (id: string | null) => void;
+  setSelectedView: (view: 'layer' | 'preset-settings') => void;
 
   // Actions — playback
   play: () => void;
@@ -64,6 +68,7 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
   isDirty: false,
   selectedPresetId: null,
   selectedLayerId: null,
+  selectedView: 'layer' as const,
   playing: false,
   playbackTime: 0,
 
@@ -142,7 +147,8 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
     });
   },
 
-  selectLayer: (id) => set({ selectedLayerId: id }),
+  selectLayer: (id) => set({ selectedLayerId: id, selectedView: 'layer' }),
+  setSelectedView: (view) => set({ selectedView: view }),
 
   play: () => set({ playing: true }),
   pause: () => set({ playing: false }),


### PR DESCRIPTION
## Summary
- Add `PresetSettings` panel with editable Name and Duration fields
- Duration was hardcoded at 3.0s with no UI to change — now freely adjustable
- Settings node (⚙) in VfxTree under each preset
- Right panel routes between PresetSettings and LayerProperties based on context

PR 3 of 7 in the Méliès UI improvement series.

## Test plan
- [x] TypeScript compiles
- [x] Click ⚙ Settings in tree → right panel shows preset settings
- [x] Change duration to 10s → timeline scales, playback loops at 10s
- [x] Click a layer → right panel switches back to layer properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)