### PR TITLE
Add VFX instance runtime to C++ engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ add_library(gseurat_core OBJECT
     src/engine/gs_chunk_streamer.cpp
     src/engine/gs_particle.cpp
     src/engine/gs_animator.cpp
+    src/engine/gs_vfx.cpp
 )
 
 if(NOT WIN32)

--- a/assets/vfx/vfx1.vfx.json
+++ b/assets/vfx/vfx1.vfx.json
@@ -37,16 +37,16 @@
           0.1
         ],
         "scale_min": [
-          1,
-          1,
-          1
+          0.1,
+          0.1,
+          0.1
         ],
         "scale_max": [
-          5,
-          5,
-          5
+          0.5,
+          0.5,
+          0.5
         ],
-        "scale_end_factor": 1,
+        "scale_end_factor": 0.1,
         "opacity_start": 0.9,
         "opacity_end": 0.2,
         "emission": 0.4,

--- a/include/gseurat/engine/gs_vfx.hpp
+++ b/include/gseurat/engine/gs_vfx.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <glm/vec3.hpp>
+#include <gseurat/engine/gs_particle.hpp>
+#include <gseurat/engine/gs_animator.hpp>
+#include <gseurat/engine/scene_loader.hpp>
+
+namespace gseurat {
+
+// ── VFX layer data (parsed from .vfx.json) ──
+
+struct VfxLayerData {
+    std::string name;
+    std::string type;  // "emitter" | "animation" | "light"
+    float start = 0.0f;
+    float duration = 1.0f;
+    GsEmitterConfig emitter_config;      // populated if type=="emitter"
+    std::string emitter_preset;          // optional preset name
+    GsAnimationData animation_config;    // populated if type=="animation"
+};
+
+struct VfxPreset {
+    std::string name;
+    float duration = 3.0f;
+    std::vector<VfxLayerData> layers;
+};
+
+// ── VFX instance data (from scene.json vfx_instances) ──
+
+struct VfxInstanceData {
+    std::string vfx_file;
+    glm::vec3 position{0.0f};
+    float radius = 5.0f;
+    std::string trigger = "auto";
+    bool loop = true;
+};
+
+// ── Load a .vfx.json file ──
+
+VfxPreset load_vfx_preset(const std::string& path);
+VfxPreset parse_vfx_preset(const nlohmann::json& j);
+
+// ── Runtime VFX instance ──
+
+class VfxInstance {
+public:
+    void init(const VfxPreset& preset, const glm::vec3& position, bool loop);
+
+    /// Update timeline, activate/deactivate emitter layers.
+    /// Appends active particles to out_buffer.
+    void update(float dt, std::vector<Gaussian>& out_buffer);
+
+    bool is_finished() const { return finished_; }
+
+private:
+    VfxPreset preset_;
+    glm::vec3 position_{0.0f};
+    bool loop_ = true;
+    float elapsed_ = 0.0f;
+    bool finished_ = false;
+
+    struct EmitterState {
+        GaussianParticleEmitter emitter;
+        size_t layer_index;
+        bool activated = false;
+    };
+    std::vector<EmitterState> emitter_states_;
+};
+
+}  // namespace gseurat

--- a/include/gseurat/engine/gs_vfx.hpp
+++ b/include/gseurat/engine/gs_vfx.hpp
@@ -53,6 +53,8 @@ public:
     void update(float dt, std::vector<Gaussian>& out_buffer);
 
     bool is_finished() const { return finished_; }
+    const glm::vec3& position() const { return position_; }
+    const VfxPreset& preset() const { return preset_; }
 
 private:
     VfxPreset preset_;

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -113,6 +113,7 @@ public:
     // VFX instances (Méliès presets placed on map)
     void add_vfx_instance(VfxInstance&& inst);
     void clear_vfx_instances();
