### PR TITLE
Fix VFX animation runtime + update test assets

### DIFF
--- a/assets/scenes/test_bricklayer.json
+++ b/assets/scenes/test_bricklayer.json
@@ -177,9 +177,9 @@
     {
       "vfx_file": "assets/vfx/vfx1.vfx.json",
       "position": [
+        128,
         64,
-        0,
-        0
+        24
       ]
     }
   ]

--- a/assets/vfx/vfx1.vfx.json
+++ b/assets/vfx/vfx1.vfx.json
@@ -1,18 +1,17 @@
 {
   "name": "vfx1",
-  "duration": 30,
-  "layers": [
+  "elements": [
     {
       "name": "Emitter 1",
       "type": "emitter",
-      "start": 0,
       "duration": 30,
+      "loop": true,
       "emitter": {
         "spawn_rate": 3,
         "lifetime_min": 10,
         "lifetime_max": 30,
         "velocity_min": [
-          -0.5,
+          -4.5,
           -1,
           -0.5
         ],
@@ -42,26 +41,40 @@
           0.1
         ],
         "scale_max": [
-          0.5,
-          0.5,
-          0.5
+          1,
+          1,
+          1
         ],
         "scale_end_factor": 0.1,
         "opacity_start": 0.9,
         "opacity_end": 0.2,
         "emission": 0.4,
+        "burst_duration": 0,
         "spawn_offset_min": [
-          64,
-          192,
-          64
+          -64,
+          128,
+          -64
         ],
         "spawn_offset_max": [
+          64,
           128,
-          256,
-          128
+          -64
         ],
-        "burst_duration": 0,
-        "preset": "leaves"
+        "preset": "leaves",
+        "region": {
+          "shape": "sphere",
+          "half_extents": [
+            128,
+            128,
+            128
+          ],
+          "center": [
+            0,
+            0,
+            0
+          ],
+          "radius": 128
+        }
       },
       "animation": {
         "effect": "float",
@@ -91,10 +104,15 @@
     {
       "name": "Animation",
       "type": "animation",
-      "start": 0,
+      "position": [
+        0,
+        5,
+        0
+      ],
       "duration": 30,
+      "loop": true,
       "animation": {
-        "effect": "pulse",
+        "effect": "float",
         "params": {
           "rotations": 1,
           "rotations_easing": "linear",
@@ -116,7 +134,32 @@
           "wave_speed": 10,
           "pulse_frequency": 8
         }
+      },
+      "region": {
+        "shape": "sphere",
+        "radius": 64
       }
+    },
+    {
+      "name": "Animation",
+      "type": "animation",
+      "position": [
+        0,
+        6,
+        0
+      ],
+      "duration": 30,
+      "loop": true,
+      "region": {
+        "shape": "sphere",
+        "radius": 64
+      }
+    },
+    {
+      "name": "Object",
+      "type": "object",
+      "duration": 0
     }
-  ]
+  ],
+  "duration": 30
 }

--- a/include/gseurat/engine/gs_vfx.hpp
+++ b/include/gseurat/engine/gs_vfx.hpp
@@ -59,7 +59,8 @@ public:
 
     /// Update timeline, activate/deactivate emitter layers.
     /// Appends active particles to out_buffer.
-    void update(float dt, std::vector<Gaussian>& out_buffer);
+    /// Tags animation regions on the provided animator.
+    void update(float dt, std::vector<Gaussian>& out_buffer, GaussianAnimator& animator);
 
     bool is_finished() const { return finished_; }
     const glm::vec3& position() const { return position_; }
@@ -78,6 +79,13 @@ private:
         bool activated = false;
     };
     std::vector<EmitterState> emitter_states_;
+
+    struct AnimState {
+        size_t element_index;
+        uint32_t group_id = 0;
+        bool activated = false;
+    };
+    std::vector<AnimState> anim_states_;
 };
 
 }  // namespace gseurat

--- a/src/engine/gs_vfx.cpp
+++ b/src/engine/gs_vfx.cpp
@@ -98,20 +98,26 @@ void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool 
 
     // Pre-create emitter states for all emitter elements
     emitter_states_.clear();
