### PR TITLE
VFX instance Y-axis rotation

### DIFF
--- a/include/gseurat/engine/gs_vfx.hpp
+++ b/include/gseurat/engine/gs_vfx.hpp
@@ -45,6 +45,7 @@ struct VfxPreset {
 struct VfxInstanceData {
     std::string vfx_file;
     glm::vec3 position{0.0f};
+    float rotation_y = 0.0f;  // Y-axis rotation in degrees
     float radius = 5.0f;
     std::string trigger = "auto";
     bool loop = true;
@@ -59,7 +60,8 @@ VfxPreset parse_vfx_preset(const nlohmann::json& j);
 
 class VfxInstance {
 public:
-    void init(const VfxPreset& preset, const glm::vec3& position, bool loop);
+    void init(const VfxPreset& preset, const glm::vec3& position, bool loop,
+              float rotation_y = 0.0f);
 
     /// Append static object Gaussians to the buffer (call before animator runs).
     void append_objects(std::vector<Gaussian>& out_buffer);
@@ -83,6 +85,7 @@ public:
 private:
     VfxPreset preset_;
     glm::vec3 position_{0.0f};
+    float rotation_y_ = 0.0f;
     bool loop_ = true;
     float elapsed_ = 0.0f;
     bool finished_ = false;

--- a/include/gseurat/engine/scene_loader.hpp
+++ b/include/gseurat/engine/scene_loader.hpp
@@ -156,6 +156,7 @@ struct SceneData {
     struct VfxInstanceRef {
         std::string vfx_file;
         glm::vec3 position{0.0f};
+        float rotation_y = 0.0f;
         float radius = 5.0f;
         std::string trigger = "auto";
         bool loop = true;

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -121,6 +121,10 @@
         "loop": {
           "type": "boolean",
           "description": "Repeat after duration ends"
+        },
+        "rotation_y": {
+          "type": "number",
+          "description": "Y-axis rotation in degrees (turntable orientation)"
         }
       },
       "additionalProperties": false

--- a/src/demo/demo_app.cpp
+++ b/src/demo/demo_app.cpp
@@ -238,7 +238,7 @@ void DemoApp::init_scene(const std::string& scene_path) {
                 auto pos = vi.position;
                 pos.x += aabb.min.x;
                 pos.y += aabb.min.y;
-                inst.init(preset, pos, vi.loop);
+                inst.init(preset, pos, vi.loop, vi.rotation_y);
                 std::fprintf(stderr, "VFX: Loaded '%s' at (%.1f, %.1f, %.1f) with %zu elements\n",
                     preset.name.c_str(), pos.x, pos.y, pos.z, preset.elements.size());
                 renderer_.add_vfx_instance(std::move(inst));

--- a/src/engine/gs_vfx.cpp
+++ b/src/engine/gs_vfx.cpp
@@ -102,9 +102,18 @@ VfxPreset load_vfx_preset(const std::string& path) {
 
 // ── VfxInstance ──
 
-void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool loop) {
+// Rotate a vec3 around the Y axis by angle (radians)
+static glm::vec3 rotate_y(const glm::vec3& v, float angle_rad) {
+    float c = std::cos(angle_rad);
+    float s = std::sin(angle_rad);
+    return {v.x * c + v.z * s, v.y, -v.x * s + v.z * c};
+}
+
+void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool loop,
+                       float rotation_y) {
     preset_ = preset;
     position_ = position;
+    rotation_y_ = rotation_y;
     loop_ = loop;
     elapsed_ = 0.0f;
     finished_ = false;
@@ -116,14 +125,18 @@ void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool 
     active_lights_.clear();
     object_gaussians_.clear();
 
+    float rot_rad = glm::radians(rotation_y_);
+
     for (size_t i = 0; i < preset_.elements.size(); ++i) {
         const auto& el = preset_.elements[i];
+        glm::vec3 rotated_pos = rotate_y(el.position, rot_rad);
+
         if (el.type == "emitter") {
             EmitterState es;
             es.element_index = i;
             es.activated = false;
             es.emitter.configure(el.emitter_config);
-            es.emitter.set_position(position_ + el.position);
+            es.emitter.set_position(position_ + rotated_pos);
             emitter_states_.push_back(std::move(es));
         } else if (el.type == "animation") {
             AnimState as;
@@ -140,10 +153,11 @@ void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool 
             if (std::filesystem::exists(ply_path)) {
                 auto cloud = GaussianCloud::load_ply(ply_path);
                 const auto& gs = cloud.gaussians();
-                glm::vec3 offset = position_ + el.position;
+                glm::vec3 offset = position_ + rotated_pos;
                 for (const auto& src : gs) {
                     Gaussian g = src;
-                    g.position = g.position * el.scale + offset;
+                    // Rotate Gaussian position around prefab origin, then offset
+                    g.position = rotate_y(g.position * el.scale, rot_rad) + position_ + rotated_pos;
                     object_gaussians_.push_back(g);
                 }
                 std::fprintf(stderr, "VFX: Object '%s' loaded %zu Gaussians from %s\n",
@@ -233,7 +247,7 @@ void VfxInstance::update(float dt, std::vector<Gaussian>& out_buffer, GaussianAn
         if (in_window && !as.activated) {
             // Tag region on the shared animator
             auto region = el.region;
-            region.center += position_ + el.position;  // offset by instance + element position
+            region.center += position_ + rotate_y(el.position, glm::radians(rotation_y_));
             auto effect_name = el.animation_config.effect;
             auto effect = GsAnimEffect::Detach;
             if (effect_name == "float") effect = GsAnimEffect::Float;
@@ -270,7 +284,7 @@ void VfxInstance::update(float dt, std::vector<Gaussian>& out_buffer, GaussianAn
 
         if (ls.activated) {
             PointLight pl;
-            glm::vec3 world_pos = position_ + el.position;
+            glm::vec3 world_pos = position_ + rotate_y(el.position, glm::radians(rotation_y_));
             // PointLight uses: x=world_x, y=scene_z, z=height, w=radius
             pl.position_and_radius = glm::vec4(world_pos.x, world_pos.z, world_pos.y, el.light_radius);
             pl.color = glm::vec4(el.light_color, el.light_intensity);

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -380,6 +380,7 @@ SceneData SceneLoader::from_json(const nlohmann::json& j) {
             SceneData::VfxInstanceRef inst;
             inst.vfx_file = vi.value("vfx_file", "");
             if (vi.contains("position")) inst.position = parse_vec3(vi["position"]);
+            inst.rotation_y = vi.value("rotation_y", 0.0f);
             inst.radius = vi.value("radius", 5.0f);
             inst.trigger = vi.value("trigger", "auto");
             inst.loop = vi.value("loop", true);

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -466,7 +466,7 @@ void StagingApp::init_scene(const std::string& scene_path) {
             auto pos = vi.position;
             pos.x += aabb_offset.x;
             pos.y += aabb_offset.y;
-            inst.init(preset, pos, vi.loop);
+            inst.init(preset, pos, vi.loop, vi.rotation_y);
             std::fprintf(stderr, "VFX: Loaded '%s' at (%.1f, %.1f, %.1f) with %zu elements\n",
                 preset.name.c_str(), pos.x, pos.y, pos.z, preset.elements.size());
             renderer_.add_vfx_instance(std::move(inst));

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -239,6 +239,7 @@ export function exportSceneJson(state: SceneStoreState): object {
         vfx_file: v.vfx_file,
         position: v.position,
       };
+      if (v.rotation_y) out.rotation_y = v.rotation_y;
       if (v.radius !== 5) out.radius = v.radius;
       if (v.trigger !== 'auto') out.trigger = v.trigger;
       if (!v.loop) out.loop = false;

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -341,6 +341,7 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
             vfx_file: `assets/vfx/${file.name}`,
             vfx_preset: preset,
             position: [0, 0, 0],
+            rotation_y: 0,
             radius: 5,
             trigger: 'auto',
             loop: true,

--- a/tools/apps/bricklayer/src/panels/ProjectTree.tsx
+++ b/tools/apps/bricklayer/src/panels/ProjectTree.tsx
@@ -451,6 +451,7 @@ export function ProjectTree() {
                       vfx_file: `assets/vfx/${safeName}.vfx.json`,
                       vfx_preset: preset,
                       position: target.xyz,
+                      rotation_y: 0,
                       radius: 5,
                       trigger: 'auto',
                       loop: true,

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -1078,6 +1078,14 @@ function VfxInstanceProperties({ vfx }: { vfx: VfxInstanceData }) {
       </div>
 
       <div style={styles.section}>
+        <span style={styles.label}>Rotation Y</span>
+        <NumberInput step={15} value={vfx.rotation_y ?? 0}
+          onChange={(v) => update(vfx.id, { rotation_y: v })}
+          style={{ ...styles.input, maxWidth: 80 }} />
+        <span style={{ fontSize: 10, color: '#666' }}>degrees</span>
+      </div>
+
+      <div style={styles.section}>
         <span style={styles.label}>Radius</span>
         <NumberInput step={0.5} min={0.1} value={vfx.radius}
           onChange={(v) => update(vfx.id, { radius: v })}

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -266,6 +266,7 @@ export interface VfxInstanceData {
   vfx_file: string;
   vfx_preset: VfxPresetData;
   position: [number, number, number];
+  rotation_y: number;  // Y-axis rotation in degrees
   radius: number;
   trigger: 'auto' | 'event';
   loop: boolean;

--- a/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
@@ -94,10 +94,11 @@ function VfxMarker({ instance, isSelected, onSelect }: {
   onSelect: () => void;
 }) {
   const { position, name, radius } = instance;
+  const rotY = (instance.rotation_y ?? 0) * Math.PI / 180;
   const color = isSelected ? '#ffffff' : '#f59e0b';
 
   return (
-    <group position={[position[0], position[1], position[2]]}>
+    <group position={[position[0], position[1], position[2]]} rotation={[0, rotY, 0]}>
       {/* Invisible hit box */}
       <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
         <sphereGeometry args={[1.0, 12, 12]} />

--- a/tools/apps/bricklayer/src/viewport/VfxRenderer.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxRenderer.tsx
@@ -299,21 +299,22 @@ function ObjectLayerRenderer({ layer, instancePos }: {
 function InstanceRenderer({ instance }: { instance: VfxInstanceData }) {
   const emitterLayers = (instance.vfx_preset.elements ?? []).filter((l) => l.type === 'emitter');
   const objectLayers = (instance.vfx_preset.elements ?? []).filter((l) => l.type === 'object');
+  const rotY = ((instance.rotation_y ?? 0) * Math.PI) / 180;
 
   return (
-    <group>
+    <group position={instance.position} rotation={[0, rotY, 0]}>
       {objectLayers.map((layer, i) => (
         <ObjectLayerRenderer
           key={`${instance.id}_obj_${i}`}
           layer={layer}
-          instancePos={instance.position}
+          instancePos={[0, 0, 0]}
         />
       ))}
       {emitterLayers.map((layer, i) => (
         <EmitterLayerRenderer
           key={`${instance.id}_${i}`}
           layer={layer}
-          instancePos={instance.position}
+          instancePos={[0, 0, 0]}
         />
       ))}
     </group>


### PR DESCRIPTION
## Summary
VFX instances can now be rotated around the Y axis (turntable orientation).

- **Schema**: `rotation_y` (degrees) added to `vfx_instance`
- **Engine**: `VfxInstance::init` applies `rotate_y()` to all element positions
  (object PLY Gaussians, emitter positions, animation regions, light positions)
- **Bricklayer**: Rotation Y input in properties panel (15° step), gizmo group
  rotation, scene export includes `rotation_y`

## Test plan
- [x] C++ builds, all 13 tests pass
- [x] TypeScript type-checks clean
- [x] Add VFX instance → set rotation → elements rotate in gizmo
- [x] Export scene → `rotation_y` in JSON
- [x] Engine renders rotated VFX correctly in Staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)