+    const std::vector<VfxInstance>& vfx_instances() const { return vfx_instances_; }
 
     void request_screenshot(const std::string& path) { screenshot_.request(path); }
     bool screenshot_write_ok() const { return screenshot_.write_ok(); }

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -6,6 +6,7 @@
 #include "gseurat/engine/gs_chunk_grid.hpp"
 #include "gseurat/engine/gs_animator.hpp"
 #include "gseurat/engine/gs_particle.hpp"
+#include "gseurat/engine/gs_vfx.hpp"
 #include "gseurat/engine/gs_renderer.hpp"
 #include "gseurat/engine/command_pool.hpp"
 #include "gseurat/engine/descriptor.hpp"
@@ -109,6 +110,10 @@ public:
     void clear_gs_animations();
     const std::vector<SceneAnimation>& gs_scene_animations() const { return gs_scene_animations_; }
 
+    // VFX instances (Méliès presets placed on map)
+    void add_vfx_instance(VfxInstance&& inst);
+    void clear_vfx_instances();
+
     void request_screenshot(const std::string& path) { screenshot_.request(path); }
     bool screenshot_write_ok() const { return screenshot_.write_ok(); }
     uint32_t screenshot_width() const { return screenshot_.width(); }
@@ -204,6 +209,7 @@ private:
     std::vector<GaussianParticleEmitter> gs_particle_emitters_;
     GaussianAnimator gs_animator_;
     std::vector<SceneAnimation> gs_scene_animations_;
+    std::vector<VfxInstance> vfx_instances_;
     std::vector<uint32_t> gs_prev_visible_;
     bool gs_skip_chunk_cull_ = false;
     uint32_t gs_gaussian_budget_ = 0;  // 0 = unlimited (no LOD decimation)

--- a/include/gseurat/engine/scene_loader.hpp
+++ b/include/gseurat/engine/scene_loader.hpp
@@ -152,6 +152,16 @@ struct SceneData {
     // Gaussian animations (effects applied to existing scene Gaussians within a region)
     std::vector<GsAnimationData> gs_animations;
 
+    // VFX instances (Méliès presets placed at map positions)
+    struct VfxInstanceRef {
+        std::string vfx_file;
+        glm::vec3 position{0.0f};
+        float radius = 5.0f;
+        std::string trigger = "auto";
+        bool loop = true;
+    };
+    std::vector<VfxInstanceRef> vfx_instances;
+
     // Minimap
     std::optional<Minimap::Config> minimap_config;
 
@@ -175,8 +185,11 @@ public:
     static SceneData from_json(const nlohmann::json& j);
     static nlohmann::json to_json(const SceneData& data);
 
-    // Public parse helpers (used by control server commands)
+    // Public parse helpers (used by control server, VFX loader)
     static EmitterConfig parse_emitter(const nlohmann::json& j);
+    static GsEmitterConfig parse_gs_emitter_config(const nlohmann::json& j);
+    static GsAnimationData parse_gs_animation(const nlohmann::json& j);
+    static GsAnimParams parse_gs_anim_params(const nlohmann::json& j);
 
 private:
     static Direction parse_direction(const std::string& s);
@@ -191,9 +204,7 @@ private:
     static nlohmann::json vec3_json(const glm::vec3& v);
     static nlohmann::json vec4_json(const glm::vec4& v);
     static nlohmann::json emitter_json(const EmitterConfig& cfg);
-    static GsEmitterConfig parse_gs_emitter_config(const nlohmann::json& j);
     static nlohmann::json gs_emitter_config_json(const GsEmitterData& em);
-    static GsAnimationData parse_gs_animation(const nlohmann::json& j);
     static nlohmann::json gs_animation_json(const GsAnimationData& anim);
 };
 

--- a/src/demo/demo_app.cpp
+++ b/src/demo/demo_app.cpp
@@ -3,6 +3,7 @@
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/gs_parallax_camera.hpp"
 #include "gseurat/engine/scene_loader.hpp"
