### PR TITLE
Animate Object PLY geometry in Méliès prefab preview

### DIFF
--- a/tools/apps/melies/src/viewport/AnimationSystem.tsx
+++ b/tools/apps/melies/src/viewport/AnimationSystem.tsx
@@ -8,6 +8,7 @@
 
 import React, { useRef, useEffect, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
 import { useVfxStore, playbackTimeRef } from '../store/useVfxStore.js';
 import type { PlyPoint } from '../lib/plyLoader.js';
 
@@ -28,8 +29,10 @@ async function ensureWasm() {
   return wasmModule;
 }
 
-export function AnimationSystem({ scenePoints, onUpdateGeometry }: {
+export function AnimationSystem({ scenePoints, objectPointsMap, objectGeoRefs, onUpdateGeometry }: {
   scenePoints: PlyPoint[];
+  objectPointsMap?: Map<string, { points: PlyPoint[]; scale: number }>;
+  objectGeoRefs?: Map<string, React.MutableRefObject<THREE.BufferGeometry | null>>;
   onUpdateGeometry: (positions: Float32Array, colors: Float32Array, scales?: Float32Array) => void;
 }) {
   const preset = useVfxStore((s) => s.presets.find((p) => p.id === s.selectedPresetId));
@@ -52,33 +55,70 @@ export function AnimationSystem({ scenePoints, onUpdateGeometry }: {
     ensureWasm().then((sim) => { if (sim) setWasmReady(true); });
   }, []);
 
-  // Cache scene data
+  // Track object point offsets for splitting output
+  const objectOffsetsRef = useRef<Map<string, { offset: number; count: number }>>(new Map());
+
+  // Cache scene + object data merged into one buffer
   useEffect(() => {
-    if (scenePoints.length === 0) return;
-    const count = scenePoints.length;
-    const positions = new Float32Array(count * 3);
-    const colors = new Float32Array(count * 3);
-    for (let i = 0; i < count; i++) {
-      positions[i * 3] = scenePoints[i].position[0];
-      positions[i * 3 + 1] = scenePoints[i].position[1];
-      positions[i * 3 + 2] = scenePoints[i].position[2];
-      colors[i * 3] = scenePoints[i].color[0];
-      colors[i * 3 + 1] = scenePoints[i].color[1];
-      colors[i * 3 + 2] = scenePoints[i].color[2];
+    // Collect all object PLY points
+    const objectEntries: { id: string; points: PlyPoint[]; scale: number; pos: [number, number, number] }[] = [];
+    if (objectPointsMap) {
+      const preset = useVfxStore.getState().presets.find((p) => p.id === useVfxStore.getState().selectedPresetId);
+      for (const [id, { points, scale }] of objectPointsMap) {
+        const el = (preset?.elements ?? []).find((e) => e.id === id);
+        const elPos = (el?.position ?? [0, 0, 0]) as [number, number, number];
+        objectEntries.push({ id, points, scale, pos: elPos });
+      }
     }
+
+    const totalObjectPoints = objectEntries.reduce((sum, e) => sum + e.points.length, 0);
+    const totalCount = scenePoints.length + totalObjectPoints;
+    if (totalCount === 0) return;
+
+    const positions = new Float32Array(totalCount * 3);
+    const colors = new Float32Array(totalCount * 3);
+    let offset = 0;
+
+    // Scene points first
+    for (let i = 0; i < scenePoints.length; i++) {
+      positions[(offset + i) * 3] = scenePoints[i].position[0];
+      positions[(offset + i) * 3 + 1] = scenePoints[i].position[1];
+      positions[(offset + i) * 3 + 2] = scenePoints[i].position[2];
+      colors[(offset + i) * 3] = scenePoints[i].color[0];
+      colors[(offset + i) * 3 + 1] = scenePoints[i].color[1];
+      colors[(offset + i) * 3 + 2] = scenePoints[i].color[2];
+    }
+    offset += scenePoints.length;
+
+    // Object points after scene
+    const offsets = new Map<string, { offset: number; count: number }>();
+    for (const { id, points, scale, pos } of objectEntries) {
+      offsets.set(id, { offset, count: points.length });
+      for (let i = 0; i < points.length; i++) {
+        positions[(offset + i) * 3] = points[i].position[0] * scale + pos[0];
+        positions[(offset + i) * 3 + 1] = points[i].position[1] * scale + pos[1];
+        positions[(offset + i) * 3 + 2] = points[i].position[2] * scale + pos[2];
+        colors[(offset + i) * 3] = points[i].color[0];
+        colors[(offset + i) * 3 + 1] = points[i].color[1];
+        colors[(offset + i) * 3 + 2] = points[i].color[2];
+      }
+      offset += points.length;
+    }
+    objectOffsetsRef.current = offsets;
+
     scenePositionsRef.current = positions;
     sceneColorsRef.current = colors;
-    sceneCountRef.current = count;
-    const oc = new Float32Array(count * 4);
-    for (let i = 0; i < count; i++) {
+    sceneCountRef.current = totalCount;
+    const oc = new Float32Array(totalCount * 4);
+    for (let i = 0; i < totalCount; i++) {
       oc[i * 4] = colors[i * 3];
       oc[i * 4 + 1] = colors[i * 3 + 1];
       oc[i * 4 + 2] = colors[i * 3 + 2];
       oc[i * 4 + 3] = 1.0;
     }
     origColorsRef.current = oc;
-    origScalesRef.current = new Float32Array(count).fill(1.0);
-  }, [scenePoints]);
+    origScalesRef.current = new Float32Array(totalCount).fill(1.0);
+  }, [scenePoints, objectPointsMap]);
 
   // Cleanup
   useEffect(() => {
@@ -89,7 +129,8 @@ export function AnimationSystem({ scenePoints, onUpdateGeometry }: {
   }, []);
 
   useFrame((_, dt) => {
-    if (!wasmReady || !wasmModule || !preset || !playing || scenePoints.length === 0) return;
+    const hasPoints = scenePoints.length > 0 || (objectPointsMap && objectPointsMap.size > 0);
+    if (!wasmReady || !wasmModule || !preset || !playing || !hasPoints) return;
     if (!scenePositionsRef.current || !sceneColorsRef.current) return;
 
     const count = sceneCountRef.current;
@@ -153,7 +194,36 @@ export function AnimationSystem({ scenePoints, onUpdateGeometry }: {
       animatorRef.current.update(Math.min(dt, 0.05));
       const data = animatorRef.current.getSceneData();
       if (data) {
-        onUpdateGeometry(data.positions, data.colors, data.scales);
+        const sceneCount = scenePoints.length;
+        // Scene geometry update (first N points)
+        if (sceneCount > 0) {
+          onUpdateGeometry(
+            data.positions.subarray(0, sceneCount * 3),
+            data.colors.subarray(0, sceneCount * 4),
+            data.scales.subarray(0, sceneCount),
+          );
+        }
+        // Object geometry updates (remaining points, split by offset)
+        if (objectGeoRefs) {
+          for (const [objId, { offset, count: objCount }] of objectOffsetsRef.current) {
+            const geo = objectGeoRefs.get(objId)?.current;
+            if (!geo) continue;
+            const posAttr = geo.getAttribute('position') as THREE.BufferAttribute;
+            const colAttr = geo.getAttribute('aColor') as THREE.BufferAttribute;
+            const scaleAttr = geo.getAttribute('aScale') as THREE.BufferAttribute;
+            if (!posAttr || !colAttr) continue;
+            // Copy subset of positions (3 floats per point)
+            posAttr.set(data.positions.subarray(offset * 3, (offset + objCount) * 3));
+            posAttr.needsUpdate = true;
+            // Copy subset of colors (4 floats per point — RGBA)
+            colAttr.set(data.colors.subarray(offset * 4, (offset + objCount) * 4));
+            colAttr.needsUpdate = true;
+            if (scaleAttr) {
+              (scaleAttr as any).array = data.scales.subarray(offset, offset + objCount);
+              scaleAttr.needsUpdate = true;
+            }
+          }
+        }
       }
     } else if (!anyActive) {
       // No animations active — clean up animator and restore original
@@ -162,7 +232,12 @@ export function AnimationSystem({ scenePoints, onUpdateGeometry }: {
         animatorRef.current = null;
         activeGroups.clear();
       }
-      onUpdateGeometry(scenePositionsRef.current!, origColorsRef.current!, origScalesRef.current!);
+      const sceneCount = scenePoints.length;
+      if (sceneCount > 0) {
+        onUpdateGeometry(scenePositionsRef.current!.subarray(0, sceneCount * 3),
+          origColorsRef.current!.subarray(0, sceneCount * 4),
+          origScalesRef.current!.subarray(0, sceneCount));
+      }
     }
   });
 

--- a/tools/apps/melies/src/viewport/AnimationSystem.tsx
+++ b/tools/apps/melies/src/viewport/AnimationSystem.tsx
@@ -56,7 +56,7 @@ export function AnimationSystem({ scenePoints, objectPointsMap, objectGeoRefs, o
   }, []);
 
   // Track object point offsets for splitting output
-  const objectOffsetsRef = useRef<Map<string, { offset: number; count: number }>>(new Map());
+  const objectOffsetsRef = useRef<Map<string, { offset: number; count: number; pos: [number, number, number] }>>(new Map());
 
   // Cache scene + object data merged into one buffer
   useEffect(() => {
@@ -91,14 +91,14 @@ export function AnimationSystem({ scenePoints, objectPointsMap, objectGeoRefs, o
     offset += scenePoints.length;
 
     // Object points after scene
-    const offsets = new Map<string, { offset: number; count: number }>();
+    const offsets = new Map<string, { offset: number; count: number; pos: [number, number, number] }>();
     for (const { id, points, scale, pos } of objectEntries) {
-      offsets.set(id, { offset, count: points.length });
+      offsets.set(id, { offset, count: points.length, pos });
       for (let i = 0; i < points.length; i++) {
-        // Object-local coordinates (element position handled by Three.js group transform)
-        positions[(offset + i) * 3] = points[i].position[0] * scale;
-        positions[(offset + i) * 3 + 1] = points[i].position[1] * scale;
-        positions[(offset + i) * 3 + 2] = points[i].position[2] * scale;
+        // Prefab-space coordinates (element position included so animation regions overlap correctly)
+        positions[(offset + i) * 3] = points[i].position[0] * scale + pos[0];
+        positions[(offset + i) * 3 + 1] = points[i].position[1] * scale + pos[1];
+        positions[(offset + i) * 3 + 2] = points[i].position[2] * scale + pos[2];
         colors[(offset + i) * 3] = points[i].color[0];
         colors[(offset + i) * 3 + 1] = points[i].color[1];
         colors[(offset + i) * 3 + 2] = points[i].color[2];
@@ -206,15 +206,23 @@ export function AnimationSystem({ scenePoints, objectPointsMap, objectGeoRefs, o
         }
         // Object geometry updates (remaining points, split by offset)
         if (objectGeoRefs) {
-          for (const [objId, { offset, count: objCount }] of objectOffsetsRef.current) {
+          for (const [objId, { offset, count: objCount, pos: objPos }] of objectOffsetsRef.current) {
             const geo = objectGeoRefs.get(objId)?.current;
             if (!geo) continue;
             const posAttr = geo.getAttribute('position') as THREE.BufferAttribute;
             const colAttr = geo.getAttribute('aColor') as THREE.BufferAttribute;
             const scaleAttr = geo.getAttribute('aScale') as THREE.BufferAttribute;
             if (!posAttr || !colAttr) continue;
-            // Copy subset of positions (3 floats per point)
-            posAttr.set(data.positions.subarray(offset * 3, (offset + objCount) * 3));
+            // Copy subset of positions, subtracting element position
+            // (ObjectGizmo's <group position={pos}> adds it back in Three.js)
+            const objPositions = data.positions.subarray(offset * 3, (offset + objCount) * 3);
+            const localPositions = new Float32Array(objCount * 3);
+            for (let i = 0; i < objCount; i++) {
+              localPositions[i * 3] = objPositions[i * 3] - objPos[0];
+              localPositions[i * 3 + 1] = objPositions[i * 3 + 1] - objPos[1];
+              localPositions[i * 3 + 2] = objPositions[i * 3 + 2] - objPos[2];
+            }
+            posAttr.set(localPositions);
             posAttr.needsUpdate = true;
             // Copy subset of colors (4 floats per point — RGBA)
             colAttr.set(data.colors.subarray(offset * 4, (offset + objCount) * 4));

--- a/tools/apps/melies/src/viewport/AnimationSystem.tsx
+++ b/tools/apps/melies/src/viewport/AnimationSystem.tsx
@@ -95,9 +95,10 @@ export function AnimationSystem({ scenePoints, objectPointsMap, objectGeoRefs, o
     for (const { id, points, scale, pos } of objectEntries) {
       offsets.set(id, { offset, count: points.length });
       for (let i = 0; i < points.length; i++) {
-        positions[(offset + i) * 3] = points[i].position[0] * scale + pos[0];
-        positions[(offset + i) * 3 + 1] = points[i].position[1] * scale + pos[1];
-        positions[(offset + i) * 3 + 2] = points[i].position[2] * scale + pos[2];
+        // Object-local coordinates (element position handled by Three.js group transform)
+        positions[(offset + i) * 3] = points[i].position[0] * scale;
+        positions[(offset + i) * 3 + 1] = points[i].position[1] * scale;
+        positions[(offset + i) * 3 + 2] = points[i].position[2] * scale;
         colors[(offset + i) * 3] = points[i].color[0];
         colors[(offset + i) * 3 + 1] = points[i].color[1];
         colors[(offset + i) * 3 + 2] = points[i].color[2];

--- a/tools/apps/melies/src/viewport/Preview.tsx
+++ b/tools/apps/melies/src/viewport/Preview.tsx
@@ -324,11 +324,15 @@ export function Preview({ scenePoints }: { scenePoints: PlyPoint[] }) {
   const showGizmos = useVfxStore((s) => s.showGizmos);
   const showPointCloud = useVfxStore((s) => s.showPointCloud);
   const sceneGeoRef = useRef<THREE.BufferGeometry | null>(null);
-  const objectPointsRef = useRef<Map<string, { points: PlyPoint[]; scale: number }>>(new Map());
+  const [objectPointsMap, setObjectPointsMap] = useState<Map<string, { points: PlyPoint[]; scale: number }>>(new Map());
   const objectGeoRefsRef = useRef<Map<string, React.MutableRefObject<THREE.BufferGeometry | null>>>(new Map());
 
   const handleObjectPointsLoaded = useCallback((layerId: string, points: PlyPoint[], scale: number) => {
-    objectPointsRef.current.set(layerId, { points, scale });
+    setObjectPointsMap((prev) => {
+      const next = new Map(prev);
+      next.set(layerId, { points, scale });
+      return next;
+    });
   }, []);
 
   // Callback for AnimationSystem to update point cloud geometry
@@ -364,7 +368,7 @@ export function Preview({ scenePoints }: { scenePoints: PlyPoint[] }) {
         {scenePoints.length > 0 && showPointCloud && <GaussianPointCloud points={scenePoints} geoRef={sceneGeoRef} />}
         <LayerGizmos showGizmos={showGizmos} onObjectPointsLoaded={handleObjectPointsLoaded} objectGeoRefs={objectGeoRefsRef} />
         <ParticleSystem />
-        <AnimationSystem scenePoints={scenePoints} objectPointsMap={objectPointsRef.current}
+        <AnimationSystem scenePoints={scenePoints} objectPointsMap={objectPointsMap}
           objectGeoRefs={objectGeoRefsRef.current} onUpdateGeometry={handleUpdateGeometry} />
         <OrbitControls />
       </Canvas>

--- a/tools/apps/melies/src/viewport/Preview.tsx
+++ b/tools/apps/melies/src/viewport/Preview.tsx
@@ -72,7 +72,10 @@ function GaussianPointCloud({ points, geoRef }: { points: PlyPoint[]; geoRef: Re
 
 type GizmoProps = { layer: VfxLayer; active: boolean; selected: boolean; onSelect: () => void };
 
-function ObjectGizmo({ layer, selected, onSelect }: GizmoProps) {
+function ObjectGizmo({ layer, selected, onSelect, onPointsLoaded, externalGeoRef }: GizmoProps & {
+  onPointsLoaded?: (layerId: string, points: PlyPoint[], scale: number) => void;
+  externalGeoRef?: React.MutableRefObject<THREE.BufferGeometry | null>;
+}) {
   const pos = layer.position ?? [0, 0, 0];
   const scale = layer.scale ?? 1;
   const [points, setPoints] = useState<PlyPoint[]>([]);
@@ -91,6 +94,11 @@ function ObjectGizmo({ layer, selected, onSelect }: GizmoProps) {
     }
   }, [layer.ply_file]);
 
+  // Report loaded points to parent for animation
+  useEffect(() => {
+    if (points.length > 0) onPointsLoaded?.(layer.id, points, scale);
+  }, [points, scale, layer.id, onPointsLoaded]);
+
   const geometry = useMemo(() => {
     if (points.length === 0) return null;
     const geo = new THREE.BufferGeometry();
@@ -106,11 +114,16 @@ function ObjectGizmo({ layer, selected, onSelect }: GizmoProps) {
       colors[i * 4 + 2] = points[i].color[2];
       colors[i * 4 + 3] = 1.0;
     }
-    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-    geo.setAttribute('aColor', new THREE.BufferAttribute(colors, 4));
-    geo.setAttribute('aScale', new THREE.BufferAttribute(new Float32Array(n).fill(1.0), 1));
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3).setUsage(THREE.DynamicDrawUsage));
+    geo.setAttribute('aColor', new THREE.BufferAttribute(colors, 4).setUsage(THREE.DynamicDrawUsage));
+    geo.setAttribute('aScale', new THREE.BufferAttribute(new Float32Array(n).fill(1.0), 1).setUsage(THREE.DynamicDrawUsage));
     return geo;
   }, [points, scale]);
+
+  // Expose geometry ref to parent for animation updates
+  useEffect(() => {
+    if (externalGeoRef) externalGeoRef.current = geometry;
+  }, [geometry, externalGeoRef]);
 
   const material = useMemo(() => new THREE.ShaderMaterial({
     uniforms: { uPixelRatio: { value: window.devicePixelRatio || 1.0 } },
@@ -238,7 +251,11 @@ function LightGizmo({ layer, active, selected, onSelect }: GizmoProps) {
   );
 }
 
-function LayerGizmos({ showGizmos }: { showGizmos: boolean }) {
+function LayerGizmos({ showGizmos, onObjectPointsLoaded, objectGeoRefs }: {
+  showGizmos: boolean;
+  onObjectPointsLoaded?: (layerId: string, points: PlyPoint[], scale: number) => void;
+  objectGeoRefs?: React.MutableRefObject<Map<string, React.MutableRefObject<THREE.BufferGeometry | null>>>;
+}) {
   const preset = useVfxStore((s) => {
     return s.presets.find((p) => p.id === s.selectedPresetId);
   });
@@ -275,7 +292,16 @@ function LayerGizmos({ showGizmos }: { showGizmos: boolean }) {
         const selected = selectedLayerId === layer.id;
         const onSelect = () => selectLayer(layer.id);
         // Object PLYs always render (they're geometry, not gizmos)
-        if (layer.type === 'object') return <ObjectGizmo key={layer.id} layer={layer} active={true} selected={selected} onSelect={onSelect} />;
+        if (layer.type === 'object') {
+          // Get or create a geoRef for this object
+          let geoRef = objectGeoRefs?.current.get(layer.id);
+          if (!geoRef && objectGeoRefs) {
+            geoRef = { current: null };
+            objectGeoRefs.current.set(layer.id, geoRef);
+          }
+          return <ObjectGizmo key={layer.id} layer={layer} active={true} selected={selected} onSelect={onSelect}
+            onPointsLoaded={onObjectPointsLoaded} externalGeoRef={geoRef} />;
+        }
         // Other gizmos respect showGizmos toggle
         if (!showGizmos) return null;
         if (layer.type === 'emitter') return <EmitterGizmo key={layer.id} layer={layer} active={active} selected={selected} onSelect={onSelect} />;
@@ -298,6 +324,12 @@ export function Preview({ scenePoints }: { scenePoints: PlyPoint[] }) {
   const showGizmos = useVfxStore((s) => s.showGizmos);
   const showPointCloud = useVfxStore((s) => s.showPointCloud);
   const sceneGeoRef = useRef<THREE.BufferGeometry | null>(null);
+  const objectPointsRef = useRef<Map<string, { points: PlyPoint[]; scale: number }>>(new Map());
+  const objectGeoRefsRef = useRef<Map<string, React.MutableRefObject<THREE.BufferGeometry | null>>>(new Map());
+
+  const handleObjectPointsLoaded = useCallback((layerId: string, points: PlyPoint[], scale: number) => {
+    objectPointsRef.current.set(layerId, { points, scale });
+  }, []);
 
   // Callback for AnimationSystem to update point cloud geometry
   const handleUpdateGeometry = useCallback((positions: Float32Array, colors: Float32Array, scales?: Float32Array) => {
@@ -330,9 +362,10 @@ export function Preview({ scenePoints }: { scenePoints: PlyPoint[] }) {
         <directionalLight position={[10, 20, 10]} intensity={0.6} />
         <Grid args={[40, 40]} cellSize={1} cellColor="#2a2a4a" sectionSize={5} sectionColor="#3a3a5a" fadeDistance={30} infiniteGrid={false} />
         {scenePoints.length > 0 && showPointCloud && <GaussianPointCloud points={scenePoints} geoRef={sceneGeoRef} />}
-        <LayerGizmos showGizmos={showGizmos} />
+        <LayerGizmos showGizmos={showGizmos} onObjectPointsLoaded={handleObjectPointsLoaded} objectGeoRefs={objectGeoRefsRef} />
         <ParticleSystem />
-        <AnimationSystem scenePoints={scenePoints} onUpdateGeometry={handleUpdateGeometry} />
+        <AnimationSystem scenePoints={scenePoints} objectPointsMap={objectPointsRef.current}
+          objectGeoRefs={objectGeoRefsRef.current} onUpdateGeometry={handleUpdateGeometry} />
         <OrbitControls />
       </Canvas>
 


### PR DESCRIPTION
## Summary
Object element PLYs now animate alongside scene PLY in Méliès. A torch prefab with Object (mesh) + Animation (wave/pulse) will show the animation on the mesh geometry.

### Architecture
- **ObjectGizmo** reports loaded points to Preview via `onPointsLoaded` callback
- **Preview** collects object points in a Map and passes to AnimationSystem
- **AnimationSystem** merges scene + object points into one WASM Animator buffer
- After `getSceneData()`, output is split back: scene → `onUpdateGeometry`, objects → direct geometry attribute updates via `objectGeoRefs`

### Data flow
```
[scene points | obj1 points | obj2 points]
         ↓ loadScene()
    WASM Animator
         ↓ getSceneData()
[scene output | obj1 output | obj2 output]
    ↓ split           ↓ split
onUpdateGeometry    objectGeoRefs update
```

## Test plan
- [x] TypeScript compiles
- [ ] Object PLY + Pulse animation → mesh visibly pulses
- [ ] Object PLY + Wave animation → mesh ripples
- [ ] Scene PLY animation still works independently
- [ ] Multiple objects animate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)