### PR TITLE
feat: GPU-driven PBD solver for foliage dynamics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,7 @@ add_gseurat_test(test_vfx_lights_rotation src/engine/gs_vfx.cpp src/engine/gs_pa
                                            src/engine/gs_spline.cpp)
 add_gseurat_test(test_gs_spline src/engine/gs_spline.cpp)
 add_gseurat_test(test_gs_post_process)
+add_gseurat_test(test_pbd_solver)
 add_gseurat_test(test_component_registry src/engine/component_registry.cpp)
 add_gseurat_test(test_system_scheduler  src/engine/system_scheduler.cpp)
 add_gseurat_test(test_island_systems    src/demo/island_systems.cpp)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Vulkan-based 3D Gaussian Splatting engine built with C++23. Named after **3DGS
 ## Features
 
 - **3D Gaussian Splatting** — GPU compute pipeline for rendering `.ply` point clouds with tile-based rasterization, dynamic point light support
+- **GPU PBD solver** — Position Based Dynamics compute shader for foliage sway, with quaternion rotation to preserve Gaussian orientation
 - **Voxel character pipeline** — MagicaVoxel import, rigid-body-part posing, GPU bone skinning in compute shader
 - **Sprite overlay** — Sprite-based entities over GS backgrounds with bloom, depth-of-field, and tone mapping
 - **Game Object System** — Unified entity model with component composition. Developers define C++ component structs + JSON schemas; level designers compose objects in Bricklayer
@@ -137,9 +138,10 @@ All disk I/O and CPU parsing runs on the worker thread. All Vulkan API calls sta
 PLY file → GaussianCloud → GsRenderer (compute) → Storage Image → Fullscreen Blit
 ```
 
-Three compute passes before the main render pass:
+Compute passes before the main render pass:
 
-1. **Preprocess** — project 3D Gaussians to 2D, frustum cull, compute 2D covariance
+0. **PBD Solver** (optional) — GPU-driven Position Based Dynamics for foliage sway, writes position + rotation deltas
+1. **Preprocess** — project 3D Gaussians to 2D, frustum cull, compute 2D covariance (reads PBD + bone transforms)
 2. **Bitonic Sort** — depth-sort projected splats front-to-back
 3. **Tile Rasterizer** — 16x16 tile-based splatting into a 320x240 HDR storage image
 
@@ -186,10 +188,14 @@ Engine: PLY load → bone_index per Gaussian → preprocess shader → skeletal 
 
 **Runtime** (Engine):
 - `bone_index` packed into `GpuGaussian.scale_pad.w` (no SSBO size change)
+- Index segmentation: 0 = no transform, 1-31 = bone skinning (binding 5), 32-63 = PBD dynamics (binding 6)
 - Bone transform SSBO at binding 5 (max 32 bones)
-- Preprocess shader applies `mat4` per bone: transforms position + rotates Gaussian orientation
+- PBD state SSBO at binding 6 (max 32 elements) — position anchors + rotation quaternions
+- Preprocess shader applies `mat4` per bone or PBD quaternion rotation per element
 - Bone 0 = identity (map Gaussians pass through untouched)
 - Rigid body part animation (action-figure style, no smooth skinning)
+
+See [docs/pbd-solver.md](docs/pbd-solver.md) for full PBD architecture and API reference.
 
 ### Scene Composition (Game Objects)
 
@@ -337,7 +343,7 @@ cd tools/apps/level-designer && pnpm dev
 
 ### C++ Engine Tests
 
-All 21 test suites are CMake targets, run via `ctest`:
+All 22 test suites are CMake targets, run via `ctest`:
 
 ```bash
 cmake --preset <platform>-debug
@@ -357,6 +363,7 @@ ctest --test-dir build/<platform>-debug --output-on-failure
 | `test_gs_parallax_camera` | 6 | Camera configuration, Y-flip, smoothing convergence |
 | `test_screenshot` | 5 | State machine, BGRA→RGBA swizzle |
 | `test_character_data` | 12 | Character animation JSON loading |
+| `test_pbd_solver` | 7 | PBD struct layout, index segmentation, quaternion math, wind sway |
 
 ### TypeScript Tool Tests
 