+#include "gseurat/engine/gs_vfx.hpp"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
@@ -65,6 +66,7 @@ void DemoApp::init_scene(const std::string& scene_path) {
     // Clear previous scene state
     renderer_.clear_gs_particle_emitters();
     renderer_.clear_gs_animations();
+    renderer_.clear_vfx_instances();
 
     // Populate scene lights for the glow overlay
     scene_.clear_lights();
@@ -223,6 +225,22 @@ void DemoApp::init_scene(const std::string& scene_path) {
                     reform = Renderer::ReformConfig{anim.reform->lifetime};
                 }
                 renderer_.add_gs_animation(anim.effect, region, anim.lifetime, anim.loop, anim.params, reform);
+            }
+
+            // Instantiate VFX instances from scene
+            renderer_.clear_vfx_instances();
+            for (const auto& vi : scene_data.vfx_instances) {
+                if (vi.trigger != "auto") continue;
+                auto preset = load_vfx_preset(vi.vfx_file);
+                if (preset.layers.empty()) continue;
+                VfxInstance inst;
+                auto pos = vi.position;
+                pos.x += aabb.min.x;
+                pos.y += aabb.min.y;
+                inst.init(preset, pos, vi.loop);
+                std::fprintf(stderr, "VFX: Loaded '%s' at (%.1f, %.1f, %.1f) with %zu layers\n",
+                    preset.name.c_str(), pos.x, pos.y, pos.z, preset.layers.size());
+                renderer_.add_vfx_instance(std::move(inst));
             }
         }
 

--- a/src/demo/gs_demo_state.cpp
+++ b/src/demo/gs_demo_state.cpp
@@ -621,10 +621,11 @@ void GsDemoState::build_draw_lists(AppBase& app) {
         y -= 16.0f;
 
         // Show marker info
-        std::snprintf(buf, sizeof(buf), "Markers: %zu  Path: %zu  Emitters: %zu  Anims: %zu",
+        std::snprintf(buf, sizeof(buf), "Markers: %zu  Path: %zu  Emitters: %zu  Anims: %zu  VFX: %zu",
                       demo_markers_.size(), demo_path_.size(),
                       app.renderer().gs_particle_emitters().size(),
-                      app.renderer().gs_scene_animations().size());
+                      app.renderer().gs_scene_animations().size(),
+                      app.renderer().vfx_instances().size());
         ui.label(buf, lx, y, scale, layer_color);
 
         // Render markers and path as projected UI panels
@@ -740,6 +741,24 @@ void GsDemoState::build_draw_lists(AppBase& app) {
                     std::snprintf(alabel, sizeof(alabel), "A%zu", i);
                     ui.label(alabel, sx - 4.0f, sy + 10.0f, 0.3f,
                              {0.0f, 0.9f, 1.0f, 1.0f});
+                }
+            }
+
+            // Draw VFX instance markers (V0, V1, ...) — amber/orange star
+            auto& vfx_insts = app.renderer().vfx_instances();
+            for (size_t i = 0; i < vfx_insts.size(); ++i) {
+                auto [sx, sy] = project(vfx_insts[i].position());
+                if (sx > 0 && sx < screen_w && sy > 0 && sy < screen_h) {
+                    // Outer glow
+                    ui.panel(sx, sy, 18.0f, 18.0f, {1.0f, 0.6f, 0.0f, 0.2f});
+                    // Diamond shape (using panels)
+                    ui.panel(sx, sy, 10.0f, 10.0f, {1.0f, 0.6f, 0.0f, 0.8f});
+                    // Center dot
+                    ui.panel(sx, sy, 3.0f, 3.0f, {1.0f, 1.0f, 1.0f, 1.0f});
+                    char vlabel[16];
+                    std::snprintf(vlabel, sizeof(vlabel), "V%zu", i);
+                    ui.label(vlabel, sx - 4.0f, sy + 12.0f, 0.3f,
+                             {1.0f, 0.7f, 0.1f, 1.0f});
                 }
             }
         }

