### PR TITLE
Demo polish v2: hybrid background, bone animation fix, NPC slimes

### DIFF
--- a/docs/superpowers/specs/2026-04-04-bone-transform-coordinate-fix-design.md
+++ b/docs/superpowers/specs/2026-04-04-bone-transform-coordinate-fix-design.md
@@ -1,0 +1,69 @@
+# Bone Transform Coordinate Space Fix
+
+**Date:** 2026-04-04
+**Status:** Approved
+
+## Problem
+
+PC bone animations cause body parts (cape, arms, legs) to fly over the head or disappear below ground. Root cause: bone pivot rotations are computed in model space but applied to Gaussians stored in world space.
+
+An 8-degree X-axis rotation around a model-space pivot causes the world-space Z coordinate (~197) to bleed into Y, producing ~27 units of vertical displacement on a character only ~5 units tall.
+
+## Solution: Approach A — Fix Bone Transform Composition
+
+Wrap the animation transform with proper world-to-model and model-to-world coordinate conversions in `update_walk_animation()`.
+
+### Transform Chain
+
+Replace:
+```cpp
+bones[i + 1] = root_xform * anim_bones[i];
+```
+
+With:
+```cpp
+bones[i + 1] = to_world * anim_bones[i] * from_world;
+```
+
+Where:
+- `from_world` = `Ry(-pi) * S_inv * T(-(spawn + y_offset))` — converts world position back to model space by undoing the spawning transform
+- `to_world` = `T(origin + y_offset) * Ry(facing) * S * Ry(pi)` — converts model space to current world position with facing rotation
+- `S` = `diag(kCharScale, kCharScale * gs_scale, kCharScale)` — the non-uniform scale applied during character spawning
+- `y_offset` = `(0, 2, 0)` — the constant vertical offset added during spawning
+
+### Mathematical Verification
+
+For a left-arm Gaussian at world pos `(187.6, 5.35, 197)` with joint pivot at `(-1.35, 0.45, 0)` and 8-degree X rotation:
+
+**Before fix (current bug):**
+- Rotation applied in world space: `Y' = 5*cos(8) - 197*sin(8) = -22.5` (27-unit displacement)
+
+**After fix:**
+- `from_world` converts to model space: `(-1.33, 3.0, 0)` (near pivot)
+- Rotation applied in model space: `Y' = 2.55*cos(8) = 2.525` (0.025-unit displacement)
+- `to_world` converts back to world space with correct small offset
+
+### State Storage
+
+Add `gs_scale_` (float) as a member variable of `IslandDemoState`, initialized from `scene_data.gaussian_splat->scale_multiplier` during `init_scene()`.
+
+All other required values (`character_spawn_pos_`, `character_origin_`, `facing_angle_`, `kCharScale`) are already stored.
+
+### Scope
+
+- **Changed:** `update_walk_animation()` in `island_demo_state.cpp` (transform composition)
+- **Changed:** `IslandDemoState` class — add `gs_scale_` member
+- **Unchanged:** `bone_animation_player.cpp` — FK chain stays the same
+- **Unchanged:** `character_manifest.cpp` — manifest loading stays the same
+- **Unchanged:** `gs_preprocess.comp` — GPU shader stays the same
+- **Unchanged:** `snes_hero.manifest.json` — animation data stays the same
+- **Unchanged:** Terrain bone (index 0) and NPC bones — not affected
+
+### Testing
+
+1. Build and launch demo
+2. Walk the PC in all directions — verify limbs stay attached to body
+3. Verify idle breathing animation looks natural
+4. Verify walk-to-idle and idle-to-walk transitions
+5. Verify NPC slimes still animate correctly
+6. Verify terrain sway still works

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -110,6 +110,7 @@ private:
     static constexpr float kPlayerAccel = 20.0f;
     static constexpr float kCameraSmoothing = 8.0f;
     static constexpr float kCameraYOffset = 2.5f;  // above character head for TPS