--- a/docs/pbd-solver.md
+++ b/docs/pbd-solver.md
@@ -1,0 +1,186 @@
+# PBD Solver — GPU-Driven Position Based Dynamics
+
+## Overview
+
+The PBD solver adds a GPU-driven physics simulation pipeline for Gaussian Splatting objects that need dynamic motion — swaying trees, rustling foliage, flapping banners, etc. It runs as a compute shader dispatched **before** the GS preprocess pass, writing per-element position and rotation deltas that the preprocess shader consumes.
+
+## The Rotation Trap
+
+In 3DGS, each Gaussian has a position and a rotation quaternion that defines its orientation. Naive physics simulation that only updates position causes Gaussians to translate while keeping their original orientation, visually tearing apart structured objects like branches and leaves.
+
+The PBD solver avoids this by providing **both position anchors and rotation quaternions**. The preprocess shader:
+1. Rotates each Gaussian's local offset (relative to its anchor) by the PBD quaternion
+2. Composes the PBD rotation with the Gaussian's original rotation
+
+This preserves rigid-body structure during bending and swaying.
+
+## Architecture
+
+```
+CPU (per frame)                    GPU Pipeline
+────────────────                   ──────────────────────────────────
+set_pbd_anchors()  ──►  pbd_ssbo_
+set_pbd_wind()     ──►  pbd_ubo_
+                                   ┌─────────────────┐
+                                   │  pbd_solver.comp │  Phase 0 (new)
+                                   │  writes rotation │
+                                   │  + position      │
+                                   └────────┬────────┘
+                                            │ barrier
+                                   ┌────────▼────────┐
+                                   │ gs_preprocess    │  Phase 1-2
+                                   │ reads pbd_states │
+                                   │ at binding 6     │
+                                   └────────┬────────┘
+                                            │
+                                   ┌────────▼────────┐
+                                   │ sort → merge →   │  Phase 3-4
+                                   │ tile rasterize   │
+                                   └─────────────────┘
+```
+
+## Index Segmentation
+
+The `bone_index` field in each Gaussian (packed into `GpuGaussian.scale_pad.w` as a float-encoded uint32) determines how it is transformed:
+
+| Range | Behavior | Maps to |
+|-------|----------|---------|
+| 0 | No transform | Pass-through |
+| 1 - 31 | Bone skinning | `bone_transforms[bone_idx]` |
+| 32 - 63 | PBD dynamics | `pbd_states[bone_idx - 32]` |
+
+This gives 32 PBD elements, each controlling a group of Gaussians. A single PBD element (e.g., index 32) can drive hundreds of Gaussians — all foliage Gaussians belonging to one tree branch would share the same PBD index.
+
+## GPU Buffers
+
+### PbdState SSBO (binding 6 in preprocess)
+
+```glsl
+struct PbdState {
+    vec4 position;  // xyz = anchor position, w = unused
+    vec4 rotation;  // xyzw = delta quaternion (identity = no change)
+};
+
+layout(set = 0, binding = 6) readonly buffer PbdBuffer {
+    PbdState pbd_states[];  // max 32 elements
+};
+```
+
+- 32 bytes per element, 1024 bytes total
+- The PBD solver writes rotation quaternions; the preprocess shader reads them
+- Identity quaternion `(0, 0, 0, 1)` = no rotation applied
+
+### PBD Uniforms (binding 1 in solver)
+
+```glsl
+layout(set = 0, binding = 1) uniform PbdUniforms {
+    vec4 params;    // x = time, y = wind_strength, z = wind_freq, w = pbd_count
+    vec4 wind_dir;  // xyz = normalized wind direction, w = unused
+};
+```
+
+## Preprocess Shader Integration
+
+In `gs_preprocess.comp`, the PBD path applies anchor-relative rotation:
+
+```glsl
+if (bone_idx >= 32 && bone_idx < 64) {
+    uint pbd_idx = bone_idx - 32;
+    PbdState pbd = pbd_states[pbd_idx];
+    vec4 pbd_q = normalize(pbd.rotation);
+
+    // Rotate local offset around anchor point
+    vec3 local_offset = pos - pbd.position.xyz;
+    vec3 t = 2.0 * cross(pbd_q.xyz, local_offset);
+    pos = pbd.position.xyz + local_offset + pbd_q.w * t + cross(pbd_q.xyz, t);
+
+    // Compose with original Gaussian rotation
+    rot_q = quat_mul(pbd_q, rot_q);
+}
+```
+
+The vector rotation uses the optimized quaternion rotation formula (`q * v * q^-1` expanded) — no matrix conversion needed.
+
+## PBD Solver Shader
+
+`pbd_solver.comp` currently implements a wind sway placeholder:
+
+- Each PBD element receives a sinusoidal oscillation based on its anchor position
+- The sway axis is perpendicular to wind direction and world up
+- Spatial phase variation via `dot(anchor, hash_vec)` prevents synchronized motion
+- Output: axis-angle quaternion written to `pbd_states[].rotation`
+
+This is designed to be replaced or extended with a full PBD constraint solver (distance constraints, bending constraints, collision) when needed.
+
+## C++ API
+
+```cpp
+// Set anchor positions for PBD elements (max 32)
+// Each anchor is the pivot point around which attached Gaussians rotate
+gs_renderer.set_pbd_anchors(anchors, count);
+
+// Configure wind parameters
+gs_renderer.set_pbd_wind(
+    glm::vec3(1, 0, 0),  // wind direction
+    0.3f,                  // strength (max sway angle in radians)
+    2.0f                   // frequency (oscillations per second)
+);
+
+// Reset all PBD state to identity (no simulation)
+gs_renderer.clear_pbd();
+```
+
+## Assigning PBD Indices to Gaussians
+
+When creating Gaussian data (e.g., in scene loading or procedural generation), set `bone_index` to values in the 32-63 range:
+
+```cpp
+Gaussian g;
+g.position = glm::vec3(10, 5, 0);
+g.bone_index = 32;  // First PBD element — tree trunk
+// Other Gaussians on the same branch also use bone_index = 32
+```
+
+Multiple Gaussians sharing the same PBD index move as a rigid group around the anchor point. Use different indices (32, 33, 34, ...) for independently moving parts (e.g., separate branches).
+
+## Dispatch Order
+
+The PBD solver is dispatched as **Phase 0** in the GS compute pipeline:
+
+1. **Phase 0**: PBD solver (if `pbd_count_ > 0`) — writes `pbd_states[]`
+2. Memory barrier (`SHADER_WRITE → SHADER_READ`)
+3. **Phase 1**: Dynamic preprocess + sort
+4. **Phase 2**: Static preprocess + sort (if dirty)
+5. **Phase 3**: Merge
+6. **Phase 4**: Tile rasterization
+7. Post-process
+
+When `pbd_count_ == 0`, Phase 0 is skipped entirely — zero overhead for scenes without PBD.
+
+## Testing
+
+`test_pbd_solver` validates the CPU-side contracts without requiring a GPU:
+
+| Test | What it verifies |
+|------|------------------|
+| PbdState layout | 32 bytes, correct field offsets for GPU std430 |
+| Index segmentation | Round-trip encoding, correct range routing (0/1-31/32-63) |
+| Quaternion multiplication | Identity, composition, unit length preservation |
+| Quaternion-vector rotation | Axis rotations, magnitude preservation |
+| PBD transform composition | Anchor-relative rotation, rigid-body distance preservation |
+| Axis-angle conversion | Zero angle → identity, unit length, 180deg edge case |
+| Wind sway output | Unit quaternions, bounded angles, spatial variation |
+
+```bash
+ctest --test-dir build/macos-debug -R test_pbd_solver
+```
+
+## Future Extensions
+
+The current wind sway placeholder establishes the GPU pipeline. Future work may include:
+
+- **Distance constraints**: maintain rest-length between connected PBD elements (chain/rope simulation)
+- **Bending constraints**: resist angular change between parent-child elements (stiff branches)
+- **Collision constraints**: prevent PBD elements from penetrating terrain or other objects
+- **Multi-iteration solver**: multiple constraint projection passes per frame for stability
+- **Scale/covariance updates**: soft-body deformation (stretching, squashing) for advanced VFX

--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -202,8 +202,13 @@ protected:
 
     // Scene data storage for round-trip serialization (kept in sync with ECS)
     std::vector<GameObjectData> scene_game_object_data_;
+
+    // PBD anchor positions assigned during game object merge (tree sway, etc.)
+    // Index in vector = pbd element index (bone_idx 32 + i)
+    std::vector<glm::vec3> pbd_anchors_;
 public:
     const std::vector<GameObjectData>& scene_game_objects() const { return scene_game_object_data_; }
+    const std::vector<glm::vec3>& pbd_anchors() const { return pbd_anchors_; }
     glm::vec2 gs_aabb_offset() const { return gs_aabb_offset_; }
 protected:
     std::vector<PointLight> static_lights_;

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -156,6 +156,17 @@ public:
     void upload_bone_transforms(const glm::mat4* transforms, uint32_t count);
     void clear_bone_transforms();
 
+    // PBD (Position Based Dynamics) solver
+    static constexpr uint32_t kMaxPbdElements = 32;
+    struct PbdState {
+        glm::vec4 position;  // xyz = anchor, w = unused
+        glm::vec4 rotation;  // xyzw = delta quaternion
+    };
+    void set_pbd_anchors(const glm::vec3* anchors, uint32_t count);
+    void set_pbd_wind(const glm::vec3& direction, float strength, float frequency);
+    void clear_pbd();
+    uint32_t pbd_count() const { return pbd_count_; }
+
     // Post-process parameters (fog, tone mapping, vignette, etc.)
     void set_post_process_params(const GsPostProcessParams& p) { gs_pp_params_ = p; }
     const GsPostProcessParams& post_process_params() const { return gs_pp_params_; }
@@ -202,6 +213,14 @@ private:
     Buffer visible_count_ssbo_;      // Atomic counter: visible Gaussians after frustum cull
     Buffer bone_ssbo_;               // Bone transforms for character skinning
     uint32_t bone_count_ = 0;
+
+    // PBD solver resources
+    Buffer pbd_ssbo_;                // PbdState array (read/write by solver, read by preprocess)
+    Buffer pbd_uniform_buffer_;      // PBD solver uniforms (time, wind params)
+    uint32_t pbd_count_ = 0;
+    glm::vec3 pbd_wind_dir_{1.0f, 0.0f, 0.0f};
+    float pbd_wind_strength_ = 0.0f;
+    float pbd_wind_freq_ = 2.0f;
 
     // Static/dynamic split buffers
     Buffer static_gaussian_ssbo_;
@@ -279,6 +298,12 @@ private:
     VkPipeline radix_histogram_pipeline_ = VK_NULL_HANDLE;
     VkPipeline radix_scan_pipeline_ = VK_NULL_HANDLE;
     VkPipeline radix_scatter_pipeline_ = VK_NULL_HANDLE;
+
+    // PBD solver pipeline
+    VkDescriptorSetLayout pbd_layout_ = VK_NULL_HANDLE;
+    VkPipelineLayout pbd_pipeline_layout_ = VK_NULL_HANDLE;
+    VkPipeline pbd_pipeline_ = VK_NULL_HANDLE;
+    VkDescriptorSet pbd_set_ = VK_NULL_HANDLE;
 
     // Post-process pipeline
     VkDescriptorSetLayout post_process_layout_ = VK_NULL_HANDLE;

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SHADER_SOURCES
     ${SHADER_SOURCE_DIR}/gs_radix_scatter.comp
     ${SHADER_SOURCE_DIR}/gs_merge.comp
     ${SHADER_SOURCE_DIR}/gs_post_process.comp
+    ${SHADER_SOURCE_DIR}/pbd_solver.comp
 )
 
 set(SHADER_OUTPUTS "")