--- a/src/engine/gs_vfx.cpp
+++ b/src/engine/gs_vfx.cpp
@@ -1,0 +1,121 @@
+#include <gseurat/engine/gs_vfx.hpp>
+#include <nlohmann/json.hpp>
+#include <fstream>
+#include <iostream>
+
+namespace gseurat {
+
+// ── Parse .vfx.json ──
+
+VfxPreset parse_vfx_preset(const nlohmann::json& j) {
+    VfxPreset preset;
+    preset.name = j.value("name", "Unnamed VFX");
+    preset.duration = j.value("duration", 3.0f);
+
+    if (j.contains("layers")) {
+        for (const auto& lj : j["layers"]) {
+            VfxLayerData layer;
+            layer.name = lj.value("name", "Unnamed");
+            layer.type = lj.value("type", "emitter");
+            layer.start = lj.value("start", 0.0f);
+            layer.duration = lj.value("duration", 1.0f);
+
+            if (layer.type == "emitter" && lj.contains("emitter")) {
+                layer.emitter_config = SceneLoader::parse_gs_emitter_config(lj["emitter"]);
+                if (lj["emitter"].contains("preset")) {
+                    layer.emitter_preset = lj["emitter"]["preset"].get<std::string>();
+                }
+            } else if (layer.type == "animation" && lj.contains("animation")) {
+                // Parse animation config — the .vfx.json animation format is
+                // { "effect": "pulse", "params": { ... } } without a region
+                // (region is determined by the instance radius at placement).
+                auto& anim = layer.animation_config;
+                const auto& aj = lj["animation"];
+                anim.effect = aj.value("effect", "detach");
+                anim.lifetime = layer.duration;  // layer duration = animation lifetime
+                if (aj.contains("params")) {
+                    anim.params = SceneLoader::parse_gs_anim_params(aj["params"]);
+                }
+            }
+
+            preset.layers.push_back(std::move(layer));
+        }
+    }
+
+    return preset;
+}
+
+VfxPreset load_vfx_preset(const std::string& path) {
+    std::ifstream ifs(path);
+    if (!ifs.is_open()) {
+        std::cerr << "[VFX] Failed to open: " << path << "\n";
+        return {};
+    }
+    auto j = nlohmann::json::parse(ifs);
+    return parse_vfx_preset(j);
+}
+
+// ── VfxInstance ──
+
+void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool loop) {
+    preset_ = preset;
+    position_ = position;
+    loop_ = loop;
+    elapsed_ = 0.0f;
+    finished_ = false;
+
+    // Pre-create emitter states for all emitter layers
+    emitter_states_.clear();
+    for (size_t i = 0; i < preset_.layers.size(); ++i) {
+        if (preset_.layers[i].type != "emitter") continue;
+        EmitterState es;
+        es.layer_index = i;
+        es.activated = false;
+        // Configure emitter from layer config
+        es.emitter.configure(preset_.layers[i].emitter_config);
+        es.emitter.set_position(position_);
+        emitter_states_.push_back(std::move(es));
+    }
+}
+
+void VfxInstance::update(float dt, std::vector<Gaussian>& out_buffer) {
+    if (finished_) return;
+
+    elapsed_ += dt;
+
+    // Check for loop/finish
+    if (elapsed_ > preset_.duration) {
+        if (loop_) {
+            elapsed_ = std::fmod(elapsed_, preset_.duration);
+            // Restart all emitters
+            for (auto& es : emitter_states_) {
+                es.activated = false;
+                es.emitter.clear();
+            }
+        } else {
+            finished_ = true;
+            return;
+        }
+    }
+
+    // Update each emitter layer based on timeline
+    for (auto& es : emitter_states_) {
+        const auto& layer = preset_.layers[es.layer_index];
+        bool in_window = elapsed_ >= layer.start && elapsed_ < layer.start + layer.duration;
+
+        if (in_window && !es.activated) {
+            es.emitter.set_active(true);
+            es.activated = true;
+        } else if (!in_window && es.activated) {
+            es.emitter.set_active(false);
+            es.activated = false;
+        }
+
+        if (es.activated) {
+            es.emitter.update(dt);
+            es.emitter.gather(out_buffer);
+        }
+    }
+}
+
+}  // namespace gseurat

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -789,7 +789,8 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             // Update particles/animations separately (no re-sort of scene)
             bool has_particles = !gs_particle_emitters_.empty()
                 || gs_animator_.has_active_groups()
