### PR TITLE
VFX light elements + WASM region tests

### DIFF
--- a/assets/vfx/torch.vfx.json
+++ b/assets/vfx/torch.vfx.json
@@ -201,6 +201,18 @@
         "radius": 1
       }
     }
+    ,
+    {
+      "name": "Flame Light",
+      "type": "light",
+      "position": [3, 14, -0.5],
+      "loop": true,
+      "light": {
+        "color": [1.0, 0.7, 0.3],
+        "intensity": 8,
+        "radius": 15
+      }
+    }
   ],
   "duration": 3
 }

--- a/include/gseurat/engine/gs_vfx.hpp
+++ b/include/gseurat/engine/gs_vfx.hpp
@@ -27,6 +27,10 @@ struct VfxElementData {
     // type=animation
     GsAnimationData animation_config;
     GsAnimRegion region;                 // animation area-of-effect
+    // type=light
+    glm::vec3 light_color{1.0f};
+    float light_intensity = 5.0f;
+    float light_radius = 10.0f;
 };
 
 struct VfxPreset {
@@ -70,6 +74,9 @@ public:
     const VfxPreset& preset() const { return preset_; }
     const std::vector<Gaussian>& object_gaussians() const { return object_gaussians_; }
 
+    /// Active lights from VFX light elements (collected by Renderer)
+    const std::vector<PointLight>& active_lights() const { return active_lights_; }
+
     /// Reset animation states so they re-tag on next update
     void reset_animations();
 
@@ -93,6 +100,13 @@ private:
         bool activated = false;
     };
     std::vector<AnimState> anim_states_;
+
+    struct LightState {
+        size_t element_index;
+        bool activated = false;
+    };
+    std::vector<LightState> light_states_;
+    std::vector<PointLight> active_lights_;
 
     // Object PLY Gaussians (static geometry, appended to buffer each frame)
     std::vector<Gaussian> object_gaussians_;

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -119,6 +119,7 @@ public:
     void clear_vfx_instances();
     const std::vector<VfxInstance>& vfx_instances() const { return vfx_instances_; }
     std::vector<VfxInstance>& vfx_instances_mutable() { return vfx_instances_; }
+    void set_gs_static_lights(const std::vector<PointLight>& lights) { gs_static_lights_ = lights; }
 
     void request_screenshot(const std::string& path) { screenshot_.request(path); }
     bool screenshot_write_ok() const { return screenshot_.write_ok(); }
@@ -238,6 +239,7 @@ private:
     float gs_blit_offset_x_ = 0.0f;
     float gs_blit_offset_y_ = 0.0f;
     uint32_t gs_prev_budget_ = 0;
+    std::vector<PointLight> gs_static_lights_;  // Scene-defined lights (for VFX light merging)
 
     // Persistent post-process params (modified by Staging panels)
     PostProcessParams pp_params_;

