### PR TITLE
VFX prefab Phase 2: Bricklayer + Engine element format

### DIFF
--- a/include/gseurat/engine/gs_vfx.hpp
+++ b/include/gseurat/engine/gs_vfx.hpp
@@ -9,22 +9,31 @@
 
 namespace gseurat {
 
-// ── VFX layer data (parsed from .vfx.json) ──
+// ── VFX element data (parsed from .vfx.json) ──
 
-struct VfxLayerData {
+struct VfxElementData {
     std::string name;
-    std::string type;  // "emitter" | "animation" | "light"
+    std::string type;  // "object" | "emitter" | "animation" | "light"
+    glm::vec3 position{0.0f};            // relative to prefab origin
     float start = 0.0f;
-    float duration = 1.0f;
-    GsEmitterConfig emitter_config;      // populated if type=="emitter"
-    std::string emitter_preset;          // optional preset name
-    GsAnimationData animation_config;    // populated if type=="animation"
+    float duration = 0.0f;              // 0 = no duration (derived or infinite)
+    bool loop = false;
+    // type=object
+    std::string ply_file;
+    float scale = 1.0f;
+    // type=emitter
+    GsEmitterConfig emitter_config;
+    std::string emitter_preset;
+    // type=animation
+    GsAnimationData animation_config;
+    GsAnimRegion region;                 // animation area-of-effect
 };
 
 struct VfxPreset {
     std::string name;
-    float duration = 3.0f;
-    std::vector<VfxLayerData> layers;
+    float duration = 0.0f;              // 0 = derived from elements
+    std::string category;
+    std::vector<VfxElementData> elements;
 };
 
 // ── VFX instance data (from scene.json vfx_instances) ──
@@ -65,7 +74,7 @@ private:
 
     struct EmitterState {
         GaussianParticleEmitter emitter;
-        size_t layer_index;
+        size_t element_index;
         bool activated = false;
     };
     std::vector<EmitterState> emitter_states_;

--- a/src/demo/demo_app.cpp
+++ b/src/demo/demo_app.cpp
@@ -232,14 +232,14 @@ void DemoApp::init_scene(const std::string& scene_path) {
             for (const auto& vi : scene_data.vfx_instances) {
                 if (vi.trigger != "auto") continue;
                 auto preset = load_vfx_preset(vi.vfx_file);
-                if (preset.layers.empty()) continue;
+                if (preset.elements.empty()) continue;
                 VfxInstance inst;
                 auto pos = vi.position;
                 pos.x += aabb.min.x;
                 pos.y += aabb.min.y;
                 inst.init(preset, pos, vi.loop);
-                std::fprintf(stderr, "VFX: Loaded '%s' at (%.1f, %.1f, %.1f) with %zu layers\n",
-                    preset.name.c_str(), pos.x, pos.y, pos.z, preset.layers.size());
+                std::fprintf(stderr, "VFX: Loaded '%s' at (%.1f, %.1f, %.1f) with %zu elements\n",
+                    preset.name.c_str(), pos.x, pos.y, pos.z, preset.elements.size());
                 renderer_.add_vfx_instance(std::move(inst));
             }
         }

--- a/src/engine/gs_vfx.cpp
+++ b/src/engine/gs_vfx.cpp
@@ -2,6 +2,7 @@
 #include <nlohmann/json.hpp>
 #include <fstream>
 #include <iostream>
+#include <algorithm>
 
 namespace gseurat {
 
@@ -10,36 +11,67 @@ namespace gseurat {
 VfxPreset parse_vfx_preset(const nlohmann::json& j) {
     VfxPreset preset;
     preset.name = j.value("name", "Unnamed VFX");
-    preset.duration = j.value("duration", 3.0f);
+    preset.duration = j.value("duration", 0.0f);
+    preset.category = j.value("category", "");
 
-    if (j.contains("layers")) {
-        for (const auto& lj : j["layers"]) {
-            VfxLayerData layer;
-            layer.name = lj.value("name", "Unnamed");
-            layer.type = lj.value("type", "emitter");
-            layer.start = lj.value("start", 0.0f);
-            layer.duration = lj.value("duration", 1.0f);
+    // v2 uses "elements", v1 used "layers" — accept both
+    const auto& raw = j.contains("elements") ? j["elements"] : j.value("layers", nlohmann::json::array());
 
-            if (layer.type == "emitter" && lj.contains("emitter")) {
-                layer.emitter_config = SceneLoader::parse_gs_emitter_config(lj["emitter"]);
-                if (lj["emitter"].contains("preset")) {
-                    layer.emitter_preset = lj["emitter"]["preset"].get<std::string>();
-                }
-            } else if (layer.type == "animation" && lj.contains("animation")) {
-                // Parse animation config — the .vfx.json animation format is
-                // { "effect": "pulse", "params": { ... } } without a region
-                // (region is determined by the instance radius at placement).
-                auto& anim = layer.animation_config;
-                const auto& aj = lj["animation"];
-                anim.effect = aj.value("effect", "detach");
-                anim.lifetime = layer.duration;  // layer duration = animation lifetime
-                if (aj.contains("params")) {
-                    anim.params = SceneLoader::parse_gs_anim_params(aj["params"]);
+    for (const auto& ej : raw) {
+        VfxElementData el;
+        el.name = ej.value("name", "Unnamed");
+        el.type = ej.value("type", "emitter");
+        if (ej.contains("position")) {
+            el.position = {ej["position"][0].get<float>(),
+                           ej["position"][1].get<float>(),
+                           ej["position"][2].get<float>()};
+        }
+        el.start = ej.value("start", 0.0f);
+        el.duration = ej.value("duration", 0.0f);
+        el.loop = ej.value("loop", false);
+
+        if (el.type == "object") {
+            el.ply_file = ej.value("ply_file", "");
+            el.scale = ej.value("scale", 1.0f);
+        } else if (el.type == "emitter" && ej.contains("emitter")) {
+            el.emitter_config = SceneLoader::parse_gs_emitter_config(ej["emitter"]);
+            if (ej["emitter"].contains("preset")) {
+                el.emitter_preset = ej["emitter"]["preset"].get<std::string>();
+            }
+        } else if (el.type == "animation" && ej.contains("animation")) {
+            auto& anim = el.animation_config;
+            const auto& aj = ej["animation"];
+            anim.effect = aj.value("effect", "detach");
+            anim.lifetime = el.duration > 0.0f ? el.duration : 9999.0f;
+            anim.loop = el.loop;
+            if (aj.contains("params")) {
+                anim.params = SceneLoader::parse_gs_anim_params(aj["params"]);
+            }
+            // Parse region if present on element
+            if (ej.contains("region")) {
+                const auto& rj = ej["region"];
+                std::string shape = rj.value("shape", "sphere");
+                el.region.shape = (shape == "box")
+                    ? GsAnimRegion::Shape::Box : GsAnimRegion::Shape::Sphere;
+                el.region.radius = rj.value("radius", 5.0f);
+                if (rj.contains("half_extents")) {
+                    el.region.half_extents = {rj["half_extents"][0].get<float>(),
+                                              rj["half_extents"][1].get<float>(),
+                                              rj["half_extents"][2].get<float>()};
                 }
             }
-
-            preset.layers.push_back(std::move(layer));
         }
+
+        preset.elements.push_back(std::move(el));
+    }
+
+    // Derive duration if not explicitly set
+    if (preset.duration <= 0.0f) {
+        for (const auto& el : preset.elements) {
+            float end = el.start + el.duration;
+            if (end > preset.duration) preset.duration = end;
+        }
+        if (preset.duration <= 0.0f) preset.duration = 3.0f;  // fallback
     }
 
     return preset;
@@ -64,16 +96,17 @@ void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool 
     elapsed_ = 0.0f;
     finished_ = false;
 
-    // Pre-create emitter states for all emitter layers
+    // Pre-create emitter states for all emitter elements
     emitter_states_.clear();
-    for (size_t i = 0; i < preset_.layers.size(); ++i) {
-        if (preset_.layers[i].type != "emitter") continue;
+    for (size_t i = 0; i < preset_.elements.size(); ++i) {
+        const auto& el = preset_.elements[i];
+        if (el.type != "emitter") continue;
         EmitterState es;
-        es.layer_index = i;
+        es.element_index = i;
         es.activated = false;
-        // Configure emitter from layer config
-        es.emitter.configure(preset_.layers[i].emitter_config);
-        es.emitter.set_position(position_);
+        es.emitter.configure(el.emitter_config);
+        // Position: instance position + element relative position
+        es.emitter.set_position(position_ + el.position);
         emitter_states_.push_back(std::move(es));
     }
 }
@@ -84,10 +117,9 @@ void VfxInstance::update(float dt, std::vector<Gaussian>& out_buffer) {
     elapsed_ += dt;
 
     // Check for loop/finish
-    if (elapsed_ > preset_.duration) {
+    if (preset_.duration > 0.0f && elapsed_ > preset_.duration) {
         if (loop_) {
             elapsed_ = std::fmod(elapsed_, preset_.duration);
-            // Restart all emitters
             for (auto& es : emitter_states_) {
                 es.activated = false;
                 es.emitter.clear();
@@ -98,10 +130,20 @@ void VfxInstance::update(float dt, std::vector<Gaussian>& out_buffer) {
         }
     }
 
-    // Update each emitter layer based on timeline
+    // Update each emitter element based on timeline
     for (auto& es : emitter_states_) {
-        const auto& layer = preset_.layers[es.layer_index];
-        bool in_window = elapsed_ >= layer.start && elapsed_ < layer.start + layer.duration;
+        const auto& el = preset_.elements[es.element_index];
+        float el_start = el.start;
+        float el_end = el.duration > 0.0f ? el.start + el.duration : preset_.duration;
+
+        // Looping elements: check within their cycle
+        bool in_window;
+        if (el.loop && el.duration > 0.0f) {
+            float cycle_elapsed = std::fmod(elapsed_ - el_start, el.duration);
+            in_window = elapsed_ >= el_start && cycle_elapsed >= 0.0f;
+        } else {
+            in_window = elapsed_ >= el_start && elapsed_ < el_end;
+        }
 
         if (in_window && !es.activated) {
             es.emitter.set_active(true);

--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -84,11 +84,13 @@ export async function saveProject(handle: FileSystemDirectoryHandle): Promise<vo
       const fileName = `${inst.name.replace(/\s+/g, '_').toLowerCase()}.vfx.json`;
       const newPath = `assets/vfx/${fileName}`;
       // Re-serialize the preset data (applies any name edits)
-      const vfxJson = JSON.stringify({
+      const out: Record<string, unknown> = {
         name: inst.name,
-        duration: inst.vfx_preset.duration,
-        layers: inst.vfx_preset.layers,
-      }, null, 2);
+        elements: inst.vfx_preset.elements,
+      };
+      if (inst.vfx_preset.duration !== undefined) out.duration = inst.vfx_preset.duration;
+      if (inst.vfx_preset.category) out.category = inst.vfx_preset.category;
+      const vfxJson = JSON.stringify(out, null, 2);
       const fh = await vfxDir.getFileHandle(fileName, { create: true });
       const w = await fh.createWritable();
       await w.write(vfxJson);

--- a/tools/apps/bricklayer/src/panels/ProjectTree.tsx
+++ b/tools/apps/bricklayer/src/panels/ProjectTree.tsx
@@ -421,17 +421,25 @@ export function ProjectTree() {
                   try {
                     const text = reader.result as string;
                     const data = JSON.parse(text);
+                    // Parse v2 elements or v1 layers
+                    const rawElements = data.elements ?? data.layers ?? [];
                     const preset = {
                       name: data.name ?? 'Unnamed VFX',
-                      duration: data.duration ?? 3.0,
-                      layers: (data.layers ?? []).map((l: Record<string, unknown>) => ({
-                        name: (l.name as string) ?? 'Unnamed',
-                        type: (l.type as string) ?? 'emitter',
-                        start: (l.start as number) ?? 0,
-                        duration: (l.duration as number) ?? 1,
-                        emitter: l.emitter,
-                        animation: l.animation,
-                        light: l.light,
+                      duration: data.duration as number | undefined,
+                      category: data.category as string | undefined,
+                      elements: rawElements.map((el: Record<string, unknown>) => ({
+                        name: (el.name as string) ?? 'Unnamed',
+                        type: (el.type as string) ?? 'emitter',
+                        position: el.position as [number, number, number] | undefined,
+                        start: el.start as number | undefined,
+                        duration: el.duration as number | undefined,
+                        loop: el.loop as boolean | undefined,
+                        ply_file: el.ply_file as string | undefined,
+                        scale: el.scale as number | undefined,
+                        emitter: el.emitter,
+                        animation: el.animation,
+                        region: el.region,
+                        light: el.light,
                       })),
                     };
                     // vfx_file is derived from name on save — no original path needed

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -1072,7 +1072,7 @@ function VfxInstanceProperties({ vfx }: { vfx: VfxInstanceData }) {
       <div style={styles.section}>
         <span style={styles.label}>Preset</span>
         <div style={{ fontSize: 10, color: '#888', marginTop: 2 }}>
-          {vfx.vfx_preset.name} ({vfx.vfx_preset.layers.length} layers, {vfx.vfx_preset.duration}s)
+          {vfx.vfx_preset.name} ({(vfx.vfx_preset.elements ?? []).length} elements{vfx.vfx_preset.duration ? `, ${vfx.vfx_preset.duration}s` : ''})
         </div>
       </div>
     </div>

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -235,20 +235,29 @@ export interface GsParticleEmitterData {
 
 // ── VFX Instances (Méliès preset placed on map) ──
 
-export interface VfxLayerData {
+export interface VfxElementData {
   name: string;
-  type: 'emitter' | 'animation' | 'light';
-  start: number;
-  duration: number;
+  type: 'object' | 'emitter' | 'animation' | 'light';
+  position?: [number, number, number];
+  start?: number;
+  duration?: number;
+  loop?: boolean;
+  ply_file?: string;
+  scale?: number;
   emitter?: Record<string, unknown>;
   animation?: Record<string, unknown>;
+  region?: { shape: string; radius?: number; half_extents?: [number, number, number] };
   light?: { color: [number, number, number]; intensity: number; radius: number };
 }
 
+/** @deprecated Use VfxElementData */
+export type VfxLayerData = VfxElementData;
+
 export interface VfxPresetData {
   name: string;
-  duration: number;
-  layers: VfxLayerData[];
+  duration?: number;
+  category?: string;
+  elements: VfxElementData[];
 }
 
 export interface VfxInstanceData {

--- a/tools/apps/bricklayer/src/viewport/VfxRenderer.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxRenderer.tsx
@@ -10,7 +10,7 @@ import React, { useRef, useEffect, useState, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useSceneStore } from '../store/useSceneStore.js';
-import type { VfxInstanceData, VfxLayerData } from '../store/types.js';
+import type { VfxInstanceData, VfxElementData } from '../store/types.js';
 
 // Dynamic import — WASM module may not be available
 let wasmModule: any = null;
@@ -34,7 +34,7 @@ const MAX_PARTICLES = 2048;
 // ── Single emitter layer renderer ──
 
 function EmitterLayerRenderer({ layer, instancePos }: {
-  layer: VfxLayerData;
+  layer: VfxElementData;
   instancePos: [number, number, number];
 }) {
   const geoRef = useRef<THREE.BufferGeometry>(null);
@@ -160,7 +160,7 @@ function EmitterLayerRenderer({ layer, instancePos }: {
 // ── Per-instance renderer ──
 
 function InstanceRenderer({ instance }: { instance: VfxInstanceData }) {
-  const emitterLayers = instance.vfx_preset.layers.filter((l) => l.type === 'emitter');
+  const emitterLayers = (instance.vfx_preset.elements ?? []).filter((l) => l.type === 'emitter');
 
   return (
     <group>


### PR DESCRIPTION
## Summary
Update Bricklayer and Engine to use the new element-based VFX format from PR #75.

### Bricklayer
- `VfxElementData` replaces `VfxLayerData` — adds position, loop, object/region support
- `VfxPresetData.elements` replaces `.layers`
- Import flow accepts both `elements` (v2) and `layers` (v1)
- VfxRenderer reads from `.elements`
- Save exports `.elements` format

### Engine
- `VfxElementData` replaces `VfxLayerData` — per-element position, loop, region, ply_file
- Parser accepts both `elements` and `layers` keys
- Duration derived from max element end time if not set
- Emitter position = instance position + element relative position
- Per-element loop with cycle-based activation

## Test plan
- [x] 13 C++ tests pass
- [x] Bricklayer TypeScript compiles
- [x] CI passes
- [x] Import v1 .vfx.json in Bricklayer → elements parsed correctly
- [ ] Engine loads VFX with element positions → emitters at correct locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)