### PR TITLE
fix: Staging PBD physics and game object gizmo position

### DIFF
--- a/include/gseurat/staging/staging_state.hpp
+++ b/include/gseurat/staging/staging_state.hpp
@@ -50,6 +50,9 @@ private:
     bool camera_initialized_ = false;
     glm::mat4 gs_vp_{1.0f};  // cached view-projection matrix (computed in update)
 
+    // Animation time (drives PBD wind sway)
+    float anim_time_ = 0.0f;
+
     // Performance tracking
     float fps_ = 0.0f;
     float fps_timer_ = 0.0f;

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -246,30 +246,7 @@ void IslandDemoState::on_enter(AppBase& app) {
         (void)char_count;
     }
 
-    // Set up PBD solver from per-element scene configs (anchors assigned during scene load)
-    {
-        const auto& anchors = app.pbd_anchors();
-        const auto& configs = app.pbd_configs();
-        if (!anchors.empty() && anchors.size() == configs.size()) {
-            uint32_t count = static_cast<uint32_t>(anchors.size());
-            std::vector<PbdPhysicsState> states(count);
-            std::vector<PbdElementParams> params(count);
-            for (uint32_t i = 0; i < count; ++i) {
-                const auto& cfg = configs[i];
-                float inv_mass = (cfg.mode == "physics" && cfg.pinned) ? 0.0f : 1.0f;
-                states[i].position = glm::vec4(anchors[i], inv_mass);
-                states[i].prev_position = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
-                states[i].velocity = glm::vec4(0.0f);
-                states[i].params = glm::vec4(cfg.sway_threshold, 0.0f, 0.0f, 0.0f);
-                params[i].gravity = glm::vec4(cfg.gravity, cfg.damping);
-                params[i].wind = glm::vec4(cfg.wind_direction, cfg.wind_strength);
-                params[i].dynamics = glm::vec4(cfg.wind_frequency, cfg.ground_y, cfg.bounce, 0.0f);
-            }
-            app.renderer().gs_renderer().upload_pbd_elements(
-                states.data(), params.data(), count);
-            std::fprintf(stderr, "[IslandDemo] PBD: %u elements uploaded from scene config\n", count);
-        }
-    }
+    // PBD upload is now handled automatically by AppBase::load_gs_scene()
 
     // Initialize camera centered on player (use header defaults for elevation/distance)
     camera_target_ = player_pos + glm::vec3(0, kCameraYOffset, 0);

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -1,6 +1,7 @@
 #include "gseurat/engine/app_base.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/gs_vfx.hpp"
+#include "gseurat/engine/pbd_types.hpp"
 #include "gseurat/demo/island_components.hpp"
 
 #define GLFW_INCLUDE_VULKAN
@@ -477,6 +478,25 @@ void AppBase::load_gs_scene(const SceneData& scene_data, const GsSceneOptions& o
                                  pbd_anchors_.size(),
                                  31 + static_cast<uint32_t>(pbd_anchors_.size()));
                 }
+            }
+
+            // Upload PBD elements to GS renderer (auto-setup for all scene loads)
+            if (!pbd_anchors_.empty() && pbd_anchors_.size() == pbd_configs_.size()) {
+                uint32_t count = static_cast<uint32_t>(pbd_anchors_.size());
+                std::vector<PbdPhysicsState> states(count);
+                std::vector<PbdElementParams> params(count);
+                for (uint32_t i = 0; i < count; ++i) {
+                    const auto& cfg = pbd_configs_[i];
+                    float inv_mass = (cfg.mode == "physics" && cfg.pinned) ? 0.0f : 1.0f;
+                    states[i].position = glm::vec4(pbd_anchors_[i], inv_mass);
+                    states[i].prev_position = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
+                    states[i].velocity = glm::vec4(0.0f);
+                    states[i].params = glm::vec4(cfg.sway_threshold, 0.0f, 0.0f, 0.0f);
+                    params[i].gravity = glm::vec4(cfg.gravity, cfg.damping);
+                    params[i].wind = glm::vec4(cfg.wind_direction, cfg.wind_strength);
+                    params[i].dynamics = glm::vec4(cfg.wind_frequency, cfg.ground_y, cfg.bounce, 0.0f);
+                }
+                renderer_.gs_renderer().upload_pbd_elements(states.data(), params.data(), count);
             }
 
             // Create ECS entities for game objects with components

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -56,6 +56,10 @@ void StagingState::on_exit(AppBase& /*app*/) {
 }
 
 void StagingState::update(AppBase& app, float dt) {
+    // Drive GS effect time for PBD wind sway
+    anim_time_ += dt;
+    app.renderer().gs_renderer().set_effect_time(anim_time_);
+
     // FPS tracking
     frame_count_++;
     fps_timer_ += dt;
@@ -743,9 +747,9 @@ void StagingState::draw_gizmos(AppBase& app) {
         auto aabb_off = app.gs_aabb_offset();
         for (size_t i = 0; i < game_objects.size(); i++) {
             const auto& go = game_objects[i];
-            // Apply AABB offset (same as emitters — raw scene coords + offset)
-            glm::vec3 pos(go.position.x + aabb_off.x,
-                          go.position.y + aabb_off.y,
+            // Game object PLYs are merged at raw world coords (no AABB offset)
+            glm::vec3 pos(go.position.x,
+                          go.position.y,
                           go.position.z);
             float sx, sy;
             if (!project_to_screen(pos, vp, sw, sh, sx, sy)) continue;


### PR DESCRIPTION
## Summary

Three fixes for Bricklayer → Staging PBD workflow:

1. **PBD upload moved to engine layer** — `upload_pbd_elements` now called in `app_base::load_gs_scene`, not island demo. Staging was silently skipping PBD setup.
2. **Gizmo position fix** — Game object gizmos no longer apply AABB offset (game object PLYs are at raw world coords, not tile coords).
3. **Staging effect time** — Drives `set_effect_time(anim_time_)` so PBD wind sway oscillates instead of being frozen at t=0.

## Test plan

- [x] `cmake --build --preset macos-debug` passes
- [x] All tests pass (25/26, pre-existing failure)
- [ ] Bricklayer → "Open in Staging": game object PLY renders at gizmo position
- [ ] Bricklayer → "Open in Staging": PBD Wind Sway config produces visible swaying
- [ ] Island demo: tree sway still works (PBD upload from engine layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)