+    anim_states_.clear();
     for (size_t i = 0; i < preset_.elements.size(); ++i) {
         const auto& el = preset_.elements[i];
-        if (el.type != "emitter") continue;
-        EmitterState es;
-        es.element_index = i;
-        es.activated = false;
-        es.emitter.configure(el.emitter_config);
-        // Position: instance position + element relative position
-        es.emitter.set_position(position_ + el.position);
-        emitter_states_.push_back(std::move(es));
+        if (el.type == "emitter") {
+            EmitterState es;
+            es.element_index = i;
+            es.activated = false;
+            es.emitter.configure(el.emitter_config);
+            es.emitter.set_position(position_ + el.position);
+            emitter_states_.push_back(std::move(es));
+        } else if (el.type == "animation") {
+            AnimState as;
+            as.element_index = i;
+            as.activated = false;
+            anim_states_.push_back(std::move(as));
+        }
     }
 }
 
-void VfxInstance::update(float dt, std::vector<Gaussian>& out_buffer) {
+void VfxInstance::update(float dt, std::vector<Gaussian>& out_buffer, GaussianAnimator& animator) {
     if (finished_) return;
 
     elapsed_ += dt;
@@ -156,6 +162,42 @@ void VfxInstance::update(float dt, std::vector<Gaussian>& out_buffer) {
         if (es.activated) {
             es.emitter.update(dt);
             es.emitter.gather(out_buffer);
+        }
+    }
+
+    // Activate/deactivate animation elements
+    for (auto& as : anim_states_) {
+        const auto& el = preset_.elements[as.element_index];
+        float el_start = el.start;
+        bool in_window;
+        if (el.loop) {
+            in_window = elapsed_ >= el_start;
+        } else {
+            float el_end = el.duration > 0.0f ? el.start + el.duration : preset_.duration;
+            in_window = elapsed_ >= el_start && elapsed_ < el_end;
+        }
+
+        if (in_window && !as.activated) {
+            // Tag region on the shared animator
+            auto region = el.region;
+            region.center += position_ + el.position;  // offset by instance + element position
+            auto effect_name = el.animation_config.effect;
+            auto effect = GsAnimEffect::Detach;
+            if (effect_name == "float") effect = GsAnimEffect::Float;
+            else if (effect_name == "orbit") effect = GsAnimEffect::Orbit;
+            else if (effect_name == "dissolve") effect = GsAnimEffect::Dissolve;
+            else if (effect_name == "reform") effect = GsAnimEffect::Reform;
+            else if (effect_name == "pulse") effect = GsAnimEffect::Pulse;
+            else if (effect_name == "vortex") effect = GsAnimEffect::Vortex;
+            else if (effect_name == "wave") effect = GsAnimEffect::Wave;
+            else if (effect_name == "scatter") effect = GsAnimEffect::Scatter;
+
+            float lifetime = el.loop ? 9999.0f : (el.duration > 0.0f ? el.duration : 9999.0f);
+            as.group_id = animator.tag_region(out_buffer, region, effect, lifetime, el.animation_config.params);
+            as.activated = true;
+        } else if (!in_window && as.activated) {
+            as.activated = false;
+            // Group expires naturally via lifetime
         }
     }
 }

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -859,9 +859,9 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                         [](const GaussianParticleEmitter& e) { return !e.active() && e.alive_count() == 0; }),
                     gs_particle_emitters_.end());
 
-                // Update VFX instances (timeline + emitters)
+                // Update VFX instances (timeline + emitters + animations)
                 for (auto& inst : vfx_instances_) {
-                    inst.update(dt, gs_active_buffer_);
+                    inst.update(dt, gs_active_buffer_, gs_animator_);
                 }
                 std::erase_if(vfx_instances_,
                     [](const VfxInstance& i) { return i.is_finished(); });


### PR DESCRIPTION
## Summary
Fixes missed from PR #78 (merged before these commits were pushed).

- **Animation element support in VFX instance runtime**: VfxInstance now activates animation elements on the shared GaussianAnimator (previously only emitter elements rendered)
- **Updated test assets**: test_bricklayer.json + vfx1.vfx.json with new region format

## Test plan
- [x] 13 C++ tests pass
- [x] Builds on release
- [x] VFX animations render in engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)