### PR TITLE
Add spline path support to Bricklayer emitters

### DIFF
--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -266,7 +266,25 @@
         },
         "spawn_offset_min": { "$ref": "#/definitions/vec3", "description": "Deprecated: use region instead" },
         "spawn_offset_max": { "$ref": "#/definitions/vec3", "description": "Deprecated: use region instead" },
-        "burst_duration": { "type": "number", "minimum": 0 }
+        "burst_duration": { "type": "number", "minimum": 0 },
+        "spline": {
+          "type": "object",
+          "description": "Optional spline path for emitter movement or particle flight",
+          "required": ["mode", "control_points"],
+          "properties": {
+            "mode": { "type": "string", "enum": ["emitter_path", "particle_path"] },
+            "control_points": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/vec3" },
+              "minItems": 2,
+              "description": "3D control points in local space (minimum 2)"
+            },
+            "emitter_speed": { "type": "number", "minimum": 0, "description": "Cycles/sec along spline (emitter_path)" },
+            "path_spread": { "type": "number", "minimum": 0, "description": "Lateral offset from spline (particle_path)" },
+            "align_to_tangent": { "type": "boolean", "description": "Orient particles along spline tangent" }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": false
     },

--- a/tools/apps/bricklayer/src/lib/catmullRom.ts
+++ b/tools/apps/bricklayer/src/lib/catmullRom.ts
@@ -1,0 +1,47 @@
+/**
+ * Catmull-Rom spline evaluation (uniform, tau=0.5).
+ * Same formula as C++ gs_spline.cpp and Méliès catmullRom.ts.
+ */
+
+type Vec3 = [number, number, number];
+
+function catmullRom(p0: Vec3, p1: Vec3, p2: Vec3, p3: Vec3, t: number): Vec3 {
+  const t2 = t * t;
+  const t3 = t2 * t;
+  return [
+    0.5 * ((2 * p1[0]) + (-p0[0] + p2[0]) * t + (2 * p0[0] - 5 * p1[0] + 4 * p2[0] - p3[0]) * t2 + (-p0[0] + 3 * p1[0] - 3 * p2[0] + p3[0]) * t3),
+    0.5 * ((2 * p1[1]) + (-p0[1] + p2[1]) * t + (2 * p0[1] - 5 * p1[1] + 4 * p2[1] - p3[1]) * t2 + (-p0[1] + 3 * p1[1] - 3 * p2[1] + p3[1]) * t3),
+    0.5 * ((2 * p1[2]) + (-p0[2] + p2[2]) * t + (2 * p0[2] - 5 * p1[2] + 4 * p2[2] - p3[2]) * t2 + (-p0[2] + 3 * p1[2] - 3 * p2[2] + p3[2]) * t3),
+  ];
+}
+
+function ghost(a: Vec3, b: Vec3): Vec3 {
+  return [2 * a[0] - b[0], 2 * a[1] - b[1], 2 * a[2] - b[2]];
+}
+
+/** Evaluate Catmull-Rom spline at parameter t in [0, 1]. */
+export function evaluateCatmullRom(points: Vec3[], t: number): Vec3 {
+  if (points.length < 2) return points[0] ?? [0, 0, 0];
+  const segments = points.length - 1;
+  const clamped = Math.max(0, Math.min(1, t));
+  const scaled = clamped * segments;
+  const seg = Math.min(Math.floor(scaled), segments - 1);
+  const localT = scaled - seg;
+
+  const p1 = points[seg];
+  const p2 = points[seg + 1];
+  const p0 = seg > 0 ? points[seg - 1] : ghost(p1, p2);
+  const p3 = seg + 2 < points.length ? points[seg + 2] : ghost(p2, p1);
+
+  return catmullRom(p0, p1, p2, p3, localT);
+}
+
+/** Sample N evenly-spaced points along the spline for line rendering. */
+export function sampleCatmullRom(points: Vec3[], numSamples = 64): Vec3[] {
+  if (points.length < 2) return [...points];
+  const result: Vec3[] = [];
+  for (let i = 0; i <= numSamples; i++) {
+    result.push(evaluateCatmullRom(points, i / numSamples));
+  }
+  return result;
+}

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -179,6 +179,7 @@ export function exportSceneJson(state: SceneStoreState): object {
       };
       if (e.preset) out.preset = e.preset;
       if (e.burst_duration > 0) out.burst_duration = e.burst_duration;
