### PR TITLE
Bricklayer: light type selector (Point/Spot/Area) in LightsTab

### DIFF
--- a/tools/apps/bricklayer/src/panels/LightsTab.tsx
+++ b/tools/apps/bricklayer/src/panels/LightsTab.tsx
@@ -1,10 +1,22 @@
 import React from 'react';
 import { NumberInput } from '../components/NumberInput.js';
+import { Vec3Input } from '../components/Vec3Input.js';
 import { useSceneStore } from '../store/useSceneStore.js';
 import type { StaticLight } from '../store/types.js';
 import { panelStyles } from '../styles/panel.js';
 
-const styles = { ...panelStyles };
+const styles: Record<string, React.CSSProperties> = {
+  ...panelStyles,
+  sectionLabel: { fontSize: 10, color: '#666', marginTop: 4 },
+};
+
+type LightType = 'point' | 'spot' | 'area';
+
+function getLightType(light: StaticLight): LightType {
+  if ((light.area_width ?? 0) > 0 && (light.area_height ?? 0) > 0) return 'area';
+  if ((light.cone_angle ?? 180) < 180) return 'spot';
+  return 'point';
+}
 
 function LightEditor({ light }: { light: StaticLight }) {
   const updateLight = useSceneStore((s) => s.updateLight);
@@ -13,6 +25,31 @@ function LightEditor({ light }: { light: StaticLight }) {
   const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
 
   const isSelected = selectedEntity?.type === 'light' && selectedEntity.id === light.id;
+  const lightType = getLightType(light);
+
+  const setLightType = (type: LightType) => {
+    switch (type) {
+      case 'point':
+        updateLight(light.id, {
+          cone_angle: undefined, direction: undefined,
+          area_width: undefined, area_height: undefined, area_normal: undefined,
+        });
+        break;
+      case 'spot':
+        updateLight(light.id, {
+          cone_angle: 45, direction: light.direction ?? [0, -1, 0],
+          area_width: undefined, area_height: undefined, area_normal: undefined,
+        });
+        break;
+      case 'area':
+        updateLight(light.id, {
+          cone_angle: undefined, direction: undefined,
+          area_width: light.area_width || 5, area_height: light.area_height || 3,
+          area_normal: light.area_normal ?? [0, 0],
+        });
+        break;
+    }
+  };
 
   return (
     <div
@@ -21,39 +58,28 @@ function LightEditor({ light }: { light: StaticLight }) {
     >
       <div style={styles.row}>
         <span style={{ fontSize: 13, flex: 1 }}>Light</span>
+        <select style={{ ...styles.select, width: 70, fontSize: 11 }}
+          value={lightType}
+          onChange={(e) => setLightType(e.target.value as LightType)}
+          onClick={(e) => e.stopPropagation()}>
+          <option value="point">Point</option>
+          <option value="spot">Spot</option>
+          <option value="area">Area</option>
+        </select>
         <button style={styles.btnDanger} onClick={(e) => { e.stopPropagation(); removeLight(light.id); }}>
           Remove
         </button>
       </div>
-      <div style={styles.row}>
-        <span style={{ fontSize: 12, minWidth: 60 }}>Pos</span>
-        <NumberInput
-          label="X"
-          value={light.position[0]}
-          onChange={(v) => updateLight(light.id, { position: [v, light.position[1], light.position[2]] })}
-          style={styles.input}
-        />
-        <NumberInput
-          label="Y"
-          value={light.position[1]}
-          onChange={(v) => updateLight(light.id, { position: [light.position[0], v, light.position[2]] })}
-          style={styles.input}
-        />
-        <NumberInput
-          label="Z"
-          value={light.position[2]}
-          onChange={(v) => updateLight(light.id, { position: [light.position[0], light.position[1], v] })}
-          style={styles.input}
-        />
-      </div>
+
+      {/* Position */}
+      <Vec3Input label="Position" value={light.position}
+        onChange={(v) => updateLight(light.id, { position: v })} style={styles.input} />
+
+      {/* Common */}
       <div style={styles.row}>
         <span style={{ fontSize: 12, minWidth: 60 }}>Radius</span>
-        <NumberInput
-          step={0.5}
-          value={light.radius}
-          onChange={(v) => updateLight(light.id, { radius: v })}
-          style={styles.input}
-        />
+        <NumberInput step={0.5} value={light.radius}
+          onChange={(v) => updateLight(light.id, { radius: v })} style={styles.input} />
       </div>
       <div style={styles.row}>
         <span style={{ fontSize: 12, minWidth: 60 }}>Color</span>
@@ -72,16 +98,55 @@ function LightEditor({ light }: { light: StaticLight }) {
           }}
           style={{ width: 40, height: 24, border: 'none', cursor: 'pointer' }}
         />
+        <span style={{ fontSize: 12, minWidth: 50 }}>Intensity</span>
+        <NumberInput step={0.1} value={light.intensity}
+          onChange={(v) => updateLight(light.id, { intensity: v })} style={styles.input} />
       </div>
-      <div style={styles.row}>
-        <span style={{ fontSize: 12, minWidth: 60 }}>Intensity</span>
-        <NumberInput
-          step={0.1}
-          value={light.intensity}
-          onChange={(v) => updateLight(light.id, { intensity: v })}
-          style={styles.input}
-        />
-      </div>
+
+      {/* Spot light */}
+      {lightType === 'spot' && (
+        <>
+          <span style={styles.sectionLabel}>Spot</span>
+          <div style={styles.row}>
+            <span style={{ fontSize: 12, minWidth: 60 }}>Cone</span>
+            <NumberInput step={5} min={1} max={179}
+              value={light.cone_angle ?? 45}
+              onChange={(v) => updateLight(light.id, { cone_angle: Math.max(1, Math.min(179, v)) })}
+              style={styles.input} />
+          </div>
+          <Vec3Input label="Direction" value={light.direction ?? [0, -1, 0]}
+            onChange={(v) => updateLight(light.id, { direction: v })} style={styles.input} />
+        </>
+      )}
+
+      {/* Area light */}
+      {lightType === 'area' && (
+        <>
+          <span style={styles.sectionLabel}>Area</span>
+          <div style={styles.row}>
+            <span style={{ fontSize: 12, minWidth: 60 }}>Size</span>
+            <NumberInput label="W" step={0.5} min={0.1}
+              value={light.area_width ?? 5}
+              onChange={(v) => updateLight(light.id, { area_width: Math.max(0.1, v) })}
+              style={styles.input} />
+            <NumberInput label="H" step={0.5} min={0.1}
+              value={light.area_height ?? 3}
+              onChange={(v) => updateLight(light.id, { area_height: Math.max(0.1, v) })}
+              style={styles.input} />
+          </div>
+          <div style={styles.row}>
+            <span style={{ fontSize: 12, minWidth: 60 }}>Normal</span>
+            <NumberInput label="X" step={0.1}
+              value={light.area_normal?.[0] ?? 0}
+              onChange={(v) => updateLight(light.id, { area_normal: [v, light.area_normal?.[1] ?? 0] })}
+              style={styles.input} />
+            <NumberInput label="Z" step={0.1}
+              value={light.area_normal?.[1] ?? 0}
+              onChange={(v) => updateLight(light.id, { area_normal: [light.area_normal?.[0] ?? 0, v] })}
+              style={styles.input} />
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- LightsTab (left panel) now has a Point/Spot/Area type dropdown
- Spot light: cone angle slider (1-179°) + direction Vec3
- Area light: width/height + normal XZ direction
- Compact row layout matching the Méliès panel style
- Uses Vec3Input for position and direction

## Test plan
- [x] TypeScript type-checks clean
- [x] Add light → type dropdown visible (Point/Spot/Area)
- [x] Switch to Spot → cone angle and direction inputs appear
- [x] Switch to Area → size and normal inputs appear
- [x] Viewport gizmos update (cone for spot, rectangle for area)

🤖 Generated with [Claude Code](https://claude.com/claude-code)