### PR TITLE
Fix VFX object Gaussians: scene buffer lifecycle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,3 +324,4 @@ add_gseurat_test(test_scene_loading  src/engine/scene_loader.cpp src/engine/tile
 add_gseurat_test(test_incremental_sync src/engine/scene_loader.cpp src/engine/tilemap.cpp
                                         src/engine/gaussian_cloud.cpp src/engine/gs_particle.cpp
                                         src/engine/gs_animator.cpp)
+add_gseurat_test(test_vfx_scene_buffer src/engine/gaussian_cloud.cpp)

--- a/include/gseurat/engine/gs_vfx.hpp
+++ b/include/gseurat/engine/gs_vfx.hpp
@@ -111,7 +111,7 @@ private:
     std::vector<LightState> light_states_;
     std::vector<PointLight> active_lights_;
 
-    // Object PLY Gaussians (static geometry, appended to buffer each frame)
+    // Object PLY Gaussians (static geometry, included in scene buffer at init/gather)
     std::vector<Gaussian> object_gaussians_;
 };
 

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -220,7 +220,8 @@ private:
     // Spatial chunk grid for GS frustum culling
     GsChunkGrid gs_chunk_grid_;
     std::vector<Gaussian> gs_active_buffer_;
-    std::vector<Gaussian> gs_scene_buffer_;   // cached scene-only Gaussians (no particles/anim)
+    std::vector<Gaussian> gs_scene_buffer_;   // cached scene + VFX object Gaussians
+    uint32_t gs_scene_base_count_ = 0;        // pure-scene Gaussian count (before VFX objects)
     std::vector<GaussianParticleEmitter> gs_particle_emitters_;
     GaussianAnimator gs_animator_;
     std::vector<SceneAnimation> gs_scene_animations_;

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -805,7 +805,13 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 } else {
                     gs_chunk_grid_.gather(visible, gs_active_buffer_);
                 }
-                gs_scene_buffer_ = gs_active_buffer_;  // cache scene-only buffer
+                gs_scene_buffer_ = gs_active_buffer_;  // cache pure-scene Gaussians
+                gs_scene_base_count_ = static_cast<uint32_t>(gs_scene_buffer_.size());
+
+                // Append VFX object Gaussians to scene buffer (static PLY geometry)
+                for (auto& inst : vfx_instances_) {
+                    inst.append_objects(gs_scene_buffer_);
+                }
 
                 // Scene buffer changed — animator indices are stale.
                 // Reset so VFX animations re-tag on the new buffer.
@@ -816,10 +822,10 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                     inst.reset_animations();
                 }
 
-                if (!gs_active_buffer_.empty()) {
+                if (!gs_scene_buffer_.empty()) {
                     gs_renderer_.update_active_gaussians(
-                        gs_active_buffer_.data(),
-                        static_cast<uint32_t>(gs_active_buffer_.size()));
+                        gs_scene_buffer_.data(),
+                        static_cast<uint32_t>(gs_scene_buffer_.size()));
                 }
             }
 
@@ -880,11 +886,8 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                     gs_active_buffer_ = gs_scene_buffer_;
                 }
 
-                // Append VFX object Gaussians BEFORE animator runs,
-                // so animation tag indices remain valid.
-                for (auto& inst : vfx_instances_) {
-                    inst.append_objects(gs_active_buffer_);
-                }
+                // VFX object Gaussians are already in gs_scene_buffer_
+                // (appended at gather time), so no per-frame append needed.
 
                 // Animate tagged scene + object Gaussians (Mode 2)
                 if (flags.animation && gs_animator_.has_active_groups()) {
@@ -1091,19 +1094,23 @@ void Renderer::clear_gs_animations() {
 }
 
 void Renderer::add_vfx_instance(VfxInstance&& inst) {
-    // Grow SSBO capacity to fit object PLY Gaussians (appended per-frame in update)
+    // Grow SSBO capacity to fit object PLY Gaussians
     const auto& obj_gs = inst.object_gaussians();
     if (!obj_gs.empty()) {
         uint32_t current_base = gs_renderer_.max_gaussian_count() - GsRenderer::kParticleHeadroom;
         uint32_t new_base = current_base + static_cast<uint32_t>(obj_gs.size());
         gs_renderer_.ensure_capacity(new_base);
-        std::fprintf(stderr, "VFX: Grew capacity for %zu object Gaussians\n", obj_gs.size());
+        // Include in cached scene buffer so no per-frame append is needed
+        gs_scene_buffer_.insert(gs_scene_buffer_.end(), obj_gs.begin(), obj_gs.end());
+        std::fprintf(stderr, "VFX: Added %zu object Gaussians to scene buffer\n", obj_gs.size());
     }
     vfx_instances_.push_back(std::move(inst));
 }
 
 void Renderer::clear_vfx_instances() {
     vfx_instances_.clear();
+    // Remove VFX object Gaussians from scene buffer (trim to pure-scene count)
+    gs_scene_buffer_.resize(gs_scene_base_count_);
 }
 
 }  // namespace gseurat

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -829,123 +829,124 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 }
             }
 
