### PR TITLE
feat: GPU PBD physics solver with Verlet integration and constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Vulkan-based 3D Gaussian Splatting engine built with C++23. Named after **3DGS
 ## Features
 
 - **3D Gaussian Splatting** — GPU compute pipeline for rendering `.ply` point clouds with tile-based rasterization, dynamic point light support
-- **GPU PBD solver** — Position Based Dynamics compute shader for foliage sway, with quaternion rotation to preserve Gaussian orientation
+- **GPU PBD solver** — Position Based Dynamics compute shader with Verlet integration, iterative distance constraints, and ground collision. Dual-mode: wind-only (backward-compatible foliage sway) and full physics (dangling chains, pendulums)
 - **Voxel character pipeline** — MagicaVoxel import, rigid-body-part posing, GPU bone skinning in compute shader
 - **Sprite overlay** — Sprite-based entities over GS backgrounds with bloom, depth-of-field, and tone mapping
 - **Game Object System** — Unified entity model with component composition. Developers define C++ component structs + JSON schemas; level designers compose objects in Bricklayer
@@ -140,7 +140,7 @@ PLY file → GaussianCloud → GsRenderer (compute) → Storage Image → Fullsc
 
 Compute passes before the main render pass:
 
-0. **PBD Solver** (optional) — GPU-driven Position Based Dynamics for foliage sway, writes position + rotation deltas
+0. **PBD Solver** (optional) — GPU-driven Position Based Dynamics physics solver: Verlet integration, distance constraint projection, ground collision. Writes position + rotation deltas
 1. **Preprocess** — project 3D Gaussians to 2D, frustum cull, compute 2D covariance (reads PBD + bone transforms)
 2. **Bitonic Sort** — depth-sort projected splats front-to-back
 3. **Tile Rasterizer** — 16x16 tile-based splatting into a 320x240 HDR storage image
@@ -166,6 +166,7 @@ Output is sampled with nearest-neighbor filtering for stylized upscale.
 | P | Toggle shadow box (parallax) mode |
 | T/L/F/G/X | Toon / Light / Fire / Water / Touch |
 | E/V/H/Y/C/B | Explode / Voxel / Pulse / X-Ray / Swirl / Burn |
+| J | Toggle chain demo (3 PBD elements, 2 distance constraints) |
 | K | Toggle character demo (procedural walking humanoid) |
 | N | Toggle scene layers (auto-generate heightmap, nav, light probes) |
 
@@ -190,7 +191,8 @@ Engine: PLY load → bone_index per Gaussian → preprocess shader → skeletal 
 - `bone_index` packed into `GpuGaussian.scale_pad.w` (no SSBO size change)
 - Index segmentation: 0 = no transform, 1-31 = bone skinning (binding 5), 32-63 = PBD dynamics (binding 6)
 - Bone transform SSBO at binding 5 (max 32 bones)
-- PBD state SSBO at binding 6 (max 32 elements) — position anchors + rotation quaternions
+- PBD state SSBO at binding 6 (max 64 elements) — position anchors + rotation quaternions
+- PBD API: `upload_pbd_elements()`, `upload_pbd_constraints()`, `clear_pbd()` on `GsRenderer`
 - Preprocess shader applies `mat4` per bone or PBD quaternion rotation per element
 - Bone 0 = identity (map Gaussians pass through untouched)
 - Rigid body part animation (action-figure style, no smooth skinning)
@@ -363,7 +365,7 @@ ctest --test-dir build/<platform>-debug --output-on-failure
 | `test_gs_parallax_camera` | 6 | Camera configuration, Y-flip, smoothing convergence |
 | `test_screenshot` | 5 | State machine, BGRA→RGBA swizzle |
 | `test_character_data` | 12 | Character animation JSON loading |
-| `test_pbd_solver` | 7 | PBD struct layout, index segmentation, quaternion math, wind sway |
+| `test_pbd_solver` | 10 | PBD struct layouts (64/48/32 bytes), index segmentation, quaternion math, Verlet integration, distance constraint projection, wind sway |
 
 ### TypeScript Tool Tests
 

--- a/docs/pbd-solver.md
+++ b/docs/pbd-solver.md
@@ -1,175 +1,210 @@
-# PBD Solver — GPU-Driven Position Based Dynamics
+# PBD Solver -- GPU-Driven Position Based Dynamics
 
 ## Overview
 
-The PBD solver adds a GPU-driven physics simulation pipeline for Gaussian Splatting objects that need dynamic motion — swaying trees, rustling foliage, flapping banners, etc. It runs as a compute shader dispatched **before** the GS preprocess pass, writing per-element position and rotation deltas that the preprocess shader consumes.
+Position Based Dynamics (PBD) is a physics simulation method that works directly on particle positions rather than forces and accelerations. The GSeurat PBD solver runs as a GPU compute shader, enabling physically plausible motion for Gaussian Splatting objects: swaying foliage, dangling chains, falling objects, flapping flags, and more.
 
-## The Rotation Trap
-
-In 3DGS, each Gaussian has a position and a rotation quaternion that defines its orientation. Naive physics simulation that only updates position causes Gaussians to translate while keeping their original orientation, visually tearing apart structured objects like branches and leaves.
-
-The PBD solver avoids this by providing **both position anchors and rotation quaternions**. The preprocess shader:
-1. Rotates each Gaussian's local offset (relative to its anchor) by the PBD quaternion
-2. Composes the PBD rotation with the Gaussian's original rotation
-
-This preserves rigid-body structure during bending and swaying.
+The solver implements Verlet integration for time-stepping, iterative distance constraint projection for connectivity, and ground plane collision. It dispatches before the GS preprocess pass, writing per-element positions and rotations that the preprocess shader consumes to transform attached Gaussians.
 
 ## Architecture
 
 ```
-CPU (per frame)                    GPU Pipeline
-────────────────                   ──────────────────────────────────
-set_pbd_anchors()  ──►  pbd_ssbo_
-set_pbd_wind()     ──►  pbd_ubo_
-                                   ┌─────────────────┐
-                                   │  pbd_solver.comp │  Phase 0 (new)
-                                   │  writes rotation │
-                                   │  + position      │
-                                   └────────┬────────┘
-                                            │ barrier
-                                   ┌────────▼────────┐
-                                   │ gs_preprocess    │  Phase 1-2
-                                   │ reads pbd_states │
-                                   │ at binding 6     │
-                                   └────────┬────────┘
-                                            │
-                                   ┌────────▼────────┐
-                                   │ sort → merge →   │  Phase 3-4
-                                   │ tile rasterize   │
-                                   └─────────────────┘
+CPU (per frame)                         GPU Pipeline
+------------------------------------    ------------------------------------------
+upload_pbd_elements()  -->  states_ssbo_    (binding 0, read/write)
+                       -->  params_ssbo_    (binding 1, read-only)
+upload_pbd_constraints() -> constraints_ssbo_ (binding 2, read-only)
+                            pbd_ubo_        (binding 3, time/dt/iterations/counts)
+
+                                        +---------------------+
+                                        |  pbd_solver.comp    |  Phase 0
+                                        |  Verlet predict     |
+                                        |  ground collision   |
+                                        |  constraint project |
+                                        |  rotation output    |
+                                        +---------+-----------+
+                                                  | barrier (SHADER_WRITE -> SHADER_READ)
+                                        +---------+-----------+
+                                        | gs_preprocess.comp  |  Phase 1-2
+                                        | reads pbd_states[]  |
+                                        | at binding 6        |
+                                        +---------+-----------+
+                                                  |
+                                        +---------+-----------+
+                                        | sort -> merge ->    |  Phase 3-4
+                                        | tile rasterize      |
+                                        +---------------------+
 ```
+
+The preprocess shader sees PBD output as a `PbdState { vec4 position; vec4 rotation; }` at binding 6. The solver writes the rotation quaternion into the `prev_position` slot of `PbdPhysicsState`, which aligns with the `rotation` field of the preprocess `PbdState` struct (both are the second vec4).
+
+## GPU Buffers
+
+### PbdPhysicsState (binding 0, read/write, 64 bytes)
+
+```glsl
+struct PbdPhysicsState {
+    vec4 position;       // xyz = current position, w = inv_mass (0 = pinned)
+    vec4 prev_position;  // xyz = previous frame position, w = unused
+    vec4 velocity;       // xyz = current velocity, w = unused
+    vec4 params;         // x = sway_threshold, yzw = reserved
+};
+```
+
+- **inv_mass** (position.w): Inverse mass. Zero means pinned (immovable anchor). Positive values allow motion; higher values = lighter.
+- **prev_position**: Used for Verlet velocity estimation. After the solver finishes, this slot is overwritten with the output rotation quaternion for the preprocess shader.
+- Max elements: 64 (`kMaxPbdElements`)
+
+### PbdElementParams (binding 1, read-only, 48 bytes)
+
+```glsl
+struct PbdElementParams {
+    vec4 gravity;   // xyz = gravity vector, w = damping (0-1)
+    vec4 wind;      // xyz = wind direction, w = wind_strength
+    vec4 dynamics;  // x = wind_frequency, y = ground_y, z = bounce, w = unused
+};
+```
+
+Each element has its own gravity, wind, and collision parameters, allowing different behavior per object (e.g., heavy chains vs. light foliage).
+
+### PbdConstraint (binding 2, read-only, 32 bytes)
+
+```glsl
+struct PbdConstraint {
+    uvec4 indices;  // x = element_a, y = element_b, zw = unused
+    vec4 params;    // x = rest_length, y = stiffness (0-1), zw = unused
+};
+```
+
+Distance constraints maintain a target rest length between two elements. Max constraints: 128 (`kMaxPbdConstraints`).
+
+### PBD Uniforms (binding 3)
+
+```glsl
+layout(set = 0, binding = 3) uniform PbdUniforms {
+    float time;              // elapsed time (for wind phase)
+    float dt;                // frame delta time
+    uint  iterations;        // constraint solver iterations (default 4)
+    uint  count;             // number of active elements
+    uint  constraint_count;  // number of active constraints
+    uint  pad0, pad1, pad2;  // alignment padding
+};
+```
+
+## Solver Algorithm
+
+The solver executes in a single compute dispatch (`local_size_x = 64`). Each thread processes one PBD element:
+
+1. **External forces**: Accumulate gravity and sinusoidal wind force. Wind uses per-element phase variation via `dot(pos, hash_vec)` to prevent synchronized motion.
+
+2. **Verlet integration**: Predict the next position from the current and previous positions:
+   ```
+   velocity = (position - prev_position) * damping
+   predicted = position + velocity + acceleration * dt^2
+   ```
+
+3. **Ground collision**: If `predicted.y < ground_y`, clamp to the ground plane. Reflect the previous position above ground scaled by the bounce coefficient for restitution.
+
+4. **Write predicted position** and synchronize (`memoryBarrierBuffer` + `barrier`).
+
+5. **Constraint projection** (N iterations, default 4): For each constraint involving this element, compute the position correction:
+   ```
+   error = (distance - rest_length) / distance
+   correction = delta * error * stiffness / iterations
+   ```
+   Corrections are distributed between the two elements proportional to their inverse masses. Each iteration is followed by a barrier.
+
+6. **Velocity update**: Derive the post-solve velocity from the position change: `velocity = (position - prev_position) / dt`.
+
+7. **Rotation output**: Compute a quaternion and write it into `prev_position` for the preprocess shader:
+   - In wind sway mode (no constraints): procedural sine-wave axis-angle rotation
+   - In constraint mode: velocity-derived tilt rotation (lean in direction of movement, capped at ~28 degrees)
+   - Pinned elements: identity quaternion (no rotation)
 
 ## Index Segmentation
 
