### PR TITLE
Méliès: PLY import for objects + emitter region gizmo

### DIFF
--- a/tools/apps/melies/src/panels/LayerProperties.tsx
+++ b/tools/apps/melies/src/panels/LayerProperties.tsx
@@ -587,9 +587,34 @@ export function LayerProperties() {
           <SectionHeader>Object Config</SectionHeader>
           <div>
             <label style={sectionLabel}>PLY File</label>
-            <input type="text" value={layer.ply_file ?? ''}
-              onChange={(e) => update({ ply_file: e.target.value })}
-              placeholder="path/to/model.ply" style={inputStyle} />
+            <div style={{ display: 'flex', gap: 4 }}>
+              <input type="text" value={layer.ply_file ?? ''} readOnly
+                style={{ ...inputStyle, flex: 1, opacity: layer.ply_file ? 1 : 0.5 }}
+                placeholder="No file selected" />
+              <button onClick={() => {
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.accept = '.ply';
+                input.onchange = async () => {
+                  const file = input.files?.[0];
+                  if (!file) return;
+                  const store = useVfxStore.getState();
+                  if (store.projectHandle) {
+                    // Copy PLY into project directory
+                    const { copyPlyToProject } = await import('../lib/projectIO.js');
+                    const path = await copyPlyToProject(store.projectHandle, file);
+                    update({ ply_file: path });
+                  } else {
+                    // No project directory — just use filename
+                    update({ ply_file: file.name });
+                  }
+                };
+                input.click();
+              }} style={{
+                padding: '4px 8px', background: T.surface, border: `1px solid ${T.border}`,
+                borderRadius: 4, color: T.accent, cursor: 'pointer', fontSize: 11, whiteSpace: 'nowrap',
+              }}>Import</button>
+            </div>
           </div>
           <div>
             <label style={sectionLabel}>Scale</label>

--- a/tools/apps/melies/src/viewport/Preview.tsx
+++ b/tools/apps/melies/src/viewport/Preview.tsx
@@ -4,7 +4,8 @@ import { OrbitControls, Grid } from '@react-three/drei';
 import * as THREE from 'three';
 import { useVfxStore, playbackTimeRef } from '../store/useVfxStore.js';
 import type { VfxElement as VfxLayer } from '../store/types.js';
-import type { PlyPoint } from '../lib/plyLoader.js';
+import { loadPly, type PlyPoint } from '../lib/plyLoader.js';
+import { loadPlyFromProject } from '../lib/projectIO.js';
 import { ParticleSystem } from './ParticleSystem.js';
 import { AnimationSystem } from './AnimationSystem.js';
 
@@ -73,13 +74,79 @@ type GizmoProps = { layer: VfxLayer; active: boolean; selected: boolean; onSelec
 
 function ObjectGizmo({ layer, selected, onSelect }: GizmoProps) {
   const pos = layer.position ?? [0, 0, 0];
-  const color = selected ? '#ffffff' : '#aaaaaa';
+  const scale = layer.scale ?? 1;
+  const [points, setPoints] = useState<PlyPoint[]>([]);
+
+  // Load PLY file from project directory
+  useEffect(() => {
+    if (!layer.ply_file) return;
+    const store = useVfxStore.getState();
+    if (store.projectHandle) {
+      loadPlyFromProject(store.projectHandle, layer.ply_file).then(async (file) => {
+        if (file) {
+          const pts = await loadPly(file);
+          setPoints(pts);
+        }
+      });
+    }
+  }, [layer.ply_file]);
+
+  const geometry = useMemo(() => {
+    if (points.length === 0) return null;
+    const geo = new THREE.BufferGeometry();
+    const n = points.length;
+    const positions = new Float32Array(n * 3);
+    const colors = new Float32Array(n * 4);
+    for (let i = 0; i < n; i++) {
+      positions[i * 3] = points[i].position[0] * scale;
+      positions[i * 3 + 1] = points[i].position[1] * scale;
+      positions[i * 3 + 2] = points[i].position[2] * scale;
+      colors[i * 4] = points[i].color[0];
+      colors[i * 4 + 1] = points[i].color[1];
+      colors[i * 4 + 2] = points[i].color[2];
+      colors[i * 4 + 3] = 1.0;
+    }
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geo.setAttribute('aColor', new THREE.BufferAttribute(colors, 4));
+    geo.setAttribute('aScale', new THREE.BufferAttribute(new Float32Array(n).fill(1.0), 1));
+    return geo;
+  }, [points, scale]);
+
+  const material = useMemo(() => new THREE.ShaderMaterial({
+    uniforms: { uPixelRatio: { value: window.devicePixelRatio || 1.0 } },
+    vertexShader: `
+      attribute vec4 aColor;
+      attribute float aScale;
+      uniform float uPixelRatio;
+      varying vec4 vColor;
+      void main() {
+        vColor = aColor;
+        vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+        gl_PointSize = max(3.0 * aScale, 0.5) * uPixelRatio * (300.0 / -mvPosition.z);
+        gl_Position = projectionMatrix * mvPosition;
+      }
+    `,
+    fragmentShader: `
+      varying vec4 vColor;
+      void main() {
+        float d = length(gl_PointCoord - vec2(0.5));
+        if (d > 0.5) discard;
+        float alpha = vColor.a * smoothstep(0.5, 0.2, d);
+        gl_FragColor = vec4(vColor.rgb, alpha);
+      }
+    `,
+    transparent: true, depthWrite: false,
+  }), []);
+
   return (
     <group position={pos}>
+      {/* Clickable marker (always visible) */}
       <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
-        <octahedronGeometry args={[0.5]} />
-        <meshBasicMaterial color={color} transparent opacity={selected ? 0.9 : 0.5} />
+        <octahedronGeometry args={[0.3]} />
+        <meshBasicMaterial color={selected ? '#ffffff' : '#aaaaaa'} transparent opacity={selected ? 0.9 : 0.4} />
       </mesh>
+      {/* PLY point cloud */}
+      {geometry && <points geometry={geometry} material={material} />}
     </group>
   );
 }

--- a/tools/apps/melies/src/viewport/Preview.tsx
+++ b/tools/apps/melies/src/viewport/Preview.tsx
@@ -87,8 +87,12 @@ function ObjectGizmo({ layer, selected, onSelect }: GizmoProps) {
 function EmitterGizmo({ layer, active, selected, onSelect }: GizmoProps) {
   const pos = layer.position ?? [0, 0, 0];
   const color = selected ? '#ffffff' : '#ec4899';
+  const cfg = layer.emitter as Record<string, unknown> | undefined;
+  const region = cfg?.region as { shape?: string; center?: [number, number, number]; radius?: number; half_extents?: [number, number, number] } | undefined;
+  const regionCenter = region?.center ?? [0, 0, 0];
   return (
     <group position={pos}>
+      {/* Center sphere */}
       <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
         <sphereGeometry args={[0.3, 12, 12]} />
         <meshBasicMaterial color={color} transparent opacity={active ? 0.8 : 0.3} />
@@ -97,6 +101,17 @@ function EmitterGizmo({ layer, active, selected, onSelect }: GizmoProps) {
         <mesh>
           <sphereGeometry args={[0.5, 12, 12]} />
           <meshBasicMaterial color="#ec4899" transparent opacity={0.2} />
+        </mesh>
+      )}
+      {/* Spawn region wireframe */}
+      {region && (
+        <mesh position={regionCenter}>
+          {region.shape === 'sphere' ? (
+            <sphereGeometry args={[region.radius ?? 1, 16, 12]} />
+          ) : (
+            <boxGeometry args={((region.half_extents ?? [1, 1, 1]) as [number, number, number]).map((v) => v * 2) as [number, number, number]} />
+          )}
+          <meshBasicMaterial color="#ec4899" wireframe transparent opacity={selected ? 0.4 : 0.15} />
         </mesh>
       )}
     </group>


### PR DESCRIPTION
## Summary
Two Méliès improvements:

### Object PLY import
- Replace plain text input with **Import** button + file picker
- PLY file is copied into the project's `scene/` directory
- Path stored as relative project reference

### Emitter spawn region gizmo
- Wireframe visualization of the emitter's spawn region in the viewport
- Box region: wireframe box at region center offset, sized by half_extents
- Sphere region: wireframe sphere with radius
- Selected elements show brighter wireframe

## Test plan
- [x] TypeScript compiles
- [ ] Object element: click Import → file picker → PLY path set
- [ ] Emitter element: region wireframe visible in viewport
- [ ] Region shape change (sphere/box) → gizmo updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)