### PR TITLE
Wire spline config through WASM bindings for particle preview

### DIFF
--- a/tests/test_gs_particle.cpp
+++ b/tests/test_gs_particle.cpp
@@ -413,6 +413,166 @@ int main() {
         std::printf("PASS: gs_animation reform config round-trip\n");
     }
 
+    // ═══════════════════════════════════════════════
+    // 3. Spline-based particle emission
+    // ═══════════════════════════════════════════════
+
+    // 3.1 EmitterPath: emitter position moves along spline
+    {
+        GaussianParticleEmitter emitter;
+        GsEmitterConfig config;
+        config.spawn_rate = 100.0f;
+        config.lifetime_min = 2.0f;
+        config.lifetime_max = 2.0f;
+        config.position = {0.0f, 0.0f, 0.0f};
+        config.velocity_min = {0.0f, 0.0f, 0.0f};
+        config.velocity_max = {0.0f, 0.0f, 0.0f};
+        config.acceleration = {0.0f, 0.0f, 0.0f};
+
+        SplineConfig spline;
+        spline.mode = SplineMode::EmitterPath;
+        spline.emitter_speed = 1.0f;  // 1 cycle/sec
+        spline.path.control_points = {
+            {0.0f, 0.0f, 0.0f},
+            {10.0f, 0.0f, 0.0f},
+            {10.0f, 10.0f, 0.0f},
+        };
+        config.spline = spline;
+        emitter.configure(config);
+        emitter.set_active(true);
+
+        // After 0.5s at 1 cycle/sec, emitter should be midway along spline
+        emitter.update(0.5f);
+
+        std::vector<Gaussian> out;
+        emitter.gather(out);
+        assert(!out.empty());
+
+        // Particles should be near the spline midpoint, not all at origin
+        bool found_offset = false;
+        for (const auto& g : out) {
+            if (g.position.x > 2.0f) { found_offset = true; break; }
+        }
+        assert(found_offset);
+
+        std::printf("PASS: EmitterPath moves emitter along spline\n");
+    }
+
+    // 3.2 ParticlePath: particles follow spline over lifetime
+    {
+        GaussianParticleEmitter emitter;
+        GsEmitterConfig config;
+        config.spawn_rate = 50.0f;
+        config.lifetime_min = 1.0f;
+        config.lifetime_max = 1.0f;
+        config.position = {0.0f, 0.0f, 0.0f};
+        config.velocity_min = {0.0f, 0.0f, 0.0f};
+        config.velocity_max = {0.0f, 0.0f, 0.0f};
+        config.acceleration = {0.0f, 0.0f, 0.0f};
+        config.spawn_region.radius = 0.0f;  // point spawn
+
+        SplineConfig spline;
+        spline.mode = SplineMode::ParticlePath;
+        spline.path.control_points = {
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 10.0f, 0.0f},
+        };
+        config.spline = spline;
+        emitter.configure(config);
+        emitter.set_active(true);
+
+        // Spawn particles, then let them age
+        emitter.update(0.05f);  // spawn some
+        emitter.set_active(false);
+        emitter.update(0.5f);   // age to ~50% of lifetime
+
+        std::vector<Gaussian> out;
+        emitter.gather(out);
+        assert(!out.empty());
+
+        // Particles at ~50% lifetime should be around y=5 (midpoint of spline)
+        for (const auto& g : out) {
+            assert(g.position.y > 2.0f);  // should have moved along spline
+        }
+
+        std::printf("PASS: ParticlePath moves particles along spline\n");
+    }
+
+    // 3.3 ParticlePath with path_spread gives lateral offset
+    {
+        GaussianParticleEmitter emitter;
+        GsEmitterConfig config;
+        config.spawn_rate = 200.0f;
+        config.lifetime_min = 1.0f;
+        config.lifetime_max = 1.0f;
+        config.position = {0.0f, 0.0f, 0.0f};
+        config.velocity_min = {0.0f, 0.0f, 0.0f};
+        config.velocity_max = {0.0f, 0.0f, 0.0f};
+        config.acceleration = {0.0f, 0.0f, 0.0f};
+        config.spawn_region.radius = 0.0f;
+
+        SplineConfig spline;
+        spline.mode = SplineMode::ParticlePath;
+        spline.path_spread = 5.0f;  // significant lateral spread
+        // Use a horizontal spline so tangent cross up-vector is non-zero
+        spline.path.control_points = {
+            {0.0f, 0.0f, 0.0f},
+            {10.0f, 0.0f, 0.0f},
+        };
+        config.spline = spline;
+        emitter.configure(config);
+        emitter.set_active(true);
+
+        emitter.update(0.1f);
+        emitter.set_active(false);
+        emitter.update(0.3f);
+
+        std::vector<Gaussian> out;
+        emitter.gather(out);
+        assert(!out.empty());
+
+        // With spread=5 and horizontal tangent, some particles should have z offset
+        bool found_lateral = false;
+        for (const auto& g : out) {
+            if (std::fabs(g.position.z) > 0.1f) {
+                found_lateral = true;
+                break;
+            }
+        }
+        assert(found_lateral);
+
+        std::printf("PASS: ParticlePath with path_spread gives lateral offset\n");
+    }
+
+    // 3.4 No spline: standard kinematic update (regression check)
+    {
+        GaussianParticleEmitter emitter;
+        GsEmitterConfig config;
+        config.spawn_rate = 50.0f;
+        config.lifetime_min = 2.0f;
+        config.lifetime_max = 2.0f;
+        config.position = {0.0f, 0.0f, 0.0f};
+        config.velocity_min = {0.0f, 5.0f, 0.0f};
+        config.velocity_max = {0.0f, 5.0f, 0.0f};
+        config.acceleration = {0.0f, 0.0f, 0.0f};
+        config.spawn_region.radius = 0.0f;  // point spawn at origin
+        // No spline
+        emitter.configure(config);
+        emitter.set_active(true);
+        emitter.update(0.1f);
+
+        std::vector<Gaussian> out;
+        emitter.gather(out);
+        assert(!out.empty());
+
+        // Particles should have moved in +Y via velocity (no spline override)
+        for (const auto& g : out) {
+            assert(g.position.y > 0.0f);
+        }
+
+        std::printf("PASS: No spline uses standard kinematic update\n");
+    }
+
     std::printf("\nAll GS particle/animator tests passed.\n");
     return 0;
 }

