### PR TITLE
feat(gs): PBD chain visual demo + dynamic Gaussian fixes

### DIFF
--- a/docs/superpowers/plans/2026-04-07-pbd-chain-visual-demo.md
+++ b/docs/superpowers/plans/2026-04-07-pbd-chain-visual-demo.md
@@ -1,0 +1,449 @@
+# PBD Chain Visual Demo Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the GPU PBD hijack chain demo with a CPU-side PBD simulation rendered as glowing orbs + rope segments via dynamic Gaussians.
+
+**Architecture:** CPU Verlet physics stored in `IslandDemoState`, visual Gaussians appended to `Renderer::gs_pending_dynamics_` during `update()`, merged into the dynamic buffer during `record_gs_compute()`. No GPU PBD pipeline changes.
+
+**Tech Stack:** C++23, GLM, existing `Gaussian` struct and dynamic buffer pipeline.
+
+**Spec:** `docs/superpowers/specs/2026-04-07-pbd-chain-visual-demo-design.md`
+
+---
+
+### File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `include/gseurat/engine/renderer.hpp` | Add `gs_pending_dynamics_` staging buffer and `append_dynamic_gaussians()` public method |
+| `src/engine/renderer.cpp` | Drain `gs_pending_dynamics_` into `gs_dynamic_buffer_` during `record_gs_compute()` |
+| `include/gseurat/demo/island_demo_state.hpp` | Add PbdNode/PbdLink structs, simulation state, step/gather method declarations |
+| `src/demo/island_demo_state.cpp` | Replace J handler, implement CPU PBD simulation + visual gather |
+
+---
+
+### Task 1: Add pending dynamics staging buffer to Renderer
+
+**Files:**
+- Modify: `include/gseurat/engine/renderer.hpp:236`
+- Modify: `src/engine/renderer.cpp:963-1012`
+
+- [ ] **Step 1: Add staging buffer and public method to renderer.hpp**
+
+In `include/gseurat/engine/renderer.hpp`, add a public method after the existing `gs_particle_emitters()` accessor (around line 100):
+
+```cpp
+void append_dynamic_gaussians(const Gaussian* data, uint32_t count);
+```
+
+Add the staging buffer as a private member after `gs_dynamic_buffer_` (after line 236):
+
+```cpp
+std::vector<Gaussian> gs_pending_dynamics_;
+```
+
+- [ ] **Step 2: Implement append method and drain in record_gs_compute**
+
+In `src/engine/renderer.cpp`, add the append method:
+
+```cpp
+void Renderer::append_dynamic_gaussians(const Gaussian* data, uint32_t count) {
+    gs_pending_dynamics_.insert(gs_pending_dynamics_.end(), data, data + count);
+}
+```
+
+In `record_gs_compute`, after the VFX instance loop (after the `std::erase_if(vfx_instances_, ...)` at line 984) and before the dynamic upload block (line 1006), insert:
+
+```cpp
+// Append pending dynamics from game states (e.g., PBD chain demo)
+if (!gs_pending_dynamics_.empty()) {
+    gs_dynamic_buffer_.insert(gs_dynamic_buffer_.end(),
+                              gs_pending_dynamics_.begin(),
+                              gs_pending_dynamics_.end());
+    gs_pending_dynamics_.clear();
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds with no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add include/gseurat/engine/renderer.hpp src/engine/renderer.cpp
+git commit -m "feat(renderer): add pending dynamics staging buffer for game state Gaussians"
+```
+
+---
+
+### Task 2: Add CPU PBD structs and members to IslandDemoState
+
+**Files:**
+- Modify: `include/gseurat/demo/island_demo_state.hpp`
+
+- [ ] **Step 1: Add PBD structs and member variables**
+
+In `include/gseurat/demo/island_demo_state.hpp`, add the structs inside the `IslandDemoState` class private section, near the existing `pbd_chain_active_` member (around line 92):
+
+Replace:
+```cpp
+    bool pbd_chain_active_ = false;
+```
+
+With:
+```cpp
+    bool pbd_chain_active_ = false;
+
+    // CPU-side PBD chain simulation (J key demo)
+    struct PbdNode {
+        glm::vec3 position{0.0f};
+        glm::vec3 prev_position{0.0f};
+        glm::vec3 velocity{0.0f};
+        float inv_mass = 0.0f;
+    };
+    struct PbdLink {
+        uint32_t a = 0, b = 0;
+        float rest_length = 3.0f;
+        float stiffness = 0.8f;
+    };
+    static constexpr int kPbdNodeCount = 3;
+    static constexpr int kPbdLinkCount = 2;
+    static constexpr int kPbdIterations = 4;
+    static constexpr float kPbdDamping = 0.98f;
+    static constexpr float kPbdGravity = -9.8f;
+    std::array<PbdNode, kPbdNodeCount> pbd_nodes_;
+    std::array<PbdLink, kPbdLinkCount> pbd_links_;
+```
+
+Add `#include <array>` at the top of the file if not already present.
+
+Add private method declarations alongside the existing methods (after `update_environment_animation`):
+
+```cpp
+    void step_pbd_chain(float dt);
+    void gather_pbd_chain(Renderer& renderer);
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add include/gseurat/demo/island_demo_state.hpp
+git commit -m "feat(island): add CPU PBD chain structs and member declarations"
+```
+
+---
+
+### Task 3: Replace J key handler with CPU PBD initialization
+
+**Files:**
+- Modify: `src/demo/island_demo_state.cpp:331-364`
+
+- [ ] **Step 1: Replace the J key handler**
+
+Replace the entire J key block (lines 331-364) with:
+
+```cpp
+    // J → toggle PBD chain demo (CPU-side, rendered as dynamic Gaussians)
+    if (app.input().was_key_pressed(GLFW_KEY_J)) {
+        if (pbd_chain_active_) {
+            pbd_chain_active_ = false;
+            std::fprintf(stderr, "[IslandDemo] PBD chain demo OFF\n");
+        } else {
+            glm::vec3 top = character_origin_ + glm::vec3(3.0f, 8.0f, 0.0f);
+            for (int i = 0; i < kPbdNodeCount; ++i) {
+                glm::vec3 p = top - glm::vec3(0.0f, static_cast<float>(i) * 3.0f, 0.0f);
+                pbd_nodes_[i].position = p;
+                pbd_nodes_[i].prev_position = p;
+                pbd_nodes_[i].velocity = glm::vec3(0.0f);
+                pbd_nodes_[i].inv_mass = (i == 0) ? 0.0f : 1.0f;
+            }
+            pbd_links_[0] = {0, 1, 3.0f, 0.8f};
+            pbd_links_[1] = {1, 2, 3.0f, 0.8f};
+            pbd_chain_active_ = true;
+            std::fprintf(stderr, "[IslandDemo] PBD chain demo ON (CPU, 3 nodes, 2 links)\n");
+        }
+    }
+```
+
+- [ ] **Step 2: Remove the PBD types include if no longer needed**
+
+Check if `#include "gseurat/engine/pbd_types.hpp"` is still used elsewhere in `island_demo_state.cpp` (it was only used for `PbdPhysicsState`, `PbdElementParams`, `PbdConstraint` in the old J handler). If no other usage remains, remove the include.
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds. Warnings about unused includes are acceptable.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/demo/island_demo_state.cpp
+git commit -m "feat(island): replace GPU PBD chain toggle with CPU PBD initialization"
+```
+
+---
+
+### Task 4: Implement CPU PBD simulation step
+
+**Files:**
+- Modify: `src/demo/island_demo_state.cpp`
+
+- [ ] **Step 1: Implement step_pbd_chain**
+
+Add the following method at the end of `island_demo_state.cpp` (before the closing namespace brace, or after `update_environment_animation`):
+
+```cpp
+void IslandDemoState::step_pbd_chain(float dt) {
+    // Pin node 0 to follow the player
+    pbd_nodes_[0].position = character_origin_ + glm::vec3(3.0f, 8.0f, 0.0f);
+    pbd_nodes_[0].prev_position = pbd_nodes_[0].position;
+
+    float ground_y = character_origin_.y - 2.0f;
+
+    // Verlet integration for free nodes
+    for (int i = 0; i < kPbdNodeCount; ++i) {
+        if (pbd_nodes_[i].inv_mass <= 0.0f) continue;
+
+        glm::vec3 pos = pbd_nodes_[i].position;
+        glm::vec3 prev = pbd_nodes_[i].prev_position;
+        glm::vec3 vel = (pos - prev) * kPbdDamping;
+        glm::vec3 accel(0.0f, kPbdGravity, 0.0f);
+
+        pbd_nodes_[i].prev_position = pos;
+        pbd_nodes_[i].position = pos + vel + accel * dt * dt;
+
+        // Ground collision
+        if (pbd_nodes_[i].position.y < ground_y) {
+            pbd_nodes_[i].position.y = ground_y;
+            if (pbd_nodes_[i].prev_position.y > ground_y) {
+                pbd_nodes_[i].prev_position.y =
+                    ground_y + (pbd_nodes_[i].prev_position.y - ground_y) * 0.3f;
+            }
+        }
+    }
+
+    // Constraint projection
+    for (int iter = 0; iter < kPbdIterations; ++iter) {
+        for (int li = 0; li < kPbdLinkCount; ++li) {
+            const auto& link = pbd_links_[li];
+            auto& na = pbd_nodes_[link.a];
+            auto& nb = pbd_nodes_[link.b];
+
+            glm::vec3 delta = nb.position - na.position;
+            float dist = glm::length(delta);
+            if (dist < 1e-6f) continue;
+
+            float error = (dist - link.rest_length) / dist;
+            glm::vec3 correction = delta * error * link.stiffness / static_cast<float>(kPbdIterations);
+
+            float w_sum = na.inv_mass + nb.inv_mass;
+            if (w_sum < 1e-6f) continue;
+
+            if (na.inv_mass > 0.0f)
+                na.position += correction * (na.inv_mass / w_sum);
+            if (nb.inv_mass > 0.0f)
+                nb.position -= correction * (nb.inv_mass / w_sum);
+        }
+    }
+
+    // Update velocities
+    for (int i = 0; i < kPbdNodeCount; ++i) {
+        pbd_nodes_[i].velocity =
+            (pbd_nodes_[i].position - pbd_nodes_[i].prev_position) / std::max(dt, 1e-6f);
+    }
+}
+```
+
+- [ ] **Step 2: Wire step into update()**
+
+In the `update()` method, after the `update_walk_animation(app, dt);` call (line 424) and before `update_camera(app, dt);` (line 430), add:
+
+```cpp
+    // PBD chain physics step
+    if (pbd_chain_active_) {
+        step_pbd_chain(dt);
+    }
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/demo/island_demo_state.cpp
+git commit -m "feat(island): implement CPU Verlet PBD simulation for chain demo"
+```
+
+---
+
+### Task 5: Implement visual gather (glowing orbs + rope segments)
+
+**Files:**
+- Modify: `src/demo/island_demo_state.cpp`
+
+- [ ] **Step 1: Add a deterministic hash helper at file scope**
+
+Near the top of `island_demo_state.cpp` (in the anonymous namespace or as a static function):
+
+```cpp
+namespace {
+// Deterministic offset from index — no frame-to-frame jitter
+glm::vec3 det_offset(uint32_t seed, float radius) {
+    // Simple hash → 3 floats in [-1, 1]
+    auto h = [](uint32_t n) -> float {
+        n = (n << 13u) ^ n;
+        n = n * (n * n * 15731u + 789221u) + 1376312589u;
+        return static_cast<float>(n & 0x7fffffffu) / static_cast<float>(0x7fffffff) * 2.0f - 1.0f;
+    };
+    return glm::vec3(h(seed), h(seed * 7u + 3u), h(seed * 13u + 17u)) * radius;
+}
+}  // namespace
+```
+
+- [ ] **Step 2: Implement gather_pbd_chain**
+
+Add the method after `step_pbd_chain`:
+
+```cpp
+void IslandDemoState::gather_pbd_chain(Renderer& renderer) {
+    std::vector<Gaussian> buf;
+    buf.reserve(120);
+
+    uint32_t seed = 0;
+
+    // --- Orb nodes ---
+    for (int ni = 0; ni < kPbdNodeCount; ++ni) {
+        const auto& node = pbd_nodes_[ni];
+        float speed = glm::length(node.velocity);
+        glm::vec3 center = node.position;
+
+        // Core (5 Gaussians)
+        for (int i = 0; i < 5; ++i) {
+            Gaussian g{};
+            g.position = center + det_offset(seed++, 0.1f);
+            g.scale = glm::vec3(0.3f);
+            g.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+            g.color = glm::vec3(1.0f, 0.85f, 0.3f);
+            g.opacity = 0.95f;
+            g.emission = 3.0f + speed * 0.3f;
+            buf.push_back(g);
+        }
+
+        // Mid layer (8 Gaussians)
+        for (int i = 0; i < 8; ++i) {
+            Gaussian g{};
+            g.position = center + det_offset(seed++, 0.3f);
+            g.scale = glm::vec3(0.5f);
+            g.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+            g.color = glm::vec3(1.0f, 0.6f, 0.15f);
+            g.opacity = 0.7f;
+            g.emission = 1.0f;
+            buf.push_back(g);
+        }
+
+        // Halo (12 Gaussians)
+        for (int i = 0; i < 12; ++i) {
+            Gaussian g{};
+            g.position = center + det_offset(seed++, 0.6f);
+            g.scale = glm::vec3(0.9f);
+            g.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+            g.color = glm::vec3(1.0f, 0.9f, 0.7f);
+            g.opacity = 0.25f;
+            g.emission = 0.3f;
+            buf.push_back(g);
+        }
+    }
+
+    // --- Rope segments ---
+    for (int li = 0; li < kPbdLinkCount; ++li) {
+        const auto& link = pbd_links_[li];
+        glm::vec3 pa = pbd_nodes_[link.a].position;
+        glm::vec3 pb = pbd_nodes_[link.b].position;
+
+        constexpr int kRopeCount = 15;
+        for (int i = 0; i < kRopeCount; ++i) {
+            float t = static_cast<float>(i + 1) / static_cast<float>(kRopeCount + 1);
+            Gaussian g{};
+            g.position = glm::mix(pa, pb, t);
+            g.scale = glm::vec3(0.15f);
+            g.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+            g.color = glm::vec3(1.0f, 0.7f, 0.2f);
+            g.opacity = 0.6f * (1.0f - 2.0f * std::abs(t - 0.5f));
+            g.emission = 0.5f;
+            buf.push_back(g);
+        }
+    }
+
+    renderer.append_dynamic_gaussians(buf.data(), static_cast<uint32_t>(buf.size()));
+}
+```
+
+- [ ] **Step 3: Wire gather into update()**
+
+In the `update()` method, right after the `step_pbd_chain(dt)` call added in Task 4, add the gather call inside the same `if` block:
+
+```cpp
+    // PBD chain physics step + visual gather
+    if (pbd_chain_active_) {
+        step_pbd_chain(dt);
+        gather_pbd_chain(app.renderer());
+    }
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/demo/island_demo_state.cpp
+git commit -m "feat(island): render PBD chain as glowing orbs + rope segments"
+```
+
+---
+
+### Task 6: Clean up old PBD includes and verify end-to-end
+
+**Files:**
+- Modify: `src/demo/island_demo_state.cpp` (if needed)
+
+- [ ] **Step 1: Check for remaining GPU PBD references in island_demo_state.cpp**
+
+Search for any remaining references to `upload_pbd_elements`, `upload_pbd_constraints`, `clear_pbd`, `PbdPhysicsState`, `PbdElementParams`, `PbdConstraint` in `src/demo/island_demo_state.cpp`. The terrain PBD re-upload at line ~250-272 (inside `on_enter`) should remain — it uses the GPU PBD for tree sway and is unrelated to the chain demo.
+
+If the only remaining uses of `pbd_types.hpp` are in the terrain re-upload block, keep the include. If the include is no longer used at all, remove it.
+
+- [ ] **Step 2: Full rebuild**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds with no new warnings.
+
+- [ ] **Step 3: Verify visually**
+
+Run the demo and press J:
+- Expect: 3 glowing gold orbs appear above and to the right of the player
+- The top orb stays pinned, the lower two swing as a pendulum
+- Amber rope dots connect the orbs
+- Trees continue swaying normally (terrain PBD unaffected)
+- Press J again: orbs and ropes disappear immediately
+- Press J while walking: the pinned orb follows the player
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "chore(island): clean up PBD chain demo — remove unused GPU PBD references"
+```

