### PR TITLE
Fix spline origin: respect emitter position

### DIFF
--- a/src/engine/gs_particle.cpp
+++ b/src/engine/gs_particle.cpp
@@ -34,6 +34,7 @@ void GaussianParticleEmitter::configure(const GsEmitterConfig& config) {
 
 void GaussianParticleEmitter::set_position(const glm::vec3& pos) {
     config_.position = pos;
+    base_position_ = pos;  // keep spline origin in sync
 }
 
 void GaussianParticleEmitter::set_active(bool active) {


### PR DESCRIPTION
## Summary
`set_position()` updated `config_.position` but not `base_position_`, so spline paths always started at the origin instead of the emitter's world position. One-line fix: sync `base_position_` in `set_position()`.

## Test plan
- [x] 18/18 C++ tests pass
- [x] VFX emitter with position offset + spline → particles follow spline from emitter position

🤖 Generated with [Claude Code](https://claude.com/claude-code)