-The `bone_index` field in each Gaussian (packed into `GpuGaussian.scale_pad.w` as a float-encoded uint32) determines how it is transformed:
+The `bone_index` field in each Gaussian determines how it is transformed by the preprocess shader:
 
 | Range | Behavior | Maps to |
 |-------|----------|---------|
 | 0 | No transform | Pass-through |
-| 1 - 31 | Bone skinning | `bone_transforms[bone_idx]` |
-| 32 - 63 | PBD dynamics | `pbd_states[bone_idx - 32]` |
+| 1-31 | Bone skinning | `bone_transforms[bone_idx]` |
+| 32-63 | PBD dynamics | `pbd_states[bone_idx - 32]` |
 
-This gives 32 PBD elements, each controlling a group of Gaussians. A single PBD element (e.g., index 32) can drive hundreds of Gaussians — all foliage Gaussians belonging to one tree branch would share the same PBD index.
-
-## GPU Buffers
-
-### PbdState SSBO (binding 6 in preprocess)
-
-```glsl
-struct PbdState {
-    vec4 position;  // xyz = anchor position, w = unused
-    vec4 rotation;  // xyzw = delta quaternion (identity = no change)
-};
-
-layout(set = 0, binding = 6) readonly buffer PbdBuffer {
-    PbdState pbd_states[];  // max 32 elements
-};
-```
-
-- 32 bytes per element, 1024 bytes total
-- The PBD solver writes rotation quaternions; the preprocess shader reads them
-- Identity quaternion `(0, 0, 0, 1)` = no rotation applied
-
-### PBD Uniforms (binding 1 in solver)
-
-```glsl
-layout(set = 0, binding = 1) uniform PbdUniforms {
-    vec4 params;    // x = time, y = wind_strength, z = wind_freq, w = pbd_count
-    vec4 wind_dir;  // xyz = normalized wind direction, w = unused
-};
-```
-
-## Preprocess Shader Integration
-
-In `gs_preprocess.comp`, the PBD path applies anchor-relative rotation:
-
-```glsl
-if (bone_idx >= 32 && bone_idx < 64) {
-    uint pbd_idx = bone_idx - 32;
-    PbdState pbd = pbd_states[pbd_idx];
-    vec4 pbd_q = normalize(pbd.rotation);
-
-    // Rotate local offset around anchor point
-    vec3 local_offset = pos - pbd.position.xyz;
-    vec3 t = 2.0 * cross(pbd_q.xyz, local_offset);
-    pos = pbd.position.xyz + local_offset + pbd_q.w * t + cross(pbd_q.xyz, t);
-
-    // Compose with original Gaussian rotation
-    rot_q = quat_mul(pbd_q, rot_q);
-}
-```
-
-The vector rotation uses the optimized quaternion rotation formula (`q * v * q^-1` expanded) — no matrix conversion needed.
-
-## PBD Solver Shader
-
-`pbd_solver.comp` currently implements a wind sway placeholder:
-
-- Each PBD element receives a sinusoidal oscillation based on its anchor position
-- The sway axis is perpendicular to wind direction and world up
-- Spatial phase variation via `dot(anchor, hash_vec)` prevents synchronized motion
-- Output: axis-angle quaternion written to `pbd_states[].rotation`
-
-This is designed to be replaced or extended with a full PBD constraint solver (distance constraints, bending constraints, collision) when needed.
+A single PBD element can drive hundreds of Gaussians. All foliage Gaussians belonging to one tree branch share the same PBD index. Set `bone_index` to values 32-63 when creating Gaussian data.
 
 ## C++ API
 
 ```cpp
-// Set anchor positions for PBD elements (max 32)
-// Each anchor is the pivot point around which attached Gaussians rotate
-gs_renderer.set_pbd_anchors(anchors, count);
+#include <gseurat/engine/pbd_types.hpp>
 
-// Configure wind parameters
-gs_renderer.set_pbd_wind(
-    glm::vec3(1, 0, 0),  // wind direction
-    0.3f,                  // strength (max sway angle in radians)
-    2.0f                   // frequency (oscillations per second)
-);
+// Upload element states and per-element parameters (max kMaxPbdElements = 64)
+gs_renderer.upload_pbd_elements(states, params, count);
 
-// Reset all PBD state to identity (no simulation)
+// Upload distance constraints (max kMaxPbdConstraints = 128)
+gs_renderer.upload_pbd_constraints(constraints, count);
+
+// Reset all PBD state (zero elements and constraints)
 gs_renderer.clear_pbd();
+
+// Query
+gs_renderer.pbd_count();             // active element count
+gs_renderer.pbd_constraint_count();  // active constraint count
 ```
 
-## Assigning PBD Indices to Gaussians
+## Parameters Reference
 
-When creating Gaussian data (e.g., in scene loading or procedural generation), set `bone_index` to values in the 32-63 range:
+| Parameter | Location | Description | Typical Value |
+|-----------|----------|-------------|---------------|
+| inv_mass | PbdPhysicsState.position.w | Inverse mass (0 = pinned/anchor) | 0.0 (pinned) or 1.0 |
+| gravity | PbdElementParams.gravity.xyz | Gravity acceleration vector | (0, -9.8, 0) |
+| damping | PbdElementParams.gravity.w | Velocity damping per frame (0 = full damp, 1 = none) | 0.98 |
+| wind_dir | PbdElementParams.wind.xyz | Wind direction (normalized) | (1, 0, 0) |
+| wind_strength | PbdElementParams.wind.w | Wind force amplitude | 0.3 |
+| wind_freq | PbdElementParams.dynamics.x | Wind oscillation frequency | 2.0 |
+| ground_y | PbdElementParams.dynamics.y | Ground collision plane Y | -100.0 (disabled) |
+| bounce | PbdElementParams.dynamics.z | Restitution coefficient (0-1) | 0.3 |
+| rest_length | PbdConstraint.params.x | Target distance between elements | Varies |
+| stiffness | PbdConstraint.params.y | Constraint stiffness (0-1) | 0.8 |
 
-```cpp
-Gaussian g;
-g.position = glm::vec3(10, 5, 0);
-g.bone_index = 32;  // First PBD element — tree trunk
-// Other Gaussians on the same branch also use bone_index = 32
-```
+## Wind Sway Mode
 
-Multiple Gaussians sharing the same PBD index move as a rigid group around the anchor point. Use different indices (32, 33, 34, ...) for independently moving parts (e.g., separate branches).
+When `constraint_count == 0`, the solver falls back to a backward-compatible wind sway mode. Instead of deriving rotation from velocity, it generates procedural sine-wave rotations from the wind parameters -- the same visual behavior as the original pre-physics placeholder. This means existing scenes that only use `upload_pbd_elements()` without constraints continue to work unchanged.
 
 ## Dispatch Order
 
 The PBD solver is dispatched as **Phase 0** in the GS compute pipeline:
 
-1. **Phase 0**: PBD solver (if `pbd_count_ > 0`) — writes `pbd_states[]`
-2. Memory barrier (`SHADER_WRITE → SHADER_READ`)
+1. **Phase 0**: PBD solver (if `pbd_count_ > 0`) -- writes element states
+2. Memory barrier (`SHADER_WRITE -> SHADER_READ`)
 3. **Phase 1**: Dynamic preprocess + sort
 4. **Phase 2**: Static preprocess + sort (if dirty)
 5. **Phase 3**: Merge
 6. **Phase 4**: Tile rasterization
 7. Post-process
 
-When `pbd_count_ == 0`, Phase 0 is skipped entirely — zero overhead for scenes without PBD.
+When `pbd_count_ == 0`, Phase 0 is skipped entirely -- zero overhead for scenes without PBD.
+
+## Demo Controls
+
+- **J key** (island demo): Toggles a dangling chain demo. Spawns 3 PBD elements (1 pinned anchor + 2 free-hanging) connected by 2 distance constraints near the player character. Press J again to clear.
 
 ## Testing
 
-`test_pbd_solver` validates the CPU-side contracts without requiring a GPU:
+`test_pbd_solver` validates CPU-side contracts without requiring a GPU:
 
 | Test | What it verifies |
 |------|------------------|
