### PR TITLE
Fix VFX animations tagging wrong buffer

### DIFF
--- a/include/gseurat/engine/gs_vfx.hpp
+++ b/include/gseurat/engine/gs_vfx.hpp
@@ -82,6 +82,9 @@ public:
     /// Reset animation states so they re-tag on next update
     void reset_animations();
 
+    /// Tag animation regions on the static buffer (call after append_objects, before animator update)
+    void tag_animations(std::vector<Gaussian>& static_buffer, GaussianAnimator& animator);
+
 private:
     VfxPreset preset_;
     glm::vec3 position_{0.0f};

--- a/src/engine/gs_vfx.cpp
+++ b/src/engine/gs_vfx.cpp
@@ -227,46 +227,8 @@ void VfxInstance::update(float dt, std::vector<Gaussian>& out_buffer, GaussianAn
         }
     }
 
-    // Activate/deactivate animation elements
-    for (auto& as : anim_states_) {
-        const auto& el = preset_.elements[as.element_index];
-        float el_start = el.start;
-        bool in_window;
-        if (el.loop) {
-            in_window = elapsed_ >= el_start;
-        } else {
-            float el_end = el.duration > 0.0f ? el.start + el.duration : preset_.duration;
-            in_window = elapsed_ >= el_start && elapsed_ < el_end;
-        }
-
-        // For looping animations: re-tag when previous group has expired
-        if (as.activated && el.loop && !animator.has_group(as.group_id)) {
-            as.activated = false;  // allow re-tag
-        }
-
-        if (in_window && !as.activated) {
-            // Tag region on the shared animator
-            auto region = el.region;
-            region.center += position_ + rotate_y(el.position, glm::radians(rotation_y_));
-            auto effect_name = el.animation_config.effect;
-            auto effect = GsAnimEffect::Detach;
-            if (effect_name == "float") effect = GsAnimEffect::Float;
-            else if (effect_name == "orbit") effect = GsAnimEffect::Orbit;
-            else if (effect_name == "dissolve") effect = GsAnimEffect::Dissolve;
-            else if (effect_name == "reform") effect = GsAnimEffect::Reform;
-            else if (effect_name == "pulse") effect = GsAnimEffect::Pulse;
-            else if (effect_name == "vortex") effect = GsAnimEffect::Vortex;
-            else if (effect_name == "wave") effect = GsAnimEffect::Wave;
-            else if (effect_name == "scatter") effect = GsAnimEffect::Scatter;
-
-            // Looping: use element duration so the group expires and re-tags with fresh baselines
-            float lifetime = el.duration > 0.0f ? el.duration : 9999.0f;
-            as.group_id = animator.tag_region(out_buffer, region, effect, lifetime, el.animation_config.params);
-            as.activated = true;
-        } else if (!in_window && as.activated) {
-            as.activated = false;
-        }
-    }
+    // Animation tagging is now handled by tag_animations() on the static buffer.
+    // See renderer.cpp camera_dirty block.
 
     // Activate/deactivate light elements and build active lights list
     active_lights_.clear();
@@ -297,6 +259,48 @@ void VfxInstance::reset_animations() {
     for (auto& as : anim_states_) {
         as.activated = false;
         as.group_id = 0;
+    }
+}
+
+void VfxInstance::tag_animations(std::vector<Gaussian>& static_buffer, GaussianAnimator& animator) {
+    if (finished_) return;
+
+    for (auto& as : anim_states_) {
+        const auto& el = preset_.elements[as.element_index];
+        float el_start = el.start;
+        bool in_window;
+        if (el.loop) {
+            in_window = elapsed_ >= el_start;
+        } else {
+            float el_end = el.duration > 0.0f ? el.start + el.duration : preset_.duration;
+            in_window = elapsed_ >= el_start && elapsed_ < el_end;
+        }
+
+        // For looping animations: re-tag when previous group has expired
+        if (as.activated && el.loop && !animator.has_group(as.group_id)) {
+            as.activated = false;
+        }
+
+        if (in_window && !as.activated) {
+            auto region = el.region;
+            region.center += position_ + rotate_y(el.position, glm::radians(rotation_y_));
+            auto effect_name = el.animation_config.effect;
+            auto effect = GsAnimEffect::Detach;
+            if (effect_name == "float") effect = GsAnimEffect::Float;
+            else if (effect_name == "orbit") effect = GsAnimEffect::Orbit;
+            else if (effect_name == "dissolve") effect = GsAnimEffect::Dissolve;
+            else if (effect_name == "reform") effect = GsAnimEffect::Reform;
+            else if (effect_name == "pulse") effect = GsAnimEffect::Pulse;
+            else if (effect_name == "vortex") effect = GsAnimEffect::Vortex;
+            else if (effect_name == "wave") effect = GsAnimEffect::Wave;
+            else if (effect_name == "scatter") effect = GsAnimEffect::Scatter;
+
+            float lifetime = el.duration > 0.0f ? el.duration : 9999.0f;
+            as.group_id = animator.tag_region(static_buffer, region, effect, lifetime, el.animation_config.params);
+            as.activated = true;
+        } else if (!in_window && as.activated) {
+            as.activated = false;
+        }
     }
 }
 

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -870,9 +870,14 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             // Reset so VFX animations re-tag on the new buffer.
             gs_animator_.reset();
 
-            // Reset VFX animation states so they re-tag
+            // Reset VFX animation states so they re-tag on the fresh static buffer
             for (auto& inst : vfx_instances_) {
                 inst.reset_animations();
+            }
+
+            // Tag VFX animations on the static buffer (where object PLYs live)
+            for (auto& inst : vfx_instances_) {
+                inst.tag_animations(gs_static_buffer_, gs_animator_);
             }
 
             // Phase-based state machine for scene animations


### PR DESCRIPTION
## Summary
- VFX animation `tag_region` was called with `gs_dynamic_buffer_` but torch object Gaussians live in `gs_static_buffer_` → tag found nothing → no animation
- Extract animation tagging into `tag_animations()` method, called on `gs_static_buffer_` inside camera_dirty block

## Test plan
- [x] Open Bricklayer, load scene with torch VFX instance
- [x] Preview in Staging — wave, float, reform animations should play
- [x] Verify island demo animations still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)