### PR TITLE
Fix control server: support multiple concurrent clients

### DIFF
--- a/include/gseurat/engine/control_server.hpp
+++ b/include/gseurat/engine/control_server.hpp
@@ -13,14 +13,17 @@ public:
 
     bool start(const std::string& socket_path = "/tmp/gseurat.sock");
     void stop();
-    bool has_client() const { return client_fd_ >= 0; }
+    bool has_client() const { return !clients_.empty(); }
 
     // Called each frame — non-blocking accept + read.
     // Returns parsed JSON command objects (empty if none).
     std::vector<nlohmann::json> poll();
 
-    // Send JSON line to connected client.
+    // Send JSON line to the client that sent the most recent command.
     void send(const nlohmann::json& msg);
+
+    // Broadcast JSON line to all connected clients.
+    void broadcast(const nlohmann::json& msg);
 
     // Event subscription filtering
     void subscribe_events(const std::vector<std::string>& events);
@@ -28,14 +31,20 @@ public:
     bool is_event_subscribed(const std::string& event) const;
 
 private:
+    struct Client {
+        int fd = -1;
+        std::string read_buffer;
+    };
+
     int server_fd_ = -1;
-    int client_fd_ = -1;
     std::string socket_path_;
-    std::string read_buffer_;
-    std::set<std::string> subscribed_events_;  // empty = all events pass through
+    std::vector<Client> clients_;
+    int reply_fd_ = -1;  // fd of client whose command is being processed
+    std::set<std::string> subscribed_events_;
 
     void try_accept();
-    void disconnect_client();
+    void disconnect_client(size_t index);
+    void send_to(int fd, const nlohmann::json& msg);
 };
 
 }  // namespace gseurat

--- a/src/engine/control_server.cpp
+++ b/src/engine/control_server.cpp
@@ -41,7 +41,7 @@ bool ControlServer::start(const std::string& socket_path) {
         return false;
     }
 