-| PbdState layout | 32 bytes, correct field offsets for GPU std430 |
+| PbdPhysicsState layout | 64 bytes, correct field offsets for GPU std430 |
+| PbdElementParams layout | 48 bytes, correct field offsets |
+| PbdConstraint layout | 32 bytes, correct field offsets |
 | Index segmentation | Round-trip encoding, correct range routing (0/1-31/32-63) |
 | Quaternion multiplication | Identity, composition, unit length preservation |
 | Quaternion-vector rotation | Axis rotations, magnitude preservation |
 | PBD transform composition | Anchor-relative rotation, rigid-body distance preservation |
-| Axis-angle conversion | Zero angle → identity, unit length, 180deg edge case |
-| Wind sway output | Unit quaternions, bounded angles, spatial variation |
+| Axis-angle conversion | Zero angle -> identity, unit length, 180deg edge case |
+| Verlet integration | Position prediction with gravity and damping |
+| Constraint projection | Distance correction, mass-weighted distribution, pinned elements |
 
 ```bash
 ctest --test-dir build/macos-debug -R test_pbd_solver
@@ -177,10 +212,8 @@ ctest --test-dir build/macos-debug -R test_pbd_solver
 
 ## Future Extensions
 
-The current wind sway placeholder establishes the GPU pipeline. Future work may include:
-
-- **Distance constraints**: maintain rest-length between connected PBD elements (chain/rope simulation)
-- **Bending constraints**: resist angular change between parent-child elements (stiff branches)
-- **Collision constraints**: prevent PBD elements from penetrating terrain or other objects
-- **Multi-iteration solver**: multiple constraint projection passes per frame for stability
-- **Scale/covariance updates**: soft-body deformation (stretching, squashing) for advanced VFX
+- **Bending constraints**: Resist angular change between three connected elements (stiff branches, hair)
+- **Cloth grids**: 2D constraint grids for flags and fabric simulation
+- **Bricklayer UI**: Visual PBD element placement, constraint wiring, parameter tuning in the map editor
+- **Scale/covariance updates**: Soft-body deformation (stretching, squashing) for advanced VFX
+- **Self-collision**: Prevent PBD elements from overlapping each other

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -88,8 +88,9 @@ private:
     enum class HudMode { kOff, kCompact, kFull };
     HudMode hud_mode_ = HudMode::kOff;
 
-    // Toggle flags (P = particles, N = animation)
+    // Toggle flags (P = particles, N = animation, J = PBD chain)
     bool anim_enabled_ = true;
+    bool pbd_chain_active_ = false;
 
     // FPS tracking
     std::chrono::steady_clock::time_point fps_clock_{};

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -2,6 +2,7 @@
 
 #include "gseurat/engine/buffer.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/pbd_types.hpp"
 #include "gseurat/engine/types.hpp"
 
 #include <vk_mem_alloc.h>
@@ -157,15 +158,13 @@ public:
     void clear_bone_transforms();
 
     // PBD (Position Based Dynamics) solver
-    static constexpr uint32_t kMaxPbdElements = 32;
-    struct PbdState {
-        glm::vec4 position;  // xyz = anchor, w = unused
-        glm::vec4 rotation;  // xyzw = delta quaternion
-    };
-    void set_pbd_anchors(const glm::vec3* anchors, uint32_t count);
-    void set_pbd_wind(const glm::vec3& direction, float strength, float frequency);
+    void upload_pbd_elements(const PbdPhysicsState* states,
+                             const PbdElementParams* params,
+                             uint32_t count);
+    void upload_pbd_constraints(const PbdConstraint* constraints, uint32_t count);
     void clear_pbd();
     uint32_t pbd_count() const { return pbd_count_; }
+    uint32_t pbd_constraint_count() const { return pbd_constraint_count_; }
 
     // Post-process parameters (fog, tone mapping, vignette, etc.)
     void set_post_process_params(const GsPostProcessParams& p) { gs_pp_params_ = p; }
@@ -215,12 +214,12 @@ private:
     uint32_t bone_count_ = 0;
 
     // PBD solver resources
-    Buffer pbd_ssbo_;                // PbdState array (read/write by solver, read by preprocess)
-    Buffer pbd_uniform_buffer_;      // PBD solver uniforms (time, wind params)
+    Buffer pbd_state_ssbo_;
+    Buffer pbd_params_ssbo_;
+    Buffer pbd_constraint_ssbo_;
+    Buffer pbd_uniform_buffer_;
     uint32_t pbd_count_ = 0;
-    glm::vec3 pbd_wind_dir_{1.0f, 0.0f, 0.0f};
-    float pbd_wind_strength_ = 0.0f;
-    float pbd_wind_freq_ = 2.0f;
+    uint32_t pbd_constraint_count_ = 0;
 
     // Static/dynamic split buffers
     Buffer static_gaussian_ssbo_;

--- a/include/gseurat/engine/pbd_types.hpp
+++ b/include/gseurat/engine/pbd_types.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <cstdint>
+
+namespace gseurat {
+
+// GPU PBD state per element (std430, 4 × vec4 = 64 bytes)
+struct PbdPhysicsState {
+    glm::vec4 position;       // xyz = current position, w = inv_mass (0 = pinned)
+    glm::vec4 prev_position;  // xyz = previous frame position, w = unused
+    glm::vec4 velocity;       // xyz = current velocity, w = unused
+    glm::vec4 params;         // x = sway_threshold, yzw = unused (reserved)
+};
+
+// Distance constraint between two PBD elements (std430, 2 × vec4 = 32 bytes)
+struct PbdConstraint {
+    glm::uvec4 indices;  // x = element_a, y = element_b, zw = unused
+    glm::vec4 params;    // x = rest_length, y = stiffness (0-1), zw = unused
+};
+
+// Per-element simulation parameters (std430, 3 × vec4 = 48 bytes)
+struct PbdElementParams {
+    glm::vec4 gravity;   // xyz = gravity vector, w = damping (0-1)
+    glm::vec4 wind;      // xyz = wind direction, w = wind_strength
+    glm::vec4 dynamics;  // x = wind_frequency, y = ground_y (collision plane), z = bounce, w = unused
+};
+
+// Limits
+static constexpr uint32_t kMaxPbdElements = 64;
+static constexpr uint32_t kMaxPbdConstraints = 128;
+static constexpr uint32_t kPbdSolverIterations = 4;
+
+}  // namespace gseurat

--- a/shaders/gs_preprocess.comp
+++ b/shaders/gs_preprocess.comp
@@ -65,9 +65,12 @@ layout(set = 0, binding = 5) readonly buffer BoneBuffer {
 };
 
 // PBD (Position Based Dynamics) state — written by pbd_solver.comp
+// Must match PbdPhysicsState layout (64 bytes) for correct array stride
 struct PbdState {
-    vec4 position; // xyz = anchor position, w = unused
-    vec4 rotation; // xyzw = delta quaternion (identity = no change)
+    vec4 position; // xyz = position, w = inv_mass
+    vec4 rotation; // xyzw = delta quaternion (solver writes rotation here)
+    vec4 _pad0;    // velocity (unused by preprocess)
+    vec4 _pad1;    // params (unused by preprocess)
 };
 
 layout(set = 0, binding = 6) readonly buffer PbdBuffer {

--- a/shaders/pbd_solver.comp
+++ b/shaders/pbd_solver.comp
@@ -2,19 +2,45 @@
 
 layout(local_size_x = 64) in;
 
-// PBD state output — consumed by gs_preprocess.comp at binding 6
-struct PbdState {
-    vec4 position; // xyz = anchor position, w = unused
-    vec4 rotation; // xyzw = delta quaternion (identity = no change)
+struct PbdPhysicsState {
+    vec4 position;       // xyz = pos, w = inv_mass
+    vec4 prev_position;  // xyz = prev pos, w = unused
+    vec4 velocity;       // xyz = velocity, w = unused
+    vec4 params;         // x = sway_threshold, yzw = reserved
 };
 
-layout(set = 0, binding = 0) buffer PbdBuffer {
-    PbdState pbd_states[];
+struct PbdElementParams {
+    vec4 gravity;   // xyz = gravity, w = damping
+    vec4 wind;      // xyz = wind_dir, w = wind_strength
+    vec4 dynamics;  // x = wind_freq, y = ground_y, z = bounce, w = unused
 };
 
-layout(set = 0, binding = 1) uniform PbdUniforms {
-    vec4 params;       // x = time, y = wind_strength, z = wind_freq, w = pbd_count
-    vec4 wind_dir;     // xyz = wind direction (normalized), w = unused
+struct PbdConstraint {
+    uvec4 indices;  // x = elem_a, y = elem_b, zw = unused
+    vec4 params;    // x = rest_length, y = stiffness, zw = unused
+};
+
+layout(set = 0, binding = 0) buffer StateBuffer {
+    PbdPhysicsState states[];
+};
+
+layout(set = 0, binding = 1) readonly buffer ParamsBuffer {
+    PbdElementParams elem_params[];
+};
+
+layout(set = 0, binding = 2) readonly buffer ConstraintBuffer {
+    PbdConstraint constraints[];
+};
+
+layout(set = 0, binding = 3) uniform PbdUniforms {
+    float time;
+    float dt;
+    uint iterations;
+    uint count;
+    uint constraint_count;
+    uint pad0;
+    uint pad1;
+    uint pad2;
 };
 
 layout(push_constant) uniform PushConstants {
@@ -32,29 +58,139 @@ void main() {
     uint idx = gl_GlobalInvocationID.x;
     if (idx >= pbd_count) return;
 
-    PbdState state = pbd_states[idx];
-    vec3 anchor = state.position.xyz;
+    PbdPhysicsState state = states[idx];
+    PbdElementParams ep = elem_params[idx];
 
-    float time = params.x;
-    float wind_strength = params.y;
-    float wind_freq = params.z;
-    vec3 wind = normalize(wind_dir.xyz);
+    float inv_mass = state.position.w;
+    vec3 pos = state.position.xyz;
+    vec3 prev_pos = state.prev_position.xyz;
 
-    // --- Placeholder: sinusoidal wind sway ---
-    // Each PBD element gets a phase-shifted oscillation based on its anchor position
-    float phase = dot(anchor, vec3(0.37, 0.13, 0.71));  // spatial hash for variation
-    float sway_angle = sin(time * wind_freq + phase) * wind_strength;
+    // Store original position for rotation derivation
+    vec3 original_pos = pos;
 
-    // Rotation axis is perpendicular to wind direction and up
-    vec3 sway_axis = normalize(cross(wind, vec3(0.0, 1.0, 0.0)));
-    // Fallback if wind is exactly vertical
-    if (length(sway_axis) < 0.001) {
-        sway_axis = vec3(1.0, 0.0, 0.0);
+    // Skip pinned elements (inv_mass == 0)
+    if (inv_mass > 0.0) {
+        // --- External forces ---
+        vec3 accel = ep.gravity.xyz;
+        float damping = ep.gravity.w;
+
+        // Wind force (sinusoidal, per-element phase variation)
+        float wind_strength = ep.wind.w;
+        if (wind_strength > 0.0) {
+            vec3 wind_dir = normalize(ep.wind.xyz);
+            float freq = ep.dynamics.x;
+            float phase = dot(pos, vec3(0.37, 0.13, 0.71));
+            float wind_force = sin(time * freq + phase) * wind_strength;
+            accel += wind_dir * wind_force;
+        }
+
+        // --- Verlet integration ---
+        vec3 vel = (pos - prev_pos) * damping;
+        vec3 predicted = pos + vel + accel * dt * dt;
+
+        prev_pos = pos;
+        pos = predicted;
+
+        // --- Ground collision ---
+        float ground_y = ep.dynamics.y;
+        float bounce = ep.dynamics.z;
+        if (pos.y < ground_y) {
+            pos.y = ground_y;
+            if (prev_pos.y > ground_y) {
+                float penetration_vel = (prev_pos.y - ground_y);
+                prev_pos.y = pos.y + penetration_vel * bounce;
+            }
+        }
     }
 
-    // Write delta quaternion (rotation to apply in preprocess)
-    state.rotation = axis_angle_to_quat(sway_axis, sway_angle);
+    // Write predicted position (constraints will correct it)
+    states[idx].prev_position = vec4(prev_pos, 0.0);
+    states[idx].position = vec4(pos, inv_mass);
 
-    // Position anchor unchanged (PBD constraints would update this in a full solver)
-    pbd_states[idx] = state;
+    // --- Synchronize before constraint solving ---
+    memoryBarrierBuffer();
+    barrier();
+
+    // --- Constraint projection (iterative) ---
+    for (uint iter = 0; iter < iterations; iter++) {
+        for (uint ci = 0; ci < constraint_count; ci++) {
+            PbdConstraint c = constraints[ci];
+            uint a = c.indices.x;
+            uint b = c.indices.y;
+
+            if (a != idx && b != idx) continue;
+
+            float rest_length = c.params.x;
+            float stiffness = c.params.y;
+
+            vec3 pos_a = states[a].position.xyz;
+            vec3 pos_b = states[b].position.xyz;
+            float inv_mass_a = states[a].position.w;
+            float inv_mass_b = states[b].position.w;
+
+            vec3 delta = pos_b - pos_a;
+            float dist = length(delta);
+            if (dist < 1e-6) continue;
+
+            float w_sum = inv_mass_a + inv_mass_b;
+            if (w_sum < 1e-6) continue;
+
+            float error = (dist - rest_length) / dist;
+            vec3 correction = delta * error * stiffness / float(iterations);
+
+            if (a == idx && inv_mass_a > 0.0) {
+                pos = states[idx].position.xyz + correction * (inv_mass_a / w_sum);
+                states[idx].position = vec4(pos, inv_mass);
+            }
+            if (b == idx && inv_mass_b > 0.0) {
+                pos = states[idx].position.xyz - correction * (inv_mass_b / w_sum);
+                states[idx].position = vec4(pos, inv_mass);
+            }
+        }
+
+        memoryBarrierBuffer();
+        barrier();
+    }
+
+    // --- Update velocity from position change ---
+    pos = states[idx].position.xyz;
+    prev_pos = states[idx].prev_position.xyz;
+    vec3 final_vel = (pos - prev_pos) / max(dt, 1e-6);
+    states[idx].velocity = vec4(final_vel, 0.0);
+
+    // --- Compute rotation for preprocess shader ---
+    // For wind sway (no constraints): use sine-wave rotation as before
+    // For constrained elements: derive rotation from displacement
+    vec4 rot = vec4(0.0, 0.0, 0.0, 1.0);  // identity
+
+    if (inv_mass > 0.0) {
+        if (constraint_count == 0) {
+            // Wind sway mode: procedural rotation from wind params
+            float wind_strength = ep.wind.w;
+            if (wind_strength > 0.0) {
+                vec3 wind_dir = normalize(ep.wind.xyz);
+                float freq = ep.dynamics.x;
+                float phase = dot(pos, vec3(0.37, 0.13, 0.71));
+                float sway_angle = sin(time * freq + phase) * wind_strength;
+                vec3 sway_axis = normalize(cross(wind_dir, vec3(0, 1, 0)));
+                if (length(sway_axis) < 0.001) sway_axis = vec3(1, 0, 0);
+                rot = axis_angle_to_quat(sway_axis, sway_angle);
+            }
+        } else {
+            // Constraint mode: derive rotation from velocity direction
+            float speed = length(final_vel);
+            if (speed > 0.1) {
+                vec3 vel_dir = final_vel / speed;
+                // Tilt rotation: lean in direction of movement
+                vec3 tilt_axis = normalize(cross(vec3(0, 1, 0), vel_dir));
+                if (length(tilt_axis) > 0.001) {
+                    float tilt_angle = min(speed * 0.02, 0.5);  // cap at ~28 degrees
+                    rot = axis_angle_to_quat(tilt_axis, tilt_angle);
+                }
+            }
+        }
+    }
+
+    // Write rotation into prev_position slot — preprocess reads this as PbdState.rotation
+    states[idx].prev_position = rot;
 }

--- a/shaders/pbd_solver.comp
+++ b/shaders/pbd_solver.comp
@@ -56,116 +56,121 @@ vec4 axis_angle_to_quat(vec3 axis, float angle) {
 
 void main() {
     uint idx = gl_GlobalInvocationID.x;
-    if (idx >= pbd_count) return;
 
-    PbdPhysicsState state = states[idx];
-    PbdElementParams ep = elem_params[idx];
+    // All threads must participate in barrier() calls.
+    // Out-of-range threads skip work but still hit barriers.
+    bool is_valid = (idx < pbd_count);
 
-    float inv_mass = state.position.w;
-    vec3 pos = state.position.xyz;
-    vec3 prev_pos = state.prev_position.xyz;
+    float inv_mass = 0.0;
+    vec3 pos = vec3(0.0);
+    vec3 prev_pos = vec3(0.0);
+    PbdElementParams ep;
 
-    // Store original position for rotation derivation
-    vec3 original_pos = pos;
+    if (is_valid) {
+        PbdPhysicsState state = states[idx];
+        ep = elem_params[idx];
 
-    // Skip pinned elements (inv_mass == 0)
-    if (inv_mass > 0.0) {
-        // --- External forces ---
-        vec3 accel = ep.gravity.xyz;
-        float damping = ep.gravity.w;
+        inv_mass = state.position.w;
+        pos = state.position.xyz;
+        prev_pos = state.prev_position.xyz;
 
-        // Wind force (sinusoidal, per-element phase variation)
-        float wind_strength = ep.wind.w;
-        if (wind_strength > 0.0) {
-            vec3 wind_dir = normalize(ep.wind.xyz);
-            float freq = ep.dynamics.x;
-            float phase = dot(pos, vec3(0.37, 0.13, 0.71));
-            float wind_force = sin(time * freq + phase) * wind_strength;
-            accel += wind_dir * wind_force;
-        }
+        // Physics integration for free elements
+        if (inv_mass > 0.0) {
+            vec3 accel = ep.gravity.xyz;
+            float damping = ep.gravity.w;
 
-        // --- Verlet integration ---
-        vec3 vel = (pos - prev_pos) * damping;
-        vec3 predicted = pos + vel + accel * dt * dt;
+            // Wind force
+            float wind_strength = ep.wind.w;
+            if (wind_strength > 0.0) {
+                vec3 wind_dir = normalize(ep.wind.xyz);
+                float freq = ep.dynamics.x;
+                float phase = dot(pos, vec3(0.37, 0.13, 0.71));
+                float wind_force = sin(time * freq + phase) * wind_strength;
+                accel += wind_dir * wind_force;
+            }
 
-        prev_pos = pos;
-        pos = predicted;
+            // Verlet integration
+            vec3 vel = (pos - prev_pos) * damping;
+            vec3 predicted = pos + vel + accel * dt * dt;
+            prev_pos = pos;
+            pos = predicted;
 
-        // --- Ground collision ---
-        float ground_y = ep.dynamics.y;
-        float bounce = ep.dynamics.z;
-        if (pos.y < ground_y) {
-            pos.y = ground_y;
-            if (prev_pos.y > ground_y) {
-                float penetration_vel = (prev_pos.y - ground_y);
-                prev_pos.y = pos.y + penetration_vel * bounce;
+            // Ground collision
+            float ground_y = ep.dynamics.y;
+            float bounce = ep.dynamics.z;
+            if (pos.y < ground_y) {
+                pos.y = ground_y;
+                if (prev_pos.y > ground_y) {
+                    prev_pos.y = pos.y + (prev_pos.y - ground_y) * bounce;
+                }
             }
         }
+
+        states[idx].prev_position = vec4(prev_pos, 0.0);
+        states[idx].position = vec4(pos, inv_mass);
     }
 
-    // Write predicted position (constraints will correct it)
-    states[idx].prev_position = vec4(prev_pos, 0.0);
-    states[idx].position = vec4(pos, inv_mass);
-
-    // --- Synchronize before constraint solving ---
+    // All threads must hit this barrier
     memoryBarrierBuffer();
     barrier();
 
-    // --- Constraint projection (iterative) ---
+    // Constraint projection (iterative)
     for (uint iter = 0; iter < iterations; iter++) {
-        for (uint ci = 0; ci < constraint_count; ci++) {
-            PbdConstraint c = constraints[ci];
-            uint a = c.indices.x;
-            uint b = c.indices.y;
+        if (is_valid) {
+            for (uint ci = 0; ci < constraint_count; ci++) {
+                PbdConstraint c = constraints[ci];
+                uint a = c.indices.x;
+                uint b = c.indices.y;
+                if (a != idx && b != idx) continue;
 
-            if (a != idx && b != idx) continue;
+                float rest_length = c.params.x;
+                float stiffness = c.params.y;
 
-            float rest_length = c.params.x;
-            float stiffness = c.params.y;
+                vec3 pos_a = states[a].position.xyz;
+                vec3 pos_b = states[b].position.xyz;
+                float inv_mass_a = states[a].position.w;
+                float inv_mass_b = states[b].position.w;
 
-            vec3 pos_a = states[a].position.xyz;
-            vec3 pos_b = states[b].position.xyz;
-            float inv_mass_a = states[a].position.w;
-            float inv_mass_b = states[b].position.w;
+                vec3 delta = pos_b - pos_a;
+                float dist = length(delta);
+                if (dist < 1e-6) continue;
 
-            vec3 delta = pos_b - pos_a;
-            float dist = length(delta);
-            if (dist < 1e-6) continue;
+                float w_sum = inv_mass_a + inv_mass_b;
+                if (w_sum < 1e-6) continue;
 
-            float w_sum = inv_mass_a + inv_mass_b;
-            if (w_sum < 1e-6) continue;
+                float error = (dist - rest_length) / dist;
+                vec3 correction = delta * error * stiffness / float(iterations);
 
-            float error = (dist - rest_length) / dist;
-            vec3 correction = delta * error * stiffness / float(iterations);
-
-            if (a == idx && inv_mass_a > 0.0) {
-                pos = states[idx].position.xyz + correction * (inv_mass_a / w_sum);
-                states[idx].position = vec4(pos, inv_mass);
-            }
-            if (b == idx && inv_mass_b > 0.0) {
-                pos = states[idx].position.xyz - correction * (inv_mass_b / w_sum);
-                states[idx].position = vec4(pos, inv_mass);
+                if (a == idx && inv_mass_a > 0.0) {
+                    vec3 p = states[idx].position.xyz + correction * (inv_mass_a / w_sum);
+                    states[idx].position = vec4(p, inv_mass);
+                }
+                if (b == idx && inv_mass_b > 0.0) {
+                    vec3 p = states[idx].position.xyz - correction * (inv_mass_b / w_sum);
+                    states[idx].position = vec4(p, inv_mass);
+                }
             }
         }
 
+        // All threads must hit this barrier
         memoryBarrierBuffer();
         barrier();
     }
 
-    // --- Update velocity from position change ---
+    if (!is_valid) return;
+
+    // Update velocity
     pos = states[idx].position.xyz;
     prev_pos = states[idx].prev_position.xyz;
     vec3 final_vel = (pos - prev_pos) / max(dt, 1e-6);
     states[idx].velocity = vec4(final_vel, 0.0);
 
-    // --- Compute rotation for preprocess shader ---
-    // For wind sway (no constraints): use sine-wave rotation as before
-    // For constrained elements: derive rotation from displacement
+    // Compute rotation for preprocess shader
     vec4 rot = vec4(0.0, 0.0, 0.0, 1.0);  // identity
 
     if (inv_mass > 0.0) {
         if (constraint_count == 0) {
-            // Wind sway mode: procedural rotation from wind params
+            // Wind sway mode
             float wind_strength = ep.wind.w;
             if (wind_strength > 0.0) {
                 vec3 wind_dir = normalize(ep.wind.xyz);
@@ -177,20 +182,19 @@ void main() {
                 rot = axis_angle_to_quat(sway_axis, sway_angle);
             }
         } else {
-            // Constraint mode: derive rotation from velocity direction
+            // Constraint mode: tilt based on velocity
             float speed = length(final_vel);
             if (speed > 0.1) {
                 vec3 vel_dir = final_vel / speed;
-                // Tilt rotation: lean in direction of movement
                 vec3 tilt_axis = normalize(cross(vec3(0, 1, 0), vel_dir));
                 if (length(tilt_axis) > 0.001) {
-                    float tilt_angle = min(speed * 0.02, 0.5);  // cap at ~28 degrees
+                    float tilt_angle = min(speed * 0.02, 0.5);
                     rot = axis_angle_to_quat(tilt_axis, tilt_angle);
                 }
             }
         }
     }
 
-    // Write rotation into prev_position slot — preprocess reads this as PbdState.rotation
+    // Write rotation into prev_position slot for preprocess compatibility
     states[idx].prev_position = rot;
 }

--- a/shaders/pbd_solver.comp
+++ b/shaders/pbd_solver.comp
@@ -74,8 +74,12 @@ void main() {
         pos = state.position.xyz;
         prev_pos = state.prev_position.xyz;
 
-        // Physics integration for free elements
-        if (inv_mass > 0.0) {
+        // Wind-only mode: no constraints → skip physics, just compute rotation
+        // (prev_position is reused as rotation output, so Verlet can't read it)
+        if (constraint_count == 0) {
+            // Rotation computed after barriers — don't touch state here
+        } else if (inv_mass > 0.0) {
+            // Full physics mode: Verlet integration for constrained elements
             vec3 accel = ep.gravity.xyz;
             float damping = ep.gravity.w;
 
@@ -104,10 +108,10 @@ void main() {
                     prev_pos.y = pos.y + (prev_pos.y - ground_y) * bounce;
                 }
             }
-        }
 
-        states[idx].prev_position = vec4(prev_pos, 0.0);
-        states[idx].position = vec4(pos, inv_mass);
+            states[idx].prev_position = vec4(prev_pos, 0.0);
+            states[idx].position = vec4(pos, inv_mass);
+        }
     }
 
     // All threads must hit this barrier

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -254,8 +254,8 @@ void IslandDemoState::on_enter(AppBase& app) {
             std::vector<PbdPhysicsState> states(count);
             std::vector<PbdElementParams> params(count);
             for (uint32_t i = 0; i < count; ++i) {
-                states[i].position = glm::vec4(anchors[i], 0.0f);
-                states[i].prev_position = glm::vec4(anchors[i], 0.0f);
+                states[i].position = glm::vec4(anchors[i], 1.0f);  // inv_mass=1 (free, for wind sway)
+                states[i].prev_position = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);  // identity quat
                 states[i].velocity = glm::vec4(0.0f);
                 states[i].params = glm::vec4(0.0f);
                 params[i].gravity = glm::vec4(0.0f, 0.0f, 0.0f, 0.98f);  // damping

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -250,13 +250,21 @@ void IslandDemoState::on_enter(AppBase& app) {
     {
         const auto& anchors = app.pbd_anchors();
         if (!anchors.empty()) {
-            app.renderer().gs_renderer().set_pbd_anchors(
-                anchors.data(), static_cast<uint32_t>(anchors.size()));
-            app.renderer().gs_renderer().set_pbd_wind(
-                glm::vec3(1.0f, 0.0f, 0.3f),  // wind direction (mostly +X)
-                0.06f,                           // strength (gentle sway angle)
-                0.8f);                           // frequency (slow, natural rhythm)
-            std::fprintf(stderr, "[IslandDemo] PBD tree sway: %zu trees, wind=(1,0,0.3) str=0.08 freq=1.5\n",
+            uint32_t count = static_cast<uint32_t>(anchors.size());
+            std::vector<PbdPhysicsState> states(count);
+            std::vector<PbdElementParams> params(count);
+            for (uint32_t i = 0; i < count; ++i) {
+                states[i].position = glm::vec4(anchors[i], 0.0f);
+                states[i].prev_position = glm::vec4(anchors[i], 0.0f);
+                states[i].velocity = glm::vec4(0.0f);
+                states[i].params = glm::vec4(0.0f);
+                params[i].gravity = glm::vec4(0.0f, 0.0f, 0.0f, 0.98f);  // damping
+                params[i].wind = glm::vec4(1.0f, 0.0f, 0.3f, 0.06f);     // dir + strength
+                params[i].dynamics = glm::vec4(0.8f, -1000.0f, 0.0f, 0.0f);  // freq, ground, bounce
+            }
+            app.renderer().gs_renderer().upload_pbd_elements(
+                states.data(), params.data(), count);
+            std::fprintf(stderr, "[IslandDemo] PBD tree sway: %zu trees, wind=(1,0,0.3) str=0.06 freq=0.8\n",
                          anchors.size());
         }
     }

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -325,6 +325,42 @@ void IslandDemoState::update(AppBase& app, float dt) {
         anim_enabled_ = !anim_enabled_;
     }
 
+    // J → toggle PBD chain demo
+    if (app.input().was_key_pressed(GLFW_KEY_J)) {
+        if (pbd_chain_active_) {
+            app.renderer().gs_renderer().clear_pbd();
+            pbd_chain_active_ = false;
+            std::fprintf(stderr, "[IslandDemo] PBD chain demo OFF\n");
+        } else {
+            glm::vec3 top = character_origin_ + glm::vec3(3.0f, 8.0f, 0.0f);
+            PbdPhysicsState states[3];
+            PbdElementParams params[3];
+
+            for (int i = 0; i < 3; ++i) {
+                glm::vec3 p = top - glm::vec3(0.0f, static_cast<float>(i) * 3.0f, 0.0f);
+                states[i].position = glm::vec4(p, i == 0 ? 0.0f : 1.0f);
+                states[i].prev_position = glm::vec4(p, 0.0f);
+                states[i].velocity = glm::vec4(0.0f);
+                states[i].params = glm::vec4(0.0f);
+
+                params[i].gravity = glm::vec4(0.0f, -9.8f, 0.0f, 0.98f);
+                params[i].wind = glm::vec4(0.0f);
+                params[i].dynamics = glm::vec4(0.0f, top.y - 10.0f, 0.3f, 0.0f);
+            }
+
+            PbdConstraint constraints[2];
+            constraints[0].indices = glm::uvec4(0, 1, 0, 0);
+            constraints[0].params = glm::vec4(3.0f, 0.8f, 0.0f, 0.0f);
+            constraints[1].indices = glm::uvec4(1, 2, 0, 0);
+            constraints[1].params = glm::vec4(3.0f, 0.8f, 0.0f, 0.0f);
+
+            app.renderer().gs_renderer().upload_pbd_elements(states, params, 3);
+            app.renderer().gs_renderer().upload_pbd_constraints(constraints, 2);
+            pbd_chain_active_ = true;
+            std::fprintf(stderr, "[IslandDemo] PBD chain demo ON (3 elements, 2 constraints)\n");
+        }
+    }
+
     // FPS counter
     {
         auto now = std::chrono::steady_clock::now();

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -428,7 +428,7 @@ void AppBase::load_gs_scene(const SceneData& scene_data, const GsSceneOptions& o
                         // Assign PBD index to tree game objects (upper canopy sways)
                         bool is_tree = go.id.find("tree") != std::string::npos;
                         uint32_t pbd_idx = 0;
-                        if (is_tree && pbd_anchors_.size() < GsRenderer::kMaxPbdElements) {
+                        if (is_tree && pbd_anchors_.size() < kMaxPbdElements) {
                             pbd_idx = 32 + static_cast<uint32_t>(pbd_anchors_.size());
                             pbd_anchors_.push_back(adjusted_pos);
                         }

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -334,15 +334,17 @@ void GsRenderer::create_descriptor_resources() {
         vkCreateDescriptorSetLayout(device_, &ci, nullptr, &merge_layout_);
     }
 
-    // PBD solver layout: { pbd_states (rw), pbd_uniforms }
+    // PBD solver layout: { pbd_states (rw), pbd_params (ro), pbd_constraints (ro), pbd_uniforms }
     {
         VkDescriptorSetLayoutBinding bindings[] = {
             {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {3, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
         };
         VkDescriptorSetLayoutCreateInfo ci{};
         ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        ci.bindingCount = 2;
+        ci.bindingCount = 4;
         ci.pBindings = bindings;
         vkCreateDescriptorSetLayout(device_, &ci, nullptr, &pbd_layout_);
     }
@@ -575,17 +577,24 @@ void GsRenderer::load_cloud(const GaussianCloud& cloud) {
         for (uint32_t i = 0; i < kMaxBones; ++i) bones[i] = glm::mat4(1.0f);
     }
 
-    // PBD state SSBO (always allocated, identity rotation if unused)
-    pbd_ssbo_ = Buffer::create_storage(allocator_, kMaxPbdElements * sizeof(PbdState));
+    // PBD state, params, and constraint SSBOs (always allocated, zeroed if unused)
+    pbd_state_ssbo_ = Buffer::create_storage(allocator_,
+        kMaxPbdElements * sizeof(PbdPhysicsState));
+    pbd_params_ssbo_ = Buffer::create_storage(allocator_,
+        kMaxPbdElements * sizeof(PbdElementParams));
+    pbd_constraint_ssbo_ = Buffer::create_storage(allocator_,
+        kMaxPbdConstraints * sizeof(PbdConstraint));
     pbd_count_ = 0;
+    pbd_constraint_count_ = 0;
     {
-        auto* states = static_cast<PbdState*>(pbd_ssbo_.mapped());
+        auto* states = static_cast<PbdPhysicsState*>(pbd_state_ssbo_.mapped());
         for (uint32_t i = 0; i < kMaxPbdElements; ++i) {
-            states[i].position = glm::vec4(0.0f);
-            states[i].rotation = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);  // identity quat
+            states[i].position = glm::vec4(0.0f, 0.0f, 0.0f, 0.0f);
+            states[i].prev_position = glm::vec4(0.0f);
+            states[i].velocity = glm::vec4(0.0f);
+            states[i].params = glm::vec4(0.0f);
         }
     }
-    // PBD uniform buffer: params (vec4) + wind_dir (vec4) = 32 bytes
     pbd_uniform_buffer_ = Buffer::create_storage(allocator_, 32);
 
     // Upload Gaussian data to static buffer via staging to avoid -O3 write-reordering
@@ -849,7 +858,7 @@ void GsRenderer::update_descriptors() {
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
         VkDescriptorBufferInfo visible_count_info{visible_count_ssbo_.buffer(), 0, sizeof(uint32_t)};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo pbd_info{pbd_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo pbd_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
         VkWriteDescriptorSet writes[] = {
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 0, 0, 1,
@@ -1009,7 +1018,7 @@ void GsRenderer::update_descriptors() {
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
         VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo pbd_info{pbd_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo pbd_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
         VkWriteDescriptorSet writes[] = {
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 0, 0, 1,
@@ -1038,7 +1047,7 @@ void GsRenderer::update_descriptors() {
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
         VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo pbd_info{pbd_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo pbd_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
         VkWriteDescriptorSet writes[] = {
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 0, 0, 1,
@@ -1059,17 +1068,23 @@ void GsRenderer::update_descriptors() {
         vkUpdateDescriptorSets(device_, 7, writes, 0, nullptr);
     }
 
-    // PBD solver descriptor set: pbd_states(0), pbd_uniforms(1)
+    // PBD solver descriptor set: pbd_states(0), pbd_params(1), pbd_constraints(2), pbd_uniforms(3)
     {
-        VkDescriptorBufferInfo pbd_buf_info{pbd_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo pbd_state_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo pbd_params_info{pbd_params_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo pbd_constraint_info{pbd_constraint_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo pbd_ubo_info{pbd_uniform_buffer_.buffer(), 0, 32};
         VkWriteDescriptorSet writes[] = {
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, pbd_set_, 0, 0, 1,
-             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_buf_info, nullptr},
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_state_info, nullptr},
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, pbd_set_, 1, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_params_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, pbd_set_, 2, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_constraint_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, pbd_set_, 3, 0, 1,
              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &pbd_ubo_info, nullptr},
         };
-        vkUpdateDescriptorSets(device_, 2, writes, 0, nullptr);
+        vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
     }
 
     // Helper to write radix histogram/scan/scatter sets
@@ -1308,11 +1323,20 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
         // every frame since their positions/rotations change continuously.
         if (pbd_count_ > 0) {
             static_dirty_ = true;
-            // Update PBD uniform buffer: params(time, strength, freq, count) + wind_dir
-            struct { glm::vec4 params; glm::vec4 wind_dir; } pbd_ubo;
-            pbd_ubo.params = glm::vec4(time_, pbd_wind_strength_, pbd_wind_freq_,
-                                        static_cast<float>(pbd_count_));
-            pbd_ubo.wind_dir = glm::vec4(pbd_wind_dir_, 0.0f);
+            struct {
+                float time;
+                float dt;
+                uint32_t iterations;
+                uint32_t count;
+                uint32_t constraint_count;
+                uint32_t pad[3];
+            } pbd_ubo;
+            pbd_ubo.time = time_;
+            pbd_ubo.dt = 1.0f / 60.0f;
+            pbd_ubo.iterations = kPbdSolverIterations;
+            pbd_ubo.count = pbd_count_;
+            pbd_ubo.constraint_count = pbd_constraint_count_;
+            pbd_ubo.pad[0] = pbd_ubo.pad[1] = pbd_ubo.pad[2] = 0;
             std::memcpy(pbd_uniform_buffer_.mapped(), &pbd_ubo, sizeof(pbd_ubo));
 
             vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pbd_pipeline_);
@@ -1564,31 +1588,32 @@ void GsRenderer::clear_shadow_box_params() {
     num_sort_passes_ = 2;
 }
 
-void GsRenderer::set_pbd_anchors(const glm::vec3* anchors, uint32_t count) {
-    if (!pbd_ssbo_.mapped() || count == 0) return;
+void GsRenderer::upload_pbd_elements(const PbdPhysicsState* states,
+                                      const PbdElementParams* params,
+                                      uint32_t count) {
+    if (count == 0) return;
     uint32_t n = std::min(count, kMaxPbdElements);
-    auto* states = static_cast<PbdState*>(pbd_ssbo_.mapped());
-    for (uint32_t i = 0; i < n; ++i) {
-        states[i].position = glm::vec4(anchors[i], 0.0f);
-        states[i].rotation = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);  // identity
-    }
+    if (pbd_state_ssbo_.mapped())
+        std::memcpy(pbd_state_ssbo_.mapped(), states, n * sizeof(PbdPhysicsState));
+    if (pbd_params_ssbo_.mapped())
+        std::memcpy(pbd_params_ssbo_.mapped(), params, n * sizeof(PbdElementParams));
     pbd_count_ = n;
 }
 
-void GsRenderer::set_pbd_wind(const glm::vec3& direction, float strength, float frequency) {
-    pbd_wind_dir_ = glm::length(direction) > 0.001f ? glm::normalize(direction) : glm::vec3(1, 0, 0);
-    pbd_wind_strength_ = strength;
-    pbd_wind_freq_ = frequency;
+void GsRenderer::upload_pbd_constraints(const PbdConstraint* constraints, uint32_t count) {
+    if (count == 0) return;
+    uint32_t n = std::min(count, kMaxPbdConstraints);
+    if (pbd_constraint_ssbo_.mapped())
+        std::memcpy(pbd_constraint_ssbo_.mapped(), constraints, n * sizeof(PbdConstraint));
+    pbd_constraint_count_ = n;
 }
 
 void GsRenderer::clear_pbd() {
     pbd_count_ = 0;
-    if (pbd_ssbo_.mapped()) {
-        auto* states = static_cast<PbdState*>(pbd_ssbo_.mapped());
-        for (uint32_t i = 0; i < kMaxPbdElements; ++i) {
-            states[i].position = glm::vec4(0.0f);
-            states[i].rotation = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
-        }
+    pbd_constraint_count_ = 0;
+    if (pbd_state_ssbo_.mapped()) {
+        auto* s = static_cast<PbdPhysicsState*>(pbd_state_ssbo_.mapped());
+        for (uint32_t i = 0; i < kMaxPbdElements; ++i) s[i] = PbdPhysicsState{};
     }
 }
 
@@ -1610,7 +1635,9 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     uniform_buffer_.destroy(allocator);
     visible_count_ssbo_.destroy(allocator);
     bone_ssbo_.destroy(allocator);
-    pbd_ssbo_.destroy(allocator);
+    pbd_state_ssbo_.destroy(allocator);
+    pbd_params_ssbo_.destroy(allocator);
+    pbd_constraint_ssbo_.destroy(allocator);
     pbd_uniform_buffer_.destroy(allocator);
 
     // Split buffers

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -371,7 +371,7 @@ void GsRenderer::create_descriptor_resources() {
         render_layout_,                                    // new render with merged sort
         pbd_layout_,                                       // PBD solver
     };
-    constexpr uint32_t kSetCount = 23;
+    constexpr uint32_t kSetCount = 24;
     VkDescriptorSet sets[kSetCount];
     VkDescriptorSetAllocateInfo alloc_info{};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -405,7 +405,8 @@ void GsRenderer::create_descriptor_resources() {
     dynamic_scatter_set_ab_ = sets[19];
     dynamic_scatter_set_ba_ = sets[20];
     merge_set_ = sets[21];
-    pbd_set_ = sets[22];
+    // sets[22] is the merged render set (render_layout_)
+    pbd_set_ = sets[23];
     // Re-use render_set_ for merged rendering (set 2 already has correct layout)
 }
 
@@ -600,7 +601,7 @@ void GsRenderer::load_cloud(const GaussianCloud& cloud) {
         std::memset(pbd_constraint_ssbo_.mapped(), 0,
                     kMaxPbdConstraints * sizeof(PbdConstraint));
     }
-    pbd_uniform_buffer_ = Buffer::create_storage(allocator_, 32);
+    pbd_uniform_buffer_ = Buffer::create_uniform(allocator_, 32);
 
     // Upload Gaussian data to static buffer via staging to avoid -O3 write-reordering
     {

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -535,6 +535,10 @@ void GsRenderer::load_cloud(const GaussianCloud& cloud) {
     uniform_buffer_.destroy(allocator_);
     visible_count_ssbo_.destroy(allocator_);
     bone_ssbo_.destroy(allocator_);
+    pbd_state_ssbo_.destroy(allocator_);
+    pbd_params_ssbo_.destroy(allocator_);
+    pbd_constraint_ssbo_.destroy(allocator_);
+    pbd_uniform_buffer_.destroy(allocator_);
     static_gaussian_ssbo_.destroy(allocator_);
     dynamic_gaussian_ssbo_.destroy(allocator_);
     static_sort_a_.destroy(allocator_);

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -586,6 +586,7 @@ void GsRenderer::load_cloud(const GaussianCloud& cloud) {
         kMaxPbdConstraints * sizeof(PbdConstraint));
     pbd_count_ = 0;
     pbd_constraint_count_ = 0;
+    // Zero-initialize all PBD buffers
     {
         auto* states = static_cast<PbdPhysicsState*>(pbd_state_ssbo_.mapped());
         for (uint32_t i = 0; i < kMaxPbdElements; ++i) {
@@ -594,6 +595,10 @@ void GsRenderer::load_cloud(const GaussianCloud& cloud) {
             states[i].velocity = glm::vec4(0.0f);
             states[i].params = glm::vec4(0.0f);
         }
+        std::memset(pbd_params_ssbo_.mapped(), 0,
+                    kMaxPbdElements * sizeof(PbdElementParams));
+        std::memset(pbd_constraint_ssbo_.mapped(), 0,
+                    kMaxPbdConstraints * sizeof(PbdConstraint));
     }
     pbd_uniform_buffer_ = Buffer::create_storage(allocator_, 32);
 
@@ -1615,6 +1620,10 @@ void GsRenderer::clear_pbd() {
         auto* s = static_cast<PbdPhysicsState*>(pbd_state_ssbo_.mapped());
         for (uint32_t i = 0; i < kMaxPbdElements; ++i) s[i] = PbdPhysicsState{};
     }
+    if (pbd_params_ssbo_.mapped())
+        std::memset(pbd_params_ssbo_.mapped(), 0, kMaxPbdElements * sizeof(PbdElementParams));
+    if (pbd_constraint_ssbo_.mapped())
+        std::memset(pbd_constraint_ssbo_.mapped(), 0, kMaxPbdConstraints * sizeof(PbdConstraint));
 }
 
 void GsRenderer::set_point_lights(const std::vector<PointLight>& lights) {

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -592,7 +592,7 @@ void GsRenderer::load_cloud(const GaussianCloud& cloud) {
         auto* states = static_cast<PbdPhysicsState*>(pbd_state_ssbo_.mapped());
         for (uint32_t i = 0; i < kMaxPbdElements; ++i) {
             states[i].position = glm::vec4(0.0f, 0.0f, 0.0f, 0.0f);
-            states[i].prev_position = glm::vec4(0.0f);
+            states[i].prev_position = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);  // identity quaternion (preprocess reads as rotation)
             states[i].velocity = glm::vec4(0.0f);
             states[i].params = glm::vec4(0.0f);
         }
@@ -1619,7 +1619,10 @@ void GsRenderer::clear_pbd() {
     pbd_constraint_count_ = 0;
     if (pbd_state_ssbo_.mapped()) {
         auto* s = static_cast<PbdPhysicsState*>(pbd_state_ssbo_.mapped());
-        for (uint32_t i = 0; i < kMaxPbdElements; ++i) s[i] = PbdPhysicsState{};
+        for (uint32_t i = 0; i < kMaxPbdElements; ++i) {
+            s[i] = PbdPhysicsState{};
+            s[i].prev_position = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);  // identity quat
+        }
     }
     if (pbd_params_ssbo_.mapped())
         std::memset(pbd_params_ssbo_.mapped(), 0, kMaxPbdElements * sizeof(PbdElementParams));

--- a/tests/README.md
+++ b/tests/README.md
@@ -293,7 +293,7 @@ c++ -std=c++23 -I include \
 
 ### test_pbd_solver
 
-Tests PBD solver struct layout, index segmentation, and quaternion math used in the GPU PBD pipeline.
+Tests PBD physics solver: struct layouts for GPU std430 compatibility, index segmentation, quaternion math, Verlet integration, and distance constraint projection.
 
 **Build:**
 ```bash
