### PR TITLE
Add visibility toggles: gizmos, point cloud, layer solo/mute

### DIFF
--- a/tools/apps/vfx-editor/src/App.tsx
+++ b/tools/apps/vfx-editor/src/App.tsx
@@ -17,6 +17,7 @@ import { T, inputStyle, selectStyle, layerColor } from './styles/theme.js';
 function MenuBar({ onImportScene }: { onImportScene?: () => void }) {
   const addPreset = useVfxStore((s) => s.addPreset);
   const [fileOpen, setFileOpen] = useState(false);
+  const [openMenu, setOpenMenu] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement>(null);
 
   const handleSaveProject = async () => {
@@ -139,7 +140,29 @@ function MenuBar({ onImportScene }: { onImportScene?: () => void }) {
         )}
       </div>
       <span style={{ cursor: 'pointer', padding: '4px 8px' }}>Edit</span>
-      <span style={{ cursor: 'pointer', padding: '4px 8px' }}>View</span>
+      <div style={{ position: 'relative' }}
+        onMouseEnter={() => setOpenMenu('view')} onMouseLeave={() => setOpenMenu(null)}>
+        <span style={{ cursor: 'pointer', padding: '4px 8px' }}>View</span>
+        {openMenu === 'view' && (
+          <div style={{
+            position: 'absolute', top: '100%', left: 0, minWidth: 180, background: T.panel,
+            border: `1px solid ${T.border}`, borderRadius: 4, zIndex: 100, padding: '4px 0',
+            boxShadow: '0 4px 16px rgba(0,0,0,0.5)',
+          }}>
+            {[
+              { label: `${useVfxStore.getState().showGizmos ? '✓' : '  '} Show Gizmos`, action: () => useVfxStore.getState().toggleGizmos() },
+              { label: `${useVfxStore.getState().showPointCloud ? '✓' : '  '} Show Point Cloud`, action: () => useVfxStore.getState().togglePointCloud() },
+            ].map((item) => (
+              <div key={item.label} onClick={item.action}
+                style={{ padding: '6px 16px', cursor: 'pointer', fontSize: 12, color: T.text, fontFamily: 'monospace' }}
+                onMouseEnter={(e) => (e.currentTarget.style.background = T.surface)}
+                onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}>
+                {item.label}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
       <div style={{ flex: 1 }} />
       <span style={{ fontSize: 11, color: T.textMuted, letterSpacing: 1 }}>Méliès</span>
     </div>
@@ -176,6 +199,11 @@ const layerIcons: Record<string, string> = {
   emitter: '✦', animation: '↻', light: '☀',
 };
 
+const smBtnStyle: React.CSSProperties = {
+  padding: '0 2px', border: 'none', background: 'transparent',
+  cursor: 'pointer', fontSize: 8, fontWeight: 700, lineHeight: '1', flexShrink: 0,
+};
+
 function VfxTree() {
   const presets = useVfxStore((s) => s.presets);
   const selectedPresetId = useVfxStore((s) => s.selectedPresetId);
@@ -188,6 +216,10 @@ function VfxTree() {
   const removeLayer = useVfxStore((s) => s.removeLayer);
   const selectedView = useVfxStore((s) => s.selectedView);
   const setSelectedView = useVfxStore((s) => s.setSelectedView);
+  const toggleLayerMute = useVfxStore((s) => s.toggleLayerMute);
+  const toggleLayerSolo = useVfxStore((s) => s.toggleLayerSolo);
+  const mutedLayerIds = useVfxStore((s) => s.mutedLayerIds);
+  const soloLayerIds = useVfxStore((s) => s.soloLayerIds);
   const [openPresets, setOpenPresets] = useState<Set<string>>(new Set());
 
   const toggleOpen = (id: string) => {
@@ -255,13 +287,19 @@ function VfxTree() {
                     {preset.layers.map((layer, i) => {
                       const layerActive = selectedLayerId === layer.id;
                       const color = layerColor(layer.type);
+                      const isMuted = mutedLayerIds.includes(layer.id);
+                      const isSolod = soloLayerIds.includes(layer.id);
                       return (
                         <div key={layer.id}
-                          style={{ ...treeStyles.node, ...(layerActive ? treeStyles.nodeActive : {}) }}
+                          style={{ ...treeStyles.node, ...(layerActive ? treeStyles.nodeActive : {}), ...(isMuted ? { opacity: 0.4 } : {}) }}
                           onClick={() => { selectPreset(preset.id); selectLayer(layer.id); }}
                         >
                           <span style={{ ...treeStyles.icon, color }}>{layerIcons[layer.type] ?? '?'}</span>
                           <span style={treeStyles.label}>{layer.name}</span>
+                          <button title="Solo" style={{ ...smBtnStyle, color: isSolod ? T.accent : T.textMuted }}
+                            onClick={(e) => { e.stopPropagation(); toggleLayerSolo(layer.id); }}>S</button>
+                          <button title="Mute" style={{ ...smBtnStyle, color: isMuted ? T.danger : T.textMuted }}
+                            onClick={(e) => { e.stopPropagation(); toggleLayerMute(layer.id); }}>M</button>
                           <button style={treeStyles.removeBtn}
                             onClick={(e) => { e.stopPropagation(); removeLayer(preset.id, layer.id); }}>&times;</button>
                         </div>

--- a/tools/apps/vfx-editor/src/store/useVfxStore.ts
+++ b/tools/apps/vfx-editor/src/store/useVfxStore.ts
@@ -27,6 +27,12 @@ export interface VfxStoreState {
   // UI
   selectedView: 'layer' | 'preset-settings';
 
+  // Visibility
+  showGizmos: boolean;
+  showPointCloud: boolean;
+  mutedLayerIds: string[];
+  soloLayerIds: string[];
+
   // Playback
   playing: boolean;
   playbackTime: number;
@@ -50,6 +56,13 @@ export interface VfxStoreState {
   selectLayer: (id: string | null) => void;
   setSelectedView: (view: 'layer' | 'preset-settings') => void;
 
+  // Actions — visibility
+  toggleGizmos: () => void;
+  togglePointCloud: () => void;
+  toggleLayerMute: (layerId: string) => void;
+  toggleLayerSolo: (layerId: string) => void;
+  isLayerVisible: (layerId: string) => boolean;
+
   // Actions — playback
   play: () => void;
   pause: () => void;
@@ -69,6 +82,10 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
   selectedPresetId: null,
   selectedLayerId: null,
   selectedView: 'layer' as const,
+  showGizmos: true,
+  showPointCloud: true,
+  mutedLayerIds: [] as string[],
+  soloLayerIds: [] as string[],
   playing: false,
   playbackTime: 0,
 
@@ -149,6 +166,27 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
 
   selectLayer: (id) => set({ selectedLayerId: id, selectedView: 'layer' }),
   setSelectedView: (view) => set({ selectedView: view }),
+
+  toggleGizmos: () => set((s) => ({ showGizmos: !s.showGizmos })),
+  togglePointCloud: () => set((s) => ({ showPointCloud: !s.showPointCloud })),
+  toggleLayerMute: (layerId) => set((s) => {
+    const muted = [...s.mutedLayerIds];
+    const idx = muted.indexOf(layerId);
+    if (idx >= 0) muted.splice(idx, 1); else muted.push(layerId);
+    return { mutedLayerIds: muted };
+  }),
+  toggleLayerSolo: (layerId) => set((s) => {
+    const solo = [...s.soloLayerIds];
+    const idx = solo.indexOf(layerId);
+    if (idx >= 0) solo.splice(idx, 1); else solo.push(layerId);
+    return { soloLayerIds: solo };
+  }),
+  isLayerVisible: (layerId) => {
+    const s = get();
+    if (s.mutedLayerIds.includes(layerId)) return false;
+    if (s.soloLayerIds.length > 0 && !s.soloLayerIds.includes(layerId)) return false;
+    return true;
+  },
 
   play: () => set({ playing: true }),
   pause: () => set({ playing: false }),

--- a/tools/apps/vfx-editor/src/viewport/AnimationSystem.tsx
+++ b/tools/apps/vfx-editor/src/viewport/AnimationSystem.tsx
@@ -36,6 +36,7 @@ export function AnimationSystem({ scenePoints, onUpdateGeometry }: {
 }) {
   const preset = useVfxStore((s) => s.presets.find((p) => p.id === s.selectedPresetId));
   const playing = useVfxStore((s) => s.playing);
+  const isLayerVisible = useVfxStore((s) => s.isLayerVisible);
 
   // One animator per animation layer for isolation
   const animatorsRef = useRef<Map<string, { animator: any; groupId: number }>>(new Map());
@@ -105,7 +106,7 @@ export function AnimationSystem({ scenePoints, onUpdateGeometry }: {
     for (const layer of preset.layers) {
       if (layer.type !== 'animation') continue;
 
-      const isActive = playbackTime >= layer.start && playbackTime < layer.start + layer.duration;
+      const isActive = isLayerVisible(layer.id) && playbackTime >= layer.start && playbackTime < layer.start + layer.duration;
       const hasAnimator = animators.has(layer.id);
 
       if (isActive && !hasAnimator) {

--- a/tools/apps/vfx-editor/src/viewport/ParticleSystem.tsx
+++ b/tools/apps/vfx-editor/src/viewport/ParticleSystem.tsx
@@ -189,6 +189,7 @@ export function ParticleSystem() {
     return s.presets.find((p) => p.id === s.selectedPresetId);
   });
   const playing = useVfxStore((s) => s.playing);
+  const isLayerVisible = useVfxStore((s) => s.isLayerVisible);
   const [wasmReady, setWasmReady] = useState(false);
 
   // Load WASM on mount
@@ -206,7 +207,7 @@ export function ParticleSystem() {
         .filter((l) => l.type === 'emitter')
         .map((layer) => {
           // Active state computed per-frame in EmitterRenderer via playbackTimeRef
-          const active = playing;
+          const active = playing && isLayerVisible(layer.id);
           return (
             <EmitterRenderer
               key={layer.id}

--- a/tools/apps/vfx-editor/src/viewport/Preview.tsx
+++ b/tools/apps/vfx-editor/src/viewport/Preview.tsx
@@ -216,6 +216,8 @@ export function Preview({ scenePoints }: { scenePoints: PlyPoint[] }) {
     return p;
   });
   const playbackTime = useVfxStore((s) => s.playbackTime);
+  const showGizmos = useVfxStore((s) => s.showGizmos);
+  const showPointCloud = useVfxStore((s) => s.showPointCloud);
   const sceneGeoRef = useRef<THREE.BufferGeometry | null>(null);
 
   // Callback for AnimationSystem to update point cloud geometry
@@ -248,8 +250,8 @@ export function Preview({ scenePoints }: { scenePoints: PlyPoint[] }) {
         <ambientLight intensity={0.4} />
         <directionalLight position={[10, 20, 10]} intensity={0.6} />
         <Grid args={[40, 40]} cellSize={1} cellColor="#1a1a3a" sectionSize={5} sectionColor="#2a2a4a" fadeDistance={30} infiniteGrid={false} />
-        {scenePoints.length > 0 && <GaussianPointCloud points={scenePoints} geoRef={sceneGeoRef} />}
-        <LayerGizmos />
+        {scenePoints.length > 0 && showPointCloud && <GaussianPointCloud points={scenePoints} geoRef={sceneGeoRef} />}
+        {showGizmos && <LayerGizmos />}
         <ParticleSystem />
         <AnimationSystem scenePoints={scenePoints} onUpdateGeometry={handleUpdateGeometry} />
         <OrbitControls />

--- a/tools/apps/vfx-editor/src/viewport/Preview.tsx
+++ b/tools/apps/vfx-editor/src/viewport/Preview.tsx
@@ -249,7 +249,7 @@ export function Preview({ scenePoints }: { scenePoints: PlyPoint[] }) {
       <Canvas camera={{ position: [10, 10, 10], fov: 50 }} style={{ background: '#0f0f1e' }}>
         <ambientLight intensity={0.4} />
         <directionalLight position={[10, 20, 10]} intensity={0.6} />
-        <Grid args={[40, 40]} cellSize={1} cellColor="#1a1a3a" sectionSize={5} sectionColor="#2a2a4a" fadeDistance={30} infiniteGrid={false} />
+        <Grid args={[40, 40]} cellSize={1} cellColor="#2a2a4a" sectionSize={5} sectionColor="#3a3a5a" fadeDistance={30} infiniteGrid={false} />
         {scenePoints.length > 0 && showPointCloud && <GaussianPointCloud points={scenePoints} geoRef={sceneGeoRef} />}
         {showGizmos && <LayerGizmos />}
         <ParticleSystem />


### PR DESCRIPTION
## Summary
- **View menu**: Show Gizmos / Show Point Cloud checkmark toggles
- **Layer solo/mute** (DAW-style): S and M buttons on each layer in VfxTree
  - **Solo**: only solo'd layers play; others silenced
  - **Mute**: hide specific layers from preview
  - Muted layers shown at reduced opacity in tree
- Preview conditionally renders gizmos and point cloud
- ParticleSystem + AnimationSystem skip muted/non-solo layers

PR 5 of 7 in the Méliès UI improvement series.

## Test plan
- [x] TypeScript compiles
- [ ] View > Show Gizmos toggles gizmo visibility
- [ ] View > Show Point Cloud toggles PLY visibility
- [ ] Click M on a layer → layer stops rendering during playback
- [ ] Click S on a layer → only that layer renders (others silenced)
- [ ] Multiple solo'd layers all render

🤖 Generated with [Claude Code](https://claude.com/claude-code)