### PR TITLE
Fix VFX spline paths not working in Staging preview

### DIFF
--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -506,6 +506,11 @@ void AppBase::dispatch_command(const nlohmann::json& cmd, nlohmann::json& respon
         auto path = cmd.value("path", "");
         auto content = cmd.value("content", "");
         if (!path.empty() && !content.empty()) {
+            // Create parent directories if they don't exist
+            auto parent = std::filesystem::path(path).parent_path();
+            if (!parent.empty()) {
+                std::filesystem::create_directories(parent);
+            }
             std::ofstream ofs(path);
             if (ofs.is_open()) {
                 ofs << content;

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -4,7 +4,7 @@ import { exportPly } from '../lib/plyExport.js';
 import { exportSceneJson } from '../lib/sceneExport.js';
 import { computeFingerprint, isStructuralChange, type SceneFingerprint } from '../lib/sceneFingerprint.js';
 import { hasFileSystemAccess, openProjectDirectory, saveProject as saveProjectDir, loadProject as loadProjectDir, saveProjectAsZip, loadProjectFromZip, importAssetToProject } from '../lib/projectIO.js';
-import { sendBridgeCommand } from '@gseurat/engine-client';
+import { sendBridgeCommand, sendBridgeCommands } from '@gseurat/engine-client';
 import type { BricklayerFile } from '../store/types.js';
 
 const styles: Record<string, React.CSSProperties> = {
@@ -283,11 +283,32 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
     download(new Blob([json], { type: 'application/json' }), `${s.projectName || 'scene'}.json`);
   };
 
+  // Push VFX preset files to engine via write_temp_file before scene load.
+  // The engine resolves vfx_file paths relative to its working directory,
+  // so we write them to the expected paths before the scene references them.
+  const pushVfxFiles = (state: ReturnType<typeof useSceneStore.getState>) => {
+    const cmds: Record<string, unknown>[] = [];
+    for (const inst of state.vfxInstances) {
+      if (inst.vfx_preset && inst.vfx_file) {
+        cmds.push({
+          cmd: 'write_temp_file',
+          path: inst.vfx_file,
+          content: JSON.stringify(inst.vfx_preset, null, 2),
+        });
+      }
+    }
+    return cmds;
+  };
+
   const handleOpenInStaging = () => {
     const s = useSceneStore.getState();
     const scene = exportSceneJson(s);
     const json = JSON.stringify(scene);
-    sendBridgeCommand({ cmd: 'load_scene_json', json });
+    const cmds: Record<string, unknown>[] = [
+      ...pushVfxFiles(s),
+      { cmd: 'load_scene_json', json },
+    ];
+    sendBridgeCommands(cmds);
   };
 
   // Auto-sync: debounced incremental update to Staging.
@@ -311,12 +332,13 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
         const json = JSON.stringify(scene);
         const fp = computeFingerprint(scene);
 
+        const vfxCmds = pushVfxFiles(s);
         if (isStructuralChange(prevFingerprint.current, fp)) {
           // Structural change: full reload (re-uploads PLY)
-          sendBridgeCommand({ cmd: 'load_scene_json', json });
+          sendBridgeCommands([...vfxCmds, { cmd: 'load_scene_json', json }]);
         } else {
           // Property-only change: lightweight update (no PLY reload)
-          sendBridgeCommand({ cmd: 'update_scene_data', json });
+          sendBridgeCommands([...vfxCmds, { cmd: 'update_scene_data', json }]);
         }
         prevFingerprint.current = fp;
       }, 2000);  // 2s debounce


### PR DESCRIPTION
## Summary
- Bricklayer now pushes VFX preset files via `write_temp_file` before sending scene data to Staging
- `write_temp_file` handler creates parent directories (e.g. `assets/vfx/`) if they don't exist
- Fixes spline-controlled particles (and all VFX elements) not appearing when previewing from Bricklayer

## Root cause
Bricklayer sent scene JSON with `vfx_file: "assets/vfx/torch.vfx.json"` but never pushed the actual file. `load_vfx_preset()` failed silently (returned empty preset), so VFX instances with spline emitters were skipped entirely.

## Test plan
- [x] C++ build passes, 19/19 tests pass
- [x] Bricklayer type-check passes
- [x] Verified: VFX spline paths now work in Staging preview from Bricklayer

🤖 Generated with [Claude Code](https://claude.com/claude-code)