-                || !gs_scene_animations_.empty();
+                || !gs_scene_animations_.empty()
+                || !vfx_instances_.empty();
             if (has_particles) {
                 // Phase-based state machine for scene animations
                 // Run BEFORE buffer reset so we can detect transitions to Reforming
@@ -857,6 +858,13 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                     std::remove_if(gs_particle_emitters_.begin(), gs_particle_emitters_.end(),
                         [](const GaussianParticleEmitter& e) { return !e.active() && e.alive_count() == 0; }),
                     gs_particle_emitters_.end());
+
+                // Update VFX instances (timeline + emitters)
+                for (auto& inst : vfx_instances_) {
+                    inst.update(dt, gs_active_buffer_);
+                }
+                std::erase_if(vfx_instances_,
+                    [](const VfxInstance& i) { return i.is_finished(); });
 
                 // Clamp to allocated SSBO capacity
                 if (gs_active_buffer_.size() > gs_renderer_.max_gaussian_count()) {
@@ -1012,6 +1020,14 @@ void Renderer::add_gs_animation(const std::string& effect, const GsAnimRegion& r
 
 void Renderer::clear_gs_animations() {
     gs_scene_animations_.clear();
+}
+
+void Renderer::add_vfx_instance(VfxInstance&& inst) {
+    vfx_instances_.push_back(std::move(inst));
+}
+
+void Renderer::clear_vfx_instances() {
+    vfx_instances_.clear();
 }
 
 }  // namespace gseurat

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -374,6 +374,19 @@ SceneData SceneLoader::from_json(const nlohmann::json& j) {
         }
     }
 