-            // Update particles/animations separately (no re-sort of scene)
-            bool has_particles = !gs_particle_emitters_.empty()
-                || gs_animator_.has_active_groups()
-                || !gs_scene_animations_.empty()
-                || !vfx_instances_.empty();
-            if (has_particles) {
-                // Phase-based state machine for scene animations
-                // Run BEFORE buffer reset so we can detect transitions to Reforming
-                for (auto& sa : gs_scene_animations_) {
-                    using Phase = SceneAnimation::Phase;
-                    if (sa.phase == Phase::Effect) {
-                        if (sa.group_id == 0) {
+        }
+
+        // Update particles/animations/VFX (runs regardless of chunk culling)
+        bool has_particles = !gs_particle_emitters_.empty()
+            || gs_animator_.has_active_groups()
+            || !gs_scene_animations_.empty()
+            || !vfx_instances_.empty();
+        if (has_particles) {
+            // Phase-based state machine for scene animations
+            // Run BEFORE buffer reset so we can detect transitions to Reforming
+            for (auto& sa : gs_scene_animations_) {
+                using Phase = SceneAnimation::Phase;
+                if (sa.phase == Phase::Effect) {
+                    if (sa.group_id == 0) {
+                        sa.group_id = gs_animator_.tag_region(
+                            gs_scene_buffer_, sa.region,
+                            parse_effect_name(sa.effect), sa.lifetime, sa.params);
+                    } else if (!gs_animator_.has_group(sa.group_id)) {
+                        if (sa.reform) {
+                            sa.reform_group_id = gs_animator_.tag_region(
+                                gs_scene_buffer_, sa.region,
+                                GsAnimEffect::Reform, sa.reform->lifetime);
+                            sa.phase = Phase::Reforming;
+                        } else if (sa.loop) {
                             sa.group_id = gs_animator_.tag_region(
                                 gs_scene_buffer_, sa.region,
                                 parse_effect_name(sa.effect), sa.lifetime, sa.params);
-                        } else if (!gs_animator_.has_group(sa.group_id)) {
-                            if (sa.reform) {
-                                sa.reform_group_id = gs_animator_.tag_region(
-                                    gs_scene_buffer_, sa.region,
-                                    GsAnimEffect::Reform, sa.reform->lifetime);
-                                sa.phase = Phase::Reforming;
-                            } else if (sa.loop) {
-                                sa.group_id = gs_animator_.tag_region(
-                                    gs_scene_buffer_, sa.region,
-                                    parse_effect_name(sa.effect), sa.lifetime, sa.params);
-                            } else {
-                                sa.phase = Phase::Idle;
-                            }
+                        } else {
+                            sa.phase = Phase::Idle;
                         }
-                    } else if (sa.phase == Phase::Reforming) {
-                        if (!gs_animator_.has_group(sa.reform_group_id)) {
-                            if (sa.loop) {
-                                sa.group_id = gs_animator_.tag_region(
-                                    gs_scene_buffer_, sa.region,
-                                    parse_effect_name(sa.effect), sa.lifetime, sa.params);
-                                sa.phase = Phase::Effect;
-                            } else {
-                                sa.phase = Phase::Idle;
-                            }
+                    }
+                } else if (sa.phase == Phase::Reforming) {
+                    if (!gs_animator_.has_group(sa.reform_group_id)) {
+                        if (sa.loop) {
+                            sa.group_id = gs_animator_.tag_region(
+                                gs_scene_buffer_, sa.region,
+                                parse_effect_name(sa.effect), sa.lifetime, sa.params);
+                            sa.phase = Phase::Effect;
+                        } else {
+                            sa.phase = Phase::Idle;
                         }
                     }
                 }
-
-                // Check if any animation is reforming AFTER state transitions
-                bool any_reforming = false;
-                for (const auto& sa : gs_scene_animations_) {
-                    if (sa.phase == SceneAnimation::Phase::Reforming) {
-                        any_reforming = true;
-                        break;
-                    }
-                }
-
-                // Skip buffer reset during reform so displaced positions persist
-                if (!any_reforming) {
-                    gs_active_buffer_ = gs_scene_buffer_;
-                }
-
-                // VFX object Gaussians are already in gs_scene_buffer_
-                // (appended at gather time), so no per-frame append needed.
-
-                // Animate tagged scene + object Gaussians (Mode 2)
-                if (flags.animation && gs_animator_.has_active_groups()) {
-                    gs_animator_.update(dt, gs_active_buffer_);
-                }
-
-                // Update and append Gaussian particles from emitters
-                if (flags.particles) {
-                    for (auto& emitter : gs_particle_emitters_) {
-                        emitter.update(dt);
-                        emitter.gather(gs_active_buffer_);
-                    }
-                    // Remove dead emitters
-                    gs_particle_emitters_.erase(
-                        std::remove_if(gs_particle_emitters_.begin(), gs_particle_emitters_.end(),
-                            [](const GaussianParticleEmitter& e) { return !e.active() && e.alive_count() == 0; }),
-                        gs_particle_emitters_.end());
-                }
-
-                // Update VFX instances (timeline + emitters + animation tagging)
-                if (flags.particles || flags.animation) {
-                    for (auto& inst : vfx_instances_) {
-                        inst.update(dt, gs_active_buffer_, gs_animator_);
-                    }
-                    std::erase_if(vfx_instances_,
-                        [](const VfxInstance& i) { return i.is_finished(); });
-                }
-
-                // Collect VFX dynamic lights and merge with existing lights
-                {
-                    // Start from static scene lights (set via set_gs_static_lights)
-                    auto all_lights = gs_static_lights_;
-                    // Append VFX instance lights
-                    for (const auto& inst : vfx_instances_) {
-                        for (const auto& vl : inst.active_lights()) {
-                            if (all_lights.size() < 8) {
-                                all_lights.push_back(vl);
-                            }
-                        }
-                    }
-                    if (!all_lights.empty()) {
-                        // Auto-enable point light mode if VFX lights are present
-                        if (gs_renderer_.light_mode() < 2) {
-                            gs_renderer_.set_light_mode(2);
-                        }
-                        gs_renderer_.set_point_lights(all_lights);
-                    }
-                }
-
-                // Clamp to allocated SSBO capacity
-                if (gs_active_buffer_.size() > gs_renderer_.max_gaussian_count()) {
-                    gs_active_buffer_.resize(gs_renderer_.max_gaussian_count());
-                }
-
-                gs_renderer_.update_gaussian_data(
-                    gs_active_buffer_.data(),
-                    static_cast<uint32_t>(gs_active_buffer_.size()));
             }
+
+            // Check if any animation is reforming AFTER state transitions
+            bool any_reforming = false;
+            for (const auto& sa : gs_scene_animations_) {
+                if (sa.phase == SceneAnimation::Phase::Reforming) {
+                    any_reforming = true;
+                    break;
+                }
+            }
+
+            // Skip buffer reset during reform so displaced positions persist
+            if (!any_reforming) {
+                gs_active_buffer_ = gs_scene_buffer_;
+            }
+
+            // VFX object Gaussians are already in gs_scene_buffer_
+            // (appended at gather time), so no per-frame append needed.
+
+            // Animate tagged scene + object Gaussians (Mode 2)
+            if (flags.animation && gs_animator_.has_active_groups()) {
+                gs_animator_.update(dt, gs_active_buffer_);
+            }
+
+            // Update and append Gaussian particles from emitters
+            if (flags.particles) {
+                for (auto& emitter : gs_particle_emitters_) {
+                    emitter.update(dt);
+                    emitter.gather(gs_active_buffer_);
+                }
+                // Remove dead emitters
+                gs_particle_emitters_.erase(
+                    std::remove_if(gs_particle_emitters_.begin(), gs_particle_emitters_.end(),
+                        [](const GaussianParticleEmitter& e) { return !e.active() && e.alive_count() == 0; }),
+                    gs_particle_emitters_.end());
+            }
+
+            // Update VFX instances (timeline + emitters + animation tagging)
+            if (flags.particles || flags.animation) {
+                for (auto& inst : vfx_instances_) {
+                    inst.update(dt, gs_active_buffer_, gs_animator_);
+                }
+                std::erase_if(vfx_instances_,
+                    [](const VfxInstance& i) { return i.is_finished(); });
+            }
+
+            // Collect VFX dynamic lights and merge with existing lights
+            {
+                // Start from static scene lights (set via set_gs_static_lights)
+                auto all_lights = gs_static_lights_;
+                // Append VFX instance lights
+                for (const auto& inst : vfx_instances_) {
+                    for (const auto& vl : inst.active_lights()) {
+                        if (all_lights.size() < 8) {
+                            all_lights.push_back(vl);
+                        }
+                    }
+                }
+                if (!all_lights.empty()) {
+                    // Auto-enable point light mode if VFX lights are present
+                    if (gs_renderer_.light_mode() < 2) {
+                        gs_renderer_.set_light_mode(2);
+                    }
+                    gs_renderer_.set_point_lights(all_lights);
+                }
+            }
+
+            // Clamp to allocated SSBO capacity
+            if (gs_active_buffer_.size() > gs_renderer_.max_gaussian_count()) {
+                gs_active_buffer_.resize(gs_renderer_.max_gaussian_count());
+            }
+
+            gs_renderer_.update_gaussian_data(
+                gs_active_buffer_.data(),
+                static_cast<uint32_t>(gs_active_buffer_.size()));
         }
 
         gs_renderer_.render(cmd, gs_view_, gs_proj_);

--- a/tests/test_vfx_scene_buffer.cpp
+++ b/tests/test_vfx_scene_buffer.cpp
@@ -1,0 +1,258 @@
+// Test: VFX object Gaussians are included in the scene buffer (not appended per-frame).
+//
+// Validates that:
+// 1. Scene buffer includes VFX object Gaussians after rebuild
+// 2. Per-frame active buffer reset already contains VFX objects
+// 3. add/clear VFX instances correctly update the scene buffer
+// 4. Scene base count tracks pure-scene Gaussians separately
+//
+// Run: ctest -R test_vfx_scene_buffer
+
+#include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/gs_vfx.hpp"
+
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+static int passed = 0;
+static int failed = 0;
+
+static void check(bool cond, const char* msg) {
+    if (cond) {
+        std::printf("  PASS: %s\n", msg);
+        passed++;
+    } else {
+        std::printf("  FAIL: %s\n", msg);
+        failed++;
+    }
+}
+
+// Helper: create N Gaussians with a marker position.x = marker + index
+static std::vector<gseurat::Gaussian> make_gaussians(uint32_t count, float marker) {
+    std::vector<gseurat::Gaussian> gs(count);
+    for (uint32_t i = 0; i < count; ++i) {
+        gs[i].position = glm::vec3(marker + static_cast<float>(i), 0.0f, 0.0f);
+        gs[i].scale = glm::vec3(0.01f);
+        gs[i].rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+        gs[i].color = glm::vec3(1.0f);
+        gs[i].opacity = 1.0f;
+        gs[i].importance = 1.0f;
+        gs[i].bone_index = 0;
+        gs[i].emission = 0.0f;
+    }
+    return gs;
+}
+
+// ── Simulated scene buffer management (mirrors Renderer logic) ──
+// This tests the data-flow pattern without needing Vulkan.
+
+struct SceneBufferState {
+    std::vector<gseurat::Gaussian> scene_buffer;   // cached: scene + VFX objects
+    std::vector<gseurat::Gaussian> active_buffer;   // working: scene + VFX + particles/anim
+    uint32_t scene_base_count = 0;                  // count of pure-scene Gaussians
+
+    // Simulate chunk gather (visibility change)
+    void gather_scene(const std::vector<gseurat::Gaussian>& scene_gaussians) {
+        scene_buffer = scene_gaussians;
+        scene_base_count = static_cast<uint32_t>(scene_buffer.size());
+    }
+
+    // Append VFX object Gaussians to scene buffer (after gather)
+    void append_vfx_objects(const std::vector<gseurat::Gaussian>& vfx_objects) {
+        scene_buffer.insert(scene_buffer.end(), vfx_objects.begin(), vfx_objects.end());
+    }
+
+    // Per-frame reset: active = scene buffer (already includes VFX objects)
+    void reset_active() {
+        active_buffer = scene_buffer;
+    }
+
+    // Simulate adding particles (per-frame dynamic content)
+    void append_particles(const std::vector<gseurat::Gaussian>& particles) {
+        active_buffer.insert(active_buffer.end(), particles.begin(), particles.end());
+    }
+
+    // Clear VFX objects from scene buffer (trim to base count)
+    void clear_vfx_objects() {
+        scene_buffer.resize(scene_base_count);
+    }
+};
+
+// ── Tests ──
+
+void test_scene_buffer_includes_vfx_objects() {
+    std::printf("Scene buffer includes VFX objects:\n");
+
+    SceneBufferState state;
+    auto scene = make_gaussians(100, 0.0f);       // 100 scene Gaussians
+    auto vfx_obj = make_gaussians(50, 1000.0f);   // 50 VFX object Gaussians
+
+    state.gather_scene(scene);
+    state.append_vfx_objects(vfx_obj);
+
+    check(state.scene_base_count == 100, "scene base count is 100");
+    check(state.scene_buffer.size() == 150, "scene buffer = 100 scene + 50 VFX objects");
+    check(state.scene_buffer[0].position.x == 0.0f, "first scene Gaussian at marker 0");
+    check(state.scene_buffer[100].position.x == 1000.0f, "first VFX object at marker 1000");
+}
+
+void test_active_buffer_reset_contains_vfx() {
+    std::printf("Active buffer reset already contains VFX objects:\n");
+
+    SceneBufferState state;
+    auto scene = make_gaussians(100, 0.0f);
+    auto vfx_obj = make_gaussians(50, 1000.0f);
+
+    state.gather_scene(scene);
+    state.append_vfx_objects(vfx_obj);
+    state.reset_active();
+
+    check(state.active_buffer.size() == 150,
+          "active buffer after reset = 150 (scene + VFX, no per-frame append)");
+
+    // Simulate particles added per-frame
+    auto particles = make_gaussians(10, 2000.0f);
+    state.append_particles(particles);
+    check(state.active_buffer.size() == 160, "active buffer = 160 after particles");
+
+    // Next frame reset — particles gone, VFX objects still there
+    state.reset_active();
+    check(state.active_buffer.size() == 150,
+          "next frame reset = 150 (particles cleared, VFX objects persist)");
+}
+
+void test_no_per_frame_vfx_append_needed() {
+    std::printf("No per-frame VFX append needed:\n");
+
+    SceneBufferState state;
+    auto scene = make_gaussians(100, 0.0f);
+    auto vfx_obj = make_gaussians(50000, 1000.0f);  // 50K VFX object Gaussians
+
+    state.gather_scene(scene);
+    state.append_vfx_objects(vfx_obj);
+
+    // Simulate 3 frames — VFX objects should already be there after reset
+    for (int frame = 0; frame < 3; ++frame) {
+        state.reset_active();
+        // No append_objects call needed!
+        check(state.active_buffer.size() == 50100,
+              "frame N: active buffer = 50100 without per-frame append");
+    }
+}
+
+void test_clear_vfx_trims_scene_buffer() {
+    std::printf("Clear VFX trims scene buffer to base count:\n");
+
+    SceneBufferState state;
+    auto scene = make_gaussians(100, 0.0f);
+    auto vfx_obj = make_gaussians(50, 1000.0f);
+
+    state.gather_scene(scene);
+    state.append_vfx_objects(vfx_obj);
+    check(state.scene_buffer.size() == 150, "before clear: 150");
+
+    state.clear_vfx_objects();
+    check(state.scene_buffer.size() == 100, "after clear: trimmed to 100");
+    check(state.scene_base_count == 100, "base count unchanged");
+
+    state.reset_active();
+    check(state.active_buffer.size() == 100, "active buffer after clear = 100 (no VFX)");
+}
+
+void test_add_vfx_after_initial_gather() {
+    std::printf("Add VFX instance after initial gather:\n");
+
+    SceneBufferState state;
+    auto scene = make_gaussians(100, 0.0f);
+
+    state.gather_scene(scene);
+    check(state.scene_buffer.size() == 100, "initial: 100 scene only");
+
+    // Add first VFX
+    auto vfx1 = make_gaussians(30, 1000.0f);
+    state.append_vfx_objects(vfx1);
+    check(state.scene_buffer.size() == 130, "after VFX 1: 130");
+
+    // Add second VFX
+    auto vfx2 = make_gaussians(20, 2000.0f);
+    state.append_vfx_objects(vfx2);
+    check(state.scene_buffer.size() == 150, "after VFX 2: 150");
+
+    state.reset_active();
+    check(state.active_buffer.size() == 150, "active has both VFX instances");
+}
+
+void test_regather_preserves_vfx_objects() {
+    std::printf("Re-gather (visibility change) preserves VFX objects:\n");
+
+    SceneBufferState state;
+    auto scene = make_gaussians(100, 0.0f);
+    auto vfx_obj = make_gaussians(50, 1000.0f);
+
+    state.gather_scene(scene);
+    state.append_vfx_objects(vfx_obj);
+    check(state.scene_buffer.size() == 150, "initial: 150");
+
+    // Simulate visibility change — fewer scene Gaussians
+    auto scene_v2 = make_gaussians(80, 0.0f);
+    state.gather_scene(scene_v2);
+    check(state.scene_base_count == 80, "re-gather: base count = 80");
+    check(state.scene_buffer.size() == 80, "re-gather: scene buffer = 80 (VFX stripped)");
+
+    // VFX objects need to be re-appended after gather
+    state.append_vfx_objects(vfx_obj);
+    check(state.scene_buffer.size() == 130, "after re-append VFX: 130");
+}
+
+void test_clear_then_add_vfx() {
+    std::printf("Clear then add new VFX instances:\n");
+
+    SceneBufferState state;
+    auto scene = make_gaussians(100, 0.0f);
+    auto vfx_old = make_gaussians(50, 1000.0f);
+    auto vfx_new = make_gaussians(25, 3000.0f);
+
+    state.gather_scene(scene);
+    state.append_vfx_objects(vfx_old);
+    check(state.scene_buffer.size() == 150, "with old VFX: 150");
+
+    state.clear_vfx_objects();
+    state.append_vfx_objects(vfx_new);
+    check(state.scene_buffer.size() == 125, "after replace: 125");
+    check(state.scene_buffer[100].position.x == 3000.0f, "new VFX at marker 3000");
+}
+
+void test_vfx_instance_append_objects() {
+    std::printf("VfxInstance::append_objects appends static PLY Gaussians:\n");
+
+    // Create a VfxInstance with pre-loaded object Gaussians
+    // (We can't call init() without a PLY file, so test the append path directly)
+    std::vector<gseurat::Gaussian> buffer;
+    auto scene = make_gaussians(10, 0.0f);
+    buffer = scene;
+
+    // Simulate what append_objects does
+    auto vfx_objects = make_gaussians(5, 100.0f);
+    buffer.insert(buffer.end(), vfx_objects.begin(), vfx_objects.end());
+
+    check(buffer.size() == 15, "buffer = scene + VFX objects");
+    check(buffer[10].position.x == 100.0f, "VFX objects appended at correct position");
+}
+
+int main() {
+    std::printf("=== VFX Object Scene Buffer Tests ===\n\n");
+
+    test_scene_buffer_includes_vfx_objects();
+    test_active_buffer_reset_contains_vfx();
+    test_no_per_frame_vfx_append_needed();
+    test_clear_vfx_trims_scene_buffer();
+    test_add_vfx_after_initial_gather();
+    test_regather_preserves_vfx_objects();
+    test_clear_then_add_vfx();
+    test_vfx_instance_append_objects();
+
+    std::printf("\n=== Results: %d passed, %d failed ===\n", passed, failed);
+    return failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- VFX object PLY Gaussians (static geometry) were being copied into the active buffer every frame via `append_objects()` — ~3.4MB/frame for 50K Gaussians
- Now included in `gs_scene_buffer_` at gather time and when instances are added, so per-frame reset already contains them
- `add_vfx_instance` appends to scene buffer; `clear_vfx_instances` trims to pure-scene base count via `gs_scene_base_count_`

## Test plan
- [x] 16/16 C++ tests pass (including new `test_vfx_scene_buffer` with 8 test groups)
- [x] Place VFX with object elements → verify geometry renders correctly
- [x] Toggle visibility (chunk culling) → VFX objects persist after re-gather
- [x] Clear VFX instances → object Gaussians removed from buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)