### PR TITLE
Echidna: Store improvements (debug exposure, batch API)

### DIFF
--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -122,6 +122,7 @@ export interface CharacterStoreState {
   pushUndo: () => void;
   placeVoxel: (x: number, y: number, z: number) => void;
   placeVoxels: (positions: [number, number, number][]) => void;
+  batchPlaceVoxels: (voxels: Array<{ x: number; y: number; z: number; color?: [number, number, number, number] }>) => void;
   paintVoxel: (x: number, y: number, z: number) => void;
   eraseVoxel: (x: number, y: number, z: number) => void;
   eraseVoxels: (positions: [number, number, number][]) => void;
@@ -277,6 +278,17 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       if (m) next.set(voxelKey(m[0], m[1], m[2]), { color: [...activeColor] });
     }
     set({ voxels: next });
+  },
+
+  /** Batch-place voxels in a single state update. Programmatic API — does not apply mirror axis. */
+  batchPlaceVoxels: (batch) => {
+    const { voxels, activeColor } = get();
+    const newVoxels = new Map(voxels);
+    for (const { x, y, z, color } of batch) {
+      const key = voxelKey(x, y, z);
+      newVoxels.set(key, { color: color ? [...color] : [...activeColor] });
+    }
+    set({ voxels: newVoxels });
   },
 
   paintVoxel: (x, y, z) => {
@@ -586,3 +598,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     });
   },
 }));
+
+if (import.meta.env.DEV) {
+  (window as any).__debugStore = useCharacterStore;
+}


### PR DESCRIPTION
## Summary
- **#119**: Expose Zustand store as `window.__debugStore` in dev mode for debugging and automation
- **#120**: Verified all voxel mutation actions already create new Map references — no re-render bug found
- **#121**: Added `batchPlaceVoxels(voxels)` action for efficient bulk voxel placement in a single state update

## Details
- `batchPlaceVoxels` is a programmatic API that does NOT apply mirror axis (documented in JSDoc)
- Color arrays are defensively copied to prevent reference sharing
- Debug store exposure is guarded by `import.meta.env.DEV` (tree-shaken in production)

## Test plan
- [ ] Open Echidna in dev mode, verify `window.__debugStore` is accessible
- [ ] Call `__debugStore.getState().batchPlaceVoxels([{x:16,y:0,z:16}])` and verify voxels appear
- [ ] Verify production build does not expose `__debugStore`

Closes #119, closes #121. Relates to #120 (not a bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)