### PR TITLE
Fix emitter position and region in Méliès preview

### DIFF
--- a/tools/apps/melies/src/viewport/ParticleSystem.tsx
+++ b/tools/apps/melies/src/viewport/ParticleSystem.tsx
@@ -83,6 +83,9 @@ function EmitterRenderer({ layer, active }: { layer: VfxLayer; active: boolean }
       emitter.configurePreset('fire');
     }
 
+    // Set position from element's position field
+    const pos = layer.position ?? [0, 0, 0];
+    emitter.setPosition(pos[0], pos[1], pos[2]);
     emitter.setActive(true);
     emitterRef.current = emitter;
 
@@ -91,7 +94,7 @@ function EmitterRenderer({ layer, active }: { layer: VfxLayer; active: boolean }
       emitterRef.current = null;
       setParticleCount(0);
     };
-  }, [active, layer.id, layer.emitter]);
+  }, [active, layer.id, layer.emitter, layer.position]);
 
   const geoInitialized = useRef(false);
 


### PR DESCRIPTION
## Summary
Emitter particles were always spawning at origin because `setPosition()` was never called on the WASM emitter. The element's `position` field was ignored.

- Call `emitter.setPosition()` from `layer.position` after `configure()`
- Add `layer.position` to `useEffect` deps for reactive updates
- Emitter region (spawn area) passes through config to WASM correctly

## Test plan
- [x] TypeScript compiles
- [x] Emitter at position [3, 16, -0.5] → particles spawn at that location
- [x] Emitter with box region → particles spawn within the box area
- [x] Change position in panel → particles move

🤖 Generated with [Claude Code](https://claude.com/claude-code)