--- a/docs/superpowers/specs/2026-04-07-pbd-chain-visual-demo-design.md
+++ b/docs/superpowers/specs/2026-04-07-pbd-chain-visual-demo-design.md
@@ -1,0 +1,128 @@
+# PBD Chain Visual Demo
+
+**Date:** 2026-04-07
+**Status:** Approved
+
+## Problem
+
+The J key PBD chain demo in `IslandDemoState` hijacks the GPU PBD element buffer, replacing the terrain wind-sway elements with 3 chain elements. This breaks tree sway animation and produces no meaningful visual output since no Gaussians are dedicated to the chain.
+
+## Solution
+
+Run a CPU-side PBD simulation in `IslandDemoState` and render the chain as dynamic Gaussians (glowing orbs + rope segments) appended to `gs_dynamic_buffer_` each frame. The GPU PBD pipeline remains untouched — terrain sway continues working.
+
+## CPU PBD Simulation
+
+Stored as member state in `IslandDemoState`:
+
+```cpp
+struct PbdNode {
+    glm::vec3 position;
+    glm::vec3 prev_position;
+    float inv_mass;  // 0 = pinned
+};
+
+struct PbdLink {
+    uint32_t a, b;
+    float rest_length;
+    float stiffness;
+};
+
+std::array<PbdNode, 3> pbd_nodes_;
+std::array<PbdLink, 2> pbd_links_;
+```
+
+**Simulation step** (called in `update()` when `pbd_chain_active_`):
+1. Verlet integration: `vel = (pos - prev) * damping; pos += vel + gravity * dt²`
+2. Ground collision: clamp Y to `ground_y`, reflect prev for bounce
+3. Constraint projection: 4 iterations of distance constraint solving
+4. Velocity update: `vel = (pos - prev) / dt`
+
+Constants: gravity = (0, -9.8, 0), damping = 0.98, ground_y = character_origin_.y - 2.0, 4 solver iterations.
+
+## Visual Generation
+
+A `gather_pbd_chain()` method appends Gaussians to `gs_dynamic_buffer_`:
+
+### Orb Nodes (×3, ~25 Gaussians each)
+
+Three concentric layers per node:
+
+| Layer | Count | Scale | Color (RGB) | Opacity | Emission |
+|-------|-------|-------|-------------|---------|----------|
+| Core | 5 | 0.3 | (1.0, 0.85, 0.3) | 0.95 | 3.0 + speed×0.3 |
+| Mid | 8 | 0.5 | (1.0, 0.6, 0.15) | 0.7 | 1.0 |
+| Halo | 12 | 0.9 | (1.0, 0.9, 0.7) | 0.25 | 0.3 |
+
+- Core Gaussians cluster tightly at the node center with small random offsets (±0.1)
+- Mid-layer Gaussians spread at radius ~0.3 with random offsets
+- Halo Gaussians spread at radius ~0.6, large scale for soft glow
+- All positions use deterministic offsets (seeded by index) so they don't jitter frame-to-frame
+
+### Rope Segments (×2, ~15 Gaussians each)
+
+Between each connected pair of nodes:
+
+- 15 Gaussians linearly interpolated: `t = (i + 1) / 16.0` for i in 0..14
+- Position: `lerp(node_a.position, node_b.position, t)`
+- Scale: (0.15, 0.15, 0.15) — thin dots forming a dotted rope
+- Color: (1.0, 0.7, 0.2) amber
+- Emission: 0.5
+- Opacity: `0.6 * (1.0 - 2.0 * abs(t - 0.5))` — tapers to 0 at endpoints (blends into orbs)
+
+### Total Budget
+
+- 3 orbs × 25 = 75 Gaussians
+- 2 ropes × 15 = 30 Gaussians
+- **Total: 105 Gaussians/frame** (1.3% of 8192 dynamic headroom)
+
+## Integration
+
+### Toggle (J key)
+
+**ON:**
+1. Initialize `pbd_nodes_` at `character_origin_ + (3, 8, 0)`, spaced 3 units apart vertically
+2. Node 0 pinned (`inv_mass = 0`), nodes 1-2 free (`inv_mass = 1`)
+3. Initialize `pbd_links_` with rest_length = 3.0, stiffness = 0.8
+4. Set `pbd_chain_active_ = true`
+
+**OFF:**
+1. Set `pbd_chain_active_ = false`
+2. No cleanup needed — dynamic buffer is rebuilt each frame
+
+### Frame Update
+
+In `IslandDemoState::update()`, after `update_walk_animation()`:
+```
+if (pbd_chain_active_) {
+    step_pbd_chain(dt);      // advance physics
+    pbd_nodes_[0].position = character_origin_ + vec3(3, 8, 0);  // anchor follows player
+}
+```
+
+### Gather
+
+The dynamic buffer (`gs_dynamic_buffer_`) is cleared and uploaded inside `Renderer::record_gs_compute()`, which runs after `build_draw_lists()`. Game states cannot append during `build_draw_lists` since the buffer gets cleared later.
+
+**Approach:** Add a staging buffer `gs_pending_dynamics_` to `Renderer` with a public `append_dynamic_gaussians(const Gaussian*, uint32_t)` method. Game states call this during `update()`. In `record_gs_compute()`, after gathering particles/VFX, append the pending buffer contents and clear it.
+
+In `IslandDemoState::update()`:
+```
+if (pbd_chain_active_) {
+    gather_pbd_chain(app.renderer());  // calls renderer.append_dynamic_gaussians()
+}
+```
+
+## Removed
+
+- All calls to `gs_renderer().upload_pbd_elements()` / `upload_pbd_constraints()` / `clear_pbd()` from the J key handler
+- No GPU PBD interaction from the chain demo
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `include/gseurat/demo/island_demo_state.hpp` | Add PbdNode/PbdLink structs, pbd_nodes_, pbd_links_ members, step/gather methods |
+| `src/demo/island_demo_state.cpp` | Replace J handler, add step_pbd_chain(), gather_pbd_chain() |
+| `src/engine/renderer.cpp` | Append `gs_pending_dynamics_` to `gs_dynamic_buffer_` in `record_gs_compute`, then clear it |
+| `include/gseurat/engine/renderer.hpp` | Add `gs_pending_dynamics_` vector and `append_dynamic_gaussians()` method |

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -10,12 +10,15 @@
 #include "gseurat/engine/ecs/types.hpp"
 
 #include <glm/glm.hpp>