+    // VFX instances (Méliès presets placed on map)
+    if (j.contains("vfx_instances")) {
+        for (const auto& vi : j["vfx_instances"]) {
+            SceneData::VfxInstanceRef inst;
+            inst.vfx_file = vi.value("vfx_file", "");
+            if (vi.contains("position")) inst.position = parse_vec3(vi["position"]);
+            inst.radius = vi.value("radius", 5.0f);
+            inst.trigger = vi.value("trigger", "auto");
+            inst.loop = vi.value("loop", true);
+            data.vfx_instances.push_back(std::move(inst));
+        }
+    }
+
     // Weather
     if (j.contains("weather")) {
         const auto& w = j["weather"];
@@ -529,7 +542,23 @@ GsAnimationData SceneLoader::parse_gs_animation(const nlohmann::json& j) {
         if (r.contains("half_extents")) anim.region.half_extents = parse_vec3(r["half_extents"]);
     }
 
-    // Animation parameters — lifetime-centric with per-parameter easing
+    if (j.contains("params")) {
+        anim.params = parse_gs_anim_params(j["params"]);
+    }
+
+    // Optional reform config
+    if (j.contains("reform")) {
+        GsAnimReformConfig reform;
+        const auto& r = j["reform"];
+        reform.lifetime = r.value("lifetime", 2.0f);
+        anim.reform = reform;
+    }
+
+    return anim;
+}
+
+GsAnimParams SceneLoader::parse_gs_anim_params(const nlohmann::json& p) {
+    GsAnimParams params;
     auto parse_easing = [](const std::string& s) -> GsEasing {
         if (s == "in_quad"      || s == "ease_in")     return GsEasing::InQuad;
         if (s == "out_quad"     || s == "ease_out")    return GsEasing::OutQuad;
@@ -563,34 +592,22 @@ GsAnimationData SceneLoader::parse_gs_animation(const nlohmann::json& j) {
         if (s == "in_out_bounce")   return GsEasing::InOutBounce;
         return GsEasing::Linear;
     };
-    if (j.contains("params")) {
-        const auto& p = j["params"];
-        anim.params.rotations = p.value("rotations", anim.params.rotations);
-        if (p.contains("rotations_easing")) anim.params.rotations_easing = parse_easing(p["rotations_easing"]);
-        anim.params.expansion = p.value("expansion", anim.params.expansion);
-        if (p.contains("expansion_easing")) anim.params.expansion_easing = parse_easing(p["expansion_easing"]);
-        anim.params.height_rise = p.value("height_rise", anim.params.height_rise);
-        if (p.contains("height_easing")) anim.params.height_easing = parse_easing(p["height_easing"]);
-        anim.params.opacity_end = p.value("opacity_end", anim.params.opacity_end);
-        if (p.contains("opacity_easing")) anim.params.opacity_easing = parse_easing(p["opacity_easing"]);
-        anim.params.scale_end = p.value("scale_end", anim.params.scale_end);
-        if (p.contains("scale_easing")) anim.params.scale_easing = parse_easing(p["scale_easing"]);
-        anim.params.velocity = p.value("velocity", anim.params.velocity);
-        if (p.contains("gravity")) anim.params.gravity = parse_vec3(p["gravity"]);
-        anim.params.noise = p.value("noise", anim.params.noise);
-        anim.params.wave_speed = p.value("wave_speed", anim.params.wave_speed);
-        anim.params.pulse_frequency = p.value("pulse_frequency", anim.params.pulse_frequency);
-    }
-
-    // Optional reform config
-    if (j.contains("reform")) {
-        GsAnimReformConfig reform;
-        const auto& r = j["reform"];
-        reform.lifetime = r.value("lifetime", 2.0f);
-        anim.reform = reform;
-    }
-
-    return anim;
+    params.rotations = p.value("rotations", params.rotations);
+    if (p.contains("rotations_easing")) params.rotations_easing = parse_easing(p["rotations_easing"]);
+    params.expansion = p.value("expansion", params.expansion);
+    if (p.contains("expansion_easing")) params.expansion_easing = parse_easing(p["expansion_easing"]);
+    params.height_rise = p.value("height_rise", params.height_rise);
+    if (p.contains("height_easing")) params.height_easing = parse_easing(p["height_easing"]);
+    params.opacity_end = p.value("opacity_end", params.opacity_end);
+    if (p.contains("opacity_easing")) params.opacity_easing = parse_easing(p["opacity_easing"]);
+    params.scale_end = p.value("scale_end", params.scale_end);
+    if (p.contains("scale_easing")) params.scale_easing = parse_easing(p["scale_easing"]);
+    params.velocity = p.value("velocity", params.velocity);
+    if (p.contains("gravity")) params.gravity = parse_vec3(p["gravity"]);
+    params.noise = p.value("noise", params.noise);
+    params.wave_speed = p.value("wave_speed", params.wave_speed);
+    params.pulse_frequency = p.value("pulse_frequency", params.pulse_frequency);
+    return params;
 }
 
 nlohmann::json SceneLoader::gs_animation_json(const GsAnimationData& anim) {


### PR DESCRIPTION
## Summary
The engine can now parse `vfx_instances` from scene.json, load `.vfx.json` presets, and render their emitter layers as particles at map positions.

### Architecture
- **VfxPreset**: parsed from `.vfx.json` — layers with type/start/duration/config
- **VfxInstance**: runtime class managing timeline, activating emitter layers when their time window is active
- **Renderer integration**: VFX instances update alongside existing emitters/animations in the render prepass
- **Reuse**: `parse_gs_emitter_config()` and `parse_gs_anim_params()` exposed as public SceneLoader methods

### Flow
1. Scene loader parses `vfx_instances` array from scene.json
2. DemoApp loads each `.vfx.json` file via `load_vfx_preset()`
3. VfxInstance initialized with preset data + map position
4. Each frame: VfxInstance advances timeline, activates/deactivates emitter layers
5. Active emitters gather particles into `gs_active_buffer_` for GPU rendering

## Test plan
- [x] All 13 C++ tests pass
- [x] Builds on macOS debug
- [ ] CI: builds on all platforms (Linux, macOS, Windows)
- [ ] Run engine with test_bricklayer scene → VFX particles render at instance position

🤖 Generated with [Claude Code](https://claude.com/claude-code)