### PR TITLE
Add v2 element editing in Méliès

### DIFF
--- a/tools/apps/melies/src/App.tsx
+++ b/tools/apps/melies/src/App.tsx
@@ -370,8 +370,10 @@ function VfxTree() {
                         </div>
                       );
                     })}
-                    {/* Add layer buttons */}
+                    {/* Add element buttons */}
                     <div style={{ display: 'flex', gap: 2, padding: '2px 4px' }}>
+                      <button onClick={() => addLayer(preset.id, 'object', 'Object', 0, 0)}
+                        style={{ ...treeStyles.addBtn, color: T.textDim, fontSize: 9 }}>+&#9651;</button>
                       <button onClick={() => addLayer(preset.id, 'emitter', 'Emitter', 0, 1)}
                         style={{ ...treeStyles.addBtn, color: T.layerEmitter, fontSize: 9 }}>+✦</button>
                       <button onClick={() => addLayer(preset.id, 'animation', 'Animation', 0, 1)}

--- a/tools/apps/melies/src/panels/LayerProperties.tsx
+++ b/tools/apps/melies/src/panels/LayerProperties.tsx
@@ -510,33 +510,106 @@ export function LayerProperties() {
       <div>
         <label style={sectionLabel}>Type</label>
         <select value={layer.type} onChange={(e) => update({ type: e.target.value as LayerType })} style={selectStyle}>
+          <option value="object">Object (PLY)</option>
           <option value="emitter">Emitter</option>
           <option value="animation">Animation</option>
           <option value="light">Light</option>
         </select>
       </div>
 
-      {/* Timing */}
-      <div style={{ display: 'flex', gap: 8 }}>
-        <div style={{ flex: 1 }}>
-          <label style={sectionLabel}>Start (s)</label>
-          <NumberInput value={layer.start ?? 0} min={0} step={0.1}
-            onChange={(v) => update({ start: v })} style={{ ...inputStyle, width: 'auto' }} />
-        </div>
-        <div style={{ flex: 1 }}>
-          <label style={sectionLabel}>Duration (s)</label>
-          <NumberInput value={layer.duration ?? 1} min={0.01} step={0.1}
-            onChange={(v) => update({ duration: v })} style={{ ...inputStyle, width: 'auto' }} />
-        </div>
+      {/* Position (relative to prefab origin) */}
+      <div>
+        <label style={sectionLabel}>Position</label>
+        <Vec3Input value={layer.position ?? [0, 0, 0]}
+          onChange={(v) => update({ position: v })} step={0.5} />
       </div>
 
-      <SectionHeader>
-        {layer.type === 'emitter' ? 'Emitter Config' : layer.type === 'animation' ? 'Animation Config' : 'Light Config'}
-      </SectionHeader>
+      {/* Timing (not for object type) */}
+      {layer.type !== 'object' && (
+        <>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <div style={{ flex: 1 }}>
+              <label style={sectionLabel}>Start (s)</label>
+              <NumberInput value={layer.start ?? 0} min={0} step={0.1}
+                onChange={(v) => update({ start: v })} style={{ ...inputStyle, width: 'auto' }} />
+            </div>
+            <div style={{ flex: 1 }}>
+              <label style={sectionLabel}>Duration (s)</label>
+              <NumberInput value={layer.duration ?? 1} min={0.01} step={0.1}
+                onChange={(v) => update({ duration: v })} style={{ ...inputStyle, width: 'auto' }} />
+            </div>
+          </div>
+
+          {/* Loop */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <label style={sectionLabel}>Loop</label>
+            <input type="checkbox" checked={layer.loop ?? false}
+              onChange={(e) => update({ loop: e.target.checked })} />
+            <span style={{ fontSize: 9, color: T.textMuted }}>
+              {layer.loop ? 'Repeats continuously' : 'Plays once'}
+            </span>
+          </div>
+        </>
+      )}
+
+      {/* Type-specific config */}
+      {layer.type !== 'object' && (
+        <SectionHeader>
+          {layer.type === 'emitter' ? 'Emitter Config' : layer.type === 'animation' ? 'Animation Config' : 'Light Config'}
+        </SectionHeader>
+      )}
+
+      {/* Object editor */}
+      {layer.type === 'object' && (
+        <>
+          <SectionHeader>Object Config</SectionHeader>
+          <div>
+            <label style={sectionLabel}>PLY File</label>
+            <input type="text" value={layer.ply_file ?? ''}
+              onChange={(e) => update({ ply_file: e.target.value })}
+              placeholder="path/to/model.ply" style={inputStyle} />
+          </div>
+          <div>
+            <label style={sectionLabel}>Scale</label>
+            <NumberInput value={layer.scale ?? 1} min={0.01} step={0.1}
+              onChange={(v) => update({ scale: v })} style={{ ...inputStyle, width: 'auto' }} />
+          </div>
+        </>
+      )}
 
       {/* Type-specific config editors */}
       {layer.type === 'emitter' && <EmitterEditor layer={layer} update={update} />}
-      {layer.type === 'animation' && <AnimationEditor layer={layer} update={update} />}
+      {layer.type === 'animation' && (
+        <>
+          <AnimationEditor layer={layer} update={update} />
+          <SectionHeader>Region</SectionHeader>
+          <div>
+            <label style={sectionLabel}>Shape</label>
+            <select value={layer.region?.shape ?? 'sphere'}
+              onChange={(e) => update({ region: { ...layer.region, shape: e.target.value, radius: layer.region?.radius ?? 5 } })}
+              style={selectStyle}>
+              <option value="sphere">Sphere</option>
+              <option value="box">Box</option>
+            </select>
+          </div>
+          {(layer.region?.shape ?? 'sphere') === 'sphere' && (
+            <div>
+              <label style={sectionLabel}>Radius</label>
+              <NumberInput value={layer.region?.radius ?? 5} min={0.1} step={0.5}
+                onChange={(v) => update({ region: { ...layer.region, shape: 'sphere', radius: v } })}
+                style={{ ...inputStyle, width: 'auto' }} />
+            </div>
+          )}
+          {layer.region?.shape === 'box' && (
+            <div>
+              <label style={sectionLabel}>Half Extents</label>
+              <Vec3Input value={layer.region?.half_extents ?? [2, 2, 2]}
+                onChange={(v) => update({ region: { ...layer.region, shape: 'box', half_extents: v } })}
+                step={0.5} />
+            </div>
+          )}
+        </>
+      )}
       {layer.type === 'light' && <LightEditor layer={layer} update={update} />}
     </div>
   );

--- a/tools/apps/melies/src/store/useVfxStore.ts
+++ b/tools/apps/melies/src/store/useVfxStore.ts
@@ -180,7 +180,7 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
   updateLayer: (presetId, layerId, patch) => set({
     presets: get().presets.map((p) =>
       p.id === presetId
-        ? { ...p, layers: p.elements.map((l) => (l.id === layerId ? { ...l, ...patch } : l)) }
+        ? { ...p, elements: p.elements.map((l) => (l.id === layerId ? { ...l, ...patch } : l)) }
         : p
     ),
   }),
@@ -189,7 +189,7 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
     const state = get();
     set({
       presets: state.presets.map((p) =>
-        p.id === presetId ? { ...p, layers: p.elements.filter((l) => l.id !== layerId) } : p
+        p.id === presetId ? { ...p, elements: p.elements.filter((l) => l.id !== layerId) } : p
       ),
       selectedLayerId: state.selectedLayerId === layerId ? null : state.selectedLayerId,
     });

--- a/tools/apps/melies/src/styles/theme.ts
+++ b/tools/apps/melies/src/styles/theme.ts
@@ -47,5 +47,8 @@ export const labelStyle: React.CSSProperties = {
 };
 
 export const layerColor = (type: LayerType) =>
-  type === 'emitter' ? T.layerEmitter : type === 'animation' ? T.layerAnimation : T.layerLight;
+  type === 'object' ? T.textDim
+    : type === 'emitter' ? T.layerEmitter
+    : type === 'animation' ? T.layerAnimation
+    : T.layerLight;
 

--- a/tools/apps/melies/src/viewport/AnimationSystem.tsx
+++ b/tools/apps/melies/src/viewport/AnimationSystem.tsx
@@ -121,11 +121,15 @@ export function AnimationSystem({ scenePoints, onUpdateGeometry }: {
         const infiniteLifetimeEffects = ['wave', 'pulse'];
         const lifetime = infiniteLifetimeEffects.includes(effectName) ? 9999 : (layer.duration ?? 9999);
 
+        // Use element position + region (default: sphere at origin, radius 999 for full scene)
+        const pos = layer.position ?? [0, 0, 0];
+        const radius = layer.region?.radius ?? 999;
+
         let groupId: number;
         if (params && Object.keys(params).length > 0) {
-          groupId = animatorRef.current.tagSphereWithParams(0, 0, 0, 999, effect, lifetime, params);
+          groupId = animatorRef.current.tagSphereWithParams(pos[0], pos[1], pos[2], radius, effect, lifetime, params);
         } else {
-          groupId = animatorRef.current.tagSphere(0, 0, 0, 999, effect, lifetime);
+          groupId = animatorRef.current.tagSphere(pos[0], pos[1], pos[2], radius, effect, lifetime);
         }
         activeGroups.set(layer.id, groupId);
       } else if (!isActive && hasGroup) {

--- a/tools/apps/melies/src/viewport/Preview.tsx
+++ b/tools/apps/melies/src/viewport/Preview.tsx
@@ -69,83 +69,75 @@ function GaussianPointCloud({ points, geoRef }: { points: PlyPoint[]; geoRef: Re
 
 // ── Layer Gizmos ──
 
-function EmitterGizmo({ layer, active, selected }: { layer: VfxLayer; active: boolean; selected: boolean }) {
-  const cfg = layer.emitter as Record<string, unknown> | undefined;
-  const pos: [number, number, number] = (cfg?.position as [number, number, number]) ?? [0, 1, 0];
-  const offsetMin = (cfg?.spawn_offset_min as [number, number, number]) ?? [0, 0, 0];
-  const offsetMax = (cfg?.spawn_offset_max as [number, number, number]) ?? [0, 0, 0];
-  const hasOffset = offsetMin.some((v) => v !== 0) || offsetMax.some((v) => v !== 0);
-  const boxSize: [number, number, number] = [
-    offsetMax[0] - offsetMin[0] || 0.5,
-    offsetMax[1] - offsetMin[1] || 0.5,
-    offsetMax[2] - offsetMin[2] || 0.5,
-  ];
-  const boxCenter: [number, number, number] = [
-    pos[0] + (offsetMin[0] + offsetMax[0]) / 2,
-    pos[1] + (offsetMin[1] + offsetMax[1]) / 2,
-    pos[2] + (offsetMin[2] + offsetMax[2]) / 2,
-  ];
-  const opacity = active ? 0.7 : 0.2;
-  const color = selected ? '#ffffff' : '#ec4899';
+type GizmoProps = { layer: VfxLayer; active: boolean; selected: boolean; onSelect: () => void };
 
+function ObjectGizmo({ layer, selected, onSelect }: GizmoProps) {
+  const pos = layer.position ?? [0, 0, 0];
+  const color = selected ? '#ffffff' : '#aaaaaa';
   return (
-    <group>
-      {/* Center sphere */}
-      <mesh position={pos}>
+    <group position={pos}>
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
+        <octahedronGeometry args={[0.5]} />
+        <meshBasicMaterial color={color} transparent opacity={selected ? 0.9 : 0.5} />
+      </mesh>
+    </group>
+  );
+}
+
+function EmitterGizmo({ layer, active, selected, onSelect }: GizmoProps) {
+  const pos = layer.position ?? [0, 0, 0];
+  const color = selected ? '#ffffff' : '#ec4899';
+  return (
+    <group position={pos}>
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
         <sphereGeometry args={[0.3, 12, 12]} />
         <meshBasicMaterial color={color} transparent opacity={active ? 0.8 : 0.3} />
       </mesh>
-      {/* Outer glow when active */}
       {active && (
-        <mesh position={pos}>
+        <mesh>
           <sphereGeometry args={[0.5, 12, 12]} />
           <meshBasicMaterial color="#ec4899" transparent opacity={0.2} />
         </mesh>
       )}
-      {/* Spawn offset box */}
-      {hasOffset && (
-        <mesh position={boxCenter}>
-          <boxGeometry args={boxSize} />
-          <meshBasicMaterial color="#ec4899" wireframe transparent opacity={opacity * 0.5} />
-        </mesh>
-      )}
     </group>
   );
 }
 
-function AnimationGizmo({ layer, active, selected }: { layer: VfxLayer; active: boolean; selected: boolean }) {
-  const anim = layer.animation as Record<string, unknown> | undefined;
-  const effect = (anim?.effect as string) ?? 'detach';
+function AnimationGizmo({ layer, active, selected, onSelect }: GizmoProps) {
+  const pos = layer.position ?? [0, 0, 0];
+  const radius = layer.region?.radius ?? 2;
   const opacity = active ? 0.5 : 0.15;
   const color = selected ? '#ffffff' : '#06b6d4';
-
   return (
-    <group position={[0, 1, 0]}>
-      {/* Region sphere */}
-      <mesh>
-        <sphereGeometry args={[2, 16, 12]} />
-        <meshBasicMaterial color={color} wireframe transparent opacity={opacity} />
-      </mesh>
-      {/* Center dot */}
-      <mesh>
+    <group position={pos}>
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
         <sphereGeometry args={[0.15, 8, 8]} />
         <meshBasicMaterial color="#06b6d4" transparent opacity={active ? 1 : 0.4} />
       </mesh>
+      <mesh>
+        {layer.region?.shape === 'box' ? (
+          <boxGeometry args={((layer.region?.half_extents ?? [2, 2, 2]) as [number, number, number]).map((v) => v * 2) as [number, number, number]} />
+        ) : (
+          <sphereGeometry args={[radius, 16, 12]} />
+        )}
+        <meshBasicMaterial color={color} wireframe transparent opacity={opacity} />
+      </mesh>
     </group>
   );
 }
 
-function LightGizmo({ layer, active, selected }: { layer: VfxLayer; active: boolean; selected: boolean }) {
+function LightGizmo({ layer, active, selected, onSelect }: GizmoProps) {
+  const pos = layer.position ?? [0, 0, 0];
   const light = layer.light;
   const radius = light?.radius ?? 50;
   const color = light ? `rgb(${Math.round(light.color[0] * 255)},${Math.round(light.color[1] * 255)},${Math.round(light.color[2] * 255)})` : '#ffff00';
-  const displayRadius = Math.min(radius * 0.1, 5); // Scale down for viewport
+  const displayRadius = Math.min(radius * 0.1, 5);
   const opacity = active ? 0.7 : 0.2;
 
   return (
-    <group position={[0, 2, 0]}>
+    <group position={pos}>
       {/* Center sphere */}
-      <mesh>
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
         <sphereGeometry args={[0.3, 12, 12]} />
         <meshBasicMaterial color={selected ? '#ffffff' : color} transparent opacity={active ? 0.9 : 0.4} />
       </mesh>
@@ -171,6 +163,7 @@ function LayerGizmos() {
   });
   const playbackTime = useVfxStore((s) => s.playbackTime);
   const selectedLayerId = useVfxStore((s) => s.selectedLayerId);
+  const selectLayer = useVfxStore((s) => s.selectLayer);
   const lightRef = useRef<THREE.PointLight>(null);
 
   // Update dynamic point light for light layers (read ref, no React re-render)
@@ -199,9 +192,11 @@ function LayerGizmos() {
       {(preset.elements ?? []).map((layer) => {
         const active = playbackTime >= (layer.start ?? 0) && playbackTime < (layer.start ?? 0) + (layer.duration ?? 9999);
         const selected = selectedLayerId === layer.id;
-        if (layer.type === 'emitter') return <EmitterGizmo key={layer.id} layer={layer} active={active} selected={selected} />;
-        if (layer.type === 'animation') return <AnimationGizmo key={layer.id} layer={layer} active={active} selected={selected} />;
-        if (layer.type === 'light') return <LightGizmo key={layer.id} layer={layer} active={active} selected={selected} />;
+        const onSelect = () => selectLayer(layer.id);
+        if (layer.type === 'object') return <ObjectGizmo key={layer.id} layer={layer} active={true} selected={selected} onSelect={onSelect} />;
+        if (layer.type === 'emitter') return <EmitterGizmo key={layer.id} layer={layer} active={active} selected={selected} onSelect={onSelect} />;
+        if (layer.type === 'animation') return <AnimationGizmo key={layer.id} layer={layer} active={active} selected={selected} onSelect={onSelect} />;
+        if (layer.type === 'light') return <LightGizmo key={layer.id} layer={layer} active={active} selected={selected} onSelect={onSelect} />;
         return null;
       })}
     </group>


### PR DESCRIPTION
## Summary
Full editing support for the v2 VFX element format in Méliès.

### Properties panel
- **Object type**: PLY file path + scale fields
- **Position** (Vec3Input): all element types, relative to prefab origin
- **Loop** checkbox: continuous vs one-shot effects
- **Region** editor for animations: sphere/box shape, radius or half_extents

### Viewport gizmos
- All gizmos positioned from `element.position` (was hardcoded)
- **Click to select**: clicking a gizmo selects the element
- **ObjectGizmo**: octahedron marker for PLY geometry
- **AnimationGizmo**: shows actual region shape (sphere or box)

### Element creation
- `+Object` button in the tree alongside emitter/animation/light

## Test plan
- [x] TypeScript compiles
- [ ] Create Object element → PLY file + scale fields visible
- [ ] Edit position → gizmo moves in viewport
- [ ] Toggle loop → checkbox persists
- [ ] Animation: change region shape → gizmo updates
- [ ] Click gizmo in viewport → element selected in tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)