### PR TITLE
Polish: wire Export Dialog into menu, fix voxel count

### DIFF
--- a/tools/apps/echidna/src/panels/ExportDialog.tsx
+++ b/tools/apps/echidna/src/panels/ExportDialog.tsx
@@ -60,7 +60,8 @@ export function ExportDialog({ onClose }: { onClose: () => void }) {
   const [density, setDensity] = useState(1);
 
   const characterName = useCharacterStore((s) => s.characterName);
-  const voxelCount = useCharacterStore((s) => s.voxels.size);
+  const voxels = useCharacterStore((s) => s.voxels);
+  const voxelCount = voxels.size;
   const estimatedGaussians = voxelCount * density * density * density;
   const baseName = characterName.replace(/\s+/g, '_').toLowerCase() || 'character';
   const filename = format === 'ply_manifest' ? `${baseName}.ply` : `${baseName}_posed.ply`;

--- a/tools/apps/echidna/src/panels/MenuBar.tsx
+++ b/tools/apps/echidna/src/panels/MenuBar.tsx
@@ -7,6 +7,7 @@ import { sendBridgeCommand } from '@gseurat/engine-client';
 import type { EchidnaFile } from '../store/types.js';
 import { NewProjectDialog } from './NewProjectDialog.js';
 import { ResizeGridDialog } from './ResizeGridDialog.js';
+import { ExportDialog } from './ExportDialog.js';
 
 const BRIDGE_REST_URL = 'http://localhost:9101';
 
@@ -188,6 +189,7 @@ export function MenuBar() {
   const [toast, setToast] = useState<ToastState>(null);
   const [showNewDialog, setShowNewDialog] = useState(false);
   const [showResizeDialog, setShowResizeDialog] = useState(false);
+  const [showExportDialog, setShowExportDialog] = useState(false);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const showGrid = useCharacterStore((s) => s.showGrid);
@@ -343,6 +345,7 @@ export function MenuBar() {
     { label: 'Load...', shortcut: '\u2318O', action: handleLoad },
     { separator: true as const },
     { label: 'Import .vox...', action: handleImportVox },
+    { label: 'Export...', action: () => setShowExportDialog(true) },
     { label: 'Export PLY...', action: handleExportPly },
     { label: 'Export Manifest...', action: handleExportManifest },
     { separator: true as const },
@@ -405,6 +408,7 @@ export function MenuBar() {
 
       {showNewDialog && <NewProjectDialog onClose={() => setShowNewDialog(false)} />}
       {showResizeDialog && <ResizeGridDialog onClose={() => setShowResizeDialog(false)} />}
+      {showExportDialog && <ExportDialog onClose={() => setShowExportDialog(false)} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- The ExportDialog (with density dropdown) existed but was unreachable from the UI — add "Export..." to File menu
- Fix voxelCount selector in ExportDialog to subscribe to the full `voxels` Map instead of derived `.size` for reliable Zustand reactivity

## Test plan
- [ ] File > Export... opens dialog with density dropdown and correct Gaussian count
- [ ] All 10 echidna tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)