-    if (::listen(server_fd_, 1) < 0) {
+    if (::listen(server_fd_, 8) < 0) {
         std::fprintf(stderr, "ControlServer: listen() failed: %s\n", std::strerror(errno));
         ::close(server_fd_);
         server_fd_ = -1;
@@ -54,7 +54,9 @@ bool ControlServer::start(const std::string& socket_path) {
 }
 
 void ControlServer::stop() {
-    disconnect_client();
+    for (size_t i = clients_.size(); i > 0; --i) {
+        disconnect_client(i - 1);
+    }
     if (server_fd_ >= 0) {
         ::close(server_fd_);
         server_fd_ = -1;
@@ -66,68 +68,81 @@ void ControlServer::stop() {
 }
 
 void ControlServer::try_accept() {
-    if (server_fd_ < 0 || client_fd_ >= 0) return;
+    if (server_fd_ < 0) return;
 
-    int fd = ::accept(server_fd_, nullptr, nullptr);
-    if (fd < 0) return;  // EAGAIN/EWOULDBLOCK — no pending connection
+    // Accept all pending connections
+    while (true) {
+        int fd = ::accept(server_fd_, nullptr, nullptr);
+        if (fd < 0) break;  // EAGAIN/EWOULDBLOCK — no more pending
 
-    // Set client non-blocking
-    int flags = ::fcntl(fd, F_GETFL, 0);
-    ::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+        // Set client non-blocking
+        int flags = ::fcntl(fd, F_GETFL, 0);
+        ::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
 
-    client_fd_ = fd;
-    read_buffer_.clear();
-    std::fprintf(stderr, "ControlServer: client connected\n");
+        clients_.push_back(Client{fd, {}});
+        std::fprintf(stderr, "ControlServer: client connected (fd=%d, total=%zu)\n",
+                     fd, clients_.size());
+    }
 }
 
-void ControlServer::disconnect_client() {
-    if (client_fd_ >= 0) {
-        ::close(client_fd_);
-        client_fd_ = -1;
-        read_buffer_.clear();
-        std::fprintf(stderr, "ControlServer: client disconnected\n");
+void ControlServer::disconnect_client(size_t index) {
+    if (index >= clients_.size()) return;
+    int fd = clients_[index].fd;
+    if (fd >= 0) {
+        ::close(fd);
+        std::fprintf(stderr, "ControlServer: client disconnected (fd=%d)\n", fd);
     }
+    clients_.erase(clients_.begin() + static_cast<ptrdiff_t>(index));
 }
 
 std::vector<nlohmann::json> ControlServer::poll() {
     std::vector<nlohmann::json> commands;
 
-    // Try accepting a new client if none connected
+    // Accept new clients
     try_accept();
 
-    if (client_fd_ < 0) return commands;
+    // Read from all clients
+    for (size_t i = 0; i < clients_.size(); ) {
+        auto& client = clients_[i];
+        bool dead = false;
 
-    // Non-blocking read
-    char buf[4096];
-    while (true) {
-        ssize_t n = ::recv(client_fd_, buf, sizeof(buf), 0);
-        if (n > 0) {
-            read_buffer_.append(buf, static_cast<size_t>(n));
-        } else if (n == 0) {
-            // Client closed connection
-            disconnect_client();
-            return commands;
-        } else {
-            if (errno == EAGAIN || errno == EWOULDBLOCK) break;
-            // Real error
-            disconnect_client();
-            return commands;
+        char buf[4096];
+        while (true) {
+            ssize_t n = ::recv(client.fd, buf, sizeof(buf), 0);
+            if (n > 0) {
+                client.read_buffer.append(buf, static_cast<size_t>(n));
+            } else if (n == 0) {
+                dead = true;
+                break;
+            } else {
+                if (errno == EAGAIN || errno == EWOULDBLOCK) break;
+                dead = true;
+                break;
+            }
         }
-    }
 
-    // Parse complete lines
-    size_t pos;
-    while ((pos = read_buffer_.find('\n')) != std::string::npos) {
-        std::string line = read_buffer_.substr(0, pos);
-        read_buffer_.erase(0, pos + 1);
+        // Parse complete lines
+        size_t pos;
+        while ((pos = client.read_buffer.find('\n')) != std::string::npos) {
+            std::string line = client.read_buffer.substr(0, pos);
+            client.read_buffer.erase(0, pos + 1);
 
-        if (line.empty()) continue;
+            if (line.empty()) continue;
 
-        try {
-            commands.push_back(nlohmann::json::parse(line));
-        } catch (const nlohmann::json::parse_error&) {
-            // Send error for malformed JSON
-            send({{"type", "error"}, {"message", "invalid JSON"}});
+            try {
+                auto cmd = nlohmann::json::parse(line);
+                reply_fd_ = client.fd;  // track who sent this command
+                commands.push_back(std::move(cmd));
+            } catch (const nlohmann::json::parse_error&) {
+                send_to(client.fd, {{"type", "error"}, {"message", "invalid JSON"}});
+            }
+        }
+
+        if (dead) {
+            disconnect_client(i);
+            // Don't increment — erase shifted elements
+        } else {
+            ++i;
         }
     }
 
@@ -135,17 +150,35 @@ std::vector<nlohmann::json> ControlServer::poll() {
 }
 
 void ControlServer::send(const nlohmann::json& msg) {
-    if (client_fd_ < 0) return;
+    send_to(reply_fd_, msg);
+}
+
+void ControlServer::broadcast(const nlohmann::json& msg) {
+    for (size_t i = 0; i < clients_.size(); ) {
+        send_to(clients_[i].fd, msg);
+        // send_to doesn't remove clients, so always increment
+        ++i;
+    }
+}
+
+void ControlServer::send_to(int fd, const nlohmann::json& msg) {
+    if (fd < 0) return;
 
     std::string line = msg.dump() + "\n";
     const char* data = line.data();
     size_t remaining = line.size();
 
     while (remaining > 0) {
-        ssize_t n = ::write(client_fd_, data, remaining);
+        ssize_t n = ::write(fd, data, remaining);
         if (n < 0) {
             if (errno == EPIPE || errno == ECONNRESET) {
-                disconnect_client();
+                // Find and disconnect this client
+                for (size_t i = 0; i < clients_.size(); ++i) {
+                    if (clients_[i].fd == fd) {
+                        disconnect_client(i);
+                        break;
+                    }
+                }
             }
             return;
         }
@@ -166,7 +199,7 @@ void ControlServer::unsubscribe_all() {
 }
 
 bool ControlServer::is_event_subscribed(const std::string& event) const {
-    if (subscribed_events_.empty()) return true;  // empty = all pass
+    if (subscribed_events_.empty()) return true;
     return subscribed_events_.count(event) > 0;
 }
 


### PR DESCRIPTION
## Summary
- **Root cause**: Bridge server holds a persistent connection to `/tmp/gseurat.sock`. The control server only supported one client (listen backlog=1, single `client_fd_`), so all `game_director.py` connections got `ECONNREFUSED`.
- Replace single `client_fd_` with a vector of `Client` structs
- Accept multiple connections (backlog=8), read from all clients each frame
- Route responses back to the client that sent each command via `reply_fd_`
- Add `broadcast()` for future event distribution

## Test plan
- [ ] Build passes (debug + release)
- [ ] Launch demo with bridge running, verify game_director.py connects
- [ ] Multiple game_director.py commands work while bridge is connected
- [ ] Existing tests pass (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)