--- a/src/demo/demo_app.cpp
+++ b/src/demo/demo_app.cpp
@@ -194,6 +194,7 @@ void DemoApp::init_scene(const std::string& scene_path) {
             if (!gs_lights.empty()) {
                 renderer_.gs_renderer().set_light_mode(2);
                 renderer_.gs_renderer().set_point_lights(gs_lights);
+                renderer_.set_gs_static_lights(gs_lights);
                 renderer_.set_god_rays_intensity(1.0f);
                 for (size_t i = 0; i < gs_lights.size(); i++) {
                     const auto& l = gs_lights[i];

--- a/src/engine/gs_vfx.cpp
+++ b/src/engine/gs_vfx.cpp
@@ -40,6 +40,17 @@ VfxPreset parse_vfx_preset(const nlohmann::json& j) {
             if (ej["emitter"].contains("preset")) {
                 el.emitter_preset = ej["emitter"]["preset"].get<std::string>();
             }
+        } else if (el.type == "light") {
+            if (ej.contains("light")) {
+                const auto& lj = ej["light"];
+                if (lj.contains("color")) {
+                    el.light_color = {lj["color"][0].get<float>(),
+                                      lj["color"][1].get<float>(),
+                                      lj["color"][2].get<float>()};
+                }
+                el.light_intensity = lj.value("intensity", 5.0f);
+                el.light_radius = lj.value("radius", 10.0f);
+            }
         } else if (el.type == "animation" && ej.contains("animation")) {
             auto& anim = el.animation_config;
             const auto& aj = ej["animation"];
@@ -101,6 +112,8 @@ void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool 
     // Pre-create states for all elements
     emitter_states_.clear();
     anim_states_.clear();
+    light_states_.clear();
+    active_lights_.clear();
     object_gaussians_.clear();
 
     for (size_t i = 0; i < preset_.elements.size(); ++i) {
@@ -138,6 +151,11 @@ void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool 
             } else {
                 std::fprintf(stderr, "VFX: Object PLY not found: %s\n", el.ply_file.c_str());
             }
+        } else if (el.type == "light") {
+            LightState ls;
+            ls.element_index = i;
+            ls.activated = false;
+            light_states_.push_back(ls);
         }
     }
 }
@@ -233,6 +251,30 @@ void VfxInstance::update(float dt, std::vector<Gaussian>& out_buffer, GaussianAn
             as.activated = true;
         } else if (!in_window && as.activated) {
             as.activated = false;
+        }
+    }
+
+    // Activate/deactivate light elements and build active lights list
+    active_lights_.clear();
+    for (auto& ls : light_states_) {
+        const auto& el = preset_.elements[ls.element_index];
+        float el_start = el.start;
+        bool in_window;
+        if (el.loop) {
+            in_window = elapsed_ >= el_start;
+        } else {
+            float el_end = el.duration > 0.0f ? el.start + el.duration : preset_.duration;
+            in_window = elapsed_ >= el_start && elapsed_ < el_end;
+        }
+        ls.activated = in_window;
+
+        if (ls.activated) {
+            PointLight pl;
+            glm::vec3 world_pos = position_ + el.position;
+            // PointLight uses: x=world_x, y=scene_z, z=height, w=radius
+            pl.position_and_radius = glm::vec4(world_pos.x, world_pos.z, world_pos.y, el.light_radius);
+            pl.color = glm::vec4(el.light_color, el.light_intensity);
+            active_lights_.push_back(pl);
         }
     }
 }

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -913,6 +913,23 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                         [](const VfxInstance& i) { return i.is_finished(); });
                 }
 
+                // Collect VFX dynamic lights and merge with existing lights
+                {
+                    // Start from static scene lights (set via set_gs_static_lights)
+                    auto all_lights = gs_static_lights_;
+                    // Append VFX instance lights
+                    for (const auto& inst : vfx_instances_) {
+                        for (const auto& vl : inst.active_lights()) {
+                            if (all_lights.size() < 8) {
+                                all_lights.push_back(vl);
+                            }
+                        }
+                    }
+                    if (!all_lights.empty() && gs_renderer_.light_mode() >= 2) {
+                        gs_renderer_.set_point_lights(all_lights);
+                    }
+                }
+
                 // Clamp to allocated SSBO capacity
                 if (gs_active_buffer_.size() > gs_renderer_.max_gaussian_count()) {
                     gs_active_buffer_.resize(gs_renderer_.max_gaussian_count());

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -925,7 +925,11 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                             }
                         }
                     }
-                    if (!all_lights.empty() && gs_renderer_.light_mode() >= 2) {
+                    if (!all_lights.empty()) {
+                        // Auto-enable point light mode if VFX lights are present
+                        if (gs_renderer_.light_mode() < 2) {
+                            gs_renderer_.set_light_mode(2);
+                        }
                         gs_renderer_.set_point_lights(all_lights);
                     }
                 }

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -392,6 +392,7 @@ void StagingApp::init_scene(const std::string& scene_path) {
                 renderer_.gs_renderer().set_light_mode(2);
                 renderer_.gs_renderer().set_point_lights(gs_lights);
             }
