### PR TITLE
Render Object PLY elements in Bricklayer viewport

### DIFF
--- a/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
@@ -1,14 +1,75 @@
 import React from 'react';
 import { Html } from '@react-three/drei';
 import { useSceneStore } from '../store/useSceneStore.js';
+import type { VfxInstanceData, VfxElementData } from '../store/types.js';
 
-function VfxMarker({ position, name, radius, isSelected, onSelect }: {
-  position: [number, number, number];
-  name: string;
-  radius: number;
+// Element type colors
+const ELEMENT_COLORS: Record<string, string> = {
+  object: '#aaaaaa',
+  emitter: '#ec4899',
+  animation: '#06b6d4',
+  light: '#eab308',
+};
+
+function ElementGizmo({ element }: { element: VfxElementData }) {
+  const pos = element.position ?? [0, 0, 0];
+  const color = ELEMENT_COLORS[element.type] ?? '#888';
+
+  return (
+    <group position={pos}>
+      {/* Center dot */}
+      <mesh>
+        <sphereGeometry args={[0.2, 8, 8]} />
+        <meshBasicMaterial color={color} transparent opacity={0.8} />
+      </mesh>
+      {/* Type-specific gizmo */}
+      {element.type === 'emitter' && element.emitter && (
+        <mesh>
+          <sphereGeometry args={[0.5, 8, 8]} />
+          <meshBasicMaterial color={color} transparent opacity={0.15} />
+        </mesh>
+      )}
+      {element.type === 'animation' && (
+        <mesh>
+          {element.region?.shape === 'box' ? (
+            <boxGeometry args={((element.region?.half_extents ?? [2, 2, 2]) as [number, number, number]).map((v) => v * 2) as [number, number, number]} />
+          ) : (
+            <sphereGeometry args={[element.region?.radius ?? 2, 16, 12]} />
+          )}
+          <meshBasicMaterial color={color} wireframe transparent opacity={0.25} />
+        </mesh>
+      )}
+      {element.type === 'object' && (
+        <mesh rotation={[0, Math.PI / 4, 0]}>
+          <octahedronGeometry args={[0.3]} />
+          <meshBasicMaterial color={color} transparent opacity={0.5} />
+        </mesh>
+      )}
+      {element.type === 'light' && (
+        <mesh>
+          <sphereGeometry args={[0.3, 8, 8]} />
+          <meshBasicMaterial color={color} transparent opacity={0.7} />
+        </mesh>
+      )}
+      {/* Label */}
+      <Html position={[0, 0.5, 0]} center>
+        <div style={{
+          fontSize: 8, color, whiteSpace: 'nowrap', opacity: 0.7,
+          textShadow: '0 0 3px rgba(0,0,0,0.8)',
+        }}>
+          {element.name}
+        </div>
+      </Html>
+    </group>
+  );
+}
+
+function VfxMarker({ instance, isSelected, onSelect }: {
+  instance: VfxInstanceData;
   isSelected: boolean;
   onSelect: () => void;
 }) {
+  const { position, name, radius } = instance;
   const color = isSelected ? '#ffffff' : '#f59e0b';
 
   return (
@@ -39,6 +100,10 @@ function VfxMarker({ position, name, radius, isSelected, onSelect }: {
           </div>
         </Html>
       )}
+      {/* Element gizmos (shown when selected) */}
+      {isSelected && (instance.vfx_preset.elements ?? []).map((el, i) => (
+        <ElementGizmo key={`${instance.id}_el_${i}`} element={el} />
+      ))}
     </group>
   );
 }
@@ -56,9 +121,7 @@ export function VfxInstanceMarkers() {
       {instances.map((v) => (
         <VfxMarker
           key={v.id}
-          position={v.position}
-          name={v.name}
-          radius={v.radius}
+          instance={v}
           isSelected={selectedEntity?.type === 'vfx_instance' && selectedEntity.id === v.id}
           onSelect={() => setSelectedEntity({ type: 'vfx_instance', id: v.id })}
         />

--- a/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
@@ -23,12 +23,26 @@ function ElementGizmo({ element }: { element: VfxElementData }) {
         <meshBasicMaterial color={color} transparent opacity={0.8} />
       </mesh>
       {/* Type-specific gizmo */}
-      {element.type === 'emitter' && element.emitter && (
-        <mesh>
-          <sphereGeometry args={[0.5, 8, 8]} />
-          <meshBasicMaterial color={color} transparent opacity={0.15} />
-        </mesh>
-      )}
+      {element.type === 'emitter' && (() => {
+        const region = (element.emitter as Record<string, any>)?.region;
+        if (!region) return (
+          <mesh>
+            <sphereGeometry args={[0.5, 8, 8]} />
+            <meshBasicMaterial color={color} transparent opacity={0.15} />
+          </mesh>
+        );
+        const center = region.center ?? [0, 0, 0];
+        return (
+          <mesh position={center}>
+            {region.shape === 'sphere' ? (
+              <sphereGeometry args={[region.radius ?? 1, 16, 12]} />
+            ) : (
+              <boxGeometry args={((region.half_extents ?? [1, 1, 1]) as [number, number, number]).map((v: number) => v * 2) as [number, number, number]} />
+            )}
+            <meshBasicMaterial color={color} wireframe transparent opacity={0.2} />
+          </mesh>
+        );
+      })()}
       {element.type === 'animation' && (
         <mesh>
           {element.region?.shape === 'box' ? (

--- a/tools/apps/bricklayer/src/viewport/VfxRenderer.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxRenderer.tsx
@@ -157,13 +157,141 @@ function EmitterLayerRenderer({ layer, instancePos }: {
   );
 }
 
+// ── Object PLY renderer (loads and renders a PLY point cloud) ──
+
+function ObjectLayerRenderer({ layer, instancePos }: {
+  layer: VfxElementData;
+  instancePos: [number, number, number];
+}) {
+  const [geometry, setGeometry] = useState<THREE.BufferGeometry | null>(null);
+  const elPos = layer.position ?? [0, 0, 0];
+  const scale = layer.scale ?? 1;
+
+  useEffect(() => {
+    if (!layer.ply_file) return;
+    // Try loading PLY from project directory
+    const store = useSceneStore.getState();
+    const handle = store.projectHandle;
+    if (!handle) return;
+
+    (async () => {
+      try {
+        // Navigate to the file
+        const parts = layer.ply_file!.split('/');
+        let dir: FileSystemDirectoryHandle = handle;
+        for (let i = 0; i < parts.length - 1; i++) {
+          dir = await dir.getDirectoryHandle(parts[i]);
+        }
+        const fh = await dir.getFileHandle(parts[parts.length - 1]);
+        const file = await fh.getFile();
+        const buffer = await file.arrayBuffer();
+
+        // Minimal PLY parser (binary, expects f_dc_0/1/2 or red/green/blue)
+        const headerEnd = new TextDecoder().decode(new Uint8Array(buffer, 0, Math.min(2048, buffer.byteLength)));
+        const headerLines = headerEnd.split('\n');
+        let vertexCount = 0;
+        let propNames: string[] = [];
+        let dataStart = 0;
+        for (const line of headerLines) {
+          dataStart += line.length + 1;
+          if (line.startsWith('element vertex')) vertexCount = parseInt(line.split(' ')[2]);
+          if (line.startsWith('property float')) propNames.push(line.split(' ')[2]);
+          if (line.trim() === 'end_header') break;
+        }
+
+        const stride = propNames.length * 4;
+        const dataView = new DataView(buffer, dataStart);
+        const geo = new THREE.BufferGeometry();
+        const positions = new Float32Array(vertexCount * 3);
+        const colors = new Float32Array(vertexCount * 4);
+
+        const xIdx = propNames.indexOf('x');
+        const yIdx = propNames.indexOf('y');
+        const zIdx = propNames.indexOf('z');
+        const dcR = propNames.indexOf('f_dc_0');
+        const dcG = propNames.indexOf('f_dc_1');
+        const dcB = propNames.indexOf('f_dc_2');
+        const rIdx = propNames.indexOf('red');
+        const gIdx = propNames.indexOf('green');
+        const bIdx = propNames.indexOf('blue');
+
+        for (let i = 0; i < vertexCount; i++) {
+          const off = i * stride;
+          positions[i * 3] = dataView.getFloat32(off + xIdx * 4, true) * scale;
+          positions[i * 3 + 1] = dataView.getFloat32(off + yIdx * 4, true) * scale;
+          positions[i * 3 + 2] = dataView.getFloat32(off + zIdx * 4, true) * scale;
+          if (dcR >= 0) {
+            colors[i * 4] = 0.5 + 0.2820948 * dataView.getFloat32(off + dcR * 4, true);
+            colors[i * 4 + 1] = 0.5 + 0.2820948 * dataView.getFloat32(off + dcG * 4, true);
+            colors[i * 4 + 2] = 0.5 + 0.2820948 * dataView.getFloat32(off + dcB * 4, true);
+          } else if (rIdx >= 0) {
+            colors[i * 4] = dataView.getUint8(off + rIdx) / 255;
+            colors[i * 4 + 1] = dataView.getUint8(off + gIdx) / 255;
+            colors[i * 4 + 2] = dataView.getUint8(off + bIdx) / 255;
+          } else {
+            colors[i * 4] = 0.7; colors[i * 4 + 1] = 0.7; colors[i * 4 + 2] = 0.7;
+          }
+          colors[i * 4 + 3] = 1.0;
+        }
+
+        geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        geo.setAttribute('color', new THREE.BufferAttribute(colors, 4));
+        setGeometry(geo);
+      } catch (e) {
+        console.warn('[VfxRenderer] Failed to load Object PLY:', layer.ply_file, e);
+      }
+    })();
+  }, [layer.ply_file, scale]);
+
+  const material = useMemo(() => new THREE.ShaderMaterial({
+    vertexShader: `
+      varying vec4 vColor;
+      void main() {
+        vColor = color;
+        vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+        gl_PointSize = max(0.5, 0.5) * (20.0 / -mvPosition.z);
+        gl_Position = projectionMatrix * mvPosition;
+      }
+    `,
+    fragmentShader: `
+      varying vec4 vColor;
+      void main() {
+        float d = length(gl_PointCoord - vec2(0.5));
+        if (d > 0.5) discard;
+        gl_FragColor = vec4(vColor.rgb, vColor.a);
+      }
+    `,
+    vertexColors: true,
+    transparent: true,
+    depthWrite: false,
+  }), []);
+
+  if (!geometry) return null;
+
+  return (
+    <points
+      geometry={geometry}
+      material={material}
+      position={[instancePos[0] + elPos[0], instancePos[1] + elPos[1], instancePos[2] + elPos[2]]}
+    />
+  );
+}
+
 // ── Per-instance renderer ──
 
 function InstanceRenderer({ instance }: { instance: VfxInstanceData }) {
   const emitterLayers = (instance.vfx_preset.elements ?? []).filter((l) => l.type === 'emitter');
+  const objectLayers = (instance.vfx_preset.elements ?? []).filter((l) => l.type === 'object');
 
   return (
     <group>
+      {objectLayers.map((layer, i) => (
+        <ObjectLayerRenderer
+          key={`${instance.id}_obj_${i}`}
+          layer={layer}
+          instancePos={instance.position}
+        />
+      ))}
       {emitterLayers.map((layer, i) => (
         <EmitterLayerRenderer
           key={`${instance.id}_${i}`}

--- a/tools/apps/bricklayer/src/viewport/VfxRenderer.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxRenderer.tsx
@@ -176,14 +176,26 @@ function ObjectLayerRenderer({ layer, instancePos }: {
 
     (async () => {
       try {
-        // Navigate to the file
-        const parts = layer.ply_file!.split('/');
-        let dir: FileSystemDirectoryHandle = handle;
-        for (let i = 0; i < parts.length - 1; i++) {
-          dir = await dir.getDirectoryHandle(parts[i]);
+        // Try loading from project directory: first the exact path, then assets/vfx/
+        let file: File | null = null;
+        const tryPaths = [
+          layer.ply_file!,
+          `assets/vfx/${layer.ply_file!.split('/').pop()}`,
+          layer.ply_file!.split('/').pop()!,
+        ];
+        for (const tryPath of tryPaths) {
+          try {
+            const parts = tryPath.split('/');
+            let dir: FileSystemDirectoryHandle = handle;
+            for (let i = 0; i < parts.length - 1; i++) {
+              dir = await dir.getDirectoryHandle(parts[i]);
+            }
+            const fh = await dir.getFileHandle(parts[parts.length - 1]);
+            file = await fh.getFile();
+            break;
+          } catch { /* try next path */ }
         }
-        const fh = await dir.getFileHandle(parts[parts.length - 1]);
-        const file = await fh.getFile();
+        if (!file) { console.warn('[VfxRenderer] Object PLY not found:', layer.ply_file); return; }
         const buffer = await file.arrayBuffer();
 
         // Minimal PLY parser (binary, expects f_dc_0/1/2 or red/green/blue)

--- a/tools/apps/bricklayer/src/viewport/VfxRenderer.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxRenderer.tsx
@@ -75,8 +75,13 @@ function EmitterLayerRenderer({ layer, instancePos }: {
       emitter.configurePreset('fire');
     }
 
-    // Set emitter at instance position — spawn offsets are relative to this
-    emitter.setPosition(instancePos[0], instancePos[1], instancePos[2]);
+    // Set emitter at instance position + element relative position
+    const elPos = layer.position ?? [0, 0, 0];
+    emitter.setPosition(
+      instancePos[0] + elPos[0],
+      instancePos[1] + elPos[1],
+      instancePos[2] + elPos[2],
+    );
     emitter.setActive(true);
     emitterRef.current = emitter;
 


### PR DESCRIPTION
## Summary
VFX instances with Object elements now load and render PLY point clouds in the Bricklayer viewport. Previously only emitter particles were rendered.

- `ObjectLayerRenderer`: loads PLY from project directory via File System Access API
- Parses binary PLY header (supports f_dc_0/1/2 SH and red/green/blue colors)
- Positioned at instance position + element position offset with scale
- Renders alongside emitter particles in InstanceRenderer

## Test plan
- [x] TypeScript compiles
- [x] Import torch.vfx.json → torch PLY renders at instance position
- [x] Move instance → PLY follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)