### PR TITLE
Spread firefly emitters across the island

### DIFF
--- a/assets/scenes/seurat_island.json
+++ b/assets/scenes/seurat_island.json
@@ -75251,7 +75251,7 @@
     {
       "preset": "fireflies",
       "position": [
-        191.0,
+        185.0,
         4.166,
         185.0
       ]
@@ -75259,41 +75259,57 @@
     {
       "preset": "fireflies",
       "position": [
-        201.0,
-        5.3637,
-        171.0
+        215.0,
+        5.364,
+        155.0
       ]
     },
     {
       "preset": "fireflies",
       "position": [
-        171.0,
+        155.0,
         3.167,
-        201.0
+        215.0
       ]
     },
     {
       "preset": "fireflies",
       "position": [
-        221.0,
-        3.6725,
-        181.0
+        235.0,
+        3.673,
+        190.0
       ]
     },
     {
       "preset": "fireflies",
       "position": [
-        161.0,
+        140.0,
         3.039,
-        161.0
+        145.0
       ]
     },
     {
       "preset": "fireflies",
       "position": [
-        241.0,
-        2.3383,
-        211.0
+        245.0,
+        2.338,
+        225.0
+      ]
+    },
+    {
+      "preset": "fireflies",
+      "position": [
+        175.0,
+        3.5,
+        120.0
+      ]
+    },
+    {
+      "preset": "fireflies",
+      "position": [
+        170.0,
+        3.2,
+        255.0
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Push 6 existing firefly emitters further from center (~10-20 units outward)
- Add 2 new emitters at the north shore (175, 120) and south shore (170, 255)
- Better island-wide coverage instead of clustering near the house

## Test plan

- [ ] Launch demo and walk around the island perimeter
- [ ] Verify fireflies visible near north and south shores (new emitters)
- [ ] Verify fireflies still present near the center/house area

🤖 Generated with [Claude Code](https://claude.com/claude-code)