+#include <array>
 #include <chrono>
 #include <memory>
 #include <optional>
 #include <string>
 
 namespace gseurat {
+
+class Renderer;
 
 class IslandDemoState : public GameState {
 public:
@@ -33,6 +36,8 @@ private:
     void update_effects(AppBase& app, float dt);
     void update_walk_animation(AppBase& app, float dt);
     void update_environment_animation(AppBase& app, float dt);
+    void step_pbd_chain(float dt);
+    void gather_pbd_chain(Renderer& renderer);
 
     // Scene
     std::string scene_path_ = "assets/scenes/seurat_island.json";
@@ -91,6 +96,26 @@ private:
     // Toggle flags (P = particles, N = animation, J = PBD chain)
     bool anim_enabled_ = true;
     bool pbd_chain_active_ = false;
+
+    // CPU-side PBD chain simulation (J key demo)
+    struct PbdNode {
+        glm::vec3 position{0.0f};
+        glm::vec3 prev_position{0.0f};
+        glm::vec3 velocity{0.0f};
+        float inv_mass = 0.0f;
+    };
+    struct PbdLink {
+        uint32_t a = 0, b = 0;
+        float rest_length = 3.0f;
+        float stiffness = 0.8f;
+    };
+    static constexpr int kPbdNodeCount = 3;
+    static constexpr int kPbdLinkCount = 2;
+    static constexpr int kPbdIterations = 4;
+    static constexpr float kPbdDamping = 0.98f;
+    static constexpr float kPbdGravity = -9.8f;
+    std::array<PbdNode, kPbdNodeCount> pbd_nodes_;
+    std::array<PbdLink, kPbdLinkCount> pbd_links_;
 
     // FPS tracking
     std::chrono::steady_clock::time_point fps_clock_{};

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -97,6 +97,7 @@ public:
     void add_gs_particle_emitter(const GsEmitterConfig& config);
     void clear_gs_particle_emitters();
     std::vector<GaussianParticleEmitter>& gs_particle_emitters() { return gs_particle_emitters_; }
+    void append_dynamic_gaussians(const Gaussian* data, uint32_t count);
 
     // Gaussian animator (animate existing scene Gaussians)
     GaussianAnimator& gs_animator() { return gs_animator_; }
@@ -234,6 +235,7 @@ private:
     GsChunkGrid gs_chunk_grid_;
     std::vector<Gaussian> gs_static_buffer_;
     std::vector<Gaussian> gs_dynamic_buffer_;
+    std::vector<Gaussian> gs_pending_dynamics_;
     glm::mat4 gs_prev_view_{0.0f};  // for camera dirty detection
     bool gs_static_force_dirty_ = false;
     std::vector<GaussianParticleEmitter> gs_particle_emitters_;

--- a/shaders/pbd_solver.comp
+++ b/shaders/pbd_solver.comp
@@ -72,7 +72,14 @@ void main() {
 
         inv_mass = state.position.w;
         pos = state.position.xyz;
-        prev_pos = state.prev_position.xyz;
+
+        // prev_position is repurposed for rotation output (read by preprocess shader).
+        // In constraint mode, the real previous position is backed up in params.xyz.
+        if (constraint_count > 0) {
+            prev_pos = state.params.xyz;
+        } else {
+            prev_pos = state.prev_position.xyz;
+        }
 
         // Wind-only mode: no constraints → skip physics, just compute rotation
         // (prev_position is reused as rotation output, so Verlet can't read it)
@@ -197,6 +204,13 @@ void main() {
                 }
             }
         }
+    }
+
+    // Backup actual prev_position into params.xyz before overwriting with rotation.
+    // This prevents the Verlet integrator from reading the quaternion as a position
+    // on the next frame, which would cause exponential velocity divergence.
+    if (constraint_count > 0) {
+        states[idx].params = vec4(states[idx].prev_position.xyz, states[idx].params.w);
     }
 
     // Write rotation into prev_position slot for preprocess compatibility

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -407,6 +407,11 @@ void IslandDemoState::update(AppBase& app, float dt) {
     // Walk animation always runs (handles character root transform + bone poses)
     update_walk_animation(app, dt);
 
+    // PBD chain physics step + visual gather
+    if (pbd_chain_active_) {
+        step_pbd_chain(dt);
+    }
+
     // Set player position as LOD focus for foveated culling
     app.renderer().set_gs_lod_focus(character_origin_);
 
@@ -879,6 +884,68 @@ void IslandDemoState::update_environment_animation(AppBase& /*app*/, float dt) {
     // Time accumulation only — the actual terrain sway is applied via bone 0
     // in update_walk_animation, creating visible "movement of the dots" across
     // the entire Gaussian Splatting scene.
+}
+
+// ── CPU PBD simulation ──
+
+void IslandDemoState::step_pbd_chain(float dt) {
+    // Pin node 0 to follow the player
+    pbd_nodes_[0].position = character_origin_ + glm::vec3(3.0f, 8.0f, 0.0f);
+    pbd_nodes_[0].prev_position = pbd_nodes_[0].position;
+
+    float ground_y = character_origin_.y - 2.0f;
+
+    // Verlet integration for free nodes
+    for (int i = 0; i < kPbdNodeCount; ++i) {
+        if (pbd_nodes_[i].inv_mass <= 0.0f) continue;
+
+        glm::vec3 pos = pbd_nodes_[i].position;
+        glm::vec3 prev = pbd_nodes_[i].prev_position;
+        glm::vec3 vel = (pos - prev) * kPbdDamping;
+        glm::vec3 accel(0.0f, kPbdGravity, 0.0f);
+
+        pbd_nodes_[i].prev_position = pos;
+        pbd_nodes_[i].position = pos + vel + accel * dt * dt;
+
+        // Ground collision
+        if (pbd_nodes_[i].position.y < ground_y) {
+            pbd_nodes_[i].position.y = ground_y;
+            if (pbd_nodes_[i].prev_position.y > ground_y) {
+                pbd_nodes_[i].prev_position.y =
+                    ground_y + (pbd_nodes_[i].prev_position.y - ground_y) * 0.3f;
+            }
+        }
+    }
+
+    // Constraint projection
+    for (int iter = 0; iter < kPbdIterations; ++iter) {
+        for (int li = 0; li < kPbdLinkCount; ++li) {
+            const auto& link = pbd_links_[li];
+            auto& na = pbd_nodes_[link.a];
+            auto& nb = pbd_nodes_[link.b];
+
+            glm::vec3 delta = nb.position - na.position;
+            float dist = glm::length(delta);
+            if (dist < 1e-6f) continue;
+
+            float error = (dist - link.rest_length) / dist;
+            glm::vec3 correction = delta * error * link.stiffness / static_cast<float>(kPbdIterations);
+
+            float w_sum = na.inv_mass + nb.inv_mass;
+            if (w_sum < 1e-6f) continue;
+
+            if (na.inv_mass > 0.0f)
+                na.position += correction * (na.inv_mass / w_sum);
+            if (nb.inv_mass > 0.0f)
+                nb.position -= correction * (nb.inv_mass / w_sum);
+        }
+    }
+
+    // Update velocities
+    for (int i = 0; i < kPbdNodeCount; ++i) {
+        pbd_nodes_[i].velocity =
+            (pbd_nodes_[i].position - pbd_nodes_[i].prev_position) / std::max(dt, 1e-6f);
+    }
 }
 
 // ── build_draw_lists (debug HUD) ──

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -327,39 +327,24 @@ void IslandDemoState::update(AppBase& app, float dt) {
         anim_enabled_ = !anim_enabled_;
     }
 
-    // J → toggle PBD chain demo
+    // J → toggle PBD chain demo (CPU-side, rendered as dynamic Gaussians)
     if (app.input().was_key_pressed(GLFW_KEY_J)) {
         if (pbd_chain_active_) {
-            app.renderer().gs_renderer().clear_pbd();
             pbd_chain_active_ = false;
             std::fprintf(stderr, "[IslandDemo] PBD chain demo OFF\n");
         } else {
             glm::vec3 top = character_origin_ + glm::vec3(3.0f, 8.0f, 0.0f);
-            PbdPhysicsState states[3];
-            PbdElementParams params[3];
-
-            for (int i = 0; i < 3; ++i) {
+            for (int i = 0; i < kPbdNodeCount; ++i) {
                 glm::vec3 p = top - glm::vec3(0.0f, static_cast<float>(i) * 3.0f, 0.0f);
-                states[i].position = glm::vec4(p, i == 0 ? 0.0f : 1.0f);
-                states[i].prev_position = glm::vec4(p, 0.0f);
-                states[i].velocity = glm::vec4(0.0f);
-                states[i].params = glm::vec4(0.0f);
-
-                params[i].gravity = glm::vec4(0.0f, -9.8f, 0.0f, 0.98f);
-                params[i].wind = glm::vec4(0.0f);
-                params[i].dynamics = glm::vec4(0.0f, top.y - 10.0f, 0.3f, 0.0f);
+                pbd_nodes_[i].position = p;
+                pbd_nodes_[i].prev_position = p;
+                pbd_nodes_[i].velocity = glm::vec3(0.0f);
+                pbd_nodes_[i].inv_mass = (i == 0) ? 0.0f : 1.0f;
             }
-
-            PbdConstraint constraints[2];
-            constraints[0].indices = glm::uvec4(0, 1, 0, 0);
-            constraints[0].params = glm::vec4(3.0f, 0.8f, 0.0f, 0.0f);
-            constraints[1].indices = glm::uvec4(1, 2, 0, 0);
-            constraints[1].params = glm::vec4(3.0f, 0.8f, 0.0f, 0.0f);
-
-            app.renderer().gs_renderer().upload_pbd_elements(states, params, 3);
-            app.renderer().gs_renderer().upload_pbd_constraints(constraints, 2);
+            pbd_links_[0] = {0, 1, 3.0f, 0.8f};
+            pbd_links_[1] = {1, 2, 3.0f, 0.8f};
             pbd_chain_active_ = true;
-            std::fprintf(stderr, "[IslandDemo] PBD chain demo ON (3 elements, 2 constraints)\n");
+            std::fprintf(stderr, "[IslandDemo] PBD chain demo ON (CPU, 3 nodes, 2 links)\n");
         }
     }
 

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -24,6 +24,18 @@
 #include <cstdio>
 #include <string>
 
+namespace {
+// Deterministic offset from index — no frame-to-frame jitter
+glm::vec3 det_offset(uint32_t seed, float radius) {
+    auto h = [](uint32_t n) -> float {
+        n = (n << 13u) ^ n;
+        n = n * (n * n * 15731u + 789221u) + 1376312589u;
+        return static_cast<float>(n & 0x7fffffffu) / static_cast<float>(0x7fffffff) * 2.0f - 1.0f;
+    };
+    return glm::vec3(h(seed), h(seed * 7u + 3u), h(seed * 13u + 17u)) * radius;
+}
+}  // namespace
+
 namespace gseurat {
 
 // ── on_enter ──
@@ -410,6 +422,7 @@ void IslandDemoState::update(AppBase& app, float dt) {
     // PBD chain physics step + visual gather
     if (pbd_chain_active_) {
         step_pbd_chain(dt);
+        gather_pbd_chain(app.renderer());
     }
 
     // Set player position as LOD focus for foveated culling
@@ -946,6 +959,80 @@ void IslandDemoState::step_pbd_chain(float dt) {
         pbd_nodes_[i].velocity =
             (pbd_nodes_[i].position - pbd_nodes_[i].prev_position) / std::max(dt, 1e-6f);
     }
+}
+
+// ── PBD visual gather ──
+
+void IslandDemoState::gather_pbd_chain(Renderer& renderer) {
+    std::vector<Gaussian> buf;
+    buf.reserve(120);
+
+    uint32_t seed = 0;
+
+    // --- Orb nodes ---
+    for (int ni = 0; ni < kPbdNodeCount; ++ni) {
+        const auto& node = pbd_nodes_[ni];
+        float speed = glm::length(node.velocity);
+        glm::vec3 center = node.position;
+
+        // Core (5 Gaussians)
+        for (int i = 0; i < 5; ++i) {
+            Gaussian g{};
+            g.position = center + det_offset(seed++, 0.1f);
+            g.scale = glm::vec3(0.3f);
+            g.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+            g.color = glm::vec3(1.0f, 0.85f, 0.3f);
+            g.opacity = 0.95f;
+            g.emission = 3.0f + speed * 0.3f;
+            buf.push_back(g);
+        }
+
+        // Mid layer (8 Gaussians)
+        for (int i = 0; i < 8; ++i) {
+            Gaussian g{};
+            g.position = center + det_offset(seed++, 0.3f);
+            g.scale = glm::vec3(0.5f);
+            g.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+            g.color = glm::vec3(1.0f, 0.6f, 0.15f);
+            g.opacity = 0.7f;
+            g.emission = 1.0f;
+            buf.push_back(g);
+        }
+
+        // Halo (12 Gaussians)
+        for (int i = 0; i < 12; ++i) {
+            Gaussian g{};
+            g.position = center + det_offset(seed++, 0.6f);
+            g.scale = glm::vec3(0.9f);
+            g.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+            g.color = glm::vec3(1.0f, 0.9f, 0.7f);
+            g.opacity = 0.25f;
+            g.emission = 0.3f;
+            buf.push_back(g);
+        }
+    }
+
+    // --- Rope segments ---
+    for (int li = 0; li < kPbdLinkCount; ++li) {
+        const auto& link = pbd_links_[li];
+        glm::vec3 pa = pbd_nodes_[link.a].position;
+        glm::vec3 pb = pbd_nodes_[link.b].position;
+
+        constexpr int kRopeCount = 15;
+        for (int i = 0; i < kRopeCount; ++i) {
+            float t = static_cast<float>(i + 1) / static_cast<float>(kRopeCount + 1);
+            Gaussian g{};
+            g.position = glm::mix(pa, pb, t);
+            g.scale = glm::vec3(0.15f);
+            g.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+            g.color = glm::vec3(1.0f, 0.7f, 0.2f);
+            g.opacity = 0.6f * (1.0f - 2.0f * std::abs(t - 0.5f));
+            g.emission = 0.5f;
+            buf.push_back(g);
+        }
+    }
+
+    renderer.append_dynamic_gaussians(buf.data(), static_cast<uint32_t>(buf.size()));
 }
 
 // ── build_draw_lists (debug HUD) ──

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -1002,6 +1002,14 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             }
         }
 
+        // Append pending dynamics from game states (e.g., PBD chain demo)
+        if (!gs_pending_dynamics_.empty()) {
+            gs_dynamic_buffer_.insert(gs_dynamic_buffer_.end(),
+                                      gs_pending_dynamics_.begin(),
+                                      gs_pending_dynamics_.end());
+            gs_pending_dynamics_.clear();
+        }
+
         // Upload dynamic Gaussians
         {
             auto count = static_cast<uint32_t>(gs_dynamic_buffer_.size());
@@ -1134,6 +1142,10 @@ void Renderer::add_gs_particle_emitter(const GsEmitterConfig& config) {
 
 void Renderer::clear_gs_particle_emitters() {
     gs_particle_emitters_.clear();
+}
+
+void Renderer::append_dynamic_gaussians(const Gaussian* data, uint32_t count) {
+    gs_pending_dynamics_.insert(gs_pending_dynamics_.end(), data, data + count);
 }
 
 void Renderer::add_gs_animation(const std::string& effect, const GsAnimRegion& region,

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -862,6 +862,13 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             camera_dirty = true;
         }
 
+        // Dynamic Gaussians (particles, VFX, PBD) require the static sort buffers to be
+        // reinitialized each frame via update_static_gaussians. Without this, stale sort
+        // buffer state from the previous frame's radix scatter corrupts the merge output.
+        if (!gs_pending_dynamics_.empty() || !gs_particle_emitters_.empty() || !vfx_instances_.empty()) {
+            camera_dirty = true;
+        }
+
         if (camera_dirty && flags.gs_chunk_culling && !gs_skip_chunk_cull_ && !gs_chunk_grid_.empty()) {
             glm::mat4 gs_vp = gs_proj_ * gs_view_;
             auto visible = gs_chunk_grid_.visible_chunks(gs_vp);


### PR DESCRIPTION
## Summary
- **Fix black screen on J key**: PBD solver's `prev_position` was dual-purposed for Verlet integration and rotation output — constraint mode caused exponential velocity divergence. Backed up prev_position in `params.xyz` before overwriting.
- **Fix dynamic Gaussian visibility**: Particles, VFX, and PBD chain Gaussians disappeared when the camera was stationary. Stale radix sort buffer state from the previous frame corrupted the merge output. Forces `camera_dirty` when dynamic content is present.
- **Restore character PLY**: Working copy had a modified `snes_hero.ply` with Z-offset (+32 units), causing the character to appear off-center. Restored to committed version.
- **PBD chain visual demo (J key)**: Replaced GPU PBD hijack with CPU-side Verlet simulation. Chain rendered as glowing orbs (3 concentric layers with emission) connected by amber rope segments, all as dynamic Gaussians (~105/frame). Terrain wind sway now unaffected by chain toggle.
- **Pending dynamics API**: Added `Renderer::append_dynamic_gaussians()` staging buffer so game states can inject dynamic Gaussians during `update()`.
- **Méliès UI kit refactor**: Replaced local NumberInput/Vec3Input with `@gseurat/ui-kit` components.

## Test plan
- [ ] Press J: 3 glowing gold orbs appear above player, connected by amber rope dots
- [ ] Lower orbs swing as pendulum under gravity, top orb follows player
- [ ] Press J again: chain disappears immediately, trees keep swaying
- [ ] Stand still: particles, VFX smoke, and PBD chain remain visible
- [ ] Walk around: no black screen, character stays centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)