### PR TITLE
Staging: viewport gizmos + camera bookmarks

### DIFF
--- a/include/gseurat/engine/gs_animator.hpp
+++ b/include/gseurat/engine/gs_animator.hpp
@@ -105,6 +105,9 @@ public:
     // Clear all animation groups, restoring original state
     void clear(std::vector<Gaussian>& gaussians);
 
+    // Drop all groups without restoring (use when buffer has changed)
+    void reset();
+
     bool has_active_groups() const;
     bool has_group(uint32_t group_id) const;
 

--- a/include/gseurat/engine/gs_vfx.hpp
+++ b/include/gseurat/engine/gs_vfx.hpp
@@ -70,6 +70,9 @@ public:
     const VfxPreset& preset() const { return preset_; }
     const std::vector<Gaussian>& object_gaussians() const { return object_gaussians_; }
 
+    /// Reset animation states so they re-tag on next update
+    void reset_animations();
+
 private:
     VfxPreset preset_;
     glm::vec3 position_{0.0f};

--- a/include/gseurat/staging/staging_state.hpp
+++ b/include/gseurat/staging/staging_state.hpp
@@ -25,6 +25,11 @@ public:
     void update(AppBase& app, float dt) override;
     void build_draw_lists(AppBase& app) override;
 
+    // 3D → 2D projection (public for gizmo helpers)
+    bool project_to_screen(const glm::vec3& world_pos, const glm::mat4& vp,
+                           float screen_w, float screen_h,
+                           float& out_x, float& out_y) const;
+
 private:
     void draw_imgui(AppBase& app);
     void draw_viewport_info(AppBase& app);
@@ -36,11 +41,6 @@ private:
     void draw_scene_panel(AppBase& app);
     void draw_performance(AppBase& app);
     void draw_gizmos(AppBase& app);
-
-    // 3D → 2D projection helper (returns false if behind camera)
-    bool project_to_screen(const glm::vec3& world_pos, const glm::mat4& vp,
-                           float screen_w, float screen_h,
-                           float& out_x, float& out_y) const;
 
     // Camera orbit state
     float azimuth_ = 0.0f;

--- a/include/gseurat/staging/staging_state.hpp
+++ b/include/gseurat/staging/staging_state.hpp
@@ -82,6 +82,9 @@ private:
     bool show_gizmo_lights_ = true;
     bool show_gizmo_emitters_ = true;
     bool show_gizmo_vfx_ = true;
+
+    // Hide all UI (Tab key toggle)
+    bool hide_ui_ = false;
 };
 
 }  // namespace gseurat

--- a/include/gseurat/staging/staging_state.hpp
+++ b/include/gseurat/staging/staging_state.hpp
@@ -3,11 +3,20 @@
 #include "gseurat/engine/game_state.hpp"
 
 #include <glm/vec3.hpp>
+#include <glm/mat4x4.hpp>
 #include <array>
 #include <string>
 #include <vector>
 
 namespace gseurat {
+
+struct CameraBookmark {
+    std::string name;
+    float azimuth;
+    float elevation;
+    float distance;
+    glm::vec3 target;
+};
 
 class StagingState : public GameState {
 public:
@@ -26,6 +35,12 @@ private:
     void draw_camera_panel(AppBase& app);
     void draw_scene_panel(AppBase& app);
     void draw_performance(AppBase& app);
+    void draw_gizmos(AppBase& app);
+
+    // 3D → 2D projection helper (returns false if behind camera)
+    bool project_to_screen(const glm::vec3& world_pos, const glm::mat4& vp,
+                           float screen_w, float screen_h,
+                           float& out_x, float& out_y) const;
 
     // Camera orbit state
     float azimuth_ = 0.0f;
@@ -51,6 +66,9 @@ private:
     int selected_scene_ = -1;
     bool scenes_loaded_ = false;
 
+    // Camera bookmarks
+    std::vector<CameraBookmark> bookmarks_;
+
     // Panel visibility
     bool show_viewport_info_ = true;
     bool show_render_settings_ = true;
@@ -59,6 +77,11 @@ private:
     bool show_lighting_ = true;
     bool show_camera_ = true;
     bool show_performance_ = true;
+
+    // Gizmo visibility
+    bool show_gizmo_lights_ = true;
+    bool show_gizmo_emitters_ = true;
+    bool show_gizmo_vfx_ = true;
 };
 
 }  // namespace gseurat

--- a/src/engine/gs_animator.cpp
+++ b/src/engine/gs_animator.cpp
@@ -485,6 +485,11 @@ void GaussianAnimator::clear(std::vector<Gaussian>& gaussians) {
     baselines_.clear();
 }
 