@@ -311,16 +311,19 @@ c++ -std=c++23 -I include \
 ./build/test_pbd_solver
 ```
 
-**Tests (7):**
+**Tests (10):**
 | # | Test | What it verifies |
 |---|------|------------------|
-| 1 | PbdState struct layout | 32 bytes (2 x vec4), correct field offsets for GPU std430 |
-| 2 | Index segmentation | Round-trip encoding, correct routing: 0=none, 1-31=bone, 32-63=PBD |
-| 3 | Quaternion multiplication | Identity, composition, unit length preservation |
-| 4 | Quaternion-vector rotation | Axis rotations (90deg Y, 90deg Z, 180deg X), magnitude preservation |
-| 5 | PBD transform composition | Anchor-relative rotation preserves inter-Gaussian distances (rigid body) |
-| 6 | Axis-angle to quaternion | Zero angle → identity, unit length, 180deg edge case |
-| 7 | Wind sway output | Unit quaternions, bounded sway angles, spatial variation between anchors |
+| 1 | PbdPhysicsState layout | 64 bytes (4 x vec4), correct field offsets for GPU std430 |
+| 2 | PbdElementParams layout | 48 bytes (3 x vec4), correct field offsets |
+| 3 | PbdConstraint layout | 32 bytes (2 x vec4), correct field offsets |
+| 4 | Index segmentation | Round-trip encoding, correct routing: 0=none, 1-31=bone, 32-63=PBD |
+| 5 | Quaternion multiplication | Identity, composition, unit length preservation |
+| 6 | Quaternion-vector rotation | Axis rotations (90deg Y, 90deg Z, 180deg X), magnitude preservation |
+| 7 | PBD transform composition | Anchor-relative rotation preserves inter-Gaussian distances (rigid body) |
+| 8 | Axis-angle to quaternion | Zero angle → identity, unit length, 180deg edge case |
+| 9 | Verlet integration | Position prediction with gravity and damping, pinned elements unchanged |
+| 10 | Constraint projection | Distance correction toward rest length, mass-weighted distribution, pinned elements stay fixed |
 
 ### test_character_data
 

--- a/tests/test_pbd_solver.cpp
+++ b/tests/test_pbd_solver.cpp
@@ -10,6 +10,7 @@
 // Run: ctest -R test_pbd_solver
 
 #include "gseurat/engine/gs_renderer.hpp"
+#include "gseurat/engine/pbd_types.hpp"
 
 #include <cassert>
 #include <cmath>
@@ -307,10 +308,31 @@ static void test_wind_sway_output() {
           "different anchors produce different sway (spatial variation)");
 }
 
+static void test_pbd_physics_state_layout() {
+    std::printf("=== PbdPhysicsState struct layout ===\n");
+    using namespace gseurat;
+
+    check(sizeof(PbdPhysicsState) == 64, "PbdPhysicsState is 64 bytes (4 x vec4)");
+    check(offsetof(PbdPhysicsState, position) == 0, "position at offset 0");
+    check(offsetof(PbdPhysicsState, prev_position) == 16, "prev_position at offset 16");
+    check(offsetof(PbdPhysicsState, velocity) == 32, "velocity at offset 32");
+    check(offsetof(PbdPhysicsState, params) == 48, "params at offset 48");
+
+    check(sizeof(PbdConstraint) == 32, "PbdConstraint is 32 bytes (2 x vec4)");
+    check(offsetof(PbdConstraint, indices) == 0, "indices at offset 0");
+    check(offsetof(PbdConstraint, params) == 16, "params at offset 16");
+
+    check(sizeof(PbdElementParams) == 48, "PbdElementParams is 48 bytes (3 x vec4)");
+    check(offsetof(PbdElementParams, gravity) == 0, "gravity at offset 0");
+    check(offsetof(PbdElementParams, wind) == 16, "wind at offset 16");
+    check(offsetof(PbdElementParams, dynamics) == 32, "dynamics at offset 32");
+}
+
 int main() {
     std::printf("test_pbd_solver\n");
 
     test_pbd_state_layout();
+    test_pbd_physics_state_layout();
     test_index_segmentation();
     test_quat_multiplication();
     test_quat_vector_rotation();

--- a/tests/test_pbd_solver.cpp
+++ b/tests/test_pbd_solver.cpp
@@ -328,6 +328,90 @@ static void test_pbd_physics_state_layout() {
     check(offsetof(PbdElementParams, dynamics) == 32, "dynamics at offset 32");
 }
 
+// CPU mirror of Verlet integration (matches pbd_solver.comp)
+static glm::vec3 verlet_integrate(glm::vec3 pos, glm::vec3 prev_pos,
+                                   glm::vec3 accel, float dt, float damping) {
+    glm::vec3 velocity = (pos - prev_pos) * damping;
+    return pos + velocity + accel * dt * dt;
+}
+
+// CPU mirror of distance constraint projection
+static void project_distance_constraint(
+    glm::vec3& pos_a, glm::vec3& pos_b,
+    float inv_mass_a, float inv_mass_b,
+    float rest_length, float stiffness) {
+    glm::vec3 delta = pos_b - pos_a;
+    float dist = glm::length(delta);
+    if (dist < 1e-6f) return;
+    float error = (dist - rest_length) / dist;
+    float w_sum = inv_mass_a + inv_mass_b;
+    if (w_sum < 1e-6f) return;
+    glm::vec3 correction = delta * error * stiffness;
+    pos_a += correction * (inv_mass_a / w_sum);
+    pos_b -= correction * (inv_mass_b / w_sum);
+}
+
+static void test_verlet_integration() {
+    std::printf("=== Verlet integration ===\n");
+    float dt = 1.0f / 60.0f;
+
+    // Free fall from rest
+    glm::vec3 pos(0, 10, 0);
+    glm::vec3 prev(0, 10, 0);
+    glm::vec3 gravity(0, -9.8f, 0);
+    glm::vec3 new_pos = verlet_integrate(pos, prev, gravity, dt, 1.0f);
+    check(new_pos.x == 0.0f, "free fall: x unchanged");
+    check(new_pos.z == 0.0f, "free fall: z unchanged");
+    check(new_pos.y < 10.0f, "free fall: y decreased");
+    check(approx(new_pos.y, 10.0f + gravity.y * dt * dt, 0.001f), "free fall: correct displacement");
+
+    // With velocity (prev != pos)
+    pos = glm::vec3(1, 0, 0);
+    prev = glm::vec3(0, 0, 0);
+    new_pos = verlet_integrate(pos, prev, glm::vec3(0), dt, 1.0f);
+    check(new_pos.x > 1.0f, "velocity: continues moving right");
+    check(approx(new_pos.x, 2.0f, 0.01f), "velocity: x ≈ 2.0");
+
+    // Damping reduces velocity
+    new_pos = verlet_integrate(pos, prev, glm::vec3(0), dt, 0.5f);
+    check(new_pos.x < 2.0f, "damping: reduced forward motion");
+    check(approx(new_pos.x, 1.5f, 0.01f), "damping: x ≈ 1.5");
+}
+
+static void test_distance_constraint() {
+    std::printf("=== Distance constraint projection ===\n");
+
+    // Equal mass, stretched
+    glm::vec3 a(0, 0, 0);
+    glm::vec3 b(2, 0, 0);
+    project_distance_constraint(a, b, 1.0f, 1.0f, 1.0f, 1.0f);
+    float dist = glm::length(b - a);
+    check(approx(dist, 1.0f, 0.01f), "equal mass: distance corrected to rest_length");
+    check(approx(a.x, 0.5f, 0.01f), "equal mass: a moved to 0.5");
+    check(approx(b.x, 1.5f, 0.01f), "equal mass: b moved to 1.5");
+
+    // One pinned (inv_mass=0)
+    a = glm::vec3(0, 0, 0);
+    b = glm::vec3(2, 0, 0);
+    project_distance_constraint(a, b, 0.0f, 1.0f, 1.0f, 1.0f);
+    check(approx(a.x, 0.0f, 0.01f), "pinned a: didn't move");
+    check(approx(b.x, 1.0f, 0.01f), "pinned a: b moved to rest_length");
+
+    // Compressed
+    a = glm::vec3(0, 0, 0);
+    b = glm::vec3(0.5f, 0, 0);
+    project_distance_constraint(a, b, 1.0f, 1.0f, 1.0f, 1.0f);
+    dist = glm::length(b - a);
+    check(approx(dist, 1.0f, 0.01f), "compressed: pushed to rest_length");
+
+    // Partial stiffness
+    a = glm::vec3(0, 0, 0);
+    b = glm::vec3(2, 0, 0);
+    project_distance_constraint(a, b, 1.0f, 1.0f, 1.0f, 0.5f);
+    dist = glm::length(b - a);
+    check(approx(dist, 1.5f, 0.01f), "half stiffness: corrected halfway");
+}
+
 int main() {
     std::printf("test_pbd_solver\n");
 
@@ -339,6 +423,8 @@ int main() {
     test_pbd_transform_composition();
     test_axis_angle_to_quat();
     test_wind_sway_output();
+    test_verlet_integration();
+    test_distance_constraint();
 
     std::printf("\n%d passed, %d failed\n", passed, failed);
     return failed > 0 ? 1 : 0;

--- a/tests/test_pbd_solver.cpp
+++ b/tests/test_pbd_solver.cpp
@@ -74,19 +74,11 @@ static glm::vec4 axis_angle_to_quat(glm::vec3 axis, float angle) {
 // ── PbdState struct layout ──
 
 static void test_pbd_state_layout() {
-    std::printf("=== PbdState struct layout ===\n");
-    using PbdState = gseurat::GsRenderer::PbdState;
-
-    // Must be 2 * vec4 = 32 bytes for GPU std430 layout
-    check(sizeof(PbdState) == 32, "PbdState is 32 bytes (2 x vec4)");
-
-    // Verify field offsets
-    check(offsetof(PbdState, position) == 0, "position at offset 0");
-    check(offsetof(PbdState, rotation) == 16, "rotation at offset 16");
-
-    // Max elements constant
-    check(gseurat::GsRenderer::kMaxPbdElements == 32,
-          "kMaxPbdElements is 32 (matches bone_idx range 32-63)");
+    std::printf("=== PbdPhysicsState struct layout ===\n");
+    using namespace gseurat;
+    check(sizeof(PbdPhysicsState) == 64, "PbdPhysicsState is 64 bytes (4 x vec4)");
+    check(kMaxPbdElements == 64, "kMaxPbdElements is 64");
+    check(kMaxPbdConstraints == 128, "kMaxPbdConstraints is 128");
 }
 
 // ── Index segmentation ──


### PR DESCRIPTION
## Summary

- Replace procedural wind-sway PBD shader with a real Position Based Dynamics solver supporting Verlet integration, distance constraints, ground collision, and per-element parameters
- New GPU buffer layout: `PbdPhysicsState` (64B), `PbdElementParams` (48B), `PbdConstraint` (32B) — up to 64 elements and 128 constraints
- Backward compatible: wind sway still works when `constraint_count == 0`
- J key toggles a dangling chain demo (3 elements, top pinned, 2 distance constraints)

## Changes

| File | Description |
|------|-------------|
| `include/gseurat/engine/pbd_types.hpp` | New shared types header (PbdPhysicsState, PbdConstraint, PbdElementParams) |
| `shaders/pbd_solver.comp` | Full PBD solver: forces → Verlet predict → ground collision → constraint projection → velocity → rotation |
| `include/gseurat/engine/gs_renderer.hpp` | New API: `upload_pbd_elements()`, `upload_pbd_constraints()`, expanded descriptor layout |
| `src/engine/gs_renderer.cpp` | 3 SSBOs (state/params/constraints), 4-binding descriptor set, physics UBO |
| `src/engine/app_base.cpp` | Tree sway migrated to new PbdPhysicsState/PbdElementParams API |
| `src/demo/island_demo_state.cpp` | New API usage + J-key chain demo |
| `tests/test_pbd_solver.cpp` | Verlet integration tests, constraint projection tests, updated layout checks |
| `docs/pbd-solver.md` | Full architecture docs for new physics solver |

## Test plan

- [x] `cmake --build --preset macos-debug` — builds cleanly
- [x] `ctest` — 25/26 pass (pre-existing `test_gs_particle` abort)
- [x] New tests: struct layouts, Verlet math, distance constraint projection
- [ ] CI build matrix (Linux, macOS, Windows)
- [ ] Visual: tree sway still works (wind mode backward compat)
- [ ] Visual: J key chain demo dispatches without GPU crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)