+            renderer_.set_gs_static_lights(gs_lights);
 
             // Emitters
             for (const auto& em : scene_data.gs_particle_emitters) {

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -324,10 +324,38 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
   const handleImportAsset = () => {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = '.ply,.png,.jpg,.jpeg,.wav,.mp3';
+    input.accept = '.ply,.png,.jpg,.jpeg,.wav,.mp3,.json,.vfx.json';
     input.onchange = async () => {
       const file = input.files?.[0];
       if (!file) return;
+
+      // VFX preset import — load and add as VFX instance
+      if (file.name.endsWith('.vfx.json')) {
+        try {
+          const text = await file.text();
+          const preset = JSON.parse(text);
+          const store = useSceneStore.getState();
+          store.addVfxInstance({
+            id: `vfx_${Date.now()}`,
+            name: preset.name ?? file.name.replace('.vfx.json', ''),
+            vfx_file: `assets/vfx/${file.name}`,
+            vfx_preset: preset,
+            position: [0, 0, 0],
+            radius: 5,
+            trigger: 'auto',
+            loop: true,
+          });
+          // Copy to project directory
+          const handle = store.projectHandle;
+          if (handle) {
+            await importAssetToProject(handle, file);
+          }
+        } catch (e) {
+          console.warn('[Bricklayer] Failed to import VFX:', e);
+        }
+        return;
+      }
+
       // Store blob in memory
       const path = `assets/${file.name}`;
       useSceneStore.getState().storeAssetBlob(path, file);

--- a/tools/tests/src/simulation-wasm.test.ts
+++ b/tools/tests/src/simulation-wasm.test.ts
@@ -613,6 +613,138 @@ async function main() {
   }
 
   // ═══════════════════════════════════════════════════════════════
+  // 8. Emitter Region (sphere/box) (6 tests)
+  // ═══════════════════════════════════════════════════════════════
+
+  console.log('\n--- Emitter Region ---\n');
+
+  {
+    console.log('Test 8.1: Configure emitter with box region');
+    const emitter = new sim.ParticleEmitter();
+    emitter.configure({
+      spawn_rate: 100,
+      lifetime_min: 1, lifetime_max: 2,
+      velocity_min: [0, 1, 0], velocity_max: [0, 2, 0],
+      color_start: [1, 1, 1], color_end: [1, 1, 1],
+      scale_min: [0.1, 0.1, 0.1], scale_max: [0.2, 0.2, 0.2],
+      opacity_start: 1, opacity_end: 0,
+      region: { shape: 'box', center: [0, 0, 0], half_extents: [5, 2, 5] },
+    });
+    emitter.setActive(true);
+    emitter.update(0.1);
+    assert(emitter.aliveCount() > 0, 'box region emitter spawns particles');
+    emitter.delete();
+  }
+
+  {
+    console.log('Test 8.2: Configure emitter with sphere region');
+    const emitter = new sim.ParticleEmitter();
+    emitter.configure({
+      spawn_rate: 100,
+      lifetime_min: 1, lifetime_max: 2,
+      velocity_min: [0, 1, 0], velocity_max: [0, 2, 0],
+      color_start: [1, 0, 0], color_end: [0, 0, 1],
+      scale_min: [0.1, 0.1, 0.1], scale_max: [0.2, 0.2, 0.2],
+      opacity_start: 1, opacity_end: 0,
+      region: { shape: 'sphere', radius: 3 },
+    });
+    emitter.setActive(true);
+    emitter.update(0.1);
+    assert(emitter.aliveCount() > 0, 'sphere region emitter spawns particles');
+    emitter.delete();
+  }
+
+  {
+    console.log('Test 8.3: Sphere region with center offset');
+    const emitter = new sim.ParticleEmitter();
+    emitter.configure({
+      spawn_rate: 200,
+      lifetime_min: 1, lifetime_max: 2,
+      velocity_min: [0, 0, 0], velocity_max: [0, 0, 0],
+      color_start: [1, 1, 1], color_end: [1, 1, 1],
+      scale_min: [0.1, 0.1, 0.1], scale_max: [0.1, 0.1, 0.1],
+      opacity_start: 1, opacity_end: 1,
+      region: { shape: 'sphere', radius: 1, center: [10, 20, 30] },
+    });
+    emitter.setPosition(0, 0, 0);
+    emitter.setActive(true);
+    emitter.update(0.1);
+    const data = emitter.gather();
+    if (data && data.count > 0) {
+      // Particles should be near center offset (10, 20, 30)
+      const avgX = data.positions.subarray(0, data.count * 3).reduce(
+        (sum: number, v: number, i: number) => i % 3 === 0 ? sum + v : sum, 0) / data.count;
+      assert(Math.abs(avgX - 10) < 3, `avg X near 10 (got ${avgX.toFixed(1)})`);
+    }
+    emitter.delete();
+  }
+
+  {
+    console.log('Test 8.4: Backward compat — spawn_offset_min/max');
+    const emitter = new sim.ParticleEmitter();
+    emitter.configure({
+      spawn_rate: 100,
+      lifetime_min: 1, lifetime_max: 2,
+      velocity_min: [0, 1, 0], velocity_max: [0, 2, 0],
+      color_start: [1, 1, 1], color_end: [1, 1, 1],
+      scale_min: [0.1, 0.1, 0.1], scale_max: [0.2, 0.2, 0.2],
+      opacity_start: 1, opacity_end: 0,
+      spawn_offset_min: [-2, 0, -2],
+      spawn_offset_max: [2, 1, 2],
+    });
+    emitter.setActive(true);
+    emitter.update(0.1);
+    assert(emitter.aliveCount() > 0, 'legacy spawn_offset emitter works');
+    emitter.delete();
+  }
+
+  {
+    console.log('Test 8.5: Animator tagRegionWithParams — box region');
+    const animator = new sim.Animator();
+    const count = 50;
+    const positions = new Float32Array(count * 3);
+    const colors = new Float32Array(count * 3);
+    for (let i = 0; i < count; i++) {
+      positions[i * 3] = (i / count) * 10 - 5;
+      positions[i * 3 + 1] = 0;
+      positions[i * 3 + 2] = 0;
+      colors[i * 3] = 1; colors[i * 3 + 1] = 1; colors[i * 3 + 2] = 1;
+    }
+    animator.loadScene(positions, colors, count);
+    const groupId = animator.tagRegionWithParams(
+      { shape: 'box', center: [0, 0, 0], half_extents: [3, 3, 3] },
+      sim.EFFECT_WAVE, 5.0, { wave_speed: 5, noise: 0.5 });
+    assert(groupId > 0, `box region tagged (group ${groupId})`);
+    animator.update(0.1);
+    const data = animator.getSceneData();
+    assert(data !== null, 'scene data after box region tag');
+    animator.delete();
+  }
+
+  {
+    console.log('Test 8.6: Animator tagRegionWithParams — sphere region');
+    const animator = new sim.Animator();
+    const count = 50;
+    const positions = new Float32Array(count * 3);
+    const colors = new Float32Array(count * 3);
+    for (let i = 0; i < count; i++) {
+      positions[i * 3] = (i / count) * 10 - 5;
+      positions[i * 3 + 1] = 0;
+      positions[i * 3 + 2] = 0;
+      colors[i * 3] = 1; colors[i * 3 + 1] = 0; colors[i * 3 + 2] = 0;
+    }
+    animator.loadScene(positions, colors, count);
+    const groupId = animator.tagRegionWithParams(
+      { shape: 'sphere', center: [0, 0, 0], radius: 5 },
+      sim.EFFECT_PULSE, 3.0, { pulse_frequency: 8 });
+    assert(groupId > 0, `sphere region tagged (group ${groupId})`);
+    animator.update(0.1);
+    const data = animator.getSceneData();
+    assert(data !== null, 'scene data after sphere region tag');
+    animator.delete();
+  }
+
+  // ═══════════════════════════════════════════════════════════════
 
   console.log(`\n${'='.repeat(40)}`);
   console.log(`  ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## Summary
- **VFX light elements**: "light" type elements in VFX presets now render as dynamic
  point lights in the engine. Follows same timeline activation as emitters/animations.
  - Parse: `{ "light": { "color": [r,g,b], "intensity": N, "radius": N } }`
  - VfxInstance collects active lights, Renderer merges with scene lights (max 8)
- **WASM region tests**: 6 new tests validating sphere/box region handling
  - Emitter: box region, sphere region, center offset, backward-compat spawn_offset
  - Animator: tagRegionWithParams with box + wave, sphere + pulse

## Test plan
- [x] C++ builds (debug), all 13 tests pass
- [x] 155/155 WASM simulation tests pass
- [x] VFX preset with light element → light visible in Staging/demo
- [x] Light follows VFX timeline (start/duration/loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)