### PR TITLE
feat: Echidna polish fixes and Staging animation playback

### DIFF
--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -137,6 +137,9 @@ public:
     // Command dispatch
     CommandDispatcher& command_dispatcher() { return command_dispatcher_; }
 
+    // Pending character load (set by load_character command, consumed by StagingState)
+    std::string pending_character_path;  // non-empty = load request pending
+
 protected:
     void init_window();
     virtual void init_game_content();

--- a/include/gseurat/engine/command_context.hpp
+++ b/include/gseurat/engine/command_context.hpp
@@ -29,6 +29,7 @@ struct CommandContext {
 
     std::function<void(const std::string&)> init_scene;
     std::function<void()> clear_scene;
+    std::function<void(const std::string&)> load_character;  // optional: for staging animation preview
 };
 
 }  // namespace gseurat

--- a/include/gseurat/staging/staging_state.hpp
+++ b/include/gseurat/staging/staging_state.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
 #include "gseurat/engine/game_state.hpp"
+#include "gseurat/character/character_manifest.hpp"
+#include "gseurat/character/bone_animation_player.hpp"
 
 #include <glm/vec3.hpp>
 #include <glm/mat4x4.hpp>
 #include <array>
+#include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -25,6 +29,9 @@ public:
     void update(AppBase& app, float dt) override;
     void build_draw_lists(AppBase& app) override;
 
+    // Load character manifest for animation preview
+    void load_character(const std::string& manifest_path, AppBase& app);
+
     // 3D → 2D projection (public for gizmo helpers)
     bool project_to_screen(const glm::vec3& world_pos, const glm::mat4& vp,
                            float screen_w, float screen_h,
@@ -41,6 +48,7 @@ private:
     void draw_scene_panel(AppBase& app);
     void draw_performance(AppBase& app);
     void draw_gizmos(AppBase& app);
+    void draw_character_panel(AppBase& app);
 
     // Camera orbit state
     float azimuth_ = 0.0f;
@@ -93,6 +101,14 @@ private:
 
     // Track scene path for auto-recentering camera on load_scene_json
     std::string last_scene_path_;
+
+    // Character animation
+    std::optional<CharacterData> character_data_;
+    std::unique_ptr<BoneAnimationPlayer> anim_player_;
+    int selected_clip_ = 0;
+    bool anim_playing_ = false;
+    float anim_speed_ = 1.0f;
+    bool show_character_ = true;
 };
 
 }  // namespace gseurat

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -361,6 +361,7 @@ CommandContext AppBase::build_command_context() {
         .window = window_,
         .init_scene = [this](const std::string& path) { init_scene(path); },
         .clear_scene = [this]() { clear_scene(); },
+        .load_character = [this](const std::string& path) { pending_character_path = path; },
     };
 }
 

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -271,6 +271,20 @@ void CommandDispatcher::register_default_commands() {
         }
     });
 