+      if (e.spline) out.spline = e.spline;
       return out;
     });
   }

--- a/tools/apps/bricklayer/src/panels/GsEmittersTab.tsx
+++ b/tools/apps/bricklayer/src/panels/GsEmittersTab.tsx
@@ -196,8 +196,27 @@ function EmitterEditor({ emitter }: { emitter: GsParticleEmitterData }) {
       {emitter.spline && (
         <>
           {emitter.spline.control_points.map((pt, i) => (
-            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-              <span style={{ fontSize: 10, color: '#666', minWidth: 20 }}>P{i}</span>
+            <div key={i}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <span style={{ fontSize: 10, color: '#666' }}>P{i}</span>
+                <button
+                  onClick={() => {
+                    if (emitter.spline!.control_points.length <= 2) return;
+                    const pts = emitter.spline!.control_points.filter((_, idx) => idx !== i);
+                    updateGsEmitter(emitter.id, {
+                      spline: { ...emitter.spline!, control_points: pts },
+                    });
+                  }}
+                  disabled={emitter.spline!.control_points.length <= 2}
+                  style={{
+                    background: 'transparent', border: 'none', color: '#666',
+                    cursor: emitter.spline!.control_points.length <= 2 ? 'not-allowed' : 'pointer',
+                    fontSize: 14, padding: '0 4px',
+                    opacity: emitter.spline!.control_points.length <= 2 ? 0.3 : 0.7,
+                  }}>
+                  x
+                </button>
+              </div>
               <Vec3Input value={pt} step={0.5}
                 onChange={(v) => {
                   const pts = [...emitter.spline!.control_points];
@@ -206,23 +225,6 @@ function EmitterEditor({ emitter }: { emitter: GsParticleEmitterData }) {
                     spline: { ...emitter.spline!, control_points: pts },
                   });
                 }} style={styles.input} />
-              <button
-                onClick={() => {
-                  if (emitter.spline!.control_points.length <= 2) return;
-                  const pts = emitter.spline!.control_points.filter((_, idx) => idx !== i);
-                  updateGsEmitter(emitter.id, {
-                    spline: { ...emitter.spline!, control_points: pts },
-                  });
-                }}
-                disabled={emitter.spline!.control_points.length <= 2}
-                style={{
-                  background: 'transparent', border: 'none', color: '#666',
-                  cursor: emitter.spline!.control_points.length <= 2 ? 'not-allowed' : 'pointer',
-                  fontSize: 14, padding: '0 4px',
-                  opacity: emitter.spline!.control_points.length <= 2 ? 0.3 : 0.7,
-                }}>
-                x
-              </button>
             </div>
           ))}
           <button

--- a/tools/apps/bricklayer/src/panels/GsEmittersTab.tsx
+++ b/tools/apps/bricklayer/src/panels/GsEmittersTab.tsx
@@ -164,6 +164,118 @@ function EmitterEditor({ emitter }: { emitter: GsParticleEmitterData }) {
         <NumberInput value={emitter.burst_duration} min={0} step={0.1}
           onChange={(v) => updateGsEmitter(emitter.id, { burst_duration: v })} style={styles.input} />
       </div>
+
+      {/* Spline Path */}
+      <span style={styles.sectionLabel}>Spline Path</span>
+      <div style={styles.row}>
+        <span style={{ fontSize: 12, minWidth: 70 }}>Mode</span>
+        <select style={styles.select}
+          value={emitter.spline?.mode ?? 'none'}
+          onChange={(e) => {
+            const mode = e.target.value;
+            if (mode === 'none') {
+              updateGsEmitter(emitter.id, { spline: undefined });
+            } else {
+              const pts = emitter.spline?.control_points?.length
+                ? emitter.spline.control_points
+                : [[0, 0, 0], [0, 5, 0]] as [number, number, number][];
+              updateGsEmitter(emitter.id, {
+                spline: {
+                  ...emitter.spline,
+                  mode: mode as 'emitter_path' | 'particle_path',
+                  control_points: pts,
+                },
+              });
+            }
+          }}>
+          <option value="none">None</option>
+          <option value="emitter_path">Emitter Path</option>
+          <option value="particle_path">Particle Path</option>
+        </select>
+      </div>
+      {emitter.spline && (
+        <>
+          {emitter.spline.control_points.map((pt, i) => (
+            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span style={{ fontSize: 10, color: '#666', minWidth: 20 }}>P{i}</span>
+              <Vec3Input value={pt} step={0.5}
+                onChange={(v) => {
+                  const pts = [...emitter.spline!.control_points];
+                  pts[i] = v;
+                  updateGsEmitter(emitter.id, {
+                    spline: { ...emitter.spline!, control_points: pts },
+                  });
+                }} style={styles.input} />
+              <button
+                onClick={() => {
+                  if (emitter.spline!.control_points.length <= 2) return;
+                  const pts = emitter.spline!.control_points.filter((_, idx) => idx !== i);
+                  updateGsEmitter(emitter.id, {
+                    spline: { ...emitter.spline!, control_points: pts },
+                  });
+                }}
+                disabled={emitter.spline!.control_points.length <= 2}
+                style={{
+                  background: 'transparent', border: 'none', color: '#666',
+                  cursor: emitter.spline!.control_points.length <= 2 ? 'not-allowed' : 'pointer',
+                  fontSize: 14, padding: '0 4px',
+                  opacity: emitter.spline!.control_points.length <= 2 ? 0.3 : 0.7,
+                }}>
+                x
+              </button>
+            </div>
+          ))}
+          <button
+            onClick={() => {
+              const pts = emitter.spline!.control_points;
+              const last = pts[pts.length - 1];
+              const prev = pts[pts.length - 2] ?? last;
+              const next: [number, number, number] = [
+                last[0] + (last[0] - prev[0]),
+                last[1] + (last[1] - prev[1]),
+                last[2] + (last[2] - prev[2]),
+              ];
+              updateGsEmitter(emitter.id, {
+                spline: { ...emitter.spline!, control_points: [...pts, next] },
+              });
+            }}
+            style={{
+              background: '#1a1a2e', border: '1px solid #333', borderRadius: 3,
+              color: '#999', fontSize: 11, padding: '3px 8px', cursor: 'pointer',
+              marginTop: 2,
+            }}>
+            + Add Point
+          </button>
+          {emitter.spline.mode === 'emitter_path' && (
+            <div style={styles.row}>
+              <span style={{ fontSize: 12, minWidth: 70 }}>Speed</span>
+              <NumberInput value={emitter.spline.emitter_speed ?? 1} min={0} step={0.1}
+                onChange={(v) => updateGsEmitter(emitter.id, {
+                  spline: { ...emitter.spline!, emitter_speed: v },
+                })} style={styles.input} />
+            </div>
+          )}
+          {emitter.spline.mode === 'particle_path' && (
+            <>
+              <div style={styles.row}>
+                <span style={{ fontSize: 12, minWidth: 70 }}>Spread</span>
+                <NumberInput value={emitter.spline.path_spread ?? 0} min={0} step={0.1}
+                  onChange={(v) => updateGsEmitter(emitter.id, {
+                    spline: { ...emitter.spline!, path_spread: v },
+                  })} style={styles.input} />
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2 }}>
+                <input type="checkbox"
+                  checked={emitter.spline.align_to_tangent ?? false}
+                  onChange={(e) => updateGsEmitter(emitter.id, {
+                    spline: { ...emitter.spline!, align_to_tangent: e.target.checked },
+                  })} />
+                <span style={{ fontSize: 12, color: '#ccc' }}>Align to tangent</span>
+              </div>
+            </>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -823,36 +823,36 @@ function GsEmitterProperties({ emitter }: { emitter: GsParticleEmitterData }) {
       {emitter.spline && (
         <>
           {emitter.spline.control_points.map((pt, i) => (
-            <div key={i} style={styles.section}>
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                <span style={{ fontSize: 10, color: '#666' }}>P{i}</span>
-                <button
-                  onClick={() => {
-                    if (emitter.spline!.control_points.length <= 2) return;
-                    const pts = emitter.spline!.control_points.filter((_, idx) => idx !== i);
+            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 4 }}>
+              <span style={{ fontSize: 10, color: '#666', minWidth: 18, flexShrink: 0 }}>P{i}</span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <Vec3Input value={pt} step={0.5}
+                  onChange={(v) => {
+                    const pts = [...emitter.spline!.control_points];
+                    pts[i] = v;
                     update(emitter.id, {
                       spline: { ...emitter.spline!, control_points: pts },
                     });
-                  }}
-                  disabled={emitter.spline!.control_points.length <= 2}
-                  style={{
-                    background: 'transparent', border: 'none', color: '#666',
-                    cursor: emitter.spline!.control_points.length <= 2 ? 'not-allowed' : 'pointer',
-                    fontSize: 14, padding: '0 4px',
-                    opacity: emitter.spline!.control_points.length <= 2 ? 0.3 : 0.7,
-                  }}
-                >
-                  x
-                </button>
+                  }} />
               </div>
-              <Vec3Input value={pt} step={0.5}
-                onChange={(v) => {
-                  const pts = [...emitter.spline!.control_points];
-                  pts[i] = v;
+              <button
+                onClick={() => {
+                  if (emitter.spline!.control_points.length <= 2) return;
+                  const pts = emitter.spline!.control_points.filter((_, idx) => idx !== i);
                   update(emitter.id, {
                     spline: { ...emitter.spline!, control_points: pts },
                   });
-                }} />
+                }}
+                disabled={emitter.spline!.control_points.length <= 2}
+                style={{
+                  background: 'transparent', border: 'none', color: '#666',
+                  cursor: emitter.spline!.control_points.length <= 2 ? 'not-allowed' : 'pointer',
+                  fontSize: 14, padding: '0 2px', flexShrink: 0,
+                  opacity: emitter.spline!.control_points.length <= 2 ? 0.3 : 0.7,
+                }}
+              >
+                x
+              </button>
             </div>
           ))}
           <button

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -823,8 +823,28 @@ function GsEmitterProperties({ emitter }: { emitter: GsParticleEmitterData }) {
       {emitter.spline && (
         <>
           {emitter.spline.control_points.map((pt, i) => (
-            <div key={i} style={{ ...styles.section, display: 'flex', alignItems: 'center', gap: 4 }}>
-              <span style={{ fontSize: 10, color: '#666', minWidth: 20 }}>P{i}</span>
+            <div key={i} style={styles.section}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <span style={{ fontSize: 10, color: '#666' }}>P{i}</span>
+                <button
+                  onClick={() => {
+                    if (emitter.spline!.control_points.length <= 2) return;
+                    const pts = emitter.spline!.control_points.filter((_, idx) => idx !== i);
+                    update(emitter.id, {
+                      spline: { ...emitter.spline!, control_points: pts },
+                    });
+                  }}
+                  disabled={emitter.spline!.control_points.length <= 2}
+                  style={{
+                    background: 'transparent', border: 'none', color: '#666',
+                    cursor: emitter.spline!.control_points.length <= 2 ? 'not-allowed' : 'pointer',
+                    fontSize: 14, padding: '0 4px',
+                    opacity: emitter.spline!.control_points.length <= 2 ? 0.3 : 0.7,
+                  }}
+                >
+                  x
+                </button>
+              </div>
               <Vec3Input value={pt} step={0.5}
                 onChange={(v) => {
                   const pts = [...emitter.spline!.control_points];
@@ -833,24 +853,6 @@ function GsEmitterProperties({ emitter }: { emitter: GsParticleEmitterData }) {
                     spline: { ...emitter.spline!, control_points: pts },
                   });
                 }} />
-              <button
-                onClick={() => {
-                  if (emitter.spline!.control_points.length <= 2) return;
-                  const pts = emitter.spline!.control_points.filter((_, idx) => idx !== i);
-                  update(emitter.id, {
-                    spline: { ...emitter.spline!, control_points: pts },
-                  });
-                }}
-                disabled={emitter.spline!.control_points.length <= 2}
-                style={{
-                  background: 'transparent', border: 'none', color: '#666',
-                  cursor: emitter.spline!.control_points.length <= 2 ? 'not-allowed' : 'pointer',
-                  fontSize: 14, padding: '0 4px',
-                  opacity: emitter.spline!.control_points.length <= 2 ? 0.3 : 0.7,
-                }}
-              >
-                x
-              </button>
             </div>
           ))}
           <button

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -789,6 +789,125 @@ function GsEmitterProperties({ emitter }: { emitter: GsParticleEmitterData }) {
           onChange={(v) => update(emitter.id, { burst_duration: v })} style={styles.input} />
         <span style={{ fontSize: 10, color: '#666' }}>0 = continuous loop</span>
       </div>
+
+      {/* Spline Path */}
+      <div style={styles.section}>
+        <span style={styles.label}>Spline Path</span>
+        <select
+          style={styles.select}
+          value={emitter.spline?.mode ?? 'none'}
+          onChange={(e) => {
+            const mode = e.target.value;
+            if (mode === 'none') {
+              update(emitter.id, { spline: undefined });
+            } else {
+              const pts = emitter.spline?.control_points?.length
+                ? emitter.spline.control_points
+                : [[0, 0, 0], [0, 5, 0]] as [number, number, number][];
+              update(emitter.id, {
+                spline: {
+                  ...emitter.spline,
+                  mode: mode as 'emitter_path' | 'particle_path',
+                  control_points: pts,
+                },
+              });
+            }
+          }}
+        >
+          <option value="none">None</option>
+          <option value="emitter_path">Emitter Path</option>
+          <option value="particle_path">Particle Path</option>
+        </select>
+      </div>
+
+      {emitter.spline && (
+        <>
+          {emitter.spline.control_points.map((pt, i) => (
+            <div key={i} style={{ ...styles.section, display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span style={{ fontSize: 10, color: '#666', minWidth: 20 }}>P{i}</span>
+              <Vec3Input value={pt} step={0.5}
+                onChange={(v) => {
+                  const pts = [...emitter.spline!.control_points];
+                  pts[i] = v;
+                  update(emitter.id, {
+                    spline: { ...emitter.spline!, control_points: pts },
+                  });
+                }} />
+              <button
+                onClick={() => {
+                  if (emitter.spline!.control_points.length <= 2) return;
+                  const pts = emitter.spline!.control_points.filter((_, idx) => idx !== i);
+                  update(emitter.id, {
+                    spline: { ...emitter.spline!, control_points: pts },
+                  });
+                }}
+                disabled={emitter.spline!.control_points.length <= 2}
+                style={{
+                  background: 'transparent', border: 'none', color: '#666',
+                  cursor: emitter.spline!.control_points.length <= 2 ? 'not-allowed' : 'pointer',
+                  fontSize: 14, padding: '0 4px',
+                  opacity: emitter.spline!.control_points.length <= 2 ? 0.3 : 0.7,
+                }}
+              >
+                x
+              </button>
+            </div>
+          ))}
+          <button
+            onClick={() => {
+              const pts = emitter.spline!.control_points;
+              const last = pts[pts.length - 1];
+              const prev = pts[pts.length - 2] ?? last;
+              const next: [number, number, number] = [
+                last[0] + (last[0] - prev[0]),
+                last[1] + (last[1] - prev[1]),
+                last[2] + (last[2] - prev[2]),
+              ];
+              update(emitter.id, {
+                spline: { ...emitter.spline!, control_points: [...pts, next] },
+              });
+            }}
+            style={{
+              background: '#1a1a2e', border: '1px solid #333', borderRadius: 3,
+              color: '#999', fontSize: 11, padding: '4px 10px', cursor: 'pointer',
+              margin: '4px 0 4px 12px',
+            }}
+          >
+            + Add Point
+          </button>
+
+          {emitter.spline.mode === 'emitter_path' && (
+            <div style={styles.section}>
+              <span style={styles.label}>Emitter Speed</span>
+              <NumberInput value={emitter.spline.emitter_speed ?? 1} min={0} step={0.1}
+                onChange={(v) => update(emitter.id, {
+                  spline: { ...emitter.spline!, emitter_speed: v },
+                })} style={styles.input} />
+              <span style={{ fontSize: 10, color: '#666' }}>cycles/sec along spline</span>
+            </div>
+          )}
+
+          {emitter.spline.mode === 'particle_path' && (
+            <>
+              <div style={styles.section}>
+                <span style={styles.label}>Path Spread</span>
+                <NumberInput value={emitter.spline.path_spread ?? 0} min={0} step={0.1}
+                  onChange={(v) => update(emitter.id, {
+                    spline: { ...emitter.spline!, path_spread: v },
+                  })} style={styles.input} />
+              </div>
+              <div style={{ ...styles.section, display: 'flex', alignItems: 'center', gap: 6 }}>
+                <input type="checkbox"
+                  checked={emitter.spline.align_to_tangent ?? false}
+                  onChange={(e) => update(emitter.id, {
+                    spline: { ...emitter.spline!, align_to_tangent: e.target.checked },
+                  })} />
+                <span style={{ fontSize: 12, color: '#ccc' }}>Align to tangent</span>
+              </div>
+            </>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -230,6 +230,13 @@ export interface GsParticleEmitterData {
   emission: number;
   spawn_region: { shape: string; center?: [number, number, number]; radius?: number; half_extents?: [number, number, number] };
   burst_duration: number;
+  spline?: {
+    mode: 'emitter_path' | 'particle_path';
+    control_points: [number, number, number][];
+    emitter_speed?: number;
+    path_spread?: number;
+    align_to_tangent?: boolean;
+  };
 }
 
 // ── VFX Instances (Méliès preset placed on map) ──

--- a/tools/apps/bricklayer/src/viewport/GsEmitterMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/GsEmitterMarkers.tsx
@@ -1,7 +1,46 @@
-import React from 'react';
-import { Html } from '@react-three/drei';
+import React, { useMemo } from 'react';
+import { Html, Line } from '@react-three/drei';
 import { useSceneStore } from '../store/useSceneStore.js';
 import type { GsParticleEmitterData } from '../store/types.js';
+import { sampleCatmullRom } from '../lib/catmullRom.js';
+
+function SplineGizmo({ emitter, isSelected }: {
+  emitter: GsParticleEmitterData;
+  isSelected: boolean;
+}) {
+  const spline = emitter.spline;
+  const points = spline?.control_points;
+
+  const curvePoints = useMemo(
+    () => (points && points.length >= 2) ? sampleCatmullRom(points, 64) : null,
+    [points],
+  );
+
+  if (!spline || !curvePoints) return null;
+
+  const color = spline.mode === 'emitter_path' ? '#22c55e' : '#f97316';
+  const opacity = isSelected ? 0.8 : 0.3;
+
+  return (
+    <>
+      {/* Smooth spline curve */}
+      <Line
+        points={curvePoints}
+        color={color}
+        lineWidth={isSelected ? 3 : 1.5}
+        opacity={opacity}
+        transparent
+      />
+      {/* Control point handles */}
+      {spline.control_points.map((pt, i) => (
+        <mesh key={i} position={pt}>
+          <sphereGeometry args={[isSelected ? 0.25 : 0.15, 8, 8]} />
+          <meshBasicMaterial color={color} opacity={opacity} transparent />
+        </mesh>
+      ))}
+    </>
+  );
+}
 
 function EmitterMarker({ emitter, isSelected, onSelect }: {
   emitter: GsParticleEmitterData;
@@ -53,6 +92,8 @@ function EmitterMarker({ emitter, isSelected, onSelect }: {
           />
         </mesh>
       )}
+      {/* Spline path gizmo */}
+      <SplineGizmo emitter={emitter} isSelected={isSelected} />
       {/* Label */}
       {isSelected && (
         <Html position={[0, 1.2, 0]} center>

--- a/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { Html } from '@react-three/drei';
+import React, { useMemo } from 'react';
+import { Html, Line } from '@react-three/drei';
 import { useSceneStore } from '../store/useSceneStore.js';
 import type { VfxInstanceData, VfxElementData } from '../store/types.js';
+import { sampleCatmullRom } from '../lib/catmullRom.js';
 
 // Element type colors
 const ELEMENT_COLORS: Record<string, string> = {
@@ -10,6 +11,26 @@ const ELEMENT_COLORS: Record<string, string> = {
   animation: '#06b6d4',
   light: '#eab308',
 };
+
+function EmitterSplineGizmo({ points, mode }: {
+  points: [number, number, number][];
+  mode: string;
+}) {
+  const curvePoints = useMemo(() => sampleCatmullRom(points, 64), [points]);
+  const color = mode === 'emitter_path' ? '#22c55e' : '#f97316';
+
+  return (
+    <>
+      <Line points={curvePoints} color={color} lineWidth={2} opacity={0.7} transparent />
+      {points.map((pt, i) => (
+        <mesh key={i} position={pt}>
+          <sphereGeometry args={[0.2, 8, 8]} />
+          <meshBasicMaterial color={color} opacity={0.7} transparent />
+        </mesh>
+      ))}
+    </>
+  );
+}
 
 function ElementGizmo({ element }: { element: VfxElementData }) {
   const pos = element.position ?? [0, 0, 0];
@@ -24,23 +45,30 @@ function ElementGizmo({ element }: { element: VfxElementData }) {
       </mesh>
       {/* Type-specific gizmo */}
       {element.type === 'emitter' && (() => {
-        const region = (element.emitter as Record<string, any>)?.region;
-        if (!region) return (
-          <mesh>
-            <sphereGeometry args={[0.5, 8, 8]} />
-            <meshBasicMaterial color={color} transparent opacity={0.15} />
-          </mesh>
-        );
-        const center = region.center ?? [0, 0, 0];
+        const emitterData = element.emitter as Record<string, any> | undefined;
+        const region = emitterData?.region;
+        const spline = emitterData?.spline as { mode?: string; control_points?: [number, number, number][] } | undefined;
         return (
-          <mesh position={center}>
-            {region.shape === 'sphere' ? (
-              <sphereGeometry args={[region.radius ?? 1, 16, 12]} />
+          <>
+            {region ? (
+              <mesh position={region.center ?? [0, 0, 0]}>
+                {region.shape === 'sphere' ? (
+                  <sphereGeometry args={[region.radius ?? 1, 16, 12]} />
+                ) : (
+                  <boxGeometry args={((region.half_extents ?? [1, 1, 1]) as [number, number, number]).map((v: number) => v * 2) as [number, number, number]} />
+                )}
+                <meshBasicMaterial color={color} wireframe transparent opacity={0.2} />
+              </mesh>
             ) : (
-              <boxGeometry args={((region.half_extents ?? [1, 1, 1]) as [number, number, number]).map((v: number) => v * 2) as [number, number, number]} />
+              <mesh>
+                <sphereGeometry args={[0.5, 8, 8]} />
+                <meshBasicMaterial color={color} transparent opacity={0.15} />
+              </mesh>
             )}
-            <meshBasicMaterial color={color} wireframe transparent opacity={0.2} />
-          </mesh>
+            {spline?.control_points && spline.control_points.length >= 2 && (
+              <EmitterSplineGizmo points={spline.control_points} mode={spline.mode ?? 'emitter_path'} />
+            )}
+          </>
         );
       })()}
       {element.type === 'animation' && (


### PR DESCRIPTION
## Summary
- Bricklayer's GS Emitter tab now has a **Spline Path** section with mode dropdown, control point editor, and per-mode parameters
- Scene JSON export includes spline data when configured
- `scene.schema.json` updated with spline definition on `particle_emitter`

## Changes
| File | Change |
|------|--------|
| `schemas/scene.schema.json` | Add `spline` to `particle_emitter` definition |
| `tools/apps/bricklayer/src/store/types.ts` | Add `spline?` to `GsParticleEmitterData` |
| `tools/apps/bricklayer/src/lib/sceneExport.ts` | Export spline if present |
| `tools/apps/bricklayer/src/panels/GsEmittersTab.tsx` | Spline editor UI (mode, points, speed/spread/tangent) |

## Test plan
- [x] Bricklayer type-check passes
- [x] 92 standalone emitter tests pass
- [ ] Open Bricklayer, add emitter, set Spline Mode to "Emitter Path" → control points appear
- [ ] Add/remove points, adjust speed → updates in real-time
- [ ] Switch to "Particle Path" → spread + align-to-tangent fields appear
- [ ] Auto-sync to Staging → spline emitter renders correctly
- [ ] Set mode back to "None" → spline removed from export

🤖 Generated with [Claude Code](https://claude.com/claude-code)