+    static constexpr float kCharScale = 0.45f;     // character model scale (shared with spawn + animation)
 };
 
 }  // namespace gseurat

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -49,6 +49,7 @@ private:
     uint32_t debug_frame_ = 0;
     glm::vec3 character_spawn_pos_{0.0f};  // where Gaussians were placed
     glm::vec3 character_origin_{0.0f};     // current player position
+    float gs_scale_ = 1.0f;               // scene scale_multiplier (for bone coord conversion)
     std::vector<Gaussian> map_gaussians_;  // original map data before character merge
 
     // NPC tracking (for bone animation)

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -717,16 +717,6 @@ void IslandDemoState::update_effects(AppBase& app, float dt) {
 void IslandDemoState::update_walk_animation(AppBase& app, float dt) {
     if (!character_spawned_) return;
 
-    // Root transform: translate + rotate to match camera
-    glm::vec3 root_offset = character_origin_ - character_spawn_pos_;
-    glm::mat4 root_translate = glm::translate(glm::mat4(1.0f), root_offset);
-    glm::vec3 spawn = character_spawn_pos_;
-    glm::mat4 root_rotate =
-        glm::translate(glm::mat4(1.0f), spawn) *
-        glm::rotate(glm::mat4(1.0f), facing_angle_, {0, 1, 0}) *
-        glm::translate(glm::mat4(1.0f), -spawn);
-    glm::mat4 root_xform = root_translate * root_rotate;
-
     // Terrain sway (bone 0 — map Gaussians)
     env_anim_time_ += dt;
     float terrain_sway_y = std::sin(env_anim_time_ * 1.0f) * 0.05f;
@@ -739,12 +729,38 @@ void IslandDemoState::update_walk_animation(AppBase& app, float dt) {
         anim_sm_->set_state(speed > 0.1f ? "walk" : "idle");
         anim_player_->update(dt);
 
+        // Build world↔model coordinate conversion matrices.
+        // During spawning, character Gaussians were placed at:
+        //   world = spawn + Ry(pi) * model * S + (0, 2, 0)
+        // where S = diag(kCharScale, kCharScale * gs_scale, kCharScale).
+        // The animation FK chain computes pivot rotations in model space,
+        // so we must convert: world → model → animate → world.
+        constexpr float kCharScale = 0.45f;
+        const glm::vec3 y_off(0.0f, 2.0f, 0.0f);
+        const glm::vec3 scale_vec(kCharScale, kCharScale * gs_scale_, kCharScale);
+        const glm::vec3 inv_scale(1.0f / scale_vec.x, 1.0f / scale_vec.y, 1.0f / scale_vec.z);
+
+        // from_world: undo spawn transform (world pos → model pos)
+        //   = Ry(-pi) * S^-1 * T(-(spawn + y_off))
+        glm::mat4 from_world =
+            glm::rotate(glm::mat4(1.0f), -glm::pi<float>(), {0, 1, 0}) *
+            glm::scale(glm::mat4(1.0f), inv_scale) *
+            glm::translate(glm::mat4(1.0f), -(character_spawn_pos_ + y_off));
+
+        // to_world: apply current transform (model pos → current world pos)
+        //   = T(origin + y_off) * Ry(facing) * S * Ry(pi)
+        glm::mat4 to_world =
+            glm::translate(glm::mat4(1.0f), character_origin_ + y_off) *
+            glm::rotate(glm::mat4(1.0f), facing_angle_, {0, 1, 0}) *
+            glm::scale(glm::mat4(1.0f), scale_vec) *
+            glm::rotate(glm::mat4(1.0f), glm::pi<float>(), {0, 1, 0});
+
         glm::mat4 bones[32];
         bones[0] = terrain_bone;
         const auto& anim_bones = anim_player_->bone_transforms();
         int bone_count = static_cast<int>(character_data_->bones.size());
         for (int i = 0; i < bone_count && i < 31; ++i) {
-            bones[i + 1] = root_xform * anim_bones[i];
+            bones[i + 1] = to_world * anim_bones[i] * from_world;
         }
 
         // NPC bone transforms — translate from spawn to current position
@@ -760,6 +776,16 @@ void IslandDemoState::update_walk_animation(AppBase& app, float dt) {
         if (total_bones < bone_count + 1) total_bones = bone_count + 1;
         app.renderer().gs_renderer().upload_bone_transforms(bones, total_bones);
     } else {
+        // Fallback: no animation data, just translate character to current position
+        glm::vec3 root_offset = character_origin_ - character_spawn_pos_;
+        glm::mat4 root_translate = glm::translate(glm::mat4(1.0f), root_offset);
+        glm::vec3 spawn = character_spawn_pos_;
+        glm::mat4 root_rotate =
+            glm::translate(glm::mat4(1.0f), spawn) *
+            glm::rotate(glm::mat4(1.0f), facing_angle_, {0, 1, 0}) *
+            glm::translate(glm::mat4(1.0f), -spawn);
+        glm::mat4 root_xform = root_translate * root_rotate;
+
         glm::mat4 bones[2];
         bones[0] = terrain_bone;
         bones[1] = root_xform;

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -165,6 +165,7 @@ void IslandDemoState::on_enter(AppBase& app) {
         constexpr float kCharScale = 0.45f;  // smaller to match prop proportions
         const float gs_scale = scene_data.gaussian_splat
             ? scene_data.gaussian_splat->scale_multiplier : 1.0f;
+        gs_scale_ = gs_scale;
         auto char_cloud = GaussianCloud::load_ply("assets/characters/snes_hero/snes_hero.ply");
         if (!char_cloud.empty()) {
             // Scale, rotate 180° (face away from camera), and position at spawn

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -162,7 +162,7 @@ void IslandDemoState::on_enter(AppBase& app) {
         uint32_t map_count = static_cast<uint32_t>(merged.size());
 
         // Load mesh-converted character model
-        constexpr float kCharScale = 0.45f;  // smaller to match prop proportions
+        // kCharScale defined as static constexpr on the class
         const float gs_scale = scene_data.gaussian_splat
             ? scene_data.gaussian_splat->scale_multiplier : 1.0f;
         gs_scale_ = gs_scale;
@@ -733,9 +733,9 @@ void IslandDemoState::update_walk_animation(AppBase& app, float dt) {
         // During spawning, character Gaussians were placed at:
         //   world = spawn + Ry(pi) * model * S + (0, 2, 0)
         // where S = diag(kCharScale, kCharScale * gs_scale, kCharScale).
+        // (Y scale is applied in two steps in the spawn loop: uniform * gs_scale.)
         // The animation FK chain computes pivot rotations in model space,
         // so we must convert: world → model → animate → world.
-        constexpr float kCharScale = 0.45f;
         const glm::vec3 y_off(0.0f, 2.0f, 0.0f);
         const glm::vec3 scale_vec(kCharScale, kCharScale * gs_scale_, kCharScale);
         const glm::vec3 inv_scale(1.0f / scale_vec.x, 1.0f / scale_vec.y, 1.0f / scale_vec.z);


### PR DESCRIPTION
## Summary

- **Hybrid background**: ground/sky color compositing in GS post-process shader, exposed via scene JSON and control server
- **Bone animation fix**: fixed coordinate space mismatch where model-space pivot rotations were applied to world-space Gaussians, causing arms/cape/legs to fly ±27 units from the character body
- **NPC slimes**: 3 patrolling slime NPCs with per-NPC bone animation and patrol AI
- **Voxel house**: rebuilt with proper centering and collision, chimney smoke VFX
- **Interactive triggers**: per-crystal GS animations, VFX instances, spline fountain
- **Visual tuning**: reduced Gaussian scale for sharper terrain, rebalanced prop scales

## Test plan

- [ ] Build and launch demo (`cmake --build --preset macos-release`)
- [ ] Walk PC in all directions — verify limbs stay attached (bone fix)
- [ ] Verify idle breathing animation is subtle and natural
- [ ] Check NPC slimes patrol near the house
- [ ] Walk to crystals — verify proximity triggers fire GS animations
- [ ] Verify hybrid background colors (ground/sky) render correctly
- [ ] Check chimney smoke VFX on the house

🤖 Generated with [Claude Code](https://claude.com/claude-code)