### PR TITLE
Add PLY scene management to Méliès project

### DIFF
--- a/tools/apps/vfx-editor/src/App.tsx
+++ b/tools/apps/vfx-editor/src/App.tsx
@@ -257,13 +257,13 @@ function VfxTree() {
               style={{ ...treeStyles.node, ...(activeSceneId === scene.id ? treeStyles.nodeActive : {}) }}
               onClick={async () => {
                 setActiveScene(scene.id);
-                // Load PLY if we have a project handle
+                // If not cached, try loading from project directory
                 const store = useVfxStore.getState();
-                if (store.projectHandle) {
+                if (store.scenePoints.length === 0 && store.projectHandle) {
                   const file = await loadPlyFromProject(store.projectHandle, scene.path);
                   if (file) {
                     const points = await loadPly(file);
-                    setScenePoints(points);
+                    store.setScenePoints(points);
                   }
                 }
               }}

--- a/tools/apps/vfx-editor/src/App.tsx
+++ b/tools/apps/vfx-editor/src/App.tsx
@@ -3,7 +3,7 @@ import { useVfxStore, playbackTimeRef } from './store/useVfxStore.js';
 import type { VfxPreset, VfxLayer, LayerType } from './store/types.js';
 import { serializeVfx } from './lib/vfxExport.js';
 import { parseVfx } from './lib/vfxImport.js';
-import { hasFileSystemAccess, openProjectDirectory, saveProject, loadProject, downloadProject, uploadProject } from './lib/projectIO.js';
+import { hasFileSystemAccess, openProjectDirectory, saveProject, loadProject, downloadProject, uploadProject, copyPlyToProject, loadPlyFromProject } from './lib/projectIO.js';
 import { loadPly, type PlyPoint } from './lib/plyLoader.js';
 import { Preview } from './viewport/Preview.js';
 import { LayerProperties } from './panels/LayerProperties.js';
@@ -188,6 +188,12 @@ function VfxTree() {
   const removeLayer = useVfxStore((s) => s.removeLayer);
   const selectedView = useVfxStore((s) => s.selectedView);
   const setSelectedView = useVfxStore((s) => s.setSelectedView);
+  const scenes = useVfxStore((s) => s.scenes);
+  const activeSceneId = useVfxStore((s) => s.activeSceneId);
+  const addScene = useVfxStore((s) => s.addScene);
+  const removeScene = useVfxStore((s) => s.removeScene);
+  const setActiveScene = useVfxStore((s) => s.setActiveScene);
+  const setScenePoints = useVfxStore((s) => s.setScenePoints);
   const [openPresets, setOpenPresets] = useState<Set<string>>(new Set());
 
   const toggleOpen = (id: string) => {
@@ -213,6 +219,63 @@ function VfxTree() {
 
       {/* Tree */}
       <div style={{ flex: 1, overflowY: 'auto', padding: '4px 0' }}>
+        {/* Scenes section */}
+        <div style={{ ...treeStyles.node, color: T.textDim }}>
+          <span style={treeStyles.icon}>&#9650;</span>
+          <span style={treeStyles.label}>Scenes</span>
+          <span style={treeStyles.count}>({scenes.length})</span>
+          <button style={treeStyles.addBtn} onClick={(e) => {
+            e.stopPropagation();
+            const input = document.createElement('input');
+            input.type = 'file';
+            input.accept = '.ply';
+            input.onchange = async () => {
+              const file = input.files?.[0];
+              if (!file) return;
+              try {
+                const points = await loadPly(file);
+                const id = `scene_${Date.now()}`;
+                const store = useVfxStore.getState();
+                // If project has a directory handle, copy PLY into scene/ folder
+                let path = file.name;
+                if (store.projectHandle) {
+                  path = await copyPlyToProject(store.projectHandle, file);
+                }
+                addScene({ id, name: file.name.replace(/\.ply$/i, ''), path });
+                setActiveScene(id);
+                setScenePoints(points);
+              } catch (err) {
+                console.error('Failed to load PLY:', err);
+              }
+            };
+            input.click();
+          }}>+</button>
+        </div>
+        <div style={treeStyles.indent}>
+          {scenes.map((scene) => (
+            <div key={scene.id}
+              style={{ ...treeStyles.node, ...(activeSceneId === scene.id ? treeStyles.nodeActive : {}) }}
+              onClick={async () => {
+                setActiveScene(scene.id);
+                // Load PLY if we have a project handle
+                const store = useVfxStore.getState();
+                if (store.projectHandle) {
+                  const file = await loadPlyFromProject(store.projectHandle, scene.path);
+                  if (file) {
+                    const points = await loadPly(file);
+                    setScenePoints(points);
+                  }
+                }
+              }}
+            >
+              <span style={treeStyles.icon}>&#9653;</span>
+              <span style={treeStyles.label}>{scene.name}</span>
+              <button style={treeStyles.removeBtn}
+                onClick={(e) => { e.stopPropagation(); removeScene(scene.id); }}>&times;</button>
+            </div>
+          ))}
+        </div>
+
         {/* VFX Presets section */}
         <div style={{ ...treeStyles.node, color: T.textDim }}
           onClick={() => {}}>
@@ -569,7 +632,8 @@ function RightPanel() {
 }
 
 export function App() {
-  const [scenePoints, setScenePoints] = useState<PlyPoint[]>([]);
+  const scenePoints = useVfxStore((s) => s.scenePoints);
+  const storeSetScenePoints = useVfxStore((s) => s.setScenePoints);
 
   const handleImportScene = useCallback(() => {
     const input = document.createElement('input');
@@ -580,14 +644,23 @@ export function App() {
       if (!file) return;
       try {
         const points = await loadPly(file);
-        setScenePoints(points);
+        const store = useVfxStore.getState();
+        // Add as scene reference + set active
+        const id = `scene_${Date.now()}`;
+        let path = file.name;
+        if (store.projectHandle) {
+          path = await copyPlyToProject(store.projectHandle, file);
+        }
+        store.addScene({ id, name: file.name.replace(/\.ply$/i, ''), path });
+        store.setActiveScene(id);
+        storeSetScenePoints(points);
         console.log(`Loaded ${points.length} points from ${file.name}`);
       } catch (e) {
         console.error('Failed to load PLY:', e);
       }
     };
     input.click();
-  }, []);
+  }, [storeSetScenePoints]);
 
   useEffect(() => {
     const handler = async (e: KeyboardEvent) => {

--- a/tools/apps/vfx-editor/src/lib/projectIO.ts
+++ b/tools/apps/vfx-editor/src/lib/projectIO.ts
@@ -53,8 +53,38 @@ export async function saveProject(handle: FileSystemDirectoryHandle): Promise<vo
     await w.close();
   }
 
-  // Create scene/ directory (for future PLY import)
+  // Create scene/ directory
   await handle.getDirectoryHandle('scene', { create: true });
+}
+
+/**
+ * Copy a PLY file into the project's scene/ directory and return the relative path.
+ */
+export async function copyPlyToProject(handle: FileSystemDirectoryHandle, file: File): Promise<string> {
+  const sceneDir = await handle.getDirectoryHandle('scene', { create: true });
+  const fh = await sceneDir.getFileHandle(file.name, { create: true });
+  const w = await fh.createWritable();
+  await w.write(file);
+  await w.close();
+  return `scene/${file.name}`;
+}
+
+/**
+ * Load a PLY file from the project's scene/ directory.
+ */
+export async function loadPlyFromProject(handle: FileSystemDirectoryHandle, relativePath: string): Promise<File | null> {
+  try {
+    // relativePath is like "scene/blub.ply"
+    const parts = relativePath.split('/');
+    let dir: FileSystemDirectoryHandle = handle;
+    for (let i = 0; i < parts.length - 1; i++) {
+      dir = await dir.getDirectoryHandle(parts[i]);
+    }
+    const fh = await dir.getFileHandle(parts[parts.length - 1]);
+    return await fh.getFile();
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/tools/apps/vfx-editor/src/store/types.ts
+++ b/tools/apps/vfx-editor/src/store/types.ts
@@ -19,7 +19,15 @@ export interface VfxPreset {
   layers: VfxLayer[];
 }
 
+export interface PlyReference {
+  id: string;
+  name: string;
+  path: string;  // relative path in project (e.g., "scene/blub.ply")
+}
+
 export interface VfxProject {
   version: 2;
   presets: VfxPreset[];
+  scenes?: PlyReference[];
+  activeSceneId?: string;
 }

--- a/tools/apps/vfx-editor/src/store/useVfxStore.ts
+++ b/tools/apps/vfx-editor/src/store/useVfxStore.ts
@@ -14,6 +14,9 @@ function genId(prefix: string): string {
  */
 export const playbackTimeRef = { current: 0 };
 
+/** In-memory cache of loaded PLY points per scene ID (not persisted). */
+export const scenePointsCache = new Map<string, PlyPoint[]>();
+
 export interface VfxStoreState {
   // Data
   presets: VfxPreset[];
@@ -170,13 +173,25 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
   setSelectedView: (view) => set({ selectedView: view }),
 
   addScene: (ref) => set((s) => ({ scenes: [...s.scenes, ref] })),
-  removeScene: (id) => set((s) => ({
-    scenes: s.scenes.filter((sc) => sc.id !== id),
-    activeSceneId: s.activeSceneId === id ? null : s.activeSceneId,
-    scenePoints: s.activeSceneId === id ? [] : s.scenePoints,
-  })),
-  setActiveScene: (id) => set({ activeSceneId: id }),
-  setScenePoints: (points) => set({ scenePoints: points }),
+  removeScene: (id) => {
+    scenePointsCache.delete(id);
+    set((s) => ({
+      scenes: s.scenes.filter((sc) => sc.id !== id),
+      activeSceneId: s.activeSceneId === id ? null : s.activeSceneId,
+      scenePoints: s.activeSceneId === id ? [] : s.scenePoints,
+    }));
+  },
+  setActiveScene: (id) => {
+    // Restore cached points if available
+    const cached = id ? scenePointsCache.get(id) : undefined;
+    set({ activeSceneId: id, scenePoints: cached ?? [] });
+  },
+  setScenePoints: (points) => {
+    // Cache points for the active scene
+    const id = get().activeSceneId;
+    if (id) scenePointsCache.set(id, points);
+    set({ scenePoints: points });
+  },
 
   play: () => set({ playing: true }),
   pause: () => set({ playing: false }),

--- a/tools/apps/vfx-editor/src/store/useVfxStore.ts
+++ b/tools/apps/vfx-editor/src/store/useVfxStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import type { VfxPreset, VfxLayer, VfxProject, LayerType } from './types.js';
+import type { VfxPreset, VfxLayer, VfxProject, LayerType, PlyReference } from './types.js';
+import type { PlyPoint } from '../lib/plyLoader.js';
 
 let idCounter = 0;
 function genId(prefix: string): string {
@@ -23,6 +24,11 @@ export interface VfxStoreState {
   projectHandle: FileSystemDirectoryHandle | null;
   projectName: string;
   isDirty: boolean;
+
+  // Scenes (PLY)
+  scenes: PlyReference[];
+  activeSceneId: string | null;
+  scenePoints: PlyPoint[];
 
   // UI
   selectedView: 'layer' | 'preset-settings';
@@ -50,6 +56,12 @@ export interface VfxStoreState {
   selectLayer: (id: string | null) => void;
   setSelectedView: (view: 'layer' | 'preset-settings') => void;
 
+  // Actions — scenes
+  addScene: (ref: PlyReference) => void;
+  removeScene: (id: string) => void;
+  setActiveScene: (id: string | null) => void;
+  setScenePoints: (points: PlyPoint[]) => void;
+
   // Actions — playback
   play: () => void;
   pause: () => void;
@@ -68,6 +80,9 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
   isDirty: false,
   selectedPresetId: null,
   selectedLayerId: null,
+  scenes: [] as PlyReference[],
+  activeSceneId: null,
+  scenePoints: [] as PlyPoint[],
   selectedView: 'layer' as const,
   playing: false,
   playbackTime: 0,
@@ -78,11 +93,15 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
   saveProjectData: () => ({
     version: 2 as const,
     presets: get().presets,
+    scenes: get().scenes.length > 0 ? get().scenes : undefined,
+    activeSceneId: get().activeSceneId ?? undefined,
   }),
 
   loadProjectData: (data) => {
     set({
       presets: data.presets ?? [],
+      scenes: data.scenes ?? [],
+      activeSceneId: data.activeSceneId ?? null,
       selectedPresetId: data.presets.length > 0 ? data.presets[0].id : null,
       selectedLayerId: null,
       isDirty: false,
@@ -149,6 +168,15 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
 
   selectLayer: (id) => set({ selectedLayerId: id, selectedView: 'layer' }),
   setSelectedView: (view) => set({ selectedView: view }),
+
+  addScene: (ref) => set((s) => ({ scenes: [...s.scenes, ref] })),
+  removeScene: (id) => set((s) => ({
+    scenes: s.scenes.filter((sc) => sc.id !== id),
+    activeSceneId: s.activeSceneId === id ? null : s.activeSceneId,
+    scenePoints: s.activeSceneId === id ? [] : s.scenePoints,
+  })),
+  setActiveScene: (id) => set({ activeSceneId: id }),
+  setScenePoints: (points) => set({ scenePoints: points }),
 
   play: () => set({ playing: true }),
   pause: () => set({ playing: false }),


### PR DESCRIPTION
## Summary
PLY files were loaded at runtime and lost between sessions. Now they're managed as part of the project.

- **Scenes section in VfxTree**: shows all PLY references, click to switch, + to import
- **Project persistence**: PLY files copied to `scene/` directory, references saved in `project.json`
- **scenePoints in Zustand**: moved from App local state to store for consistent access
- **File > Import Scene PLY**: also registers as a scene reference (not just ephemeral)
- **PlyReference type**: `{ id, name, path }` with `scenes[]` and `activeSceneId` in VfxProject

PR 4 of 7 in the Méliès UI improvement series.

## Test plan
- [x] TypeScript compiles
- [ ] Click + in Scenes section → file picker opens, PLY loads and appears in tree
- [ ] Click different scene → point cloud switches
- [ ] Save project → scene/ directory contains PLY file, project.json has scenes array
- [ ] Reopen project → active scene auto-loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)