+void GaussianAnimator::reset() {
+    groups_.clear();
+    baselines_.clear();
+}
+
 bool GaussianAnimator::has_active_groups() const {
     return !groups_.empty();
 }

--- a/src/engine/gs_vfx.cpp
+++ b/src/engine/gs_vfx.cpp
@@ -237,4 +237,11 @@ void VfxInstance::update(float dt, std::vector<Gaussian>& out_buffer, GaussianAn
     }
 }
 
+void VfxInstance::reset_animations() {
+    for (auto& as : anim_states_) {
+        as.activated = false;
+        as.group_id = 0;
+    }
+}
+
 }  // namespace gseurat

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -803,6 +803,15 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 }
                 gs_scene_buffer_ = gs_active_buffer_;  // cache scene-only buffer
 
+                // Scene buffer changed — animator indices are stale.
+                // Reset so VFX animations re-tag on the new buffer.
+                gs_animator_.reset();
+
+                // Reset VFX animation states so they re-tag
+                for (auto& inst : vfx_instances_) {
+                    inst.reset_animations();
+                }
+
                 if (!gs_active_buffer_.empty()) {
                     gs_renderer_.update_active_gaussians(
                         gs_active_buffer_.data(),

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -51,6 +51,8 @@ void StagingApp::init_game_content() {
     // Start with all post-process/effects off — user enables what they want to review.
     // GS pipeline flags (rendering, chunk culling, LOD, adaptive budget) stay on.
     feature_flags_ = FeatureFlags::gs_viewer();
+    feature_flags_.particles = true;
+    feature_flags_.animation = true;
 
     init_imgui();
 }

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -506,11 +506,76 @@ bool StagingState::project_to_screen(const glm::vec3& world_pos, const glm::mat4
                                       float screen_w, float screen_h,
                                       float& out_x, float& out_y) const {
     glm::vec4 clip = vp * glm::vec4(world_pos, 1.0f);
-    if (clip.w <= 0.001f) return false;  // behind camera
+    if (clip.w <= 0.001f) return false;
     glm::vec3 ndc = glm::vec3(clip) / clip.w;
     out_x = (ndc.x * 0.5f + 0.5f) * screen_w;
-    out_y = (1.0f - (ndc.y * 0.5f + 0.5f)) * screen_h;  // flip Y
+    out_y = (1.0f - (ndc.y * 0.5f + 0.5f)) * screen_h;
     return ndc.z >= 0.0f && ndc.z <= 1.0f;
+}
+
+// Draw a wireframe sphere (projected as circle from center + edge point)
+static void draw_sphere_gizmo(ImDrawList* dl, const glm::vec3& center, float radius,
+                               const glm::mat4& vp, float sw, float sh, ImU32 col,
+                               bool (*proj_fn)(const glm::vec3&, const glm::mat4&, float, float, float&, float&, const void*),
+                               const void* self) {
+    float cx, cy;
+    if (!proj_fn(center, vp, sw, sh, cx, cy, self)) return;
+    glm::vec3 edge = center + glm::vec3(radius, 0.0f, 0.0f);
+    float ex, ey;
+    float sr = 15.0f;
+    if (proj_fn(edge, vp, sw, sh, ex, ey, self)) {
+        sr = std::abs(ex - cx);
+        sr = std::clamp(sr, 3.0f, 300.0f);
+    }
+    dl->AddCircle(ImVec2(cx, cy), sr, col, 24, 1.5f);
+}
+
+// Draw a wireframe box (8 corners projected, 12 edges)
+static void draw_box_gizmo(ImDrawList* dl, const glm::vec3& center, const glm::vec3& half,
+                             const glm::mat4& vp, float sw, float sh, ImU32 col,
+                             bool (*proj_fn)(const glm::vec3&, const glm::mat4&, float, float, float&, float&, const void*),
+                             const void* self) {
+    glm::vec3 corners[8] = {
+        center + glm::vec3(-half.x, -half.y, -half.z),
+        center + glm::vec3( half.x, -half.y, -half.z),
+        center + glm::vec3( half.x,  half.y, -half.z),
+        center + glm::vec3(-half.x,  half.y, -half.z),
+        center + glm::vec3(-half.x, -half.y,  half.z),
+        center + glm::vec3( half.x, -half.y,  half.z),
+        center + glm::vec3( half.x,  half.y,  half.z),
+        center + glm::vec3(-half.x,  half.y,  half.z),
+    };
+    ImVec2 pts[8];
+    bool vis[8];
+    for (int i = 0; i < 8; i++) {
+        vis[i] = proj_fn(corners[i], vp, sw, sh, pts[i].x, pts[i].y, self);
+    }
+    constexpr int edges[12][2] = {
+        {0,1},{1,2},{2,3},{3,0}, {4,5},{5,6},{6,7},{7,4}, {0,4},{1,5},{2,6},{3,7}
+    };
+    for (const auto& e : edges) {
+        if (vis[e[0]] && vis[e[1]]) {
+            dl->AddLine(pts[e[0]], pts[e[1]], col, 1.0f);
+        }
+    }
+}
+
+// Static wrapper for project_to_screen (needed for function pointers)
+static bool project_wrapper(const glm::vec3& pos, const glm::mat4& vp,
+                             float sw, float sh, float& ox, float& oy, const void* self) {
+    return static_cast<const StagingState*>(self)->project_to_screen(pos, vp, sw, sh, ox, oy);
+}
+
+// Draw region wireframe (sphere or box)
+static void draw_region_gizmo(ImDrawList* dl, const GsAnimRegion& region,
+                                const glm::vec3& offset, const glm::mat4& vp,
+                                float sw, float sh, ImU32 col, const void* self) {
+    glm::vec3 center = region.center + offset;
+    if (region.shape == GsAnimRegion::Shape::Box) {
+        draw_box_gizmo(dl, center, region.half_extents, vp, sw, sh, col, project_wrapper, self);
+    } else {
+        draw_sphere_gizmo(dl, center, region.radius, vp, sw, sh, col, project_wrapper, self);
+    }
 }
 
 void StagingState::draw_gizmos(AppBase& app) {
@@ -520,7 +585,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     float aspect = static_cast<float>(gs.output_width()) /
                    static_cast<float>(gs.output_height());
 
-    // Build VP matrix matching the camera
+    // Build VP matrix for projection
     float cos_el = std::cos(elevation_);
     glm::vec3 eye{
         target_.x + distance_ * cos_el * std::sin(azimuth_),
@@ -529,24 +594,20 @@ void StagingState::draw_gizmos(AppBase& app) {
     };
     auto view = glm::lookAt(eye, target_, glm::vec3(0, 1, 0));
     auto proj = glm::perspective(glm::radians(45.0f), aspect, 0.1f, 1000.0f);
-    proj[1][1] *= -1.0f;  // Vulkan Y-flip
-    // But for screen projection we need standard NDC (Y up), so undo the flip
-    proj[1][1] *= -1.0f;
     glm::mat4 vp = proj * view;
 
     auto& io = ImGui::GetIO();
     float sw = io.DisplaySize.x;
     float sh = io.DisplaySize.y;
 
-    ImDrawList* draw_list = ImGui::GetForegroundDrawList();
+    ImDrawList* dl = ImGui::GetForegroundDrawList();
 
     // ── Light gizmos ──
     if (show_gizmo_lights_) {
         const auto& lights = gs.point_lights();
         for (size_t i = 0; i < lights.size(); i++) {
-            // Light position: (x, y=scene_z, z=height)
             glm::vec3 pos(lights[i].position_and_radius.x,
-                          lights[i].position_and_radius.z,  // height stored in z
+                          lights[i].position_and_radius.z,
                           lights[i].position_and_radius.y);
             float sx, sy;
             if (!project_to_screen(pos, vp, sw, sh, sx, sy)) continue;
@@ -554,61 +615,106 @@ void StagingState::draw_gizmos(AppBase& app) {
             ImU32 col = ImGui::ColorConvertFloat4ToU32(
                 ImVec4(lights[i].color.r, lights[i].color.g, lights[i].color.b, 0.8f));
 
-            // Outer circle (radius indicator — approximate screen-space size)
-            float radius_world = lights[i].position_and_radius.w;
-            glm::vec3 edge_pos = pos + glm::vec3(radius_world, 0.0f, 0.0f);
-            float ex, ey;
-            float screen_radius = 20.0f;  // fallback
-            if (project_to_screen(edge_pos, vp, sw, sh, ex, ey)) {
-                screen_radius = std::abs(ex - sx);
-                screen_radius = std::clamp(screen_radius, 5.0f, 200.0f);
-            }
+            draw_sphere_gizmo(dl, pos, lights[i].position_and_radius.w,
+                              vp, sw, sh, col, project_wrapper, this);
+            dl->AddCircleFilled(ImVec2(sx, sy), 4.0f, col);
 
-            draw_list->AddCircle(ImVec2(sx, sy), screen_radius, col, 32, 1.5f);
-            draw_list->AddCircleFilled(ImVec2(sx, sy), 4.0f, col);
-
-            // Label
             char label[32];
             std::snprintf(label, sizeof(label), "L%zu", i);
-            draw_list->AddText(ImVec2(sx + 6, sy - 12), col, label);
+            dl->AddText(ImVec2(sx + 6, sy - 12), col, label);
         }
     }
 
-    // ── Emitter gizmos ──
+    // ── Standalone emitter gizmos (with spawn region) ──
     if (show_gizmo_emitters_) {
-        ImU32 emitter_col = IM_COL32(255, 100, 50, 200);  // orange
+        ImU32 emitter_col = IM_COL32(236, 72, 153, 200);  // pink
         auto& emitters = app.renderer().gs_particle_emitters();
         for (size_t i = 0; i < emitters.size(); i++) {
-            auto pos = emitters[i].config().position;
+            auto& cfg = emitters[i].config();
             float sx, sy;
-            if (!project_to_screen(pos, vp, sw, sh, sx, sy)) continue;
+            if (!project_to_screen(cfg.position, vp, sw, sh, sx, sy)) continue;
 
-            draw_list->AddCircleFilled(ImVec2(sx, sy), 5.0f, emitter_col);
-            draw_list->AddCircle(ImVec2(sx, sy), 10.0f, emitter_col, 16, 1.0f);
+            dl->AddCircleFilled(ImVec2(sx, sy), 5.0f, emitter_col);
+
+            // Draw spawn region
+            draw_region_gizmo(dl, cfg.spawn_region, cfg.position, vp, sw, sh, emitter_col, this);
 
             char label[32];
             std::snprintf(label, sizeof(label), "E%zu", i);
-            draw_list->AddText(ImVec2(sx + 8, sy - 10), emitter_col, label);
+            dl->AddText(ImVec2(sx + 8, sy - 10), emitter_col, label);
         }
     }
 
-    // ── VFX instance gizmos ──
+    // ── Scene animation gizmos (region wireframes) ──
     if (show_gizmo_vfx_) {
-        ImU32 vfx_col = IM_COL32(100, 200, 255, 200);  // cyan
+        ImU32 anim_col = IM_COL32(6, 182, 212, 180);  // cyan
+        const auto& anims = app.renderer().gs_scene_animations();
+        for (size_t i = 0; i < anims.size(); i++) {
+            float sx, sy;
+            if (!project_to_screen(anims[i].region.center, vp, sw, sh, sx, sy)) continue;
+
+            draw_region_gizmo(dl, anims[i].region, glm::vec3(0.0f), vp, sw, sh, anim_col, this);
+            dl->AddCircleFilled(ImVec2(sx, sy), 3.0f, anim_col);
+
+            char label[64];
+            std::snprintf(label, sizeof(label), "Anim:%s", anims[i].effect.c_str());
+            dl->AddText(ImVec2(sx + 6, sy - 10), anim_col, label);
+        }
+    }
+
+    // ── VFX instance gizmos (with element details) ──
+    if (show_gizmo_vfx_) {
         const auto& vfx = app.renderer().vfx_instances();
         for (size_t i = 0; i < vfx.size(); i++) {
-            auto pos = vfx[i].position();
+            auto inst_pos = vfx[i].position();
             float sx, sy;
-            if (!project_to_screen(pos, vp, sw, sh, sx, sy)) continue;
+            if (!project_to_screen(inst_pos, vp, sw, sh, sx, sy)) continue;
 
-            // Diamond shape
+            ImU32 vfx_col = IM_COL32(100, 200, 255, 220);
+            // Diamond for instance origin
             float d = 7.0f;
-            draw_list->AddQuadFilled(
+            dl->AddQuadFilled(
                 ImVec2(sx, sy - d), ImVec2(sx + d, sy),
                 ImVec2(sx, sy + d), ImVec2(sx - d, sy), vfx_col);
 
             const char* name = vfx[i].preset().name.c_str();
-            draw_list->AddText(ImVec2(sx + 10, sy - 8), vfx_col, name);
+            dl->AddText(ImVec2(sx + 10, sy - 8), vfx_col, name);
+
+            // Draw each element inside the VFX instance
+            for (const auto& el : vfx[i].preset().elements) {
+                glm::vec3 el_world = inst_pos + el.position;
+                float ex, ey;
+                if (!project_to_screen(el_world, vp, sw, sh, ex, ey)) continue;
+
+                if (el.type == "object") {
+                    ImU32 obj_col = IM_COL32(170, 170, 170, 180);
+                    dl->AddCircle(ImVec2(ex, ey), 4.0f, obj_col, 6, 1.5f);  // hexagon
+                    dl->AddText(ImVec2(ex + 6, ey - 8), obj_col, el.name.c_str());
+
+                } else if (el.type == "emitter") {
+                    ImU32 em_col = IM_COL32(236, 72, 153, 180);  // pink
+                    dl->AddCircleFilled(ImVec2(ex, ey), 3.0f, em_col);
+                    // Draw emitter spawn region
+                    draw_region_gizmo(dl, el.emitter_config.spawn_region, el_world,
+                                      vp, sw, sh, em_col, this);
+                    dl->AddText(ImVec2(ex + 6, ey - 8), em_col, el.name.c_str());
+
+                } else if (el.type == "animation") {
+                    ImU32 an_col = IM_COL32(6, 182, 212, 180);  // cyan
+                    dl->AddCircleFilled(ImVec2(ex, ey), 3.0f, an_col);
+                    // Draw animation region
+                    draw_region_gizmo(dl, el.region, el_world, vp, sw, sh, an_col, this);
+                    char label[64];
+                    std::snprintf(label, sizeof(label), "%s [%s]",
+                                  el.name.c_str(), el.animation_config.effect.c_str());
+                    dl->AddText(ImVec2(ex + 6, ey - 8), an_col, label);
+
+                } else if (el.type == "light") {
+                    ImU32 lt_col = IM_COL32(234, 179, 8, 180);  // yellow
+                    dl->AddCircleFilled(ImVec2(ex, ey), 4.0f, lt_col);
+                    dl->AddText(ImVec2(ex + 6, ey - 8), lt_col, el.name.c_str());
+                }
+            }
         }
     }
 }

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -94,6 +94,11 @@ void StagingState::update(AppBase& app, float dt) {
             distance_ = std::max(1.0f, distance_);
         }
 
+        // Toggle UI visibility (Tab)
+        if (app.input().was_key_pressed(GLFW_KEY_TAB)) {
+            hide_ui_ = !hide_ui_;
+        }
+
         // Reset camera
         if (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS && !io.WantCaptureKeyboard) {
             azimuth_ = 0.0f;
@@ -129,8 +134,10 @@ void StagingState::update(AppBase& app, float dt) {
         app.renderer().set_gs_camera(view, proj);
     }
 
-    // Draw ImGui
-    draw_imgui(app);
+    // Draw ImGui (hidden with Tab)
+    if (!hide_ui_) {
+        draw_imgui(app);
+    }
 
     // Update screen effects
     app.screen_effects().update(dt);
@@ -205,7 +212,8 @@ void StagingState::draw_viewport_info(AppBase& app) {
     ImGui::Text("Az: %.1f  El: %.1f  Dist: %.1f", azimuth_ * 57.2958f, elevation_ * 57.2958f, distance_);
     ImGui::Text("Target: %.1f, %.1f, %.1f", target_.x, target_.y, target_.z);
     ImGui::Separator();
-    ImGui::TextDisabled("Drag: Orbit  Shift+Drag: Pan  Scroll: Zoom  R: Reset");
+    ImGui::TextDisabled("Drag: Orbit  Shift+Drag: Pan  Scroll: Zoom");
+    ImGui::TextDisabled("R: Reset  Tab: Hide UI");
 
     ImGui::End();
 }

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -229,25 +229,25 @@ void StagingState::draw_render_settings(AppBase& app) {
     auto& pp = app.renderer().post_process_params();
 
     if (ImGui::CollapsingHeader("Bloom", ImGuiTreeNodeFlags_DefaultOpen)) {
-        ImGui::SliderFloat("Threshold##bloom", &pp.bloom_threshold, 0.0f, 5.0f);
-        ImGui::SliderFloat("Soft Knee##bloom", &pp.bloom_soft_knee, 0.0f, 1.0f);
-        ImGui::SliderFloat("Intensity##bloom", &pp.bloom_intensity, 0.0f, 2.0f);
+        ImGui::SliderFloat("Threshold##bloom", &pp.bloom_threshold, 0.0f, 5.0f, "%.3f", ImGuiSliderFlags_NoInput);
+        ImGui::SliderFloat("Soft Knee##bloom", &pp.bloom_soft_knee, 0.0f, 1.0f, "%.3f", ImGuiSliderFlags_NoInput);
+        ImGui::SliderFloat("Intensity##bloom", &pp.bloom_intensity, 0.0f, 2.0f, "%.3f", ImGuiSliderFlags_NoInput);
     }
     if (ImGui::CollapsingHeader("Exposure")) {
-        ImGui::SliderFloat("Exposure##pp", &pp.exposure, 0.1f, 5.0f);
+        ImGui::SliderFloat("Exposure##pp", &pp.exposure, 0.1f, 5.0f, "%.3f", ImGuiSliderFlags_NoInput);
     }
     if (ImGui::CollapsingHeader("Depth of Field")) {
-        ImGui::SliderFloat("Focus Distance##dof", &pp.dof_focus_distance, 0.1f, 200.0f);
-        ImGui::SliderFloat("Focus Range##dof", &pp.dof_focus_range, 0.1f, 50.0f);
-        ImGui::SliderFloat("Max Blur##dof", &pp.dof_max_blur, 0.0f, 2.0f);
+        ImGui::SliderFloat("Focus Distance##dof", &pp.dof_focus_distance, 0.1f, 200.0f, "%.3f", ImGuiSliderFlags_NoInput);
+        ImGui::SliderFloat("Focus Range##dof", &pp.dof_focus_range, 0.1f, 50.0f, "%.3f", ImGuiSliderFlags_NoInput);
+        ImGui::SliderFloat("Max Blur##dof", &pp.dof_max_blur, 0.0f, 2.0f, "%.3f", ImGuiSliderFlags_NoInput);
     }
     if (ImGui::CollapsingHeader("Vignette")) {
-        ImGui::SliderFloat("Radius##vig", &pp.vignette_radius, 0.0f, 1.5f);
-        ImGui::SliderFloat("Softness##vig", &pp.vignette_softness, 0.0f, 1.0f);
+        ImGui::SliderFloat("Radius##vig", &pp.vignette_radius, 0.0f, 1.5f, "%.3f", ImGuiSliderFlags_NoInput);
+        ImGui::SliderFloat("Softness##vig", &pp.vignette_softness, 0.0f, 1.0f, "%.3f", ImGuiSliderFlags_NoInput);
     }
     if (ImGui::CollapsingHeader("God Rays")) {
         float gr = app.renderer().god_rays_intensity();
-        if (ImGui::SliderFloat("Intensity##godrays", &gr, 0.0f, 3.0f)) {
+        if (ImGui::SliderFloat("Intensity##godrays", &gr, 0.0f, 3.0f, "%.3f", ImGuiSliderFlags_NoInput)) {
             app.renderer().set_god_rays_intensity(gr);
         }
     }
@@ -268,19 +268,19 @@ void StagingState::draw_gs_params(AppBase& app) {
     auto& gs = app.renderer().gs_renderer();
 
     float scale = gs.scale_multiplier();
-    if (ImGui::SliderFloat("Scale", &scale, 0.1f, 10.0f)) {
+    if (ImGui::SliderFloat("Scale", &scale, 0.1f, 10.0f, "%.3f", ImGuiSliderFlags_NoInput)) {
         gs.set_scale_multiplier(scale);
     }
 
     int toon = gs.toon_bands();
-    if (ImGui::SliderInt("Toon Bands", &toon, 0, 5)) {
+    if (ImGui::SliderInt("Toon Bands", &toon, 0, 5, "%d", ImGuiSliderFlags_NoInput)) {
         gs.set_toon_bands(toon);
     }
 
     ImGui::Separator();
 
     int budget = static_cast<int>(app.renderer().gs_gaussian_budget());
-    if (ImGui::SliderInt("LOD Budget", &budget, 0, 500000, "%d", ImGuiSliderFlags_Logarithmic)) {
+    if (ImGui::SliderInt("LOD Budget", &budget, 0, 500000, "%d", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoInput)) {
         app.renderer().set_gs_gaussian_budget(static_cast<uint32_t>(budget));
     }
     ImGui::SameLine();
@@ -344,7 +344,7 @@ void StagingState::draw_lighting(AppBase& app) {
     }
 
     float intensity = gs.light_intensity();
-    if (ImGui::SliderFloat("Global Intensity", &intensity, 0.0f, 5.0f)) {
+    if (ImGui::SliderFloat("Global Intensity", &intensity, 0.0f, 5.0f, "%.3f", ImGuiSliderFlags_NoInput)) {
         gs.set_light_intensity(intensity);
     }
 

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -168,6 +168,10 @@ void StagingState::draw_imgui(AppBase& app) {
             ImGui::MenuItem("Lighting", nullptr, &show_lighting_);
             ImGui::MenuItem("Camera", nullptr, &show_camera_);
             ImGui::MenuItem("Performance", nullptr, &show_performance_);
+            ImGui::Separator();
+            ImGui::MenuItem("Gizmo: Lights", nullptr, &show_gizmo_lights_);
+            ImGui::MenuItem("Gizmo: Emitters", nullptr, &show_gizmo_emitters_);
+            ImGui::MenuItem("Gizmo: VFX", nullptr, &show_gizmo_vfx_);
             ImGui::EndMenu();
         }
         ImGui::EndMainMenuBar();
@@ -180,6 +184,7 @@ void StagingState::draw_imgui(AppBase& app) {
     draw_lighting(app);
     draw_camera_panel(app);
     draw_performance(app);
+    draw_gizmos(app);
 }
 
 void StagingState::draw_viewport_info(AppBase& app) {
@@ -406,7 +411,7 @@ void StagingState::draw_lighting(AppBase& app) {
 
 void StagingState::draw_camera_panel(AppBase& app) {
     ImGui::SetNextWindowPos(ImVec2(270, 240), ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(280, 150), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(280, 250), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin("Camera")) {
         ImGui::End();
         return;
@@ -422,6 +427,47 @@ void StagingState::draw_camera_panel(AppBase& app) {
         elevation_ = 0.3f;
         distance_ = 100.0f;
         target_ = glm::vec3(0.0f);
+    }
+
+    // ── Bookmarks ──
+    ImGui::Separator();
+    ImGui::Text("Bookmarks");
+
+    if (ImGui::Button("Save Current")) {
+        CameraBookmark bm;
+        bm.name = "Bookmark " + std::to_string(bookmarks_.size() + 1);
+        bm.azimuth = azimuth_;
+        bm.elevation = elevation_;
+        bm.distance = distance_;
+        bm.target = target_;
+        bookmarks_.push_back(bm);
+    }
+
+    int to_remove = -1;
+    for (size_t i = 0; i < bookmarks_.size(); i++) {
+        ImGui::PushID(static_cast<int>(i));
+        if (ImGui::Button("Go")) {
+            azimuth_ = bookmarks_[i].azimuth;
+            elevation_ = bookmarks_[i].elevation;
+            distance_ = bookmarks_[i].distance;
+            target_ = bookmarks_[i].target;
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("X")) {
+            to_remove = static_cast<int>(i);
+        }
+        ImGui::SameLine();
+        // Editable name
+        char buf[64];
+        std::snprintf(buf, sizeof(buf), "%s", bookmarks_[i].name.c_str());
+        ImGui::SetNextItemWidth(150);
+        if (ImGui::InputText("##name", buf, sizeof(buf))) {
+            bookmarks_[i].name = buf;
+        }
+        ImGui::PopID();
+    }
+    if (to_remove >= 0) {
+        bookmarks_.erase(bookmarks_.begin() + to_remove);
     }
 
     ImGui::End();
@@ -452,6 +498,119 @@ void StagingState::draw_performance(AppBase& app) {
     }
 
     ImGui::End();
+}
+
+// ── Gizmos ──
+
+bool StagingState::project_to_screen(const glm::vec3& world_pos, const glm::mat4& vp,
+                                      float screen_w, float screen_h,
+                                      float& out_x, float& out_y) const {
+    glm::vec4 clip = vp * glm::vec4(world_pos, 1.0f);
+    if (clip.w <= 0.001f) return false;  // behind camera
+    glm::vec3 ndc = glm::vec3(clip) / clip.w;
+    out_x = (ndc.x * 0.5f + 0.5f) * screen_w;
+    out_y = (1.0f - (ndc.y * 0.5f + 0.5f)) * screen_h;  // flip Y
+    return ndc.z >= 0.0f && ndc.z <= 1.0f;
+}
+
+void StagingState::draw_gizmos(AppBase& app) {
+    if (!app.renderer().has_gs_cloud()) return;
+
+    auto& gs = app.renderer().gs_renderer();
+    float aspect = static_cast<float>(gs.output_width()) /
+                   static_cast<float>(gs.output_height());
+
+    // Build VP matrix matching the camera
+    float cos_el = std::cos(elevation_);
+    glm::vec3 eye{
+        target_.x + distance_ * cos_el * std::sin(azimuth_),
+        target_.y + distance_ * std::sin(elevation_),
+        target_.z + distance_ * cos_el * std::cos(azimuth_)
+    };
+    auto view = glm::lookAt(eye, target_, glm::vec3(0, 1, 0));
+    auto proj = glm::perspective(glm::radians(45.0f), aspect, 0.1f, 1000.0f);
+    proj[1][1] *= -1.0f;  // Vulkan Y-flip
+    // But for screen projection we need standard NDC (Y up), so undo the flip
+    proj[1][1] *= -1.0f;
+    glm::mat4 vp = proj * view;
+
+    auto& io = ImGui::GetIO();
+    float sw = io.DisplaySize.x;
+    float sh = io.DisplaySize.y;
+
+    ImDrawList* draw_list = ImGui::GetForegroundDrawList();
+
+    // ── Light gizmos ──
+    if (show_gizmo_lights_) {
+        const auto& lights = gs.point_lights();
+        for (size_t i = 0; i < lights.size(); i++) {
+            // Light position: (x, y=scene_z, z=height)
+            glm::vec3 pos(lights[i].position_and_radius.x,
+                          lights[i].position_and_radius.z,  // height stored in z
+                          lights[i].position_and_radius.y);
+            float sx, sy;
+            if (!project_to_screen(pos, vp, sw, sh, sx, sy)) continue;
+
+            ImU32 col = ImGui::ColorConvertFloat4ToU32(
+                ImVec4(lights[i].color.r, lights[i].color.g, lights[i].color.b, 0.8f));
+
+            // Outer circle (radius indicator — approximate screen-space size)
+            float radius_world = lights[i].position_and_radius.w;
+            glm::vec3 edge_pos = pos + glm::vec3(radius_world, 0.0f, 0.0f);
+            float ex, ey;
+            float screen_radius = 20.0f;  // fallback
+            if (project_to_screen(edge_pos, vp, sw, sh, ex, ey)) {
+                screen_radius = std::abs(ex - sx);
+                screen_radius = std::clamp(screen_radius, 5.0f, 200.0f);
+            }
+
+            draw_list->AddCircle(ImVec2(sx, sy), screen_radius, col, 32, 1.5f);
+            draw_list->AddCircleFilled(ImVec2(sx, sy), 4.0f, col);
+
+            // Label
+            char label[32];
+            std::snprintf(label, sizeof(label), "L%zu", i);
+            draw_list->AddText(ImVec2(sx + 6, sy - 12), col, label);
+        }
+    }
+
+    // ── Emitter gizmos ──
+    if (show_gizmo_emitters_) {
+        ImU32 emitter_col = IM_COL32(255, 100, 50, 200);  // orange
+        auto& emitters = app.renderer().gs_particle_emitters();
+        for (size_t i = 0; i < emitters.size(); i++) {
+            auto pos = emitters[i].config().position;
+            float sx, sy;
+            if (!project_to_screen(pos, vp, sw, sh, sx, sy)) continue;
+
+            draw_list->AddCircleFilled(ImVec2(sx, sy), 5.0f, emitter_col);
+            draw_list->AddCircle(ImVec2(sx, sy), 10.0f, emitter_col, 16, 1.0f);
+
+            char label[32];
+            std::snprintf(label, sizeof(label), "E%zu", i);
+            draw_list->AddText(ImVec2(sx + 8, sy - 10), emitter_col, label);
+        }
+    }
+
+    // ── VFX instance gizmos ──
+    if (show_gizmo_vfx_) {
+        ImU32 vfx_col = IM_COL32(100, 200, 255, 200);  // cyan
+        const auto& vfx = app.renderer().vfx_instances();
+        for (size_t i = 0; i < vfx.size(); i++) {
+            auto pos = vfx[i].position();
+            float sx, sy;
+            if (!project_to_screen(pos, vp, sw, sh, sx, sy)) continue;
+
+            // Diamond shape
+            float d = 7.0f;
+            draw_list->AddQuadFilled(
+                ImVec2(sx, sy - d), ImVec2(sx + d, sy),
+                ImVec2(sx, sy + d), ImVec2(sx - d, sy), vfx_col);
+
+            const char* name = vfx[i].preset().name.c_str();
+            draw_list->AddText(ImVec2(sx + 10, sy - 8), vfx_col, name);
+        }
+    }
 }
 
 }  // namespace gseurat


### PR DESCRIPTION
## Summary
- Viewport gizmos rendered via ImGui foreground draw list with 3D→2D projection
  - **Light gizmos**: colored wireframe circle (world-radius scaled), center dot, label
  - **Emitter gizmos**: orange dot + ring, label
  - **VFX instance gizmos**: cyan diamond, preset name
  - Per-category toggles in View menu
- Camera bookmarks: save/restore named viewpoints with Go/Remove/Rename

## Test plan
- [x] Builds (both gseurat_staging and gseurat_demo)
- [x] All 13 C++ tests pass
- [ ] Light gizmos appear at correct positions, scale with distance
- [ ] Emitter/VFX gizmos visible at world positions
- [ ] Gizmo toggles in View menu work
- [ ] Camera bookmarks: Save → Go restores position → X removes → name editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)