--- a/tools/packages/simulation-wasm/bindings.cpp
+++ b/tools/packages/simulation-wasm/bindings.cpp
@@ -9,6 +9,7 @@
 #include <emscripten/val.h>
 #include "gseurat/engine/gs_particle.hpp"
 #include "gseurat/engine/gs_animator.hpp"
+#include "gseurat/engine/gs_spline.hpp"
 #include <vector>
 
 using namespace emscripten;
@@ -91,6 +92,33 @@ GsEmitterConfig configFromJs(val jsConfig) {
         cfg.spawn_region.shape = GsAnimRegion::Shape::Box;
         cfg.spawn_region.center = (omin + omax) * 0.5f;
         cfg.spawn_region.half_extents = (omax - omin) * 0.5f;
+    }
+    // Spline path configuration
+    if (jsConfig.hasOwnProperty("spline")) {
+        val s = jsConfig["spline"];
+        SplineConfig spline;
+        if (s.hasOwnProperty("mode")) {
+            std::string mode = s["mode"].as<std::string>();
+            if (mode == "emitter_path") spline.mode = SplineMode::EmitterPath;
+            else if (mode == "particle_path") spline.mode = SplineMode::ParticlePath;
+            else spline.mode = SplineMode::None;
+        }
+        if (s.hasOwnProperty("control_points")) {
+            val pts = s["control_points"];
+            int len = pts["length"].as<int>();
+            for (int i = 0; i < len; ++i) {
+                val p = pts[i];
+                spline.path.control_points.push_back({
+                    p[0].as<float>(), p[1].as<float>(), p[2].as<float>()
+                });
+            }
+        }
+        if (s.hasOwnProperty("emitter_speed")) spline.emitter_speed = s["emitter_speed"].as<float>();
+        if (s.hasOwnProperty("path_spread")) spline.path_spread = s["path_spread"].as<float>();
+        if (s.hasOwnProperty("align_to_tangent")) spline.align_to_tangent = s["align_to_tangent"].as<bool>();
+        if (spline.mode != SplineMode::None && spline.path.valid()) {
+            cfg.spline = spline;
+        }
     }
     return cfg;
 }


### PR DESCRIPTION
## Summary
- Parse `spline` property in WASM `configFromJs()` — mode, control_points, emitter_speed, path_spread, align_to_tangent
- Both EmitterPath (emitter moves along curve) and ParticlePath (particles follow curve over lifetime) now work in Méliès and Bricklayer viewport previews
- The C++ simulation already handled spline logic; only the JS→C++ bridge was missing

## Test plan
- [x] 4 new C++ tests: EmitterPath, ParticlePath, path_spread lateral offset, no-spline regression
- [x] All 19 C++ tests pass
- [ ] Rebuild WASM (`cd tools/packages/simulation-wasm && bash build.sh`)
- [ ] Méliès: create emitter with spline path, verify particles follow the curve in preview
- [ ] Bricklayer: place VFX instance with spline emitter, verify live preview shows spline motion

🤖 Generated with [Claude Code](https://claude.com/claude-code)