+    register_command("load_character", [this, ok](const json& cmd) -> CommandResult {
+        auto path = cmd.value("path", "");
+        if (path.empty())
+            return std::unexpected(std::string("Missing 'path' parameter"));
+        if (ctx_.load_character) {
+            try {
+                ctx_.load_character(path);
+            } catch (const std::exception& e) {
+                return std::unexpected(std::string("Failed to load character: ") + e.what());
+            }
+        }
+        return ok();
+    });
+
     register_command("update_scene_data", [this](const json& cmd) -> CommandResult {
         auto json_str = cmd.value("json", "");
         if (json_str.empty())

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -63,6 +63,12 @@ void StagingState::update(AppBase& app, float dt) {
         camera_initialized_ = false;
     }
 
+    // Check for pending character load from bridge command
+    if (!app.pending_character_path.empty()) {
+        load_character(app.pending_character_path, app);
+        app.pending_character_path.clear();
+    }
+
     // Drive GS effect time for PBD wind sway
     anim_time_ += dt;
     app.renderer().gs_renderer().set_effect_time(anim_time_);
@@ -164,6 +170,14 @@ void StagingState::update(AppBase& app, float dt) {
         gs_vp_ = proj_gizmo * view;
     }
 
+    // Update character animation and upload bone transforms
+    if (anim_player_ && anim_playing_) {
+        anim_player_->update(dt * anim_speed_);
+        app.renderer().gs_renderer().upload_bone_transforms(
+            anim_player_->bone_transforms().data(),
+            static_cast<uint32_t>(character_data_->bones.size()));
+    }
+
     // Draw ImGui (hidden with Tab)
     if (!hide_ui_) {
         draw_imgui(app);
@@ -207,6 +221,7 @@ void StagingState::draw_imgui(AppBase& app) {
             ImGui::MenuItem("Lighting", nullptr, &show_lighting_);
             ImGui::MenuItem("Camera", nullptr, &show_camera_);
             ImGui::MenuItem("Performance", nullptr, &show_performance_);
+            ImGui::MenuItem("Character", nullptr, &show_character_);
             ImGui::Separator();
             ImGui::MenuItem("Gizmo: Lights", nullptr, &show_gizmo_lights_);
             ImGui::MenuItem("Gizmo: Emitters", nullptr, &show_gizmo_emitters_);
@@ -224,6 +239,7 @@ void StagingState::draw_imgui(AppBase& app) {
     draw_lighting(app);
     draw_camera_panel(app);
     draw_performance(app);
+    draw_character_panel(app);
     draw_gizmos(app);
 }
 
@@ -775,6 +791,94 @@ void StagingState::draw_gizmos(AppBase& app) {
             dl->AddText(ImVec2(sx + 6, sy - 10), col, label);
         }
     }
+}
+
+void StagingState::load_character(const std::string& manifest_path, AppBase& app) {
+    auto data = load_character_manifest(manifest_path);
+    if (!data) {
+        std::fprintf(stderr, "[Staging] Failed to load character manifest: %s\n", manifest_path.c_str());
+        return;
+    }
+    std::fprintf(stderr, "[Staging] Loaded character '%s' (%zu bones, %zu clips)\n",
+        data->name.c_str(), data->bones.size(), data->clips.size());
+
+    character_data_ = std::move(*data);
+    anim_player_ = std::make_unique<BoneAnimationPlayer>(*character_data_);
+    selected_clip_ = 0;
+    anim_playing_ = false;
+
+    // If there's at least one clip, select it
+    if (!character_data_->clips.empty()) {
+        anim_player_->play(character_data_->clips[0].name);
+    }
+
+    // Clear bone transforms (identity) until animation starts
+    app.renderer().gs_renderer().clear_bone_transforms();
+}
+
+void StagingState::draw_character_panel(AppBase& app) {
+    if (!show_character_) return;
+
+    ImGui::SetNextWindowPos(ImVec2(10, 500), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(280, 200), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Character Animation", &show_character_)) {
+        ImGui::End();
+        return;
+    }
+
+    if (!character_data_) {
+        ImGui::TextColored(ImVec4(0.6f, 0.6f, 0.6f, 1.0f), "No character loaded.");
+        ImGui::TextWrapped("Use 'Preview in Staging' from Echidna, or send load_character command.");
+        ImGui::End();
+        return;
+    }
+
+    ImGui::Text("Character: %s", character_data_->name.c_str());
+    ImGui::Text("Bones: %zu", character_data_->bones.size());
+    ImGui::Separator();
+
+    // Animation clip selection
+    if (!character_data_->clips.empty()) {
+        ImGui::Text("Animation Clips:");
+        for (int i = 0; i < static_cast<int>(character_data_->clips.size()); i++) {
+            const auto& clip = character_data_->clips[i];
+            bool is_selected = (i == selected_clip_);
+            if (ImGui::Selectable(clip.name.c_str(), is_selected)) {
+                selected_clip_ = i;
+                anim_player_->play(clip.name);
+                anim_playing_ = true;
+            }
+        }
+
+        ImGui::Separator();
+
+        // Playback controls
+        if (ImGui::Button(anim_playing_ ? "Pause" : "Play")) {
+            anim_playing_ = !anim_playing_;
+            if (anim_playing_ && anim_player_ && !anim_player_->is_playing()) {
+                if (selected_clip_ >= 0 && selected_clip_ < static_cast<int>(character_data_->clips.size())) {
+                    anim_player_->play(character_data_->clips[selected_clip_].name);
+                }
+            }
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Stop")) {
+            anim_playing_ = false;
+            app.renderer().gs_renderer().clear_bone_transforms();
+        }
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(80);
+        ImGui::SliderFloat("Speed", &anim_speed_, 0.25f, 2.0f, "%.2fx");
+
+        // Show current clip info
+        if (anim_player_ && anim_player_->is_playing()) {
+            ImGui::Text("Playing: %s", anim_player_->current_clip().c_str());
+        }
+    } else {
+        ImGui::TextColored(ImVec4(0.8f, 0.6f, 0.3f, 1.0f), "No animation clips defined.");
+    }
+
+    ImGui::End();
 }
 
 }  // namespace gseurat

--- a/tools/apps/echidna/src/App.tsx
+++ b/tools/apps/echidna/src/App.tsx
@@ -7,7 +7,7 @@ import { AnimateLeftPanel } from './panels/AnimateLeftPanel.js';
 import { AnimateRightPanel } from './panels/AnimateRightPanel.js';
 import { Timeline } from './panels/Timeline.js';
 import { useCharacterStore } from './store/useCharacterStore.js';
-import type { ToolType } from './store/types.js';
+import type { ToolType, EchidnaFile } from './store/types.js';
 
 const styles: Record<string, React.CSSProperties> = {
   root: {
@@ -215,6 +215,35 @@ export function App() {
 
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  // URL parameter loading: ?load=filename.echidna
+  // Also supports window.postMessage({ type: 'echidna:load', data: {...} })
+  useEffect(() => {
+    // URL parameter: fetch file from public directory
+    const params = new URLSearchParams(window.location.search);
+    const loadFile = params.get('load');
+    if (loadFile) {
+      fetch(`/${loadFile}`)
+        .then((r) => r.json())
+        .then((data: EchidnaFile) => {
+          useCharacterStore.getState().loadProject(data);
+          useCharacterStore.getState().setCurrentFilename(loadFile);
+        })
+        .catch((err) => console.error('Failed to load file from URL param:', err));
+    }
+
+    // Window message API for programmatic loading
+    const messageHandler = (e: MessageEvent) => {
+      if (e.data?.type === 'echidna:load' && e.data?.data) {
+        useCharacterStore.getState().loadProject(e.data.data as EchidnaFile);
+        if (e.data.filename) {
+          useCharacterStore.getState().setCurrentFilename(e.data.filename);
+        }
+      }
+    };
+    window.addEventListener('message', messageHandler);
+    return () => window.removeEventListener('message', messageHandler);
   }, []);
 
   return (

--- a/tools/apps/echidna/src/panels/AnimateRightPanel.tsx
+++ b/tools/apps/echidna/src/panels/AnimateRightPanel.tsx
@@ -47,6 +47,7 @@ function BoneProperties() {
   const parts = useCharacterStore((s) => s.characterParts);
   const selectedPart = useCharacterStore((s) => s.selectedPart);
   const updatePartJoint = useCharacterStore((s) => s.updatePartJoint);
+  const autoCenterJoint = useCharacterStore((s) => s.autoCenterJoint);
   const setPartParent = useCharacterStore((s) => s.setPartParent);
 
   const currentPart = parts.find((p) => p.id === selectedPart) ?? null;
@@ -89,6 +90,13 @@ function BoneProperties() {
             />
           </React.Fragment>
         ))}
+        <button
+          style={{ padding: '2px 6px', fontSize: 10, background: '#3a3a5a', color: '#aaa', borderWidth: 1, borderStyle: 'solid', borderColor: '#555', borderRadius: 3, cursor: 'pointer' }}
+          title="Center joint at voxel centroid"
+          onClick={() => autoCenterJoint(currentPart.id)}
+        >
+          Auto
+        </button>
       </div>
 
       <div style={{ color: '#666', fontSize: 10 }}>
@@ -107,6 +115,7 @@ function KeyframeEditor() {
   const addKeyframe = useCharacterStore((s) => s.addKeyframe);
   const removeKeyframe = useCharacterStore((s) => s.removeKeyframe);
   const updateKeyframeEasing = useCharacterStore((s) => s.updateKeyframeEasing);
+  const updateAnimationDuration = useCharacterStore((s) => s.updateAnimationDuration);
   const updatePoseRotation = useCharacterStore((s) => s.updatePoseRotation);
   const addPose = useCharacterStore((s) => s.addPose);
 
@@ -123,8 +132,17 @@ function KeyframeEditor() {
   return (
     <div style={styles.section}>
       <div style={styles.label}>Keyframes: {selectedAnimation}</div>
-      <div style={{ fontSize: 11, color: '#666', marginBottom: 4 }}>
-        Duration: {clip.duration}s | {clip.keyframes.length} keyframes
+      <div style={{ fontSize: 11, color: '#666', marginBottom: 4, display: 'flex', alignItems: 'center', gap: 4 }}>
+        Duration:
+        <input
+          type="number"
+          style={{ width: 50, padding: '1px 4px', background: '#2a2a4a', borderWidth: 1, borderStyle: 'solid', borderColor: '#444', borderRadius: 3, color: '#ddd', fontSize: 11 }}
+          value={clip.duration}
+          step={0.1}
+          min={0.1}
+          onChange={(e) => updateAnimationDuration(selectedAnimation!, Math.max(0.1, Number(e.target.value)))}
+        />
+        s | {clip.keyframes.length} keyframes
       </div>
 
       {/* Add keyframe */}

--- a/tools/apps/echidna/src/panels/MenuBar.tsx
+++ b/tools/apps/echidna/src/panels/MenuBar.tsx
@@ -430,11 +430,35 @@ export function MenuBar() {
         game_objects: [],
       };
 
+      // Upload manifest JSON for animation playback
+      const manifest = buildManifest(
+        charId, charId + '.ply', s.gridWidth,
+        s.characterParts, s.characterPoses, s.animations,
+      );
+      const manifestJson = JSON.stringify(manifest, null, 2);
+      const manifestRes = await fetch(
+        `${BRIDGE_REST_URL}/api/characters/${encodeURIComponent(charId)}/file/${encodeURIComponent(charId + '.manifest.json')}`,
+        { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: manifestJson },
+      );
+      let manifestPath = '';
+      if (manifestRes.ok) {
+        const res = await manifestRes.json() as { path: string };
+        manifestPath = res.path;
+      }
+
       // Send load_scene_json to Staging via bridge WebSocket (with 5s timeout)
       await Promise.race([
         sendBridgeCommand({ cmd: 'load_scene_json', json: JSON.stringify(scene) }),
         new Promise((_, reject) => setTimeout(() => reject(new Error('Staging not responding (timed out after 5s)')), 5000)),
       ]);
+
+      // Send load_character to enable animation playback in Staging
+      if (manifestPath) {
+        await Promise.race([
+          sendBridgeCommand({ cmd: 'load_character', path: manifestPath }),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('load_character timed out')), 5000)),
+        ]).catch(() => { /* non-critical — animation just won't be available */ });
+      }
 
       showToast('Character sent to Staging', 'success');
     } catch (err) {

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -185,6 +185,9 @@ export interface CharacterStoreState {
   addKeyframe: (animName: string, keyframe: AnimationKeyframe) => void;
   removeKeyframe: (animName: string, index: number) => void;
   updateKeyframeEasing: (animName: string, index: number, easing: import('./types.js').EasingType) => void;
+  updateAnimationDuration: (animName: string, duration: number) => void;
+  updateAnimationPlaybackMode: (animName: string, mode: import('./types.js').PlaybackMode) => void;
+  autoCenterJoint: (partId: string) => void;
   setPlaybackTime: (time: number) => void;
   togglePlayback: () => void;
   setPlaybackSpeed: (speed: number) => void;
@@ -612,6 +615,37 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     const keyframes = clip.keyframes.map((kf, i) => i === index ? { ...kf, easing } : kf);
     anims[animName] = { ...clip, keyframes };
     set({ animations: anims });
+  },
+
+  updateAnimationDuration: (animName, duration) => {
+    const anims = { ...get().animations };
+    const clip = anims[animName];
+    if (!clip) return;
+    anims[animName] = { ...clip, duration };
+    set({ animations: anims });
+  },
+
+  updateAnimationPlaybackMode: (animName, mode) => {
+    const anims = { ...get().animations };
+    const clip = anims[animName];
+    if (!clip) return;
+    anims[animName] = { ...clip, playbackMode: mode };
+    set({ animations: anims });
+  },
+
+  autoCenterJoint: (partId) => {
+    const { characterParts, voxels } = get();
+    const part = characterParts.find((p) => p.id === partId);
+    if (!part || part.voxelKeys.length === 0) return;
+    let jx = 0, jy = 0, jz = 0;
+    for (const key of part.voxelKeys) {
+      const [x, y, z] = parseKey(key);
+      jx += x; jy += y; jz += z;
+    }
+    const n = part.voxelKeys.length;
+    const joint: [number, number, number] = [Math.round(jx / n), Math.round(jy / n), Math.round(jz / n)];
+    const parts = characterParts.map((p) => p.id === partId ? { ...p, joint } : p);
+    set({ characterParts: parts });
   },
 
   setPlaybackTime: (time) => set({ playbackTime: time }),

--- a/tools/apps/echidna/src/viewport/CharacterViewport.tsx
+++ b/tools/apps/echidna/src/viewport/CharacterViewport.tsx
@@ -1,12 +1,61 @@
-import React from 'react';
-import { Canvas } from '@react-three/fiber';
+import React, { useRef, useEffect } from 'react';
+import { Canvas, useThree } from '@react-three/fiber';
 import { OrbitControls, Grid } from '@react-three/drei';
+import * as THREE from 'three';
 import { VoxelMesh } from './VoxelMesh.js';
 import { GroundPlane } from './GroundPlane.js';
 import { GhostVoxel } from './GhostVoxel.js';
 import { JointGizmos } from './JointGizmos.js';
 import { MirrorPlane } from './MirrorPlane.js';
 import { useCharacterStore } from '../store/useCharacterStore.js';
+import { parseKey } from '../lib/voxelUtils.js';
+
+/** Auto-fits the camera to the voxel bounding box when the voxel count changes significantly. */
+function CameraFitter() {
+  const voxels = useCharacterStore((s) => s.voxels);
+  const gridWidth = useCharacterStore((s) => s.gridWidth);
+  const gridDepth = useCharacterStore((s) => s.gridDepth);
+  const { camera } = useThree();
+  const prevCount = useRef(0);
+
+  useEffect(() => {
+    const count = voxels.size;
+    // Only auto-fit when going from 0 voxels to some (initial load)
+    if (prevCount.current === 0 && count > 0) {
+      let minX = Infinity, maxX = -Infinity;
+      let minY = Infinity, maxY = -Infinity;
+      let minZ = Infinity, maxZ = -Infinity;
+      for (const key of voxels.keys()) {
+        const [x, y, z] = parseKey(key);
+        if (x < minX) minX = x; if (x > maxX) maxX = x;
+        if (y < minY) minY = y; if (y > maxY) maxY = y;
+        if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+      }
+      const cx = (minX + maxX) / 2;
+      const cy = (minY + maxY) / 2;
+      const cz = (minZ + maxZ) / 2;
+      const extentX = maxX - minX + 1;
+      const extentY = maxY - minY + 1;
+      const extentZ = maxZ - minZ + 1;
+      const maxExtent = Math.max(extentX, extentY, extentZ);
+
+      // Position camera to frame the model
+      const dist = maxExtent * 1.8;
+      camera.position.set(cx, cy + dist * 0.5, cz + dist);
+      (camera as THREE.PerspectiveCamera).lookAt(cx, cy, cz);
+
+      // Update OrbitControls target
+      const controls = (camera as any).__r3f_controls;
+      if (controls?.target) {
+        controls.target.set(cx, cy, cz);
+        controls.update();
+      }
+    }
+    prevCount.current = count;
+  }, [voxels, camera, gridWidth, gridDepth]);
+
+  return null;
+}
 
 export function CharacterViewport() {
   const gridWidth = useCharacterStore((s) => s.gridWidth);
@@ -43,6 +92,7 @@ export function CharacterViewport() {
       <GhostVoxel />
       <JointGizmos />
       <MirrorPlane />
+      <CameraFitter />
 
       <OrbitControls
         target={[gridWidth / 2, 0, gridDepth / 2]}


### PR DESCRIPTION
## Summary

- **Fix #161/#164**: Add `?load=filename` URL parameter and `window.postMessage` API for programmatic character loading inside React lifecycle (fixes R3F re-render bug)
- **Fix #162**: Add `CameraFitter` component that auto-frames the model when voxels load (computes bounding box, adjusts camera + orbit target)
- **Fix #163**: Add `updateAnimationDuration()` and `updateAnimationPlaybackMode()` store actions, with editable duration input in KeyframeEditor
- **Fix #165**: Add `autoCenterJoint()` store action + "Auto" button next to joint position inputs
- **Staging animation playback**: Wire `BoneAnimationPlayer` into `StagingState` with ImGui panel (clip selection, play/pause, speed), `load_character` bridge command, and updated Echidna "Preview in Staging" to send manifest data

## Test plan

- [ ] Build succeeds on macOS (verified locally)
- [ ] All 45 Echidna TS tests pass
- [ ] Bone animation C++ tests pass (test_bone_animation_player, test_bone_animation_state_machine)
- [ ] `?load=knight.echidna` loads character on startup
- [ ] Duration input in KeyframeEditor edits clip duration
- [ ] Auto button centers joint at voxel centroid
- [ ] Preview in Staging sends both PLY + manifest
- [ ] Staging Character Animation panel shows clips and can play/pause

Closes #161, closes #162, closes #163, closes #164, closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)