### PR TITLE
Staging app: C++ ImGui rendering review tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,31 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(wren)
 
+FetchContent_Declare(
+    imgui
+    GIT_REPOSITORY https://github.com/ocornut/imgui.git
+    GIT_TAG        v1.91.8
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+)
+FetchContent_MakeAvailable(imgui)
+
+# Build Dear ImGui as a static library with Vulkan + GLFW backends
+add_library(imgui_lib STATIC
+    ${imgui_SOURCE_DIR}/imgui.cpp
+    ${imgui_SOURCE_DIR}/imgui_demo.cpp
+    ${imgui_SOURCE_DIR}/imgui_draw.cpp
+    ${imgui_SOURCE_DIR}/imgui_tables.cpp
+    ${imgui_SOURCE_DIR}/imgui_widgets.cpp
+    ${imgui_SOURCE_DIR}/backends/imgui_impl_glfw.cpp
+    ${imgui_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp
+)
+target_include_directories(imgui_lib PUBLIC
+    ${imgui_SOURCE_DIR}
+    ${imgui_SOURCE_DIR}/backends
+)
+target_link_libraries(imgui_lib PUBLIC Vulkan::Vulkan glfw)
+
 # Build wren as a static library from C sources
 add_library(wren_lib STATIC
     ${wren_SOURCE_DIR}/src/vm/wren_compiler.c
@@ -226,6 +251,23 @@ add_executable(gseurat_demo
 target_compile_definitions(gseurat_demo PRIVATE VG_BUILD_PROFILE=1)
 target_link_libraries(gseurat_demo PRIVATE gseurat_core)
 add_dependencies(gseurat_demo shaders)
+
+# --- Staging executable (ImGui-based rendering review tool) -----------------
+
+add_executable(gseurat_staging
+    src/staging_main.cpp
+    src/staging/staging_app.cpp
+    src/staging/staging_state.cpp
+)
+target_link_libraries(gseurat_staging PRIVATE gseurat_core imgui_lib)
+add_dependencies(gseurat_staging shaders)
+
+add_custom_command(TARGET gseurat_staging POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${PROJECT_SOURCE_DIR}/assets
+        $<TARGET_FILE_DIR:gseurat_staging>/assets
+    COMMENT "Copying assets to staging build directory"
+)
 
 # --- Copy assets to build directory -----------------------------------------
 

--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -2,6 +2,9 @@
 
 #include "gseurat/engine/async_loader.hpp"
 #include "gseurat/engine/audio_system.hpp"
+#ifndef _WIN32
+#include "gseurat/engine/control_server.hpp"
+#endif
 #include "gseurat/engine/collision_gen.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/day_night_system.hpp"
@@ -216,6 +219,13 @@ protected:
     // Scripting
     WrenVM wren_vm_;
     ScriptSystem script_system_;
+
+    // Control server (bridge integration)
+#ifndef _WIN32
+    ControlServer control_server_;
+#endif
+    virtual void dispatch_command(const nlohmann::json& cmd, nlohmann::json& response);
+    void poll_control_server();
 
     // Step mode / control
     bool step_mode_ = false;

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -52,6 +52,7 @@ public:
     int light_mode() const { return light_mode_; }
     void set_light_dir(const glm::vec3& d) { light_dir_ = d; }
     void set_light_intensity(float i) { light_intensity_ = i; }
+    float light_intensity() const { return light_intensity_; }
     void set_point_lights(const std::vector<PointLight>& lights);
     const std::vector<PointLight>& point_lights() const { return point_lights_; }
     void set_touch_point(const glm::vec3& p, float radius, float timer = 0.0f) {

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -236,6 +236,7 @@ private:
     static constexpr uint32_t kGsStableFramesNeeded = 30;  // ~0.5s at 60fps
     float gs_blit_offset_x_ = 0.0f;
     float gs_blit_offset_y_ = 0.0f;
+    uint32_t gs_prev_budget_ = 0;
 
     // Persistent post-process params (modified by Staging panels)
     PostProcessParams pp_params_;

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -25,6 +25,7 @@
 #include "gseurat/engine/vk_context.hpp"
 
 #include <array>
+#include <functional>
 #include <optional>
 #include <string>
 #include <vector>
@@ -79,6 +80,9 @@ public:
     void set_god_rays_intensity(float v) { god_rays_intensity_ = v; }
     float god_rays_intensity() const { return god_rays_intensity_; }
 
+    PostProcessParams& post_process_params() { return pp_params_; }
+    const PostProcessParams& post_process_params() const { return pp_params_; }
+
     // Gaussian particle emitters
     void add_gs_particle_emitter(const GsEmitterConfig& config);
     void clear_gs_particle_emitters();
@@ -122,6 +126,13 @@ public:
 
     VkContext& context() { return context_; }
     CommandPool& command_pool() { return command_pool_; }
+    Swapchain& swapchain() { return swapchain_; }
+    PostProcessPipeline& post_process() { return post_process_; }
+
+    // Overlay callback: called after composite pass with (cmd, swapchain_image_index)
+    // Used by Staging app to inject ImGui render pass
+    using OverlayCallback = std::function<void(VkCommandBuffer, uint32_t)>;
+    void set_overlay_callback(OverlayCallback cb) { overlay_callback_ = std::move(cb); }
 
 private:
     void create_sprite_pipeline();
@@ -225,8 +236,14 @@ private:
     float gs_blit_offset_x_ = 0.0f;
     float gs_blit_offset_y_ = 0.0f;
 
+    // Persistent post-process params (modified by Staging panels)
+    PostProcessParams pp_params_;
+
     // Screenshot capture
     ScreenshotCapture screenshot_;
+
+    // Overlay callback (ImGui rendering hook)
+    OverlayCallback overlay_callback_;
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -201,6 +201,7 @@ private:
     std::array<VkDescriptorSet, kMaxFramesInFlight> gs_descriptor_sets_{};    // scene UBO (unused now)
     std::array<VkDescriptorSet, kMaxFramesInFlight> gs_ui_descriptor_sets_{}; // UI orthographic UBO
     bool gs_initialized_ = false;
+    ResourceHandle<Texture> gs_bg_texture_;
     std::array<VkDescriptorSet, kMaxFramesInFlight> gs_bg_descriptor_sets_{};
     bool gs_bg_initialized_ = false;
 

--- a/include/gseurat/engine/resource_cache.hpp
+++ b/include/gseurat/engine/resource_cache.hpp
@@ -45,6 +45,16 @@ public:
 
     void clear() { cache_.clear(); }
 
+    // Call fn for each live (non-expired) resource
+    template <typename Fn>
+    void for_each_live(Fn fn) {
+        for (auto& [key, wp] : cache_) {
+            if (auto sp = wp.lock()) {
+                fn(key, *sp);
+            }
+        }
+    }
+
 private:
     LoaderFn loader_;
     std::unordered_map<std::string, std::weak_ptr<T>> cache_;

--- a/include/gseurat/staging/staging_app.hpp
+++ b/include/gseurat/staging/staging_app.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "gseurat/engine/app_base.hpp"
+
+#include <vulkan/vulkan.h>
+#include <string>
+
+namespace gseurat {
+
+class StagingApp : public AppBase {
+public:
+    void parse_args(int argc, char* argv[]);
+
+protected:
+    void init_game_content() override;
+    void main_loop() override;
+    void cleanup() override;
+    void init_scene(const std::string& scene_path) override;
+    void clear_scene() override;
+
+private:
+    void init_imgui();
+    void shutdown_imgui();
+    void create_imgui_render_pass();
+
+    std::string scene_path_ = "assets/scenes/gs_demo.json";
+
+    // ImGui Vulkan resources
+    VkDescriptorPool imgui_pool_ = VK_NULL_HANDLE;
+    VkRenderPass imgui_render_pass_ = VK_NULL_HANDLE;
+    std::vector<VkFramebuffer> imgui_framebuffers_;
+};
+
+}  // namespace gseurat

--- a/include/gseurat/staging/staging_state.hpp
+++ b/include/gseurat/staging/staging_state.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "gseurat/engine/game_state.hpp"
+
+#include <glm/vec3.hpp>
+#include <array>
+#include <string>
+#include <vector>
+
+namespace gseurat {
+
+class StagingState : public GameState {
+public:
+    void on_enter(AppBase& app) override;
+    void on_exit(AppBase& app) override;
+    void update(AppBase& app, float dt) override;
+    void build_draw_lists(AppBase& app) override;
+
+private:
+    void draw_imgui(AppBase& app);
+    void draw_viewport_info(AppBase& app);
+    void draw_render_settings(AppBase& app);
+    void draw_gs_params(AppBase& app);
+    void draw_feature_toggles(AppBase& app);
+    void draw_lighting(AppBase& app);
+    void draw_camera_panel(AppBase& app);
+    void draw_scene_panel(AppBase& app);
+    void draw_performance(AppBase& app);
+
+    // Camera orbit state
+    float azimuth_ = 0.0f;
+    float elevation_ = 0.3f;
+    float distance_ = 100.0f;
+    glm::vec3 target_{0.0f};
+    bool camera_initialized_ = false;
+
+    // Performance tracking
+    float fps_ = 0.0f;
+    float fps_timer_ = 0.0f;
+    uint32_t frame_count_ = 0;
+    std::array<float, 300> frame_times_{};
+    int frame_time_idx_ = 0;
+
+    // Mouse interaction
+    bool dragging_ = false;
+    double last_mouse_x_ = 0.0;
+    double last_mouse_y_ = 0.0;
+
+    // Scene management
+    std::vector<std::string> scene_files_;
+    int selected_scene_ = -1;
+    bool scenes_loaded_ = false;
+
+    // Panel visibility
+    bool show_viewport_info_ = true;
+    bool show_render_settings_ = true;
+    bool show_gs_params_ = true;
+    bool show_feature_toggles_ = true;
+    bool show_lighting_ = true;
+    bool show_camera_ = true;
+    bool show_performance_ = true;
+};
+
+}  // namespace gseurat

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -144,8 +144,8 @@ void AppBase::cleanup() {
     staging_uploader_.shutdown();
     wren_vm_.shutdown();
     audio_.shutdown();
-    renderer_.shutdown();
     resources_.shutdown();
+    renderer_.shutdown();
     glfwDestroyWindow(window_);
     glfwTerminate();
 }

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -4,6 +4,7 @@
 #include <GLFW/glfw3.h>
 
 #include <chrono>
+#include <filesystem>
 
 namespace gseurat {
 
@@ -50,8 +51,16 @@ void AppBase::main_loop() {
             resources_.texture_cache().insert(cache_key, std::move(sp));
         });
 
+    // Start control server for bridge integration
+#ifndef _WIN32
+    control_server_.start();
+#endif
+
     while (!glfwWindowShouldClose(window_)) {
         glfwPollEvents();
+
+        // Poll control server for bridge commands
+        poll_control_server();
 
         // Poll async loader and process GPU uploads (before game logic)
         resources_.process_async_results(async_loader_, staging_uploader_);
@@ -61,7 +70,6 @@ void AppBase::main_loop() {
         overlay_sprites_.clear();
         ui_sprites_.clear();
 
-        // Realtime mode only (no control server, no step mode)
         input_.update();
 
         auto now = std::chrono::steady_clock::now();
@@ -129,6 +137,9 @@ void AppBase::cleanup() {
     while (!state_stack_.empty()) {
         state_stack_.pop(*this);
     }
+#ifndef _WIN32
+    control_server_.stop();
+#endif
     async_loader_.shutdown();
     staging_uploader_.shutdown();
     wren_vm_.shutdown();
@@ -146,5 +157,188 @@ void AppBase::update_game(float /*dt*/) {}
 void AppBase::update_audio(float /*dt*/) {}
 SaveData AppBase::build_save_data() const { return {}; }
 void AppBase::apply_save_data(const SaveData& /*data*/) {}
+
+// ── Control Server ──
+
+void AppBase::poll_control_server() {
+#ifndef _WIN32
+    auto commands = control_server_.poll();
+    for (auto& cmd : commands) {
+        nlohmann::json response;
+        dispatch_command(cmd, response);
+        if (!response.is_null()) {
+            // Preserve bridge correlation ID
+            if (cmd.contains("_bridge_id")) {
+                response["_bridge_id"] = cmd["_bridge_id"];
+            }
+            control_server_.send(response);
+        }
+    }
+#endif
+}
+
+void AppBase::dispatch_command(const nlohmann::json& cmd, nlohmann::json& response) {
+    const auto cmd_name = cmd.value("cmd", "");
+
+    if (cmd_name == "get_features") {
+        response["type"] = "features";
+        auto add_feature = [&](const char* name, bool enabled, const char* label) {
+            nlohmann::json f;
+            f["name"] = name;
+            f["enabled"] = enabled;
+            f["label"] = label;
+            response["features"].push_back(f);
+        };
+        response["features"] = nlohmann::json::array();
+        add_feature("gs_rendering", feature_flags_.gs_rendering, "GS Rendering");
+        add_feature("gs_chunk_culling", feature_flags_.gs_chunk_culling, "Chunk Culling");
+        add_feature("gs_lod", feature_flags_.gs_lod, "LOD");
+        add_feature("gs_adaptive_budget", feature_flags_.gs_adaptive_budget, "Adaptive Budget");
+        add_feature("gs_parallax", feature_flags_.gs_parallax, "Parallax");
+        add_feature("bloom", feature_flags_.bloom, "Bloom");
+        add_feature("depth_of_field", feature_flags_.depth_of_field, "Depth of Field");
+        add_feature("vignette", feature_flags_.vignette, "Vignette");
+        add_feature("tone_mapping", feature_flags_.tone_mapping, "Tone Mapping");
+        add_feature("fog", feature_flags_.fog, "Fog");
+        add_feature("point_lights", feature_flags_.point_lights, "Point Lights");
+        add_feature("particles", feature_flags_.particles, "Particles");
+        add_feature("weather", feature_flags_.weather, "Weather");
+        add_feature("screen_effects", feature_flags_.screen_effects, "Screen Effects");
+        add_feature("music", feature_flags_.music, "Music");
+        add_feature("sfx", feature_flags_.sfx, "SFX");
+
+    } else if (cmd_name == "set_feature") {
+        auto name = cmd.value("feature", "");
+        bool enabled = cmd.value("enabled", false);
+        auto& f = feature_flags_;
+        if (name == "gs_rendering") f.gs_rendering = enabled;
+        else if (name == "gs_chunk_culling") f.gs_chunk_culling = enabled;
+        else if (name == "gs_lod") f.gs_lod = enabled;
+        else if (name == "gs_adaptive_budget") f.gs_adaptive_budget = enabled;
+        else if (name == "gs_parallax") f.gs_parallax = enabled;
+        else if (name == "bloom") f.bloom = enabled;
+        else if (name == "depth_of_field") f.depth_of_field = enabled;
+        else if (name == "vignette") f.vignette = enabled;
+        else if (name == "tone_mapping") f.tone_mapping = enabled;
+        else if (name == "fog") f.fog = enabled;
+        else if (name == "point_lights") f.point_lights = enabled;
+        else if (name == "particles") f.particles = enabled;
+        else if (name == "weather") f.weather = enabled;
+        else if (name == "screen_effects") f.screen_effects = enabled;
+        else if (name == "music") f.music = enabled;
+        else if (name == "sfx") f.sfx = enabled;
+        response["type"] = "ok";
+
+    } else if (cmd_name == "get_render_params") {
+        response["type"] = "render_params";
+        auto& pp = renderer_.post_process_params();
+        response["params"] = {
+            {"bloom_threshold", pp.bloom_threshold},
+            {"bloom_soft_knee", pp.bloom_soft_knee},
+            {"bloom_intensity", pp.bloom_intensity},
+            {"exposure", pp.exposure},
+            {"vignette_radius", pp.vignette_radius},
+            {"vignette_softness", pp.vignette_softness},
+            {"dof_focus_distance", pp.dof_focus_distance},
+            {"dof_focus_range", pp.dof_focus_range},
+            {"dof_max_blur", pp.dof_max_blur},
+            {"fog_density", pp.fog_density},
+            {"fog_color_r", pp.fog_color_r},
+            {"fog_color_g", pp.fog_color_g},
+            {"fog_color_b", pp.fog_color_b},
+            {"god_rays_intensity", renderer_.god_rays_intensity()},
+            {"scale_multiplier", renderer_.gs_renderer().scale_multiplier()},
+            {"toon_bands", renderer_.gs_renderer().toon_bands()},
+            {"light_mode", renderer_.gs_renderer().light_mode()},
+            {"light_intensity", renderer_.gs_renderer().light_intensity()},
+        };
+
+    } else if (cmd_name == "set_render_param") {
+        auto name = cmd.value("name", "");
+        float value = cmd.value("value", 0.0f);
+        auto& pp = renderer_.post_process_params();
+        if (name == "bloom_threshold") pp.bloom_threshold = value;
+        else if (name == "bloom_soft_knee") pp.bloom_soft_knee = value;
+        else if (name == "bloom_intensity") pp.bloom_intensity = value;
+        else if (name == "exposure") pp.exposure = value;
+        else if (name == "vignette_radius") pp.vignette_radius = value;
+        else if (name == "vignette_softness") pp.vignette_softness = value;
+        else if (name == "dof_focus_distance") pp.dof_focus_distance = value;
+        else if (name == "dof_focus_range") pp.dof_focus_range = value;
+        else if (name == "dof_max_blur") pp.dof_max_blur = value;
+        else if (name == "fog_density") pp.fog_density = value;
+        else if (name == "fog_color_r") pp.fog_color_r = value;
+        else if (name == "fog_color_g") pp.fog_color_g = value;
+        else if (name == "fog_color_b") pp.fog_color_b = value;
+        else if (name == "god_rays_intensity") renderer_.set_god_rays_intensity(value);
+        else if (name == "scale_multiplier") renderer_.gs_renderer().set_scale_multiplier(value);
+        else if (name == "toon_bands") renderer_.gs_renderer().set_toon_bands(static_cast<int>(value));
+        else if (name == "light_mode") renderer_.gs_renderer().set_light_mode(static_cast<int>(value));
+        else if (name == "light_intensity") renderer_.gs_renderer().set_light_intensity(value);
+        response["type"] = "ok";
+
+    } else if (cmd_name == "get_perf") {
+        response["type"] = "perf";
+        response["gaussian_count"] = renderer_.gs_renderer().gaussian_count();
+        response["visible_count"] = renderer_.gs_renderer().visible_count();
+        response["max_capacity"] = renderer_.gs_renderer().max_gaussian_count();
+
+    } else if (cmd_name == "set_ambient") {
+        float r = cmd.value("r", 0.0f);
+        float g = cmd.value("g", 0.0f);
+        float b = cmd.value("b", 0.0f);
+        float s = cmd.value("strength", 1.0f);
+        scene_.set_ambient_color({r, g, b, s});
+        response["type"] = "ok";
+
+    } else if (cmd_name == "get_scene") {
+        response["type"] = "scene";
+        response["path"] = current_scene_path_;
+        auto ac = scene_.ambient_color();
+        response["ambient_r"] = ac.r;
+        response["ambient_g"] = ac.g;
+        response["ambient_b"] = ac.b;
+        response["ambient_strength"] = ac.a;
+        response["lights"] = nlohmann::json::array();
+        for (const auto& l : scene_.lights()) {
+            nlohmann::json lj;
+            lj["x"] = l.position_and_radius.x;
+            lj["y"] = l.position_and_radius.y;
+            lj["z"] = l.position_and_radius.z;
+            lj["radius"] = l.position_and_radius.w;
+            lj["r"] = l.color.r;
+            lj["g"] = l.color.g;
+            lj["b"] = l.color.b;
+            lj["intensity"] = l.color.a;
+            response["lights"].push_back(lj);
+        }
+
+    } else if (cmd_name == "reload_scene") {
+        clear_scene();
+        init_scene(current_scene_path_);
+        response["type"] = "ok";
+
+    } else if (cmd_name == "list_scenes") {
+        response["type"] = "scenes";
+        response["files"] = nlohmann::json::array();
+        if (std::filesystem::exists("assets/scenes")) {
+            for (const auto& entry : std::filesystem::directory_iterator("assets/scenes")) {
+                if (entry.path().extension() == ".json") {
+                    response["files"].push_back(entry.path().string());
+                }
+            }
+        }
+
+    } else if (cmd_name == "screenshot") {
+        auto path = cmd.value("path", "staging_screenshot.png");
+        renderer_.request_screenshot(path);
+        response["type"] = "ok";
+        response["path"] = path;
+
+    } else {
+        response["type"] = "error";
+        response["message"] = "Unknown command: " + cmd_name;
+    }
+}
 
 }  // namespace gseurat

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -314,6 +314,11 @@ void GsRenderer::create_compute_pipelines() {
 void GsRenderer::load_cloud(const GaussianCloud& cloud) {
     if (cloud.empty()) return;
 
+    // Wait for GPU before destroying existing buffers
+    if (initialized_) {
+        vkDeviceWaitIdle(device_);
+    }
+
     sort_done_once_ = false;
     gaussian_count_ = cloud.count();
     max_gaussian_count_ = gaussian_count_ + kParticleHeadroom;

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -392,6 +392,9 @@ void GsRenderer::ensure_capacity(uint32_t needed_total) {
     uint32_t new_max = needed_total + kParticleHeadroom;
     if (new_max <= max_gaussian_count_) return;  // already large enough
 
+    // Wait for GPU to finish before destroying buffers
+    vkDeviceWaitIdle(device_);
+
     max_gaussian_count_ = new_max;
 
     // Recalculate sort sizes

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -431,13 +431,17 @@ void Renderer::draw_scene(Scene& scene,
     }
 
     // ===== Pass 2-4: Post-processing (bloom extract, blur H, blur V) + begin composite =====
-    PostProcessParams pp_params;
+    // Start from persistent params (modified by Staging panels), then apply per-frame overrides
+    PostProcessParams pp_params = pp_params_;
     pp_params.dof_near_plane = camera_.near_plane();
     pp_params.dof_far_plane = camera_.far_plane();
-    pp_params.fog_density = scene.fog_density();
-    pp_params.fog_color_r = scene.fog_color().r;
-    pp_params.fog_color_g = scene.fog_color().g;
-    pp_params.fog_color_b = scene.fog_color().b;
+    // Only override fog from scene if not already set by panels
+    if (pp_params.fog_density == 0.0f) {
+        pp_params.fog_density = scene.fog_density();
+        pp_params.fog_color_r = scene.fog_color().r;
+        pp_params.fog_color_g = scene.fog_color().g;
+        pp_params.fog_color_b = scene.fog_color().b;
+    }
 
     // Apply feature flags to post-process
     if (!flags.bloom) pp_params.bloom_intensity = 0.0f;
@@ -478,6 +482,11 @@ void Renderer::draw_scene(Scene& scene,
 
     // End composite render pass
     vkCmdEndRenderPass(cmd);
+
+    // Overlay callback (e.g., ImGui render pass)
+    if (overlay_callback_) {
+        overlay_callback_(cmd, image_index);
+    }
 
     // Screenshot: copy swapchain image to staging buffer
     bool screenshot_requested = screenshot_.has_pending();

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -568,6 +568,9 @@ void Renderer::shutdown() {
     bg_descriptor_sets_.clear();
     if (font_initialized_) {
         destroy_tex(font_texture_);
+        if (white_pixel_initialized_) {
+            white_pixel_tex_.destroy(context_.device(), context_.allocator());
+        }
         for (auto& buf : ui_uniform_buffers_) {
             buf.destroy(context_.allocator());
         }

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -229,6 +229,8 @@ void Renderer::init_gs(const GaussianCloud& cloud, uint32_t width, uint32_t heig
 void Renderer::set_gs_background(const ResourceHandle<Texture>& texture) {
     if (!font_initialized_) return;  // need UI UBOs
 
+    gs_bg_texture_ = texture;  // keep alive for proper cleanup
+
     std::array<VkBuffer, kMaxFramesInFlight> ui_ubo_buffers;
     for (uint32_t i = 0; i < kMaxFramesInFlight; i++) {
         ui_ubo_buffers[i] = ui_uniform_buffers_[i].buffer();
@@ -571,6 +573,10 @@ void Renderer::shutdown() {
         }
     }
 
+    if (gs_bg_texture_) {
+        gs_bg_texture_->destroy(context_.device(), context_.allocator());
+        gs_bg_texture_ = {};
+    }
     if (gs_initialized_) {
         gs_renderer_.shutdown(context_.allocator());
     }

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -873,22 +873,24 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 }
 
                 // Update and append Gaussian particles from emitters
-                for (auto& emitter : gs_particle_emitters_) {
-                    emitter.update(dt);
-                    emitter.gather(gs_active_buffer_);
-                }
-                // Remove dead emitters
-                gs_particle_emitters_.erase(
-                    std::remove_if(gs_particle_emitters_.begin(), gs_particle_emitters_.end(),
-                        [](const GaussianParticleEmitter& e) { return !e.active() && e.alive_count() == 0; }),
-                    gs_particle_emitters_.end());
+                if (flags.particles) {
+                    for (auto& emitter : gs_particle_emitters_) {
+                        emitter.update(dt);
+                        emitter.gather(gs_active_buffer_);
+                    }
+                    // Remove dead emitters
+                    gs_particle_emitters_.erase(
+                        std::remove_if(gs_particle_emitters_.begin(), gs_particle_emitters_.end(),
+                            [](const GaussianParticleEmitter& e) { return !e.active() && e.alive_count() == 0; }),
+                        gs_particle_emitters_.end());
 
-                // Update VFX instances (timeline + emitters + animation tagging)
-                for (auto& inst : vfx_instances_) {
-                    inst.update(dt, gs_active_buffer_, gs_animator_);
+                    // Update VFX instances (timeline + emitters + animation tagging)
+                    for (auto& inst : vfx_instances_) {
+                        inst.update(dt, gs_active_buffer_, gs_animator_);
+                    }
+                    std::erase_if(vfx_instances_,
+                        [](const VfxInstance& i) { return i.is_finished(); });
                 }
-                std::erase_if(vfx_instances_,
-                    [](const VfxInstance& i) { return i.is_finished(); });
 
                 // Clamp to allocated SSBO capacity
                 if (gs_active_buffer_.size() > gs_renderer_.max_gaussian_count()) {

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -780,7 +780,13 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             glm::mat4 gs_vp = gs_proj_ * gs_view_;
             auto visible = gs_chunk_grid_.visible_chunks(gs_vp);
 
-            if (visible != gs_prev_visible_) {
+            // Force re-gather when LOD budget changes
+            bool budget_changed = (gs_gaussian_budget_ != gs_prev_budget_);
+            if (budget_changed) {
+                gs_prev_budget_ = gs_gaussian_budget_;
+            }
+
+            if (visible != gs_prev_visible_ || budget_changed) {
                 if (gs_budget_locked_) {
                     gs_budget_locked_ = false;
                     gs_stable_frame_count_ = 0;

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -868,7 +868,7 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 }
 
                 // Animate tagged scene + object Gaussians (Mode 2)
-                if (gs_animator_.has_active_groups()) {
+                if (flags.animation && gs_animator_.has_active_groups()) {
                     gs_animator_.update(dt, gs_active_buffer_);
                 }
 
@@ -883,8 +883,10 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                         std::remove_if(gs_particle_emitters_.begin(), gs_particle_emitters_.end(),
                             [](const GaussianParticleEmitter& e) { return !e.active() && e.alive_count() == 0; }),
                         gs_particle_emitters_.end());
+                }
 
-                    // Update VFX instances (timeline + emitters + animation tagging)
+                // Update VFX instances (timeline + emitters + animation tagging)
+                if (flags.particles || flags.animation) {
                     for (auto& inst : vfx_instances_) {
                         inst.update(dt, gs_active_buffer_, gs_animator_);
                     }

--- a/src/engine/resource_manager.cpp
+++ b/src/engine/resource_manager.cpp
@@ -25,6 +25,10 @@ void ResourceManager::init(VkDevice device, VmaAllocator allocator,
 }
 
 void ResourceManager::shutdown() {
+    // Destroy VMA resources for all live textures before allocator is torn down
+    texture_cache_.for_each_live([&](const std::string& /*key*/, Texture& tex) {
+        tex.destroy(device_, allocator_);
+    });
     placeholder_ = {};
     pending_async_.clear();
     texture_cache_.clear();

--- a/src/engine/texture.cpp
+++ b/src/engine/texture.cpp
@@ -331,9 +331,9 @@ Texture Texture::create_from_image(VkDevice device,
 }
 
 void Texture::destroy(VkDevice device, VmaAllocator allocator) {
-    vkDestroySampler(device, sampler_, nullptr);
-    vkDestroyImageView(device, image_view_, nullptr);
-    vmaDestroyImage(allocator, image_, allocation_);
+    if (sampler_) { vkDestroySampler(device, sampler_, nullptr); sampler_ = VK_NULL_HANDLE; }
+    if (image_view_) { vkDestroyImageView(device, image_view_, nullptr); image_view_ = VK_NULL_HANDLE; }
+    if (image_) { vmaDestroyImage(allocator, image_, allocation_); image_ = VK_NULL_HANDLE; allocation_ = VK_NULL_HANDLE; }
 }
 
 }  // namespace gseurat

--- a/src/engine/vk_context.cpp
+++ b/src/engine/vk_context.cpp
@@ -28,6 +28,16 @@ void VkContext::init(GLFWwindow* window) {
 }
 
 void VkContext::shutdown() {
+#ifndef NDEBUG
+    // Log remaining VMA allocations to help diagnose leaks
+    VmaTotalStatistics stats{};
+    vmaCalculateStatistics(allocator_, &stats);
+    if (stats.total.statistics.allocationCount > 0) {
+        std::cerr << "[VMA] WARNING: " << stats.total.statistics.allocationCount
+                  << " allocations still alive ("
+                  << stats.total.statistics.allocationBytes << " bytes) at shutdown\n";
+    }
+#endif
     vmaDestroyAllocator(allocator_);
     vkDestroyDevice(device_, nullptr);
     vkDestroySurfaceKHR(instance_, surface_, nullptr);

--- a/src/engine/vk_context.cpp
+++ b/src/engine/vk_context.cpp
@@ -29,7 +29,6 @@ void VkContext::init(GLFWwindow* window) {
 
 void VkContext::shutdown() {
 #ifndef NDEBUG
-    // Log remaining VMA allocations to help diagnose leaks
     VmaTotalStatistics stats{};
     vmaCalculateStatistics(allocator_, &stats);
     if (stats.total.statistics.allocationCount > 0) {

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -238,7 +238,7 @@ void StagingApp::create_imgui_render_pass() {
     attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachment.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     attachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
     VkAttachmentReference color_ref{};

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -47,7 +47,10 @@ void StagingApp::init_game_content() {
     renderer_.init_shadows(resources_);
 
     ui_ctx_.init(font_atlas_, text_renderer_);
-    audio_.init("assets");
+
+    // Disable audio in Staging — review tool doesn't need sound
+    feature_flags_.music = false;
+    feature_flags_.sfx = false;
 
     init_imgui();
 }

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -68,8 +68,16 @@ void StagingApp::main_loop() {
             resources_.texture_cache().insert(cache_key, std::move(sp));
         });
 
+    // Start control server for bridge integration
+#ifndef _WIN32
+    control_server_.start();
+#endif
+
     while (!glfwWindowShouldClose(window_)) {
         glfwPollEvents();
+
+        // Poll control server for bridge commands
+        poll_control_server();
 
         resources_.process_async_results(async_loader_, staging_uploader_);
         staging_uploader_.flush();
@@ -141,6 +149,9 @@ void StagingApp::cleanup() {
     while (!state_stack_.empty()) {
         state_stack_.pop(*this);
     }
+#ifndef _WIN32
+    control_server_.stop();
+#endif
     async_loader_.shutdown();
     staging_uploader_.shutdown();
     wren_vm_.shutdown();

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -1,0 +1,444 @@
+#include "gseurat/staging/staging_app.hpp"
+#include "gseurat/staging/staging_state.hpp"
+#include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/gs_parallax_camera.hpp"
+#include "gseurat/engine/scene_loader.hpp"
+#include "gseurat/engine/gs_vfx.hpp"
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
+
+#include <imgui.h>
+#include <imgui_impl_glfw.h>
+#include <imgui_impl_vulkan.h>
+
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+
+#include <glm/gtc/matrix_transform.hpp>
+
+#include <cstdio>
+#include <filesystem>
+#include <string_view>
+
+namespace gseurat {
+
+void StagingApp::parse_args(int argc, char* argv[]) {
+    for (int i = 1; i < argc; ++i) {
+        std::string_view arg(argv[i]);
+        if (arg == "--scene" && i + 1 < argc) {
+            scene_path_ = argv[++i];
+        }
+    }
+}
+
+void StagingApp::init_game_content() {
+    init_window();
+
+    // Font atlas (ASCII only)
+    std::vector<uint32_t> codepoints;
+    for (uint32_t cp = 32; cp <= 126; cp++) codepoints.push_back(cp);
+    font_atlas_.init("assets/fonts/NotoSans-Regular.ttf", 32.0f, codepoints);
+    text_renderer_.init(font_atlas_);
+
+    renderer_.init(window_, resources_);
+    renderer_.init_font(font_atlas_, resources_);
+    renderer_.init_particles(resources_);
+    renderer_.init_shadows(resources_);
+
+    ui_ctx_.init(font_atlas_, text_renderer_);
+    audio_.init("assets");
+
+    init_imgui();
+}
+
+void StagingApp::main_loop() {
+    set_current_scene_path(scene_path_);
+    state_stack_.push(std::make_unique<StagingState>(), *this);
+
+    last_update_time_ = std::chrono::steady_clock::now();
+
+    // Initialize async loading subsystems
+    async_loader_.init();
+    staging_uploader_.init(
+        renderer_.context().device(), renderer_.context().allocator(),
+        renderer_.command_pool().pool(), renderer_.context().graphics_queue(),
+        [this](const std::string& cache_key, Texture tex) {
+            auto sp = std::make_shared<Texture>(std::move(tex));
+            resources_.texture_cache().insert(cache_key, std::move(sp));
+        });
+
+    while (!glfwWindowShouldClose(window_)) {
+        glfwPollEvents();
+
+        resources_.process_async_results(async_loader_, staging_uploader_);
+        staging_uploader_.flush();
+
+        overlay_sprites_.clear();
+        ui_sprites_.clear();
+
+        input_.update();
+
+        auto now = std::chrono::steady_clock::now();
+        float dt = std::chrono::duration<float>(now - last_update_time_).count();
+        last_update_time_ = now;
+        if (dt > 0.1f) dt = 0.1f;
+
+        // ImGui new frame
+        ImGui_ImplVulkan_NewFrame();
+        ImGui_ImplGlfw_NewFrame();
+        ImGui::NewFrame();
+
+        state_stack_.update(*this, dt);
+        play_time_ += dt;
+        tick_++;
+
+        // Feed UI context
+        {
+            ui::UIInput ui_input;
+            ui_input.mouse_pos = input_.mouse_pos();
+            ui_input.mouse_down = input_.is_mouse_down(0);
+            ui_input.mouse_pressed = input_.was_mouse_pressed(0);
+            ui_input.key_up = false;
+            ui_input.key_down_nav = false;
+            ui_input.key_enter = false;
+            ui_input.key_escape = false;
+            ui_input.scroll_delta = 0.0f;
+            ui_ctx_.set_screen_height(720.0f);
+            ui_ctx_.begin_frame(ui_input);
+        }
+
+        state_stack_.build_draw_lists(*this);
+
+        std::vector<SpriteDrawInfo> particle_sprites;
+        particles_.generate_draw_infos(particle_sprites);
+
+        std::vector<ui::UIDrawBatch> ui_batches;
+
+        // Screen effects
+        if (feature_flags_.screen_effects) {
+            auto fc = screen_effects_.flash_color() * screen_effects_.flash_alpha();
+            renderer_.set_ca_intensity(screen_effects_.ca_intensity());
+            renderer_.set_flash_color(fc.r, fc.g, fc.b);
+        } else {
+            renderer_.set_ca_intensity(0.0f);
+            renderer_.set_flash_color(0.0f, 0.0f, 0.0f);
+        }
+
+        // Finalize ImGui (before draw_scene so overlay callback can render it)
+        ImGui::Render();
+
+        renderer_.draw_scene(scene_, entity_sprites_, outline_sprites_, reflection_sprites_,
+                             shadow_sprites_, particle_sprites, overlay_sprites_, ui_batches,
+                             feature_flags_);
+    }
+}
+
+void StagingApp::cleanup() {
+    vkDeviceWaitIdle(renderer_.context().device());
+    shutdown_imgui();
+
+    while (!state_stack_.empty()) {
+        state_stack_.pop(*this);
+    }
+    async_loader_.shutdown();
+    staging_uploader_.shutdown();
+    wren_vm_.shutdown();
+    audio_.shutdown();
+    renderer_.shutdown();
+    resources_.shutdown();
+    glfwDestroyWindow(window_);
+    glfwTerminate();
+}
+
+void StagingApp::init_imgui() {
+    auto device = renderer_.context().device();
+
+    // Create descriptor pool for ImGui
+    VkDescriptorPoolSize pool_sizes[] = {
+        { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 100 },
+    };
+    VkDescriptorPoolCreateInfo pool_info{};
+    pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+    pool_info.maxSets = 100;
+    pool_info.poolSizeCount = 1;
+    pool_info.pPoolSizes = pool_sizes;
+    vkCreateDescriptorPool(device, &pool_info, nullptr, &imgui_pool_);
+
+    // Create render pass that renders on top of swapchain images
+    create_imgui_render_pass();
+
+    // Create framebuffers for ImGui render pass
+    auto& swapchain = renderer_.swapchain();
+    imgui_framebuffers_.resize(swapchain.image_count());
+    for (uint32_t i = 0; i < swapchain.image_count(); i++) {
+        VkFramebufferCreateInfo fb_info{};
+        fb_info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+        fb_info.renderPass = imgui_render_pass_;
+        fb_info.attachmentCount = 1;
+        fb_info.pAttachments = &swapchain.image_views()[i];
+        fb_info.width = swapchain.extent().width;
+        fb_info.height = swapchain.extent().height;
+        fb_info.layers = 1;
+        vkCreateFramebuffer(device, &fb_info, nullptr, &imgui_framebuffers_[i]);
+    }
+
+    // Initialize ImGui
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO();
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+
+    // Style
+    ImGui::StyleColorsDark();
+    auto& style = ImGui::GetStyle();
+    style.WindowRounding = 4.0f;
+    style.FrameRounding = 2.0f;
+    style.Alpha = 0.95f;
+
+    // Init platform/renderer backends
+    ImGui_ImplGlfw_InitForVulkan(window_, true);
+
+    ImGui_ImplVulkan_InitInfo init_info{};
+    init_info.Instance = renderer_.context().instance();
+    init_info.PhysicalDevice = renderer_.context().physical_device();
+    init_info.Device = device;
+    init_info.QueueFamily = renderer_.context().graphics_queue_family();
+    init_info.Queue = renderer_.context().graphics_queue();
+    init_info.DescriptorPool = imgui_pool_;
+    init_info.MinImageCount = 2;
+    init_info.ImageCount = swapchain.image_count();
+    init_info.RenderPass = imgui_render_pass_;
+    ImGui_ImplVulkan_Init(&init_info);
+
+    // Set overlay callback on the renderer
+    renderer_.set_overlay_callback([this](VkCommandBuffer cmd, uint32_t image_index) {
+        VkRenderPassBeginInfo rp_info{};
+        rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+        rp_info.renderPass = imgui_render_pass_;
+        rp_info.framebuffer = imgui_framebuffers_[image_index];
+        rp_info.renderArea.extent = renderer_.swapchain().extent();
+        vkCmdBeginRenderPass(cmd, &rp_info, VK_SUBPASS_CONTENTS_INLINE);
+        ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), cmd);
+        vkCmdEndRenderPass(cmd);
+    });
+
+    std::fprintf(stderr, "[Staging] ImGui initialized\n");
+}
+
+void StagingApp::create_imgui_render_pass() {
+    auto device = renderer_.context().device();
+    auto format = renderer_.swapchain().image_format();
+
+    VkAttachmentDescription attachment{};
+    attachment.format = format;
+    attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;  // preserve existing content
+    attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass{};
+    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass.colorAttachmentCount = 1;
+    subpass.pColorAttachments = &color_ref;
+
+    VkSubpassDependency dependency{};
+    dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+    dependency.dstSubpass = 0;
+    dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+
+    VkRenderPassCreateInfo rp_info{};
+    rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    rp_info.attachmentCount = 1;
+    rp_info.pAttachments = &attachment;
+    rp_info.subpassCount = 1;
+    rp_info.pSubpasses = &subpass;
+    rp_info.dependencyCount = 1;
+    rp_info.pDependencies = &dependency;
+
+    vkCreateRenderPass(device, &rp_info, nullptr, &imgui_render_pass_);
+}
+
+void StagingApp::shutdown_imgui() {
+    auto device = renderer_.context().device();
+
+    ImGui_ImplVulkan_Shutdown();
+    ImGui_ImplGlfw_Shutdown();
+    ImGui::DestroyContext();
+
+    for (auto fb : imgui_framebuffers_) {
+        vkDestroyFramebuffer(device, fb, nullptr);
+    }
+    imgui_framebuffers_.clear();
+
+    if (imgui_render_pass_) {
+        vkDestroyRenderPass(device, imgui_render_pass_, nullptr);
+        imgui_render_pass_ = VK_NULL_HANDLE;
+    }
+    if (imgui_pool_) {
+        vkDestroyDescriptorPool(device, imgui_pool_, nullptr);
+        imgui_pool_ = VK_NULL_HANDLE;
+    }
+}
+
+// ── Scene loading (reuse from DemoApp pattern) ──
+
+void StagingApp::init_scene(const std::string& scene_path) {
+    current_scene_path_ = scene_path;
+    auto scene_data = SceneLoader::load(scene_path);
+
+    renderer_.clear_gs_particle_emitters();
+    renderer_.clear_gs_animations();
+    renderer_.clear_vfx_instances();
+
+    scene_.clear_lights();
+    scene_.set_ambient_color(scene_data.ambient_color);
+    for (const auto& pl : scene_data.static_lights) {
+        scene_.add_light(pl);
+    }
+
+    if (scene_data.gaussian_splat) {
+        const auto& gs = *scene_data.gaussian_splat;
+        GaussianCloud cloud;
+        try {
+            cloud = GaussianCloud::load_ply(gs.ply_file);
+        } catch (const std::runtime_error& e) {
+            std::fprintf(stderr, "[Staging] Warning: %s\n", e.what());
+        }
+        if (!cloud.empty()) {
+            renderer_.gs_renderer().set_scale_multiplier(gs.scale_multiplier);
+
+            // Merge static placed objects
+            if (!scene_data.placed_objects.empty()) {
+                auto merged = cloud.gaussians();
+                for (const auto& obj : scene_data.placed_objects) {
+                    if (!obj.is_static) continue;
+                    try {
+                        auto placed_cloud = GaussianCloud::load_ply(obj.ply_file);
+                        if (placed_cloud.empty()) continue;
+                        auto transform = glm::translate(glm::mat4(1.0f), obj.position);
+                        transform = glm::rotate(transform, glm::radians(obj.rotation.x), {1,0,0});
+                        transform = glm::rotate(transform, glm::radians(obj.rotation.y), {0,1,0});
+                        transform = glm::rotate(transform, glm::radians(obj.rotation.z), {0,0,1});
+                        transform = glm::scale(transform, glm::vec3(obj.scale));
+                        auto rot_q = glm::quat(glm::radians(obj.rotation));
+                        auto placed_gs = placed_cloud.gaussians();
+                        for (auto& g : placed_gs) {
+                            g.position = glm::vec3(transform * glm::vec4(g.position, 1.0f));
+                            g.scale *= obj.scale;
+                            g.rotation = rot_q * g.rotation;
+                        }
+                        merged.insert(merged.end(), placed_gs.begin(), placed_gs.end());
+                    } catch (const std::runtime_error&) {}
+                }
+                cloud = GaussianCloud::from_gaussians(std::move(merged));
+            }
+
+            uint32_t gs_w = gs.render_width;
+            uint32_t gs_h = gs.render_height;
+            if (cloud.count() > 100000 && gs_w >= 320) { gs_w = 160; gs_h = 120; }
+            else if (cloud.count() > 50000 && gs_w >= 320) { gs_w = 240; gs_h = 180; }
+
+            renderer_.init_gs(cloud, gs_w, gs_h);
+
+            float aspect = static_cast<float>(gs_w) / static_cast<float>(gs_h);
+            auto gs_view = glm::lookAt(gs.camera_position, gs.camera_target, glm::vec3(0, 1, 0));
+            auto gs_proj = glm::perspective(glm::radians(gs.camera_fov), aspect, 0.1f, 1000.0f);
+            gs_proj[1][1] *= -1.0f;
+            renderer_.set_gs_camera(gs_view, gs_proj);
+
+            // Transform lights
+            auto aabb = cloud.bounds();
+            std::vector<PointLight> gs_lights;
+            for (const auto& pl : scene_data.static_lights) {
+                PointLight t = pl;
+                t.position_and_radius.x = pl.position_and_radius.x + aabb.min.x;
+                t.position_and_radius.z = pl.position_and_radius.z + aabb.min.y;
+                gs_lights.push_back(t);
+            }
+            if (gs_lights.empty()) {
+                PointLight test_light;
+                auto center = aabb.center();
+                float r = std::max({aabb.max.x - aabb.min.x, aabb.max.y - aabb.min.y, aabb.max.z - aabb.min.z}) * 0.5f;
+                test_light.position_and_radius = glm::vec4(center.x, center.z, center.y, r);
+                test_light.color = glm::vec4(0.2f, 1.0f, 0.3f, 5.0f);
+                gs_lights.push_back(test_light);
+            }
+            renderer_.gs_renderer().set_light_mode(2);
+            renderer_.gs_renderer().set_point_lights(gs_lights);
+            renderer_.set_god_rays_intensity(1.0f);
+
+            // Emitters
+            for (const auto& em : scene_data.gs_particle_emitters) {
+                auto config = em.config;
+                config.position.x += aabb.min.x;
+                config.position.y += aabb.min.y;
+                renderer_.add_gs_particle_emitter(config);
+            }
+
+            // Animations
+            for (const auto& anim : scene_data.gs_animations) {
+                auto region = anim.region;
+                region.center.x += aabb.min.x;
+                region.center.y += aabb.min.y;
+                std::optional<Renderer::ReformConfig> reform;
+                if (anim.reform) reform = Renderer::ReformConfig{anim.reform->lifetime};
+                renderer_.add_gs_animation(anim.effect, region, anim.lifetime, anim.loop, anim.params, reform);
+            }
+
+            // VFX instances
+            for (const auto& vi : scene_data.vfx_instances) {
+                if (vi.trigger != "auto") continue;
+                auto preset = load_vfx_preset(vi.vfx_file);
+                if (preset.elements.empty()) continue;
+                VfxInstance inst;
+                auto pos = vi.position;
+                pos.x += aabb.min.x;
+                pos.y += aabb.min.y;
+                inst.init(preset, pos, vi.loop);
+                renderer_.add_vfx_instance(std::move(inst));
+            }
+
+            // Background
+            if (!gs.background_image.empty()) {
+                auto bg_tex = resources_.load_texture(gs.background_image);
+                renderer_.set_gs_background(bg_tex);
+            }
+
+            // Parallax camera
+            if (feature_flags_.gs_parallax && gs.parallax) {
+                gs_parallax_camera_.configure(
+                    gs.camera_position, gs.camera_target,
+                    gs.camera_fov, gs_w, gs_h, *gs.parallax);
+                set_gs_parallax_active(true);
+            } else {
+                set_gs_parallax_active(false);
+                renderer_.set_gs_skip_chunk_cull(false);
+                renderer_.gs_renderer().clear_shadow_box_params();
+            }
+
+            std::fprintf(stderr, "[Staging] Loaded scene: %s (%u Gaussians)\n",
+                         scene_path.c_str(), cloud.count());
+        }
+    }
+}
+
+void StagingApp::clear_scene() {
+    renderer_.clear_gs_particle_emitters();
+    renderer_.clear_gs_animations();
+    renderer_.clear_vfx_instances();
+    scene_.clear_lights();
+}
+
+}  // namespace gseurat

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -156,8 +156,10 @@ void StagingApp::cleanup() {
     staging_uploader_.shutdown();
     wren_vm_.shutdown();
     audio_.shutdown();
-    renderer_.shutdown();
+    // ResourceManager must shut down before Renderer, because Renderer::shutdown()
+    // destroys the VMA allocator — any textures still in cache would leak.
     resources_.shutdown();
+    renderer_.shutdown();
     glfwDestroyWindow(window_);
     glfwTerminate();
 }

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -375,6 +375,8 @@ void StagingApp::init_scene(const std::string& scene_path) {
             renderer_.set_gs_camera(gs_view, gs_proj);
 
             // Transform lights
+            // Only load scene-defined lights — no default test light.
+            // Users place lights via the Staging UI.
             auto aabb = cloud.bounds();
             std::vector<PointLight> gs_lights;
             for (const auto& pl : scene_data.static_lights) {
@@ -383,17 +385,10 @@ void StagingApp::init_scene(const std::string& scene_path) {
                 t.position_and_radius.z = pl.position_and_radius.z + aabb.min.y;
                 gs_lights.push_back(t);
             }
-            if (gs_lights.empty()) {
-                PointLight test_light;
-                auto center = aabb.center();
-                float r = std::max({aabb.max.x - aabb.min.x, aabb.max.y - aabb.min.y, aabb.max.z - aabb.min.z}) * 0.5f;
-                test_light.position_and_radius = glm::vec4(center.x, center.z, center.y, r);
-                test_light.color = glm::vec4(0.2f, 1.0f, 0.3f, 5.0f);
-                gs_lights.push_back(test_light);
+            if (!gs_lights.empty()) {
+                renderer_.gs_renderer().set_light_mode(2);
+                renderer_.gs_renderer().set_point_lights(gs_lights);
             }
-            renderer_.gs_renderer().set_light_mode(2);
-            renderer_.gs_renderer().set_point_lights(gs_lights);
-            renderer_.set_god_rays_intensity(1.0f);
 
             // Emitters
             for (const auto& em : scene_data.gs_particle_emitters) {

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -48,9 +48,9 @@ void StagingApp::init_game_content() {
 
     ui_ctx_.init(font_atlas_, text_renderer_);
 
-    // Disable audio in Staging — review tool doesn't need sound
-    feature_flags_.music = false;
-    feature_flags_.sfx = false;
+    // Start with all post-process/effects off — user enables what they want to review.
+    // GS pipeline flags (rendering, chunk culling, LOD, adaptive budget) stay on.
+    feature_flags_ = FeatureFlags::gs_viewer();
 
     init_imgui();
 }

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -230,15 +230,6 @@ void StagingState::draw_render_settings(AppBase& app) {
         ImGui::SliderFloat("Radius##vig", &pp.vignette_radius, 0.0f, 1.5f);
         ImGui::SliderFloat("Softness##vig", &pp.vignette_softness, 0.0f, 1.0f);
     }
-    if (ImGui::CollapsingHeader("Fog")) {
-        ImGui::SliderFloat("Density##fog", &pp.fog_density, 0.0f, 1.0f);
-        float fog_color[3] = {pp.fog_color_r, pp.fog_color_g, pp.fog_color_b};
-        if (ImGui::ColorEdit3("Color##fog", fog_color)) {
-            pp.fog_color_r = fog_color[0];
-            pp.fog_color_g = fog_color[1];
-            pp.fog_color_b = fog_color[2];
-        }
-    }
     if (ImGui::CollapsingHeader("God Rays")) {
         float gr = app.renderer().god_rays_intensity();
         if (ImGui::SliderFloat("Intensity##godrays", &gr, 0.0f, 3.0f)) {
@@ -295,31 +286,22 @@ void StagingState::draw_feature_toggles(AppBase& app) {
 
     auto& f = app.feature_flags();
 
-    if (ImGui::CollapsingHeader("Rendering", ImGuiTreeNodeFlags_DefaultOpen)) {
+    if (ImGui::CollapsingHeader("Post-Process", ImGuiTreeNodeFlags_DefaultOpen)) {
         ImGui::Checkbox("Bloom", &f.bloom);
         ImGui::Checkbox("Depth of Field", &f.depth_of_field);
         ImGui::Checkbox("Vignette", &f.vignette);
         ImGui::Checkbox("Tone Mapping", &f.tone_mapping);
-        ImGui::Checkbox("Fog", &f.fog);
         ImGui::Checkbox("Point Lights", &f.point_lights);
+        ImGui::Checkbox("Screen Effects", &f.screen_effects);
     }
-    if (ImGui::CollapsingHeader("GS")) {
+    if (ImGui::CollapsingHeader("GS Pipeline")) {
         ImGui::Checkbox("GS Rendering", &f.gs_rendering);
         ImGui::Checkbox("Chunk Culling", &f.gs_chunk_culling);
         ImGui::Checkbox("LOD", &f.gs_lod);
         ImGui::Checkbox("Adaptive Budget", &f.gs_adaptive_budget);
-        ImGui::Checkbox("Parallax", &f.gs_parallax);
     }
-    if (ImGui::CollapsingHeader("Effects")) {
+    if (ImGui::CollapsingHeader("Scene")) {
         ImGui::Checkbox("Particles", &f.particles);
-        ImGui::Checkbox("Weather", &f.weather);
-        ImGui::Checkbox("Animated Tiles", &f.animated_tiles);
-        ImGui::Checkbox("Screen Effects", &f.screen_effects);
-        ImGui::Checkbox("Camera Shake", &f.camera_shake);
-    }
-    if (ImGui::CollapsingHeader("Audio")) {
-        ImGui::Checkbox("Music", &f.music);
-        ImGui::Checkbox("SFX", &f.sfx);
     }
 
     ImGui::End();

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -264,6 +264,19 @@ void StagingState::draw_gs_params(AppBase& app) {
         gs.set_toon_bands(toon);
     }
 
+    ImGui::Separator();
+
+    int budget = static_cast<int>(app.renderer().gs_gaussian_budget());
+    if (ImGui::SliderInt("LOD Budget", &budget, 0, 500000, "%d", ImGuiSliderFlags_Logarithmic)) {
+        app.renderer().set_gs_gaussian_budget(static_cast<uint32_t>(budget));
+    }
+    ImGui::SameLine();
+    ImGui::TextDisabled("(0 = unlimited)");
+
+    if (budget > 0 && app.renderer().has_gs_cloud()) {
+        ImGui::Text("Active: %u / %u", gs.gaussian_count(), gs.max_gaussian_count());
+    }
+
     ImGui::End();
 }
 

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -214,26 +214,26 @@ void StagingState::draw_render_settings(AppBase& app) {
     auto& pp = app.renderer().post_process_params();
 
     if (ImGui::CollapsingHeader("Bloom", ImGuiTreeNodeFlags_DefaultOpen)) {
-        ImGui::SliderFloat("Threshold", &pp.bloom_threshold, 0.0f, 5.0f);
-        ImGui::SliderFloat("Soft Knee", &pp.bloom_soft_knee, 0.0f, 1.0f);
-        ImGui::SliderFloat("Intensity", &pp.bloom_intensity, 0.0f, 2.0f);
+        ImGui::SliderFloat("Threshold##bloom", &pp.bloom_threshold, 0.0f, 5.0f);
+        ImGui::SliderFloat("Soft Knee##bloom", &pp.bloom_soft_knee, 0.0f, 1.0f);
+        ImGui::SliderFloat("Intensity##bloom", &pp.bloom_intensity, 0.0f, 2.0f);
     }
     if (ImGui::CollapsingHeader("Exposure")) {
-        ImGui::SliderFloat("Exposure", &pp.exposure, 0.1f, 5.0f);
+        ImGui::SliderFloat("Exposure##pp", &pp.exposure, 0.1f, 5.0f);
     }
     if (ImGui::CollapsingHeader("Depth of Field")) {
-        ImGui::SliderFloat("Focus Distance", &pp.dof_focus_distance, 0.1f, 200.0f);
-        ImGui::SliderFloat("Focus Range", &pp.dof_focus_range, 0.1f, 50.0f);
-        ImGui::SliderFloat("Max Blur", &pp.dof_max_blur, 0.0f, 2.0f);
+        ImGui::SliderFloat("Focus Distance##dof", &pp.dof_focus_distance, 0.1f, 200.0f);
+        ImGui::SliderFloat("Focus Range##dof", &pp.dof_focus_range, 0.1f, 50.0f);
+        ImGui::SliderFloat("Max Blur##dof", &pp.dof_max_blur, 0.0f, 2.0f);
     }
     if (ImGui::CollapsingHeader("Vignette")) {
-        ImGui::SliderFloat("Radius", &pp.vignette_radius, 0.0f, 1.5f);
-        ImGui::SliderFloat("Softness", &pp.vignette_softness, 0.0f, 1.0f);
+        ImGui::SliderFloat("Radius##vig", &pp.vignette_radius, 0.0f, 1.5f);
+        ImGui::SliderFloat("Softness##vig", &pp.vignette_softness, 0.0f, 1.0f);
     }
     if (ImGui::CollapsingHeader("Fog")) {
-        ImGui::SliderFloat("Density", &pp.fog_density, 0.0f, 1.0f);
+        ImGui::SliderFloat("Density##fog", &pp.fog_density, 0.0f, 1.0f);
         float fog_color[3] = {pp.fog_color_r, pp.fog_color_g, pp.fog_color_b};
-        if (ImGui::ColorEdit3("Color", fog_color)) {
+        if (ImGui::ColorEdit3("Color##fog", fog_color)) {
             pp.fog_color_r = fog_color[0];
             pp.fog_color_g = fog_color[1];
             pp.fog_color_b = fog_color[2];
@@ -241,7 +241,7 @@ void StagingState::draw_render_settings(AppBase& app) {
     }
     if (ImGui::CollapsingHeader("God Rays")) {
         float gr = app.renderer().god_rays_intensity();
-        if (ImGui::SliderFloat("Intensity##gr", &gr, 0.0f, 3.0f)) {
+        if (ImGui::SliderFloat("Intensity##godrays", &gr, 0.0f, 3.0f)) {
             app.renderer().set_god_rays_intensity(gr);
         }
     }

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -262,17 +262,6 @@ void StagingState::draw_gs_params(AppBase& app) {
         gs.set_toon_bands(toon);
     }
 
-    int light_mode = gs.light_mode();
-    const char* light_modes[] = {"Off", "Directional", "Point Lights"};
-    if (ImGui::Combo("Light Mode", &light_mode, light_modes, 3)) {
-        gs.set_light_mode(light_mode);
-    }
-
-    float intensity = gs.light_intensity();
-    if (ImGui::SliderFloat("Light Intensity", &intensity, 0.0f, 5.0f)) {
-        gs.set_light_intensity(intensity);
-    }
-
     ImGui::End();
 }
 
@@ -291,7 +280,6 @@ void StagingState::draw_feature_toggles(AppBase& app) {
         ImGui::Checkbox("Depth of Field", &f.depth_of_field);
         ImGui::Checkbox("Vignette", &f.vignette);
         ImGui::Checkbox("Tone Mapping", &f.tone_mapping);
-        ImGui::Checkbox("Point Lights", &f.point_lights);
         ImGui::Checkbox("Screen Effects", &f.screen_effects);
     }
     if (ImGui::CollapsingHeader("GS Pipeline")) {
@@ -308,20 +296,94 @@ void StagingState::draw_feature_toggles(AppBase& app) {
 }
 
 void StagingState::draw_lighting(AppBase& app) {
+    if (!app.renderer().has_gs_cloud()) return;
+
     ImGui::SetNextWindowPos(ImVec2(270, 30), ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(280, 200), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(300, 400), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin("Lighting")) {
         ImGui::End();
         return;
     }
 
+    auto& gs = app.renderer().gs_renderer();
+
+    // Light mode
+    int light_mode = gs.light_mode();
+    const char* light_modes[] = {"Off", "Directional", "Point Lights"};
+    if (ImGui::Combo("Light Mode", &light_mode, light_modes, 3)) {
+        gs.set_light_mode(light_mode);
+    }
+
+    float intensity = gs.light_intensity();
+    if (ImGui::SliderFloat("Global Intensity", &intensity, 0.0f, 5.0f)) {
+        gs.set_light_intensity(intensity);
+    }
+
+    ImGui::Separator();
+
+    // Ambient
     auto ambient = app.scene().ambient_color();
     float amb[4] = {ambient.r, ambient.g, ambient.b, ambient.a};
     if (ImGui::ColorEdit4("Ambient", amb)) {
         app.scene().set_ambient_color({amb[0], amb[1], amb[2], amb[3]});
     }
 
-    ImGui::Text("Lights: %zu / 8", app.scene().lights().size());
+    ImGui::Separator();
+
+    // Point lights list
+    auto lights = gs.point_lights();  // copy for editing
+    bool lights_changed = false;
+    ImGui::Text("Point Lights: %zu / 8", lights.size());
+
+    for (size_t i = 0; i < lights.size(); i++) {
+        ImGui::PushID(static_cast<int>(i));
+        if (ImGui::CollapsingHeader(("Light " + std::to_string(i)).c_str())) {
+            float pos[3] = {lights[i].position_and_radius.x,
+                            lights[i].position_and_radius.y,
+                            lights[i].position_and_radius.z};
+            if (ImGui::DragFloat3("Position", pos, 0.5f)) {
+                lights[i].position_and_radius.x = pos[0];
+                lights[i].position_and_radius.y = pos[1];
+                lights[i].position_and_radius.z = pos[2];
+                lights_changed = true;
+            }
+            if (ImGui::DragFloat("Radius", &lights[i].position_and_radius.w, 0.5f, 0.1f, 500.0f)) {
+                lights_changed = true;
+            }
+            float col[3] = {lights[i].color.r, lights[i].color.g, lights[i].color.b};
+            if (ImGui::ColorEdit3("Color", col)) {
+                lights[i].color.r = col[0];
+                lights[i].color.g = col[1];
+                lights[i].color.b = col[2];
+                lights_changed = true;
+            }
+            if (ImGui::DragFloat("Intensity##light", &lights[i].color.a, 0.1f, 0.0f, 20.0f)) {
+                lights_changed = true;
+            }
+            if (ImGui::Button("Remove")) {
+                lights.erase(lights.begin() + static_cast<ptrdiff_t>(i));
+                lights_changed = true;
+                ImGui::PopID();
+                break;
+            }
+        }
+        ImGui::PopID();
+    }
+
+    if (lights.size() < 8 && ImGui::Button("+ Add Light")) {
+        PointLight new_light;
+        new_light.position_and_radius = glm::vec4(0.0f, 0.0f, 0.0f, 50.0f);
+        new_light.color = glm::vec4(1.0f, 1.0f, 1.0f, 5.0f);
+        lights.push_back(new_light);
+        lights_changed = true;
+        if (light_mode == 0) {
+            gs.set_light_mode(2);
+        }
+    }
+
+    if (lights_changed) {
+        gs.set_point_lights(lights);
+    }
 
     ImGui::End();
 }

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -1,0 +1,397 @@
+#include "gseurat/staging/staging_state.hpp"
+#include "gseurat/engine/app_base.hpp"
+#include "gseurat/engine/post_process.hpp"
+
+#include <imgui.h>
+
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+
+#include <glm/gtc/matrix_transform.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <filesystem>
+
+namespace gseurat {
+
+static constexpr float kOrbitSensitivity = 0.01f;
+static constexpr float kZoomSensitivity  = 3.0f;
+static constexpr float kPanSensitivity   = 0.05f;
+
+void StagingState::on_enter(AppBase& app) {
+    // Load scene files list
+    scene_files_.clear();
+    for (const auto& entry : std::filesystem::directory_iterator("assets/scenes")) {
+        if (entry.path().extension() == ".json") {
+            scene_files_.push_back(entry.path().string());
+        }
+    }
+    std::sort(scene_files_.begin(), scene_files_.end());
+    scenes_loaded_ = true;
+
+    // Initialize scene
+    app.init_scene(app.current_scene_path());
+    std::fprintf(stderr, "[Staging] Ready\n");
+}
+
+void StagingState::on_exit(AppBase& /*app*/) {
+}
+
+void StagingState::update(AppBase& app, float dt) {
+    // FPS tracking
+    frame_count_++;
+    fps_timer_ += dt;
+    if (fps_timer_ >= 0.5f) {
+        fps_ = static_cast<float>(frame_count_) / fps_timer_;
+        frame_count_ = 0;
+        fps_timer_ = 0.0f;
+    }
+    frame_times_[frame_time_idx_] = dt * 1000.0f;
+    frame_time_idx_ = (frame_time_idx_ + 1) % frame_times_.size();
+
+    // Camera orbit — only when ImGui doesn't want the mouse
+    auto& io = ImGui::GetIO();
+    if (!io.WantCaptureMouse) {
+        auto* window = app.window();
+        double mx, my;
+        glfwGetCursorPos(window, &mx, &my);
+
+        if (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS) {
+            if (!dragging_) {
+                dragging_ = true;
+                last_mouse_x_ = mx;
+                last_mouse_y_ = my;
+            }
+            double dx = mx - last_mouse_x_;
+            double dy = my - last_mouse_y_;
+            last_mouse_x_ = mx;
+            last_mouse_y_ = my;
+
+            if (glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS) {
+                // Pan
+                float pan_scale = distance_ * kPanSensitivity * 0.01f;
+                float cos_az = std::cos(azimuth_);
+                float sin_az = std::sin(azimuth_);
+                target_.x -= static_cast<float>(dx) * pan_scale * cos_az;
+                target_.z -= static_cast<float>(dx) * pan_scale * sin_az;
+                target_.y += static_cast<float>(dy) * pan_scale;
+            } else {
+                // Orbit
+                azimuth_ -= static_cast<float>(dx) * kOrbitSensitivity;
+                elevation_ += static_cast<float>(dy) * kOrbitSensitivity;
+                elevation_ = std::clamp(elevation_, -1.5f, 1.5f);
+            }
+        } else {
+            dragging_ = false;
+        }
+
+        // Scroll zoom
+        float scroll = app.input().scroll_y_delta();
+        if (scroll != 0.0f) {
+            distance_ -= scroll * kZoomSensitivity;
+            distance_ = std::max(1.0f, distance_);
+        }
+
+        // Reset camera
+        if (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS && !io.WantCaptureKeyboard) {
+            azimuth_ = 0.0f;
+            elevation_ = 0.3f;
+            distance_ = 100.0f;
+            target_ = glm::vec3(0.0f);
+            camera_initialized_ = false;
+        }
+    }
+
+    // Initialize camera from scene if not done
+    if (!camera_initialized_ && app.renderer().has_gs_cloud()) {
+        auto& gs_renderer = app.renderer().gs_renderer();
+        // Start centered at the scene
+        distance_ = 100.0f;
+        camera_initialized_ = true;
+    }
+
+    // Apply camera
+    if (app.renderer().has_gs_cloud()) {
+        float cos_el = std::cos(elevation_);
+        glm::vec3 eye{
+            target_.x + distance_ * cos_el * std::sin(azimuth_),
+            target_.y + distance_ * std::sin(elevation_),
+            target_.z + distance_ * cos_el * std::cos(azimuth_)
+        };
+        auto& gs_renderer = app.renderer().gs_renderer();
+        float aspect = static_cast<float>(gs_renderer.output_width()) /
+                       static_cast<float>(gs_renderer.output_height());
+        auto view = glm::lookAt(eye, target_, glm::vec3(0, 1, 0));
+        auto proj = glm::perspective(glm::radians(45.0f), aspect, 0.1f, 1000.0f);
+        proj[1][1] *= -1.0f;  // Vulkan Y-flip
+        app.renderer().set_gs_camera(view, proj);
+    }
+
+    // Draw ImGui
+    draw_imgui(app);
+
+    // Update screen effects
+    app.screen_effects().update(dt);
+}
+
+void StagingState::build_draw_lists(AppBase& /*app*/) {
+    // No sprite draw lists — ImGui handles everything
+}
+
+// ── ImGui Panels ──
+
+void StagingState::draw_imgui(AppBase& app) {
+    // Main menu bar
+    if (ImGui::BeginMainMenuBar()) {
+        if (ImGui::BeginMenu("Scene")) {
+            if (ImGui::MenuItem("Reload")) {
+                app.clear_scene();
+                app.init_scene(app.current_scene_path());
+            }
+            ImGui::Separator();
+            for (const auto& path : scene_files_) {
+                auto name = std::filesystem::path(path).filename().string();
+                if (ImGui::MenuItem(name.c_str())) {
+                    app.clear_scene();
+                    app.init_scene(path);
+                }
+            }
+            ImGui::EndMenu();
+        }
+        if (ImGui::BeginMenu("View")) {
+            ImGui::MenuItem("Viewport Info", nullptr, &show_viewport_info_);
+            ImGui::MenuItem("Render Settings", nullptr, &show_render_settings_);
+            ImGui::MenuItem("GS Parameters", nullptr, &show_gs_params_);
+            ImGui::MenuItem("Feature Toggles", nullptr, &show_feature_toggles_);
+            ImGui::MenuItem("Lighting", nullptr, &show_lighting_);
+            ImGui::MenuItem("Camera", nullptr, &show_camera_);
+            ImGui::MenuItem("Performance", nullptr, &show_performance_);
+            ImGui::EndMenu();
+        }
+        ImGui::EndMainMenuBar();
+    }
+
+    draw_viewport_info(app);
+    draw_render_settings(app);
+    draw_gs_params(app);
+    draw_feature_toggles(app);
+    draw_lighting(app);
+    draw_camera_panel(app);
+    draw_performance(app);
+}
+
+void StagingState::draw_viewport_info(AppBase& app) {
+    ImGui::SetNextWindowPos(ImVec2(10, 30), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(250, 120), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Viewport Info", nullptr, ImGuiWindowFlags_NoCollapse)) {
+        ImGui::End();
+        return;
+    }
+
+    ImGui::Text("FPS: %.1f", fps_);
+    if (app.renderer().has_gs_cloud()) {
+        auto& gs = app.renderer().gs_renderer();
+        ImGui::Text("Gaussians: %u / %u", gs.visible_count(), gs.gaussian_count());
+    }
+    ImGui::Text("Scene: %s", std::filesystem::path(app.current_scene_path()).filename().string().c_str());
+    ImGui::Separator();
+    ImGui::Text("Az: %.1f  El: %.1f  Dist: %.1f", azimuth_ * 57.2958f, elevation_ * 57.2958f, distance_);
+    ImGui::Text("Target: %.1f, %.1f, %.1f", target_.x, target_.y, target_.z);
+
+    ImGui::End();
+}
+
+void StagingState::draw_render_settings(AppBase& app) {
+    ImGui::SetNextWindowPos(ImVec2(1020, 30), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(250, 400), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Render Settings")) {
+        ImGui::End();
+        return;
+    }
+
+    auto& pp = app.renderer().post_process_params();
+
+    if (ImGui::CollapsingHeader("Bloom", ImGuiTreeNodeFlags_DefaultOpen)) {
+        ImGui::SliderFloat("Threshold", &pp.bloom_threshold, 0.0f, 5.0f);
+        ImGui::SliderFloat("Soft Knee", &pp.bloom_soft_knee, 0.0f, 1.0f);
+        ImGui::SliderFloat("Intensity", &pp.bloom_intensity, 0.0f, 2.0f);
+    }
+    if (ImGui::CollapsingHeader("Exposure")) {
+        ImGui::SliderFloat("Exposure", &pp.exposure, 0.1f, 5.0f);
+    }
+    if (ImGui::CollapsingHeader("Depth of Field")) {
+        ImGui::SliderFloat("Focus Distance", &pp.dof_focus_distance, 0.1f, 200.0f);
+        ImGui::SliderFloat("Focus Range", &pp.dof_focus_range, 0.1f, 50.0f);
+        ImGui::SliderFloat("Max Blur", &pp.dof_max_blur, 0.0f, 2.0f);
+    }
+    if (ImGui::CollapsingHeader("Vignette")) {
+        ImGui::SliderFloat("Radius", &pp.vignette_radius, 0.0f, 1.5f);
+        ImGui::SliderFloat("Softness", &pp.vignette_softness, 0.0f, 1.0f);
+    }
+    if (ImGui::CollapsingHeader("Fog")) {
+        ImGui::SliderFloat("Density", &pp.fog_density, 0.0f, 1.0f);
+        float fog_color[3] = {pp.fog_color_r, pp.fog_color_g, pp.fog_color_b};
+        if (ImGui::ColorEdit3("Color", fog_color)) {
+            pp.fog_color_r = fog_color[0];
+            pp.fog_color_g = fog_color[1];
+            pp.fog_color_b = fog_color[2];
+        }
+    }
+    if (ImGui::CollapsingHeader("God Rays")) {
+        float gr = app.renderer().god_rays_intensity();
+        if (ImGui::SliderFloat("Intensity##gr", &gr, 0.0f, 3.0f)) {
+            app.renderer().set_god_rays_intensity(gr);
+        }
+    }
+
+    ImGui::End();
+}
+
+void StagingState::draw_gs_params(AppBase& app) {
+    if (!app.renderer().has_gs_cloud()) return;
+
+    ImGui::SetNextWindowPos(ImVec2(1020, 440), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(250, 250), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("GS Parameters")) {
+        ImGui::End();
+        return;
+    }
+
+    auto& gs = app.renderer().gs_renderer();
+
+    float scale = gs.scale_multiplier();
+    if (ImGui::SliderFloat("Scale", &scale, 0.1f, 10.0f)) {
+        gs.set_scale_multiplier(scale);
+    }
+
+    int toon = gs.toon_bands();
+    if (ImGui::SliderInt("Toon Bands", &toon, 0, 5)) {
+        gs.set_toon_bands(toon);
+    }
+
+    int light_mode = gs.light_mode();
+    const char* light_modes[] = {"Off", "Directional", "Point Lights"};
+    if (ImGui::Combo("Light Mode", &light_mode, light_modes, 3)) {
+        gs.set_light_mode(light_mode);
+    }
+
+    float intensity = gs.light_intensity();
+    if (ImGui::SliderFloat("Light Intensity", &intensity, 0.0f, 5.0f)) {
+        gs.set_light_intensity(intensity);
+    }
+
+    ImGui::End();
+}
+
+void StagingState::draw_feature_toggles(AppBase& app) {
+    ImGui::SetNextWindowPos(ImVec2(10, 400), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(250, 350), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Feature Toggles")) {
+        ImGui::End();
+        return;
+    }
+
+    auto& f = app.feature_flags();
+
+    if (ImGui::CollapsingHeader("Rendering", ImGuiTreeNodeFlags_DefaultOpen)) {
+        ImGui::Checkbox("Bloom", &f.bloom);
+        ImGui::Checkbox("Depth of Field", &f.depth_of_field);
+        ImGui::Checkbox("Vignette", &f.vignette);
+        ImGui::Checkbox("Tone Mapping", &f.tone_mapping);
+        ImGui::Checkbox("Fog", &f.fog);
+        ImGui::Checkbox("Point Lights", &f.point_lights);
+    }
+    if (ImGui::CollapsingHeader("GS")) {
+        ImGui::Checkbox("GS Rendering", &f.gs_rendering);
+        ImGui::Checkbox("Chunk Culling", &f.gs_chunk_culling);
+        ImGui::Checkbox("LOD", &f.gs_lod);
+        ImGui::Checkbox("Adaptive Budget", &f.gs_adaptive_budget);
+        ImGui::Checkbox("Parallax", &f.gs_parallax);
+    }
+    if (ImGui::CollapsingHeader("Effects")) {
+        ImGui::Checkbox("Particles", &f.particles);
+        ImGui::Checkbox("Weather", &f.weather);
+        ImGui::Checkbox("Animated Tiles", &f.animated_tiles);
+        ImGui::Checkbox("Screen Effects", &f.screen_effects);
+        ImGui::Checkbox("Camera Shake", &f.camera_shake);
+    }
+    if (ImGui::CollapsingHeader("Audio")) {
+        ImGui::Checkbox("Music", &f.music);
+        ImGui::Checkbox("SFX", &f.sfx);
+    }
+
+    ImGui::End();
+}
+
+void StagingState::draw_lighting(AppBase& app) {
+    ImGui::SetNextWindowPos(ImVec2(270, 30), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(280, 200), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Lighting")) {
+        ImGui::End();
+        return;
+    }
+
+    auto ambient = app.scene().ambient_color();
+    float amb[4] = {ambient.r, ambient.g, ambient.b, ambient.a};
+    if (ImGui::ColorEdit4("Ambient", amb)) {
+        app.scene().set_ambient_color({amb[0], amb[1], amb[2], amb[3]});
+    }
+
+    ImGui::Text("Lights: %zu / 8", app.scene().lights().size());
+
+    ImGui::End();
+}
+
+void StagingState::draw_camera_panel(AppBase& app) {
+    ImGui::SetNextWindowPos(ImVec2(270, 240), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(280, 150), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Camera")) {
+        ImGui::End();
+        return;
+    }
+
+    ImGui::DragFloat("Azimuth", &azimuth_, 0.01f);
+    ImGui::DragFloat("Elevation", &elevation_, 0.01f, -1.5f, 1.5f);
+    ImGui::DragFloat("Distance", &distance_, 1.0f, 1.0f, 1000.0f);
+    ImGui::DragFloat3("Target", &target_.x, 0.5f);
+
+    if (ImGui::Button("Reset")) {
+        azimuth_ = 0.0f;
+        elevation_ = 0.3f;
+        distance_ = 100.0f;
+        target_ = glm::vec3(0.0f);
+    }
+
+    ImGui::End();
+}
+
+void StagingState::draw_performance(AppBase& app) {
+    ImGui::SetNextWindowPos(ImVec2(10, 160), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(250, 200), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Performance")) {
+        ImGui::End();
+        return;
+    }
+
+    ImGui::Text("FPS: %.1f (%.2f ms)", fps_, fps_ > 0.0f ? 1000.0f / fps_ : 0.0f);
+
+    // Reorder ring buffer for ImGui::PlotLines
+    float ordered[300];
+    for (int i = 0; i < 300; i++) {
+        ordered[i] = frame_times_[(frame_time_idx_ + i) % 300];
+    }
+    ImGui::PlotLines("Frame Time", ordered, 300, 0, nullptr, 0.0f, 50.0f, ImVec2(0, 80));
+
+    if (app.renderer().has_gs_cloud()) {
+        auto& gs = app.renderer().gs_renderer();
+        ImGui::Text("Gaussian Count: %u", gs.gaussian_count());
+        ImGui::Text("Visible: %u", gs.visible_count());
+        ImGui::Text("Max Capacity: %u", gs.max_gaussian_count());
+    }
+
+    ImGui::End();
+}
+
+}  // namespace gseurat

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -199,6 +199,8 @@ void StagingState::draw_viewport_info(AppBase& app) {
     ImGui::Separator();
     ImGui::Text("Az: %.1f  El: %.1f  Dist: %.1f", azimuth_ * 57.2958f, elevation_ * 57.2958f, distance_);
     ImGui::Text("Target: %.1f, %.1f, %.1f", target_.x, target_.y, target_.z);
+    ImGui::Separator();
+    ImGui::TextDisabled("Drag: Orbit  Shift+Drag: Pan  Scroll: Zoom  R: Reset");
 
     ImGui::End();
 }
@@ -290,6 +292,7 @@ void StagingState::draw_feature_toggles(AppBase& app) {
     }
     if (ImGui::CollapsingHeader("Scene")) {
         ImGui::Checkbox("Particles", &f.particles);
+        ImGui::Checkbox("Animation", &f.animation);
     }
 
     ImGui::End();

--- a/src/staging_main.cpp
+++ b/src/staging_main.cpp
@@ -1,0 +1,19 @@
+#include "gseurat/staging/staging_app.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char* argv[]) {
+    gseurat::StagingApp staging;
+    staging.parse_args(argc, argv);
+
+    try {
+        staging.run();
+    } catch (const std::exception& e) {
+        std::cerr << "Fatal error: " << e.what() << '\n';
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- New `gseurat_staging` C++ executable with Dear ImGui overlay for engine rendering review
- ImGui panels: Viewport Info, Render Settings (bloom/DoF/fog/vignette/god rays), GS Parameters (scale/toon/lighting), Feature Toggles (32 flags), Lighting (ambient), Camera (orbit/pan/zoom), Performance (FPS/frame time graph/Gaussian counts)
- Camera control: left drag = orbit, shift+left = pan, scroll = zoom, R = reset
- ControlServer wired into AppBase (engine layer) with command dispatch for bridge integration
- Bridge commands: get_features, set_feature, get_render_params, set_render_param, get_perf, set_ambient, get_scene, reload_scene, list_scenes, screenshot
- Scene loading via `--scene` CLI arg + Scene menu
- PostProcessParams as persistent Renderer member for live panel editing

## Test plan
- [x] `cmake --build --preset macos-debug` builds both gseurat_demo and gseurat_staging
- [x] All 13 C++ tests pass
- [x] `./gseurat_staging --scene assets/scenes/test_bricklayer.json` shows engine viewport with ImGui overlay
- [x] Camera orbit/pan/zoom works when not hovering ImGui panels
- [x] Render setting sliders produce visible changes (bloom, DoF, fog)
- [x] Feature toggles enable/disable effects in real-time
- [x] Scene menu lists and loads available scenes
- [x] Bridge connects and responds to commands (get_features, set_render_param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)