--- a/shaders/gs_preprocess.comp
+++ b/shaders/gs_preprocess.comp
@@ -64,6 +64,16 @@ layout(set = 0, binding = 5) readonly buffer BoneBuffer {
     mat4 bone_transforms[];
 };
 
+// PBD (Position Based Dynamics) state — written by pbd_solver.comp
+struct PbdState {
+    vec4 position; // xyz = anchor position, w = unused
+    vec4 rotation; // xyzw = delta quaternion (identity = no change)
+};
+
+layout(set = 0, binding = 6) readonly buffer PbdBuffer {
+    PbdState pbd_states[];
+};
+
 layout(push_constant) uniform PushConstants {
     uint projected_offset;  // 0 for static, max_static_count for dynamic
     uint gaussian_count;    // number of Gaussians in this layer
@@ -131,9 +141,25 @@ void main() {
     vec3 col = g.color_pad.rgb;
     vec4 rot_q = g.rot;
 
-    // --- Bone skinning ---
+    // --- Bone skinning / PBD dynamics ---
     uint bone_idx = floatBitsToUint(g.scale_pad.w);
-    if (bone_idx > 0 && bone_idx < 32) {
+    if (bone_idx >= 32 && bone_idx < 64) {
+        // PBD-driven Gaussian: index 32-63 maps to pbd_states[0-31]
+        uint pbd_idx = bone_idx - 32;
+        PbdState pbd = pbd_states[pbd_idx];
+
+        // Apply PBD: rotate the local offset around the anchor, then translate
+        // This preserves relative structure while allowing bending/swaying
+        vec4 pbd_q = normalize(pbd.rotation);
+        vec3 local_offset = pos - pbd.position.xyz;
+        // Rotate local offset by PBD quaternion
+        vec3 t = 2.0 * cross(pbd_q.xyz, local_offset);
+        pos = pbd.position.xyz + local_offset + pbd_q.w * t + cross(pbd_q.xyz, t);
+
+        // Compose PBD rotation with original Gaussian rotation
+        rot_q = quat_mul(pbd_q, rot_q);
+    } else if (bone_idx > 0 && bone_idx < 32) {
+        // Standard bone skinning
         mat4 bone_tf = bone_transforms[bone_idx];
         pos = (bone_tf * vec4(pos, 1.0)).xyz;
         mat3 bone_rot = mat3(bone_tf);

--- a/shaders/pbd_solver.comp
+++ b/shaders/pbd_solver.comp
@@ -1,0 +1,60 @@
+#version 450
+
+layout(local_size_x = 64) in;
+
+// PBD state output — consumed by gs_preprocess.comp at binding 6
+struct PbdState {
+    vec4 position; // xyz = anchor position, w = unused
+    vec4 rotation; // xyzw = delta quaternion (identity = no change)
+};
+
+layout(set = 0, binding = 0) buffer PbdBuffer {
+    PbdState pbd_states[];
+};
+
+layout(set = 0, binding = 1) uniform PbdUniforms {
+    vec4 params;       // x = time, y = wind_strength, z = wind_freq, w = pbd_count
+    vec4 wind_dir;     // xyz = wind direction (normalized), w = unused
+};
+
+layout(push_constant) uniform PushConstants {
+    uint pbd_count;
+};
+
+// Build quaternion from axis-angle
+vec4 axis_angle_to_quat(vec3 axis, float angle) {
+    float half_a = angle * 0.5;
+    float s = sin(half_a);
+    return vec4(axis * s, cos(half_a));
+}
+
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    if (idx >= pbd_count) return;
+
+    PbdState state = pbd_states[idx];
+    vec3 anchor = state.position.xyz;
+
+    float time = params.x;
+    float wind_strength = params.y;
+    float wind_freq = params.z;
+    vec3 wind = normalize(wind_dir.xyz);
+
+    // --- Placeholder: sinusoidal wind sway ---
+    // Each PBD element gets a phase-shifted oscillation based on its anchor position
+    float phase = dot(anchor, vec3(0.37, 0.13, 0.71));  // spatial hash for variation
+    float sway_angle = sin(time * wind_freq + phase) * wind_strength;
+
+    // Rotation axis is perpendicular to wind direction and up
+    vec3 sway_axis = normalize(cross(wind, vec3(0.0, 1.0, 0.0)));
+    // Fallback if wind is exactly vertical
+    if (length(sway_axis) < 0.001) {
+        sway_axis = vec3(1.0, 0.0, 0.0);
+    }
+
+    // Write delta quaternion (rotation to apply in preprocess)
+    state.rotation = axis_angle_to_quat(sway_axis, sway_angle);
+
+    // Position anchor unchanged (PBD constraints would update this in a full solver)
+    pbd_states[idx] = state;
+}

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -244,6 +244,21 @@ void IslandDemoState::on_enter(AppBase& app) {
         (void)char_count;
     }
 
+    // Set up PBD solver for tree sway (anchors assigned during scene load)
+    {
+        const auto& anchors = app.pbd_anchors();
+        if (!anchors.empty()) {
+            app.renderer().gs_renderer().set_pbd_anchors(
+                anchors.data(), static_cast<uint32_t>(anchors.size()));
+            app.renderer().gs_renderer().set_pbd_wind(
+                glm::vec3(1.0f, 0.0f, 0.3f),  // wind direction (mostly +X)
+                0.08f,                           // strength (subtle sway angle)
+                1.5f);                           // frequency (gentle rhythm)
+            std::fprintf(stderr, "[IslandDemo] PBD tree sway: %zu trees, wind=(1,0,0.3) str=0.08 freq=1.5\n",
+                         anchors.size());
+        }
+    }
+
     // Initialize camera centered on player (use header defaults for elevation/distance)
     camera_target_ = player_pos + glm::vec3(0, kCameraYOffset, 0);
 
@@ -269,6 +284,7 @@ void IslandDemoState::on_exit(AppBase& app) {
 
     if (character_spawned_) {
         app.renderer().gs_renderer().clear_bone_transforms();
+        app.renderer().gs_renderer().clear_pbd();
         character_spawned_ = false;
     }
 }

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -252,8 +252,8 @@ void IslandDemoState::on_enter(AppBase& app) {
                 anchors.data(), static_cast<uint32_t>(anchors.size()));
             app.renderer().gs_renderer().set_pbd_wind(
                 glm::vec3(1.0f, 0.0f, 0.3f),  // wind direction (mostly +X)
-                0.15f,                           // strength (visible but natural sway)
-                1.5f);                           // frequency (gentle rhythm)
+                0.06f,                           // strength (gentle sway angle)
+                0.8f);                           // frequency (slow, natural rhythm)
             std::fprintf(stderr, "[IslandDemo] PBD tree sway: %zu trees, wind=(1,0,0.3) str=0.08 freq=1.5\n",
                          anchors.size());
         }

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -252,7 +252,7 @@ void IslandDemoState::on_enter(AppBase& app) {
                 anchors.data(), static_cast<uint32_t>(anchors.size()));
             app.renderer().gs_renderer().set_pbd_wind(
                 glm::vec3(1.0f, 0.0f, 0.3f),  // wind direction (mostly +X)
-                0.08f,                           // strength (subtle sway angle)
+                0.15f,                           // strength (visible but natural sway)
                 1.5f);                           // frequency (gentle rhythm)
             std::fprintf(stderr, "[IslandDemo] PBD tree sway: %zu trees, wind=(1,0,0.3) str=0.08 freq=1.5\n",
                          anchors.size());
@@ -367,6 +367,9 @@ void IslandDemoState::update(AppBase& app, float dt) {
     if (anim_enabled_) {
         update_environment_animation(app, dt);
     }
+
+    // Drive GS effect time for PBD solver (wind sway needs advancing time)
+    app.renderer().gs_renderer().set_effect_time(env_anim_time_);
 
     // Walk animation always runs (handles character root transform + bone poses)
     update_walk_animation(app, dt);

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -432,8 +432,9 @@ void AppBase::load_gs_scene(const SceneData& scene_data, const GsSceneOptions& o
                             pbd_idx = 32 + static_cast<uint32_t>(pbd_anchors_.size());
                             pbd_anchors_.push_back(adjusted_pos);
                         }
-                        // Sway threshold: upper 60% of the tree (canopy)
-                        float sway_threshold = local_min_y + (local_max_y - local_min_y) * 0.4f;
+                        // Sway threshold: upper 30% of the tree (canopy tips only)
+                        // Higher threshold = less of the tree sways, avoiding visible seam
+                        float sway_threshold = local_min_y + (local_max_y - local_min_y) * 0.7f;
 
                         auto placed_gs = placed_cloud.gaussians();
                         for (auto& g : placed_gs) {

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -398,6 +398,7 @@ void AppBase::load_gs_scene(const SceneData& scene_data, const GsSceneOptions& o
             scene_game_object_data_ = snapped_objects;
 
             // Merge all game objects with PLY visuals into the GS cloud
+            pbd_anchors_.clear();
             {
                 auto merged = cloud.gaussians();
                 uint32_t merged_count = 0;
@@ -406,11 +407,12 @@ void AppBase::load_gs_scene(const SceneData& scene_data, const GsSceneOptions& o
                     try {
                         auto placed_cloud = GaussianCloud::load_ply(go.ply_file);
                         if (placed_cloud.empty()) continue;
-                        // Compute local AABB min Y so we can offset the prop
-                        // to sit ON the terrain (PLY origins are often at center)
+                        // Compute local AABB min/max Y
                         float local_min_y = 1e9f;
+                        float local_max_y = -1e9f;
                         for (const auto& g : placed_cloud.gaussians()) {
                             if (g.position.y < local_min_y) local_min_y = g.position.y;
+                            if (g.position.y > local_max_y) local_max_y = g.position.y;
                         }
                         glm::vec3 adjusted_pos = go.position;
                         if (local_min_y < -0.01f) {
@@ -422,11 +424,27 @@ void AppBase::load_gs_scene(const SceneData& scene_data, const GsSceneOptions& o
                         transform = glm::rotate(transform, glm::radians(go.rotation.z), {0,0,1});
                         transform = glm::scale(transform, glm::vec3(go.scale));
                         auto rot_q = glm::quat(glm::radians(go.rotation));
+
+                        // Assign PBD index to tree game objects (upper canopy sways)
+                        bool is_tree = go.id.find("tree") != std::string::npos;
+                        uint32_t pbd_idx = 0;
+                        if (is_tree && pbd_anchors_.size() < GsRenderer::kMaxPbdElements) {
+                            pbd_idx = 32 + static_cast<uint32_t>(pbd_anchors_.size());
+                            pbd_anchors_.push_back(adjusted_pos);
+                        }
+                        // Sway threshold: upper 60% of the tree (canopy)
+                        float sway_threshold = local_min_y + (local_max_y - local_min_y) * 0.4f;
+
                         auto placed_gs = placed_cloud.gaussians();
                         for (auto& g : placed_gs) {
+                            float local_y = g.position.y;  // before transform
                             g.position = glm::vec3(transform * glm::vec4(g.position, 1.0f));
                             g.scale *= go.scale;
                             g.rotation = rot_q * g.rotation;
+                            // Tag canopy Gaussians with PBD index
+                            if (pbd_idx > 0 && local_y > sway_threshold) {
+                                g.bone_index = pbd_idx;
+                            }
                         }
                         merged.insert(merged.end(), placed_gs.begin(), placed_gs.end());
                         merged_count++;
@@ -437,6 +455,11 @@ void AppBase::load_gs_scene(const SceneData& scene_data, const GsSceneOptions& o
                 }
                 if (merged_count > 0) {
                     cloud = GaussianCloud::from_gaussians(std::move(merged));
+                }
+                if (!pbd_anchors_.empty()) {
+                    std::fprintf(stderr, "[GS] PBD: %zu tree anchors assigned (idx 32-%u)\n",
+                                 pbd_anchors_.size(),
+                                 31 + static_cast<uint32_t>(pbd_anchors_.size()));
                 }
             }
 

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1304,7 +1304,10 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
         vkCmdClearColorImage(cmd, depth_image_, VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &range);
 
         // === PBD solver dispatch (before any preprocess) ===
+        // PBD-tagged Gaussians live in the static buffer but need re-preprocessing
+        // every frame since their positions/rotations change continuously.
         if (pbd_count_ > 0) {
+            static_dirty_ = true;
             // Update PBD uniform buffer: params(time, strength, freq, count) + wind_dir
             struct { glm::vec4 params; glm::vec4 wind_dir; } pbd_ubo;
             pbd_ubo.params = glm::vec4(time_, pbd_wind_strength_, pbd_wind_freq_,

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -217,7 +217,7 @@ void GsRenderer::create_descriptor_resources() {
         throw std::runtime_error("Failed to create GS descriptor pool");
     }
 
-    // Preprocess layout: { gaussians, projected, sort_keys, uniforms, visible_count, bones }
+    // Preprocess layout: { gaussians, projected, sort_keys, uniforms, visible_count, bones, pbd_states }
     {
         VkDescriptorSetLayoutBinding bindings[] = {
             {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
@@ -226,10 +226,11 @@ void GsRenderer::create_descriptor_resources() {
             {3, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
             {4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
             {5, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {6, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},  // PBD
         };
         VkDescriptorSetLayoutCreateInfo ci{};
         ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        ci.bindingCount = 6;
+        ci.bindingCount = 7;
         ci.pBindings = bindings;
         vkCreateDescriptorSetLayout(device_, &ci, nullptr, &preprocess_layout_);
     }
@@ -333,6 +334,19 @@ void GsRenderer::create_descriptor_resources() {
         vkCreateDescriptorSetLayout(device_, &ci, nullptr, &merge_layout_);
     }
 
+    // PBD solver layout: { pbd_states (rw), pbd_uniforms }
+    {
+        VkDescriptorSetLayoutBinding bindings[] = {
+            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        };
+        VkDescriptorSetLayoutCreateInfo ci{};
+        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        ci.bindingCount = 2;
+        ci.pBindings = bindings;
+        vkCreateDescriptorSetLayout(device_, &ci, nullptr, &pbd_layout_);
+    }
+
     // Allocate all descriptor sets
     // Reset pool to free previously allocated sets before reallocating
     vkResetDescriptorPool(device_, gs_pool_, 0);
@@ -353,8 +367,9 @@ void GsRenderer::create_descriptor_resources() {
         radix_scatter_layout_, radix_scatter_layout_,      // dynamic scatter AB/BA
         merge_layout_,                                     // merge
         render_layout_,                                    // new render with merged sort
+        pbd_layout_,                                       // PBD solver
     };
-    constexpr uint32_t kSetCount = 22;
+    constexpr uint32_t kSetCount = 23;
     VkDescriptorSet sets[kSetCount];
     VkDescriptorSetAllocateInfo alloc_info{};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -388,6 +403,7 @@ void GsRenderer::create_descriptor_resources() {
     dynamic_scatter_set_ab_ = sets[19];
     dynamic_scatter_set_ba_ = sets[20];
     merge_set_ = sets[21];
+    pbd_set_ = sets[22];
     // Re-use render_set_ for merged rendering (set 2 already has correct layout)
 }
 
@@ -441,6 +457,11 @@ void GsRenderer::create_compute_pipelines() {
     // Post-process pipeline (no push constants — dimensions in UBO)
     create_pipeline("shaders/gs_post_process.comp.spv", post_process_layout_, 0,
                     post_process_pipeline_layout_, post_process_pipeline_);
+
+    // PBD solver pipeline (push constant = pbd_count)
+    create_pipeline("shaders/pbd_solver.comp.spv", pbd_layout_,
+                    static_cast<uint32_t>(sizeof(uint32_t)),
+                    pbd_pipeline_layout_, pbd_pipeline_);
 
     // Merge pipeline (no push constants)
     create_pipeline("shaders/gs_merge.comp.spv", merge_layout_, 0,
@@ -553,6 +574,19 @@ void GsRenderer::load_cloud(const GaussianCloud& cloud) {
         auto* bones = static_cast<glm::mat4*>(bone_ssbo_.mapped());
         for (uint32_t i = 0; i < kMaxBones; ++i) bones[i] = glm::mat4(1.0f);
     }
+
+    // PBD state SSBO (always allocated, identity rotation if unused)
+    pbd_ssbo_ = Buffer::create_storage(allocator_, kMaxPbdElements * sizeof(PbdState));
+    pbd_count_ = 0;
+    {
+        auto* states = static_cast<PbdState*>(pbd_ssbo_.mapped());
+        for (uint32_t i = 0; i < kMaxPbdElements; ++i) {
+            states[i].position = glm::vec4(0.0f);
+            states[i].rotation = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);  // identity quat
+        }
+    }
+    // PBD uniform buffer: params (vec4) + wind_dir (vec4) = 32 bytes
+    pbd_uniform_buffer_ = Buffer::create_storage(allocator_, 32);
 
     // Upload Gaussian data to static buffer via staging to avoid -O3 write-reordering
     {
@@ -807,7 +841,7 @@ void GsRenderer::clear_bone_transforms() {
 }
 
 void GsRenderer::update_descriptors() {
-    // Preprocess set: gaussians(0), projected(1), sort_keys_A(2), uniforms(3), visible_count(4), bones(5)
+    // Preprocess set: gaussians(0), projected(1), sort_keys_A(2), uniforms(3), visible_count(4), bones(5), pbd(6)
     {
         VkDescriptorBufferInfo gaussian_info{gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
@@ -815,6 +849,7 @@ void GsRenderer::update_descriptors() {
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
         VkDescriptorBufferInfo visible_count_info{visible_count_ssbo_.buffer(), 0, sizeof(uint32_t)};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo pbd_info{pbd_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
         VkWriteDescriptorSet writes[] = {
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 0, 0, 1,
@@ -829,8 +864,10 @@ void GsRenderer::update_descriptors() {
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &visible_count_info, nullptr},
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 5, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &bone_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 6, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_info, nullptr},
         };
-        vkUpdateDescriptorSets(device_, 6, writes, 0, nullptr);
+        vkUpdateDescriptorSets(device_, 7, writes, 0, nullptr);
     }
 
     // Legacy sort set
@@ -964,14 +1001,15 @@ void GsRenderer::update_descriptors() {
     // Only write these if the split buffers have been allocated
     if (!static_gaussian_ssbo_.buffer() || !counts_ssbo_.buffer()) return;
 
-    // Static preprocess set: static_gaussian(0), projected(1), static_sort_a(2), uniforms(3), counts[0](4), bones(5)
+    // Static preprocess set: static_gaussian(0), projected(1), static_sort_a(2), uniforms(3), counts[0](4), bones(5), pbd(6)
     {
         VkDescriptorBufferInfo gaussian_info{static_gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo sort_info{static_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
-        VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};  // full counts buffer, shader indexes by push constant
+        VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo pbd_info{pbd_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
         VkWriteDescriptorSet writes[] = {
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 0, 0, 1,
@@ -986,18 +1024,21 @@ void GsRenderer::update_descriptors() {
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &counts_info, nullptr},
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 5, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &bone_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 6, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_info, nullptr},
         };
-        vkUpdateDescriptorSets(device_, 6, writes, 0, nullptr);
+        vkUpdateDescriptorSets(device_, 7, writes, 0, nullptr);
     }
 
-    // Dynamic preprocess set: dynamic_gaussian(0), projected(1), dynamic_sort_a(2), uniforms(3), counts[1](4), bones(5)
+    // Dynamic preprocess set: dynamic_gaussian(0), projected(1), dynamic_sort_a(2), uniforms(3), counts[1](4), bones(5), pbd(6)
     {
         VkDescriptorBufferInfo gaussian_info{dynamic_gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo sort_info{dynamic_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
-        VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};  // full counts buffer, shader indexes by push constant
+        VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo pbd_info{pbd_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
         VkWriteDescriptorSet writes[] = {
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 0, 0, 1,
@@ -1012,8 +1053,23 @@ void GsRenderer::update_descriptors() {
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &counts_info, nullptr},
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 5, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &bone_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 6, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_info, nullptr},
         };
-        vkUpdateDescriptorSets(device_, 6, writes, 0, nullptr);
+        vkUpdateDescriptorSets(device_, 7, writes, 0, nullptr);
+    }
+
+    // PBD solver descriptor set: pbd_states(0), pbd_uniforms(1)
+    {
+        VkDescriptorBufferInfo pbd_buf_info{pbd_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo pbd_ubo_info{pbd_uniform_buffer_.buffer(), 0, 32};
+        VkWriteDescriptorSet writes[] = {
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, pbd_set_, 0, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_buf_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, pbd_set_, 1, 0, 1,
+             VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &pbd_ubo_info, nullptr},
+        };
+        vkUpdateDescriptorSets(device_, 2, writes, 0, nullptr);
     }
 
     // Helper to write radix histogram/scan/scatter sets
@@ -1247,6 +1303,33 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
         vkCmdClearColorImage(cmd, output_image_, VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &range);
         vkCmdClearColorImage(cmd, depth_image_, VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &range);
 
+        // === PBD solver dispatch (before any preprocess) ===
+        if (pbd_count_ > 0) {
+            // Update PBD uniform buffer: params(time, strength, freq, count) + wind_dir
+            struct { glm::vec4 params; glm::vec4 wind_dir; } pbd_ubo;
+            pbd_ubo.params = glm::vec4(time_, pbd_wind_strength_, pbd_wind_freq_,
+                                        static_cast<float>(pbd_count_));
+            pbd_ubo.wind_dir = glm::vec4(pbd_wind_dir_, 0.0f);
+            std::memcpy(pbd_uniform_buffer_.mapped(), &pbd_ubo, sizeof(pbd_ubo));
+
+            vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pbd_pipeline_);
+            vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                    pbd_pipeline_layout_, 0, 1, &pbd_set_, 0, nullptr);
+            vkCmdPushConstants(cmd, pbd_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                               0, sizeof(uint32_t), &pbd_count_);
+            vkCmdDispatch(cmd, (pbd_count_ + 63) / 64, 1, 1);
+
+            // Barrier: PBD write → preprocess read
+            VkMemoryBarrier pbd_barrier{};
+            pbd_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+            pbd_barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+            pbd_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            vkCmdPipelineBarrier(cmd,
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                0, 1, &pbd_barrier, 0, nullptr, 0, nullptr);
+        }
+
         // Use split pipeline if split buffers are allocated, otherwise legacy path
         bool use_split = static_gaussian_ssbo_.buffer() && counts_ssbo_.buffer();
 
@@ -1478,6 +1561,34 @@ void GsRenderer::clear_shadow_box_params() {
     num_sort_passes_ = 2;
 }
 
+void GsRenderer::set_pbd_anchors(const glm::vec3* anchors, uint32_t count) {
+    if (!pbd_ssbo_.mapped() || count == 0) return;
+    uint32_t n = std::min(count, kMaxPbdElements);
+    auto* states = static_cast<PbdState*>(pbd_ssbo_.mapped());
+    for (uint32_t i = 0; i < n; ++i) {
+        states[i].position = glm::vec4(anchors[i], 0.0f);
+        states[i].rotation = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);  // identity
+    }
+    pbd_count_ = n;
+}
+
+void GsRenderer::set_pbd_wind(const glm::vec3& direction, float strength, float frequency) {
+    pbd_wind_dir_ = glm::length(direction) > 0.001f ? glm::normalize(direction) : glm::vec3(1, 0, 0);
+    pbd_wind_strength_ = strength;
+    pbd_wind_freq_ = frequency;
+}
+
+void GsRenderer::clear_pbd() {
+    pbd_count_ = 0;
+    if (pbd_ssbo_.mapped()) {
+        auto* states = static_cast<PbdState*>(pbd_ssbo_.mapped());
+        for (uint32_t i = 0; i < kMaxPbdElements; ++i) {
+            states[i].position = glm::vec4(0.0f);
+            states[i].rotation = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
+        }
+    }
+}
+
 void GsRenderer::set_point_lights(const std::vector<PointLight>& lights) {
     point_lights_.assign(lights.begin(),
                          lights.begin() + std::min(lights.size(),
@@ -1496,6 +1607,8 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     uniform_buffer_.destroy(allocator);
     visible_count_ssbo_.destroy(allocator);
     bone_ssbo_.destroy(allocator);
+    pbd_ssbo_.destroy(allocator);
+    pbd_uniform_buffer_.destroy(allocator);
 
     // Split buffers
     static_gaussian_ssbo_.destroy(allocator);
@@ -1528,6 +1641,7 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     destroy_pipeline(render_pipeline_);
     destroy_pipeline(post_process_pipeline_);
     destroy_pipeline(merge_pipeline_);
+    destroy_pipeline(pbd_pipeline_);
     destroy_pipeline(radix_histogram_pipeline_);
     destroy_pipeline(radix_scan_pipeline_);
     destroy_pipeline(radix_scatter_pipeline_);
@@ -1537,6 +1651,7 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     destroy_layout(render_pipeline_layout_);
     destroy_layout(post_process_pipeline_layout_);
     destroy_layout(merge_pipeline_layout_);
+    destroy_layout(pbd_pipeline_layout_);
     destroy_layout(radix_histogram_pipeline_layout_);
     destroy_layout(radix_scan_pipeline_layout_);
     destroy_layout(radix_scatter_pipeline_layout_);
@@ -1546,6 +1661,7 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     destroy_set_layout(render_layout_);
     destroy_set_layout(post_process_layout_);
     destroy_set_layout(merge_layout_);
+    destroy_set_layout(pbd_layout_);
     destroy_set_layout(radix_histogram_layout_);
     destroy_set_layout(radix_scan_layout_);
     destroy_set_layout(radix_scatter_layout_);

--- a/tests/README.md
+++ b/tests/README.md
@@ -291,6 +291,37 @@ c++ -std=c++23 -I include \
 | 6 | active_set_dirty flag | Set on load, cleared by assemble_active() |
 | 7 | Assemble with frustum culling | Narrow VP returns fewer Gaussians than wide VP |
 
+### test_pbd_solver
+
+Tests PBD solver struct layout, index segmentation, and quaternion math used in the GPU PBD pipeline.
+
+**Build:**
+```bash
+c++ -std=c++23 -I include \
+    -I build/macos-debug/_deps/glm-src \
+    -I build/macos-debug/_deps/stb-src \
+    -I build/macos-debug/_deps/vma-src/include \
+    $(pkg-config --cflags vulkan 2>/dev/null || echo "-I$VULKAN_SDK/include") \
+    tests/test_pbd_solver.cpp \
+    -o build/test_pbd_solver
+```
+
+**Run:**
+```bash
+./build/test_pbd_solver
+```
+
+**Tests (7):**
+| # | Test | What it verifies |
+|---|------|------------------|
+| 1 | PbdState struct layout | 32 bytes (2 x vec4), correct field offsets for GPU std430 |
+| 2 | Index segmentation | Round-trip encoding, correct routing: 0=none, 1-31=bone, 32-63=PBD |
+| 3 | Quaternion multiplication | Identity, composition, unit length preservation |
+| 4 | Quaternion-vector rotation | Axis rotations (90deg Y, 90deg Z, 180deg X), magnitude preservation |
+| 5 | PBD transform composition | Anchor-relative rotation preserves inter-Gaussian distances (rigid body) |
+| 6 | Axis-angle to quaternion | Zero angle → identity, unit length, 180deg edge case |
+| 7 | Wind sway output | Unit quaternions, bounded sway angles, spatial variation between anchors |
+
 ### test_character_data
 
 Tests character animation JSON loading.

--- a/tests/test_pbd_solver.cpp
+++ b/tests/test_pbd_solver.cpp
@@ -1,0 +1,319 @@
+// Test: PBD solver struct layout, index segmentation, and quaternion math.
+//
+// Validates:
+// 1. PbdState struct size and alignment for GPU (std430)
+// 2. Bone index segmentation: 0 = none, 1-31 = bone, 32-63 = PBD
+// 3. Quaternion multiplication matches expected results
+// 4. Quaternion-vector rotation (the formula used in gs_preprocess.comp)
+// 5. Axis-angle to quaternion conversion (used in pbd_solver.comp)
+//
+// Run: ctest -R test_pbd_solver
+
+#include "gseurat/engine/gs_renderer.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+static int passed = 0;
+static int failed = 0;
+
+static void check(bool cond, const char* msg) {
+    if (cond) {
+        std::printf("  PASS: %s\n", msg);
+        passed++;
+    } else {
+        std::printf("  FAIL: %s\n", msg);
+        failed++;
+    }
+}
+
+static bool approx(float a, float b, float eps = 0.001f) {
+    return std::fabs(a - b) < eps;
+}
+
+static bool approx_vec3(glm::vec3 a, glm::vec3 b, float eps = 0.001f) {
+    return approx(a.x, b.x, eps) && approx(a.y, b.y, eps) && approx(a.z, b.z, eps);
+}
+
+static bool approx_vec4(glm::vec4 a, glm::vec4 b, float eps = 0.001f) {
+    return approx(a.x, b.x, eps) && approx(a.y, b.y, eps) &&
+           approx(a.z, b.z, eps) && approx(a.w, b.w, eps);
+}
+
+// Mirror the GLSL quat_mul from gs_preprocess.comp (xyzw layout)
+static glm::vec4 quat_mul(glm::vec4 a, glm::vec4 b) {
+    return glm::vec4(
+        a.w*b.x + a.x*b.w + a.y*b.z - a.z*b.y,
+        a.w*b.y - a.x*b.z + a.y*b.w + a.z*b.x,
+        a.w*b.z + a.x*b.y - a.y*b.x + a.z*b.w,
+        a.w*b.w - a.x*b.x - a.y*b.y - a.z*b.z
+    );
+}
+
+// Mirror the GLSL quaternion-vector rotation from gs_preprocess.comp
+static glm::vec3 quat_rotate_vec(glm::vec4 q, glm::vec3 v) {
+    glm::vec3 qv(q.x, q.y, q.z);
+    glm::vec3 t = 2.0f * glm::cross(qv, v);
+    return v + q.w * t + glm::cross(qv, t);
+}
+
+// Mirror the GLSL axis_angle_to_quat from pbd_solver.comp
+static glm::vec4 axis_angle_to_quat(glm::vec3 axis, float angle) {
+    float half_a = angle * 0.5f;
+    float s = std::sin(half_a);
+    return glm::vec4(axis * s, std::cos(half_a));
+}
+
+// ── PbdState struct layout ──
+
+static void test_pbd_state_layout() {
+    std::printf("=== PbdState struct layout ===\n");
+    using PbdState = gseurat::GsRenderer::PbdState;
+
+    // Must be 2 * vec4 = 32 bytes for GPU std430 layout
+    check(sizeof(PbdState) == 32, "PbdState is 32 bytes (2 x vec4)");
+
+    // Verify field offsets
+    check(offsetof(PbdState, position) == 0, "position at offset 0");
+    check(offsetof(PbdState, rotation) == 16, "rotation at offset 16");
+
+    // Max elements constant
+    check(gseurat::GsRenderer::kMaxPbdElements == 32,
+          "kMaxPbdElements is 32 (matches bone_idx range 32-63)");
+}
+
+// ── Index segmentation ──
+
+static void test_index_segmentation() {
+    std::printf("=== Index segmentation (bone vs PBD) ===\n");
+
+    // Bone index encoding: uint32 → float via memcpy (mirrors gs_renderer.cpp)
+    auto encode = [](uint32_t idx) -> float {
+        float f;
+        std::memcpy(&f, &idx, sizeof(float));
+        return f;
+    };
+    auto decode = [](float f) -> uint32_t {
+        uint32_t idx;
+        std::memcpy(&idx, &f, sizeof(uint32_t));
+        return idx;
+    };
+
+    // Round-trip encoding
+    check(decode(encode(0)) == 0, "bone_idx 0 round-trips (no transform)");
+    check(decode(encode(1)) == 1, "bone_idx 1 round-trips (first bone)");
+    check(decode(encode(31)) == 31, "bone_idx 31 round-trips (last bone)");
+    check(decode(encode(32)) == 32, "bone_idx 32 round-trips (first PBD)");
+    check(decode(encode(63)) == 63, "bone_idx 63 round-trips (last PBD)");
+
+    // Verify segmentation logic (mirrors gs_preprocess.comp)
+    for (uint32_t idx = 0; idx < 64; ++idx) {
+        uint32_t decoded = decode(encode(idx));
+        bool is_bone = (decoded > 0 && decoded < 32);
+        bool is_pbd = (decoded >= 32 && decoded < 64);
+        bool is_none = (decoded == 0);
+
+        if (idx == 0) {
+            check(is_none && !is_bone && !is_pbd, "idx 0 = no transform");
+        } else if (idx < 32) {
+            check(!is_none && is_bone && !is_pbd,
+                  (std::string("idx ") + std::to_string(idx) + " = bone").c_str());
+        } else {
+            check(!is_none && !is_bone && is_pbd,
+                  (std::string("idx ") + std::to_string(idx) + " = PBD").c_str());
+        }
+    }
+
+    // PBD index mapping: bone_idx 32 → pbd_states[0], bone_idx 63 → pbd_states[31]
+    check(32 - 32 == 0, "bone_idx 32 maps to pbd_states[0]");
+    check(63 - 32 == 31, "bone_idx 63 maps to pbd_states[31]");
+}
+
+// ── Quaternion multiplication ──
+
+static void test_quat_multiplication() {
+    std::printf("=== Quaternion multiplication ===\n");
+
+    // Identity * identity = identity
+    glm::vec4 id(0, 0, 0, 1);
+    check(approx_vec4(quat_mul(id, id), id), "identity * identity = identity");
+
+    // q * identity = q
+    glm::vec4 q90z(0, 0, std::sin(M_PI / 4.0f), std::cos(M_PI / 4.0f));  // 90deg around Z
+    check(approx_vec4(quat_mul(q90z, id), q90z), "q * identity = q");
+    check(approx_vec4(quat_mul(id, q90z), q90z), "identity * q = q");
+
+    // 90deg Z * 90deg Z = 180deg Z
+    glm::vec4 result = quat_mul(q90z, q90z);
+    glm::vec4 q180z(0, 0, std::sin(M_PI / 2.0f), std::cos(M_PI / 2.0f));  // 180deg around Z
+    check(approx_vec4(result, q180z), "90deg Z * 90deg Z = 180deg Z");
+
+    // Verify quaternion is unit length
+    float len = std::sqrt(result.x * result.x + result.y * result.y +
+                          result.z * result.z + result.w * result.w);
+    check(approx(len, 1.0f), "product quaternion is unit length");
+}
+
+// ── Quaternion-vector rotation ──
+
+static void test_quat_vector_rotation() {
+    std::printf("=== Quaternion-vector rotation ===\n");
+
+    // Identity rotation leaves vector unchanged
+    glm::vec4 id(0, 0, 0, 1);
+    glm::vec3 v(1, 2, 3);
+    check(approx_vec3(quat_rotate_vec(id, v), v), "identity rotation preserves vector");
+
+    // 90deg around Y: (1,0,0) → (0,0,-1)
+    glm::vec4 q90y(0, std::sin(M_PI / 4.0f), 0, std::cos(M_PI / 4.0f));
+    glm::vec3 rotated = quat_rotate_vec(q90y, glm::vec3(1, 0, 0));
+    check(approx_vec3(rotated, glm::vec3(0, 0, -1)), "90deg Y rotates X-axis to -Z");
+
+    // 90deg around Z: (1,0,0) → (0,1,0)
+    glm::vec4 q90z(0, 0, std::sin(M_PI / 4.0f), std::cos(M_PI / 4.0f));
+    rotated = quat_rotate_vec(q90z, glm::vec3(1, 0, 0));
+    check(approx_vec3(rotated, glm::vec3(0, 1, 0)), "90deg Z rotates X-axis to Y");
+
+    // 180deg around X: (0,1,0) → (0,-1,0)
+    glm::vec4 q180x(std::sin(M_PI / 2.0f), 0, 0, std::cos(M_PI / 2.0f));
+    rotated = quat_rotate_vec(q180x, glm::vec3(0, 1, 0));
+    check(approx_vec3(rotated, glm::vec3(0, -1, 0)), "180deg X flips Y to -Y");
+
+    // Rotation preserves vector magnitude
+    glm::vec4 q_arb = glm::normalize(glm::vec4(0.3f, 0.5f, 0.1f, 0.8f));
+    glm::vec3 v_arb(3, 4, 5);
+    glm::vec3 v_rot = quat_rotate_vec(q_arb, v_arb);
+    float orig_len = glm::length(v_arb);
+    float rot_len = glm::length(v_rot);
+    check(approx(orig_len, rot_len, 0.01f), "rotation preserves vector magnitude");
+}
+
+// ── PBD transform composition ──
+
+static void test_pbd_transform_composition() {
+    std::printf("=== PBD transform composition (anchor + rotation) ===\n");
+
+    // Simulates the gs_preprocess.comp PBD path:
+    //   local_offset = pos - anchor
+    //   pos = anchor + quat_rotate(pbd_q, local_offset)
+    //   rot_q = quat_mul(pbd_q, rot_q)
+
+    glm::vec3 anchor(10, 0, 0);
+    glm::vec3 pos(11, 0, 0);  // 1 unit to the right of anchor
+    glm::vec4 orig_rot(0, 0, 0, 1);  // identity
+
+    // PBD rotation: 90deg around Y
+    glm::vec4 pbd_q(0, std::sin(M_PI / 4.0f), 0, std::cos(M_PI / 4.0f));
+
+    // Apply PBD transform (mirror shader logic)
+    glm::vec3 local_offset = pos - anchor;
+    glm::vec3 new_pos = anchor + quat_rotate_vec(pbd_q, local_offset);
+    glm::vec4 new_rot = quat_mul(pbd_q, orig_rot);
+
+    // The point (1,0,0) relative to anchor should rotate to (0,0,-1) relative to anchor
+    check(approx_vec3(new_pos, glm::vec3(10, 0, -1)),
+          "PBD rotates position around anchor correctly");
+    check(approx_vec4(new_rot, pbd_q),
+          "PBD composes rotation with identity correctly");
+
+    // Multiple Gaussians at different offsets from same anchor should maintain relative structure
+    glm::vec3 pos2(10, 1, 0);  // 1 unit above anchor
+    glm::vec3 local2 = pos2 - anchor;
+    glm::vec3 new_pos2 = anchor + quat_rotate_vec(pbd_q, local2);
+    // (0,1,0) rotated 90deg around Y stays (0,1,0)
+    check(approx_vec3(new_pos2, glm::vec3(10, 1, 0)),
+          "Y-axis point unchanged by Y-axis rotation (correct anchor pivot)");
+
+    // Distance between the two transformed points should equal original distance
+    float orig_dist = glm::length(pos - pos2);
+    float new_dist = glm::length(new_pos - new_pos2);
+    check(approx(orig_dist, new_dist, 0.01f),
+          "PBD preserves inter-Gaussian distances (rigid body)");
+}
+
+// ── Axis-angle to quaternion ──
+
+static void test_axis_angle_to_quat() {
+    std::printf("=== Axis-angle to quaternion ===\n");
+
+    // Zero angle → identity
+    glm::vec4 q = axis_angle_to_quat(glm::vec3(1, 0, 0), 0.0f);
+    check(approx_vec4(q, glm::vec4(0, 0, 0, 1)), "zero angle → identity quaternion");
+
+    // 90deg around Z
+    q = axis_angle_to_quat(glm::vec3(0, 0, 1), static_cast<float>(M_PI / 2.0));
+    float expected_s = std::sin(M_PI / 4.0f);
+    float expected_c = std::cos(M_PI / 4.0f);
+    check(approx_vec4(q, glm::vec4(0, 0, expected_s, expected_c)),
+          "90deg around Z produces correct quaternion");
+
+    // Result is unit length
+    float len = glm::length(q);
+    check(approx(len, 1.0f), "axis-angle quaternion is unit length");
+
+    // 180deg around arbitrary axis
+    glm::vec3 axis = glm::normalize(glm::vec3(1, 1, 0));
+    q = axis_angle_to_quat(axis, static_cast<float>(M_PI));
+    len = glm::length(q);
+    check(approx(len, 1.0f), "180deg quaternion is unit length");
+    // w should be cos(pi/2) = 0
+    check(approx(q.w, 0.0f, 0.01f), "180deg rotation has w ≈ 0");
+}
+
+// ── Wind sway produces valid output ──
+
+static void test_wind_sway_output() {
+    std::printf("=== Wind sway produces valid rotations ===\n");
+
+    // Simulate pbd_solver.comp logic for a few anchors
+    glm::vec3 wind = glm::normalize(glm::vec3(1, 0, 0));
+    float strength = 0.3f;
+    float freq = 2.0f;
+    float time = 1.5f;
+
+    glm::vec3 anchors[] = {
+        {0, 0, 0}, {10, 5, 3}, {-5, 0, 20}
+    };
+
+    for (int i = 0; i < 3; ++i) {
+        glm::vec3 anchor = anchors[i];
+        float phase = glm::dot(anchor, glm::vec3(0.37f, 0.13f, 0.71f));
+        float sway_angle = std::sin(time * freq + phase) * strength;
+
+        glm::vec3 sway_axis = glm::normalize(glm::cross(wind, glm::vec3(0, 1, 0)));
+        glm::vec4 q = axis_angle_to_quat(sway_axis, sway_angle);
+
+        float len = glm::length(q);
+        check(approx(len, 1.0f, 0.001f),
+              (std::string("wind sway quat ") + std::to_string(i) + " is unit length").c_str());
+
+        // Sway angle should be within [-strength, +strength]
+        check(std::fabs(sway_angle) <= strength + 0.001f,
+              (std::string("sway angle ") + std::to_string(i) + " within bounds").c_str());
+    }
+
+    // Different anchors should produce different sway angles (spatial variation)
+    float phase0 = glm::dot(anchors[0], glm::vec3(0.37f, 0.13f, 0.71f));
+    float phase1 = glm::dot(anchors[1], glm::vec3(0.37f, 0.13f, 0.71f));
+    float angle0 = std::sin(time * freq + phase0) * strength;
+    float angle1 = std::sin(time * freq + phase1) * strength;
+    check(!approx(angle0, angle1, 0.0001f),
+          "different anchors produce different sway (spatial variation)");
+}
+
+int main() {
+    std::printf("test_pbd_solver\n");
+
+    test_pbd_state_layout();
+    test_index_segmentation();
+    test_quat_multiplication();
+    test_quat_vector_rotation();
+    test_pbd_transform_composition();
+    test_axis_angle_to_quat();
+    test_wind_sway_output();
+
+    std::printf("\n%d passed, %d failed\n", passed, failed);
+    return failed > 0 ? 1 : 0;
+}

--- a/tests/test_pbd_solver.cpp
+++ b/tests/test_pbd_solver.cpp
@@ -16,6 +16,10 @@
 #include <cstdio>
 #include <cstring>
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 static int passed = 0;
 static int failed = 0;
 
@@ -137,7 +141,7 @@ static void test_quat_multiplication() {
     std::printf("=== Quaternion multiplication ===\n");
 
     // Identity * identity = identity
-    glm::vec4 id(0, 0, 0, 1);
+    glm::vec4 id(0.0f, 0.0f, 0.0f, 1.0f);
     check(approx_vec4(quat_mul(id, id), id), "identity * identity = identity");
 
     // q * identity = q
@@ -162,7 +166,7 @@ static void test_quat_vector_rotation() {
     std::printf("=== Quaternion-vector rotation ===\n");
 
     // Identity rotation leaves vector unchanged
-    glm::vec4 id(0, 0, 0, 1);
+    glm::vec4 id(0.0f, 0.0f, 0.0f, 1.0f);
     glm::vec3 v(1, 2, 3);
     check(approx_vec3(quat_rotate_vec(id, v), v), "identity rotation preserves vector");
 
@@ -202,7 +206,7 @@ static void test_pbd_transform_composition() {
 
     glm::vec3 anchor(10, 0, 0);
     glm::vec3 pos(11, 0, 0);  // 1 unit to the right of anchor
-    glm::vec4 orig_rot(0, 0, 0, 1);  // identity
+    glm::vec4 orig_rot(0.0f, 0.0f, 0.0f, 1.0f);  // identity
 
     // PBD rotation: 90deg around Y
     glm::vec4 pbd_q(0, std::sin(M_PI / 4.0f), 0, std::cos(M_PI / 4.0f));
@@ -240,13 +244,13 @@ static void test_axis_angle_to_quat() {
 
     // Zero angle → identity
     glm::vec4 q = axis_angle_to_quat(glm::vec3(1, 0, 0), 0.0f);
-    check(approx_vec4(q, glm::vec4(0, 0, 0, 1)), "zero angle → identity quaternion");
+    check(approx_vec4(q, glm::vec4(0.0f, 0.0f, 0.0f, 1.0f)), "zero angle → identity quaternion");
 
     // 90deg around Z
     q = axis_angle_to_quat(glm::vec3(0, 0, 1), static_cast<float>(M_PI / 2.0));
     float expected_s = std::sin(M_PI / 4.0f);
     float expected_c = std::cos(M_PI / 4.0f);
-    check(approx_vec4(q, glm::vec4(0, 0, expected_s, expected_c)),
+    check(approx_vec4(q, glm::vec4(0.0f, 0.0f, expected_s, expected_c)),
           "90deg around Z produces correct quaternion");
 
     // Result is unit length


### PR DESCRIPTION
## Summary

- Add a GPU-driven Position Based Dynamics (PBD) compute shader that provides both position and rotation updates, solving the "rotation trap" where Gaussians translate but keep their original orientation
- Reserve `bone_idx` range 32-63 for PBD elements alongside existing bone skinning (1-31), with a new `PbdBuffer` SSBO at binding 6 in the preprocess descriptor set
- Include wind sway placeholder in `pbd_solver.comp`, full test suite (`test_pbd_solver`), and architecture docs (`docs/pbd-solver.md`)

## Changes

| File | Description |
|------|-------------|
| `shaders/pbd_solver.comp` | New compute shader — wind sway placeholder writing position + rotation |
| `shaders/gs_preprocess.comp` | Read `PbdBuffer` at binding 6; anchor-relative quaternion rotation for idx 32-63 |
| `include/gseurat/engine/gs_renderer.hpp` | `PbdState` struct, PBD pipeline members, public API |
| `src/engine/gs_renderer.cpp` | Buffer/descriptor/pipeline creation, Phase 0 dispatch, API implementations |
| `shaders/CMakeLists.txt` | Add `pbd_solver.comp` to shader compilation |
| `tests/test_pbd_solver.cpp` | 7 test groups: struct layout, index segmentation, quaternion math, wind sway |
| `CMakeLists.txt` | Register `test_pbd_solver` |
| `docs/pbd-solver.md` | Architecture reference (pipeline diagram, buffer layouts, API, dispatch order) |
| `README.md` | Add PBD to features, pipeline section, character pipeline, test table |
| `tests/README.md` | Add `test_pbd_solver` documentation |

## Test plan

- [x] `cmake --build --preset macos-debug` — builds without errors
- [x] `ctest --test-dir build/macos-debug -R test_pbd_solver` — all 7 test groups pass
- [x] Full test suite — 25/26 pass (pre-existing `test_gs_particle` abort unchanged)
- [ ] CI build matrix (Linux, macOS, Windows)
- [ ] Visual verification: assign PBD indices to foliage Gaussians, confirm sway with wind params

🤖 Generated with [Claude Code](https://claude.com/claude-code)