### PR TITLE
feat(bricklayer): Phase 2 camera zone editor

### DIFF
--- a/docs/superpowers/plans/2026-04-07-camera-bricklayer-editor.md
+++ b/docs/superpowers/plans/2026-04-07-camera-bricklayer-editor.md
@@ -1,0 +1,948 @@
+# Camera Zone Bricklayer Editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add interactive camera zone editing to Bricklayer — volumes, triggers, and rails with draggable gizmos, frustum visualization, and possess-camera preview mode.
+
+**Architecture:** Follow the established Bricklayer entity pattern: TypeScript types → Zustand store (add/update/remove) → ProjectTree navigation → ScenePropertiesPanel editors → viewport gizmo markers → scene export. New files: 3 editor panels, 3 viewport components (markers, frustum, possess mode). Modified: types, store, tree, properties panel, viewport, export.
+
+**Tech Stack:** TypeScript, React, Zustand, Three.js, React Three Fiber (R3F), drei (Html, Line, TransformControls)
+
+**Spec:** `docs/superpowers/specs/2026-04-07-camera-bricklayer-editor-design.md`
+
+---
+
+### File Structure
+
+| File | Purpose |
+|------|---------|
+| `tools/apps/bricklayer/src/store/types.ts` | Add CameraShape, CameraZoneParams, CameraZoneVolume, CameraZoneTrigger, CameraZoneRail types (modify) |
+| `tools/apps/bricklayer/src/store/useSceneStore.ts` | Add camera state + actions + save/load (modify) |
+| `tools/apps/bricklayer/src/panels/ProjectTree.tsx` | Add Camera section with Volumes/Triggers/Rails (modify) |
+| `tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx` | Route to camera editors (modify) |
+| `tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx` | Volume parameter editor + Possess button (new) |
+| `tools/apps/bricklayer/src/panels/CameraTriggerEditor.tsx` | Trigger parameter editor (new) |
+| `tools/apps/bricklayer/src/panels/CameraRailEditor.tsx` | Rail control point editor (new) |
+| `tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx` | Volume/trigger wireframes + TransformControls (new) |
+| `tools/apps/bricklayer/src/viewport/CameraRailMarkers.tsx` | Rail spline line + control point spheres (new) |
+| `tools/apps/bricklayer/src/viewport/CameraFrustumGizmo.tsx` | FOV frustum + pitch/yaw constraint fans (new) |
+| `tools/apps/bricklayer/src/viewport/Viewport.tsx` | Include new marker components (modify) |
+| `tools/apps/bricklayer/src/lib/sceneExport.ts` | Export camera_zones block (modify) |
+| `tools/apps/bricklayer/src/App.tsx` | Possess mode state + keyboard shortcut (modify) |
+
+---
+
+### Task 1: Type Definitions
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/store/types.ts`
+
+- [ ] **Step 1: Add CameraShape and CameraZoneParams interfaces**
+
+Add after the `VfxInstanceData` interface (around line 310) in `types.ts`:
+
+```typescript
+// ── Camera Zone Types (Phase 2) ──
+
+export interface CameraShape {
+  type: 'aabb' | 'sphere';
+  center: [number, number, number];
+  half_extents?: [number, number, number];  // AABB only
+  radius?: number;                           // Sphere only
+}
+
+export interface CameraZoneParams {
+  mode: 'free_look' | 'rail_follow' | 'cinematic_rail' | 'fixed_point' | 'side_scroll';
+  priority: number;
+  blend_time: number;
+  allow_user_orbit: boolean;
+  pitch_min: number;
+  pitch_max: number;
+  yaw_min: number;
+  yaw_max: number;
+  fov: number;
+  orbit_distance: number;
+  offset: [number, number, number];
+  fixed_position?: [number, number, number];
+  rail_id?: string;
+}
+
+export const DEFAULT_CAMERA_ZONE_PARAMS: CameraZoneParams = {
+  mode: 'free_look',
+  priority: 0,
+  blend_time: 1.0,
+  allow_user_orbit: true,
+  pitch_min: -60,
+  pitch_max: 10,
+  yaw_min: -180,
+  yaw_max: 180,
+  fov: 45,
+  orbit_distance: 10,
+  offset: [0, 5, -10],
+};
+
+export interface CameraZoneVolume {
+  id: string;
+  name: string;
+  shape: CameraShape;
+  params: CameraZoneParams;
+}
+
+export interface CameraZoneTrigger {
+  id: string;
+  shape: CameraShape;
+  from_zone?: string;
+  to_zone: string;
+  blend_override: number;
+}
+
+export interface CameraZoneRail {
+  id: string;
+  name: string;
+  control_points: [number, number, number][];
+  target_points?: [number, number, number][];
+}
+```
+
+- [ ] **Step 2: Add camera fields to BricklayerFile scene type**
+
+In the `BricklayerFile` interface's `scene` block (around line 395), add after `vfxInstances`:
+
+```typescript
+    cameraVolumes?: CameraZoneVolume[];
+    cameraTriggers?: CameraZoneTrigger[];
+    cameraRails?: CameraZoneRail[];
+    cameraDefaultParams?: Partial<CameraZoneParams>;
+    cameraShowDebugVolumes?: boolean;
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `cd tools && pnpm --filter bricklayer build 2>&1 | head -20`
+
+Expected: No type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/store/types.ts
+git commit -m "feat(bricklayer): add camera zone type definitions"
+```
+
+---
+
+### Task 2: Store — State and Actions
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/store/useSceneStore.ts`
+
+- [ ] **Step 1: Add camera state fields to SceneStoreState**
+
+In the `SceneStoreState` interface, after `navZoneNames` (around line 225), add:
+
+```typescript
+  // Camera zones
+  cameraVolumes: CameraZoneVolume[];
+  cameraTriggers: CameraZoneTrigger[];
+  cameraRails: CameraZoneRail[];
+  cameraDefaultParams: Partial<CameraZoneParams>;
+  cameraShowDebugVolumes: boolean;
+```
+
+Add imports at the top of the file:
+
+```typescript
+import type { CameraZoneVolume, CameraZoneTrigger, CameraZoneRail, CameraZoneParams, CameraShape } from './types.js';
+import { DEFAULT_CAMERA_ZONE_PARAMS } from './types.js';
+```
+
+- [ ] **Step 2: Add action declarations**
+
+In the actions section of `SceneStoreState` (after `removeVfxInstance`), add:
+
+```typescript
+  // Camera zones
+  addCameraVolume: (position?: [number, number, number]) => void;
+  updateCameraVolume: (id: string, patch: Partial<CameraZoneVolume>) => void;
+  removeCameraVolume: (id: string) => void;
+  addCameraTrigger: (position?: [number, number, number]) => void;
+  updateCameraTrigger: (id: string, patch: Partial<CameraZoneTrigger>) => void;
+  removeCameraTrigger: (id: string) => void;
+  addCameraRail: () => void;
+  updateCameraRail: (id: string, patch: Partial<CameraZoneRail>) => void;
+  removeCameraRail: (id: string) => void;
+  addRailControlPoint: (railId: string, point: [number, number, number]) => void;
+  removeRailControlPoint: (railId: string, index: number) => void;
+  updateRailControlPoint: (railId: string, index: number, point: [number, number, number]) => void;
+  updateCameraDefaultParams: (patch: Partial<CameraZoneParams>) => void;
+  setCameraShowDebugVolumes: (show: boolean) => void;
+```
+
+- [ ] **Step 3: Add initial state values**
+
+In the `create()` initial state object, add after the `navZoneNames` initializer:
+
+```typescript
+      cameraVolumes: [],
+      cameraTriggers: [],
+      cameraRails: [],
+      cameraDefaultParams: {},
+      cameraShowDebugVolumes: false,
+```
+
+- [ ] **Step 4: Implement actions**
+
+After the VFX actions (around line 730), add:
+
+```typescript
+      // ── Camera Zone Actions ──
+
+      addCameraVolume: (pos) => {
+        const vol: CameraZoneVolume = {
+          id: genId('camvol'),
+          name: `Volume ${get().cameraVolumes.length + 1}`,
+          shape: { type: 'aabb', center: pos ?? [0, 2, 0], half_extents: [5, 5, 5] },
+          params: { ...DEFAULT_CAMERA_ZONE_PARAMS },
+        };
+        set({ cameraVolumes: [...get().cameraVolumes, vol], isDirty: true });
+      },
+      updateCameraVolume: (id, patch) => set({
+        cameraVolumes: get().cameraVolumes.map((v) => (v.id === id ? { ...v, ...patch } : v)),
+        isDirty: true,
+      }),
+      removeCameraVolume: (id) => set({
+        cameraVolumes: get().cameraVolumes.filter((v) => v.id !== id),
+        isDirty: true,
+      }),
+
+      addCameraTrigger: (pos) => {
+        const trig: CameraZoneTrigger = {
+          id: genId('camtrig'),
+          shape: { type: 'aabb', center: pos ?? [0, 2, 0], half_extents: [1, 3, 3] },
+          to_zone: '',
+          blend_override: -1,
+        };
+        set({ cameraTriggers: [...get().cameraTriggers, trig], isDirty: true });
+      },
+      updateCameraTrigger: (id, patch) => set({
+        cameraTriggers: get().cameraTriggers.map((t) => (t.id === id ? { ...t, ...patch } : t)),
+        isDirty: true,
+      }),
+      removeCameraTrigger: (id) => set({
+        cameraTriggers: get().cameraTriggers.filter((t) => t.id !== id),
+        isDirty: true,
+      }),
+
+      addCameraRail: () => {
+        const rail: CameraZoneRail = {
+          id: genId('camrail'),
+          name: `Rail ${get().cameraRails.length + 1}`,
+          control_points: [[0, 5, 0], [5, 5, 0], [10, 5, 0]],
+        };
+        set({ cameraRails: [...get().cameraRails, rail], isDirty: true });
+      },
+      updateCameraRail: (id, patch) => set({
+        cameraRails: get().cameraRails.map((r) => (r.id === id ? { ...r, ...patch } : r)),
+        isDirty: true,
+      }),
+      removeCameraRail: (id) => set({
+        cameraRails: get().cameraRails.filter((r) => r.id !== id),
+        isDirty: true,
+      }),
+      addRailControlPoint: (railId, point) => set({
+        cameraRails: get().cameraRails.map((r) =>
+          r.id === railId ? { ...r, control_points: [...r.control_points, point] } : r),
+        isDirty: true,
+      }),
+      removeRailControlPoint: (railId, index) => set({
+        cameraRails: get().cameraRails.map((r) =>
+          r.id === railId ? { ...r, control_points: r.control_points.filter((_, i) => i !== index) } : r),
+        isDirty: true,
+      }),
+      updateRailControlPoint: (railId, index, point) => set({
+        cameraRails: get().cameraRails.map((r) =>
+          r.id === railId ? { ...r, control_points: r.control_points.map((p, i) => i === index ? point : p) } : r),
+        isDirty: true,
+      }),
+      updateCameraDefaultParams: (patch) => set({
+        cameraDefaultParams: { ...get().cameraDefaultParams, ...patch },
+        isDirty: true,
+      }),
+      setCameraShowDebugVolumes: (show) => set({ cameraShowDebugVolumes: show, isDirty: true }),
+```
+
+- [ ] **Step 5: Update saveProject**
+
+In `saveProject()`, add to the `scene` object after `vfxInstances`:
+
+```typescript
+        cameraVolumes: s.cameraVolumes.length > 0 ? s.cameraVolumes : undefined,
+        cameraTriggers: s.cameraTriggers.length > 0 ? s.cameraTriggers : undefined,
+        cameraRails: s.cameraRails.length > 0 ? s.cameraRails : undefined,
+        cameraDefaultParams: Object.keys(s.cameraDefaultParams).length > 0 ? s.cameraDefaultParams : undefined,
+        cameraShowDebugVolumes: s.cameraShowDebugVolumes || undefined,
+```
+
+- [ ] **Step 6: Update loadProject**
+
+In `loadProject()`, add to the state restoration (after `vfxInstances`):
+
+```typescript
+      cameraVolumes: data.scene.cameraVolumes ?? [],
+      cameraTriggers: data.scene.cameraTriggers ?? [],
+      cameraRails: data.scene.cameraRails ?? [],
+      cameraDefaultParams: data.scene.cameraDefaultParams ?? {},
+      cameraShowDebugVolumes: data.scene.cameraShowDebugVolumes ?? false,
+```
+
+- [ ] **Step 7: Build and verify**
+
+Run: `cd tools && pnpm --filter bricklayer build 2>&1 | head -20`
+
+Expected: No errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/store/useSceneStore.ts
+git commit -m "feat(bricklayer): add camera zone store state and actions"
+```
+
+---
+
+### Task 3: Project Tree — Camera Section
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/panels/ProjectTree.tsx`
+
+- [ ] **Step 1: Add store selectors for camera data**
+
+At the top of the component where other store selectors are declared, add:
+
+```typescript
+  const cameraVolumes = useSceneStore((s) => s.cameraVolumes);
+  const cameraTriggers = useSceneStore((s) => s.cameraTriggers);
+  const cameraRails = useSceneStore((s) => s.cameraRails);
+  const addCameraVolume = useSceneStore((s) => s.addCameraVolume);
+  const addCameraTrigger = useSceneStore((s) => s.addCameraTrigger);
+  const addCameraRail = useSceneStore((s) => s.addCameraRail);
+  const removeCameraVolume = useSceneStore((s) => s.removeCameraVolume);
+  const removeCameraTrigger = useSceneStore((s) => s.removeCameraTrigger);
+  const removeCameraRail = useSceneStore((s) => s.removeCameraRail);
+```
+
+Add state for section open/closed:
+
+```typescript
+  const [cameraOpen, setCameraOpen] = useState(false);
+  const [camVolOpen, setCamVolOpen] = useState(true);
+  const [camTrigOpen, setCamTrigOpen] = useState(true);
+  const [camRailOpen, setCamRailOpen] = useState(true);
+```
+
+- [ ] **Step 2: Add Camera tree section**
+
+After the VFX section in the JSX (after the VFX `TreeNode`), add:
+
+```tsx
+          {/* Camera Zones */}
+          <TreeNode
+            icon="📹" label="Camera"
+            count={cameraVolumes.length + cameraTriggers.length + cameraRails.length}
+            arrow={cameraOpen ? '\u25BE' : '\u25B8'}
+            isActive={false}
+            onClick={() => setCameraOpen(!cameraOpen)}
+            isOpen={cameraOpen}
+          >
+            {/* Volumes */}
+            <TreeNode
+              icon="📦" label="Volumes" count={cameraVolumes.length}
+              arrow={camVolOpen ? '\u25BE' : '\u25B8'}
+              isActive={false}
+              onClick={() => setCamVolOpen(!camVolOpen)}
+              actions={addBtn(() => addCameraVolume())}
+              isOpen={camVolOpen}
+            >
+              {cameraVolumes.map((v) => (
+                <TreeNode
+                  key={v.id}
+                  icon="📦"
+                  label={v.name}
+                  isActive={isActive({ kind: 'scene_item', entityType: 'camera_volume', entityId: v.id })}
+                  onClick={() => click({ kind: 'scene_item', entityType: 'camera_volume', entityId: v.id })}
+                  actions={removeBtn(() => removeCameraVolume(v.id))}
+                />
+              ))}
+            </TreeNode>
+
+            {/* Triggers */}
+            <TreeNode
+              icon="⚡" label="Triggers" count={cameraTriggers.length}
+              arrow={camTrigOpen ? '\u25BE' : '\u25B8'}
+              isActive={false}
+              onClick={() => setCamTrigOpen(!camTrigOpen)}
+              actions={addBtn(() => addCameraTrigger())}
+              isOpen={camTrigOpen}
+            >
+              {cameraTriggers.map((t) => (
+                <TreeNode
+                  key={t.id}
+                  icon="⚡"
+                  label={`${t.from_zone || '*'} → ${t.to_zone || '?'}`}
+                  isActive={isActive({ kind: 'scene_item', entityType: 'camera_trigger', entityId: t.id })}
+                  onClick={() => click({ kind: 'scene_item', entityType: 'camera_trigger', entityId: t.id })}
+                  actions={removeBtn(() => removeCameraTrigger(t.id))}
+                />
+              ))}
+            </TreeNode>
+
+            {/* Rails */}
+            <TreeNode
+              icon="🛤️" label="Rails" count={cameraRails.length}
+              arrow={camRailOpen ? '\u25BE' : '\u25B8'}
+              isActive={false}
+              onClick={() => setCamRailOpen(!camRailOpen)}
+              actions={addBtn(() => addCameraRail())}
+              isOpen={camRailOpen}
+            >
+              {cameraRails.map((r) => (
+                <TreeNode
+                  key={r.id}
+                  icon="🛤️"
+                  label={r.name}
+                  isActive={isActive({ kind: 'scene_item', entityType: 'camera_rail', entityId: r.id })}
+                  onClick={() => click({ kind: 'scene_item', entityType: 'camera_rail', entityId: r.id })}
+                  actions={removeBtn(() => removeCameraRail(r.id))}
+                />
+              ))}
+            </TreeNode>
+          </TreeNode>
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd tools && pnpm --filter bricklayer build 2>&1 | head -20`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/panels/ProjectTree.tsx
+git commit -m "feat(bricklayer): add Camera section to project tree"
+```
+
+---
+
+### Task 4: Property Panel Editors
+
+**Files:**
+- Create: `tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx`
+- Create: `tools/apps/bricklayer/src/panels/CameraTriggerEditor.tsx`
+- Create: `tools/apps/bricklayer/src/panels/CameraRailEditor.tsx`
+- Modify: `tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx`
+
+- [ ] **Step 1: Create CameraVolumeEditor.tsx**
+
+Create `tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx`. This component edits a single `CameraZoneVolume`. Follow the `LightEditor` pattern from `LightsTab.tsx`. Include:
+
+- Name text input
+- Shape type dropdown (aabb / sphere)
+- Center Vec3Input
+- Half Extents Vec3Input (AABB) or Radius NumberInput (Sphere)
+- Mode dropdown (5 modes)
+- Priority, Blend Time, FOV, Orbit Distance as NumberInput
+- Allow User Orbit checkbox
+- Pitch Min/Max, Yaw Min/Max as NumberInput pairs
+- Offset Vec3Input (free_look / side_scroll)
+- Fixed Position Vec3Input (fixed_point)
+- Rail dropdown (rail_follow / cinematic_rail)
+- "Possess Camera" button (stores `possessVolumeId` in app state — wired in Task 7)
+
+Use `useSceneStore` selectors for `updateCameraVolume` and `cameraRails` (for the rail dropdown). All field changes call `updateCameraVolume(volume.id, { ... })`.
+
+For shape changes, update the full shape object:
+```typescript
+// Switch to sphere
+updateCameraVolume(volume.id, {
+  shape: { ...volume.shape, type: 'sphere', radius: volume.shape.radius ?? 5 }
+});
+```
+
+Mode-dependent fields: show Orbit Distance and Offset only when mode is `free_look` or `side_scroll`. Show Fixed Position only when `fixed_point`. Show Rail dropdown only when `rail_follow` or `cinematic_rail`.
+
+- [ ] **Step 2: Create CameraTriggerEditor.tsx**
+
+Create `tools/apps/bricklayer/src/panels/CameraTriggerEditor.tsx`. Similar to CameraVolumeEditor but simpler:
+
+- Shape type dropdown + center + half_extents/radius
+- From Zone dropdown (volume IDs + "Any" option)
+- To Zone dropdown (volume IDs)
+- Blend Override NumberInput (-1 = default)
+
+Use `cameraVolumes` from store to populate dropdowns.
+
+- [ ] **Step 3: Create CameraRailEditor.tsx**
+
+Create `tools/apps/bricklayer/src/panels/CameraRailEditor.tsx`:
+
+- Name text input
+- Control Points: ordered list of Vec3Inputs, each with index number and [x] remove button
+- [+ Add Point] button (appends `[0, 5, 0]`)
+- Target Points: checkbox to enable, then same ordered list pattern
+
+Use `updateRailControlPoint`, `addRailControlPoint`, `removeRailControlPoint` from store.
+
+- [ ] **Step 4: Wire editors into ScenePropertiesPanel.tsx**
+
+In `ScenePropertiesPanel.tsx`, add imports:
+
+```typescript
+import { CameraVolumeEditor } from './CameraVolumeEditor.js';
+import { CameraTriggerEditor } from './CameraTriggerEditor.js';
+import { CameraRailEditor } from './CameraRailEditor.js';
+```
+
+Add store selectors:
+
+```typescript
+const cameraVolumes = useSceneStore((s) => s.cameraVolumes);
+const cameraTriggers = useSceneStore((s) => s.cameraTriggers);
+const cameraRails = useSceneStore((s) => s.cameraRails);
+```
+
+Add routing cases after the existing entity type checks (after `vfx_instance`):
+
+```typescript
+  if (selectedEntity.type === 'camera_volume') {
+    const vol = cameraVolumes.find((v) => v.id === selectedEntity.id);
+    if (!vol) return <div style={styles.empty}>Camera volume not found</div>;
+    return <CameraVolumeEditor volume={vol} />;
+  }
+
+  if (selectedEntity.type === 'camera_trigger') {
+    const trig = cameraTriggers.find((t) => t.id === selectedEntity.id);
+    if (!trig) return <div style={styles.empty}>Camera trigger not found</div>;
+    return <CameraTriggerEditor trigger={trig} />;
+  }
+
+  if (selectedEntity.type === 'camera_rail') {
+    const rail = cameraRails.find((r) => r.id === selectedEntity.id);
+    if (!rail) return <div style={styles.empty}>Camera rail not found</div>;
+    return <CameraRailEditor rail={rail} />;
+  }
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `cd tools && pnpm --filter bricklayer build 2>&1 | head -20`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx \
+        tools/apps/bricklayer/src/panels/CameraTriggerEditor.tsx \
+        tools/apps/bricklayer/src/panels/CameraRailEditor.tsx \
+        tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+git commit -m "feat(bricklayer): add camera zone property panel editors"
+```
+
+---
+
+### Task 5: Viewport Gizmos — Volume and Trigger Markers
+
+**Files:**
+- Create: `tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx`
+- Modify: `tools/apps/bricklayer/src/viewport/Viewport.tsx`
+
+- [ ] **Step 1: Create CameraZoneMarkers.tsx**
+
+Create `tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx`. Follow the `LightGizmos.tsx` pattern.
+
+Render all volumes and triggers as wireframe shapes:
+
+```typescript
+import React, { useRef } from 'react';
+import * as THREE from 'three';
+import { Html, TransformControls } from '@react-three/drei';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { CameraShape, CameraZoneVolume, CameraZoneTrigger } from '../store/types.js';
+```
+
+**VolumeMarker component:** Takes a `CameraZoneVolume`, renders:
+- For AABB: `<mesh>` with `BoxGeometry(2*hx, 2*hy, 2*hz)` + `EdgesGeometry` for wireframe. Semi-transparent cyan fill (`opacity: 0.08`). Edges as `<lineSegments>`.
+- For Sphere: same pattern with `SphereGeometry(radius, 24, 16)`.
+- Invisible hit mesh for click detection (`<mesh onPointerDown={...}>` with `visible={false}`).
+- When selected: bright cyan edges, `Html` label above center.
+- When selected: `TransformControls` with `mode="translate"` for center dragging. On change: `updateCameraVolume(id, { shape: { ...shape, center: [x, y, z] } })`.
+
+**TriggerMarker component:** Same as VolumeMarker but magenta color scheme (`#cc00cc` / `#ff00ff`).
+
+**CameraZoneMarkers export:** Renders all volumes + triggers, checks `showGizmos`.
+
+**Raycast layer separation:** Use `meshRef.current.layers.set(1)` on invisible hit meshes and `layers.set(0)` on TransformControls to prevent gizmo drags from being absorbed by hit meshes. Set raycaster layers in the pointer event handlers.
+
+- [ ] **Step 2: Add to Viewport.tsx**
+
+In `Viewport.tsx`, import and add the component in `SceneContent` (after `VfxInstanceMarkers`):
+
+```typescript
+import { CameraZoneMarkers } from './CameraZoneMarkers.js';
+```
+
+```tsx
+<CameraZoneMarkers />
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd tools && pnpm --filter bricklayer build 2>&1 | head -20`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx \
+        tools/apps/bricklayer/src/viewport/Viewport.tsx
+git commit -m "feat(bricklayer): add camera volume/trigger viewport gizmos"
+```
+
+---
+
+### Task 6: Viewport — Rail Markers
+
+**Files:**
+- Create: `tools/apps/bricklayer/src/viewport/CameraRailMarkers.tsx`
+- Modify: `tools/apps/bricklayer/src/viewport/Viewport.tsx`
+
+- [ ] **Step 1: Create CameraRailMarkers.tsx**
+
+Render each rail as:
+- drei `Line` component through `control_points` in yellow (`#cccc00`).
+- Small spheres (`SphereGeometry(0.3)`) at each control point, clickable.
+- When selected: bright yellow line, `Html` label with rail name.
+- `TransformControls` on selected control point for dragging — updates via `updateRailControlPoint(railId, index, newPos)`.
+- If `target_points` present: second `Line` in dashed orange (`#cc8800`).
+
+**Catmull-Rom interpolation:** Use `THREE.CatmullRomCurve3` with the control points to generate smooth curve points for the Line. This ensures the displayed curve matches the C++ engine's Catmull-Rom evaluation.
+
+```typescript
+const curve = new THREE.CatmullRomCurve3(
+  rail.control_points.map(p => new THREE.Vector3(p[0], p[1], p[2])),
+  false, 'catmullrom'
+);
+const points = curve.getPoints(64);
+```
+
+- [ ] **Step 2: Add to Viewport.tsx**
+
+```typescript
+import { CameraRailMarkers } from './CameraRailMarkers.js';
+```
+
+```tsx
+<CameraRailMarkers />
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd tools && pnpm --filter bricklayer build 2>&1 | head -20`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/viewport/CameraRailMarkers.tsx \
+        tools/apps/bricklayer/src/viewport/Viewport.tsx
+git commit -m "feat(bricklayer): add camera rail viewport markers with Catmull-Rom spline"
+```
+
+---
+
+### Task 7: Frustum Visualization
+
+**Files:**
+- Create: `tools/apps/bricklayer/src/viewport/CameraFrustumGizmo.tsx`
+- Modify: `tools/apps/bricklayer/src/viewport/Viewport.tsx`
+
+- [ ] **Step 1: Create CameraFrustumGizmo.tsx**
+
+Render when a camera volume is selected. Computes:
+
+1. **Camera origin** based on mode:
+   - `free_look`: center + offset + orbit vector (azimuth=0, elevation=0, orbit_distance)
+   - `fixed_point`: fixed_position (render camera icon sprite here)
+   - `rail_follow`/`cinematic_rail`: first control point of referenced rail
+   - `side_scroll`: center + offset
+
+2. **Frustum edges:** 4 lines from origin outward at FOV half-angle, clipped at display distance (~10 units). Near/far plane rectangles as wireframe.
+
+3. **Pitch/Yaw constraint fans:** Semi-transparent surfaces showing allowed rotation range.
+   - Pitch fan: vertical arc from `pitch_min` to `pitch_max` using `THREE.ShapeGeometry` built from arc points.
+   - Yaw fan: horizontal arc from `yaw_min` to `yaw_max`.
+   - Color: `#00ffff` with `opacity: 0.12`.
+   - Update in real-time when slider values change.
+
+4. **Fixed-point camera icon:** A small group of Three.js meshes forming a camera silhouette (box body + cone lens) at `fixed_position`. Dashed line to volume center.
+
+- [ ] **Step 2: Add to Viewport.tsx**
+
+```typescript
+import { CameraFrustumGizmo } from './CameraFrustumGizmo.js';
+```
+
+```tsx
+<CameraFrustumGizmo />
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd tools && pnpm --filter bricklayer build 2>&1 | head -20`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/viewport/CameraFrustumGizmo.tsx \
+        tools/apps/bricklayer/src/viewport/Viewport.tsx
+git commit -m "feat(bricklayer): add camera frustum + pitch/yaw constraint visualization"
+```
+
+---
+
+### Task 8: Possess Mode (Camera Preview)
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/App.tsx`
+- Modify: `tools/apps/bricklayer/src/store/useSceneStore.ts` (add possess state)
+- Modify: `tools/apps/bricklayer/src/viewport/Viewport.tsx`
+
+- [ ] **Step 1: Add possess mode state to store**
+
+In `useSceneStore.ts`, add to state:
+
+```typescript
+  possessVolumeId: string | null;  // null = normal editing, string = preview mode
+  savedEditorCamera: { position: [number,number,number]; target: [number,number,number] } | null;
+```
+
+Add actions:
+
+```typescript
+  enterPossessMode: (volumeId: string) => void;
+  exitPossessMode: () => void;
+```
+
+Implement:
+
+```typescript
+      enterPossessMode: (volumeId) => set({ possessVolumeId: volumeId }),
+      exitPossessMode: () => set({ possessVolumeId: null, savedEditorCamera: null }),
+```
+
+Initial state: `possessVolumeId: null, savedEditorCamera: null`.
+
+- [ ] **Step 2: Implement possess mode in Viewport.tsx**
+
+In the `SceneContent` component, add possess mode logic:
+
+When `possessVolumeId` is set:
+1. Find the volume in `cameraVolumes`.
+2. Compute the zone's camera position (same logic as CameraFrustumGizmo).
+3. Override `OrbitControls` target to the volume center.
+4. Set `controls.minPolarAngle` / `maxPolarAngle` from `pitch_min`/`pitch_max` (convert degrees to radians, offset by π/2 for Three.js polar convention).
+5. Set `controls.minAzimuthAngle` / `maxAzimuthAngle` from `yaw_min`/`yaw_max` (convert degrees to radians).
+6. Apply rotation damping near limits: set `controls.enableDamping = true`, `controls.dampingFactor` increases as angle approaches limit (use `controls.addEventListener('change', ...)` to check proximity).
+
+Render a "PREVIEW MODE — Escape to exit" banner:
+
+```tsx
+{possessVolumeId && (
+  <Html fullscreen>
+    <div style={{
+      position: 'absolute', top: 0, left: 0, right: 0,
+      background: 'rgba(0,0,0,0.7)', color: '#00ffff',
+      textAlign: 'center', padding: '8px', fontSize: '14px', fontWeight: 'bold',
+      zIndex: 1000,
+    }}>
+      PREVIEW MODE — Press Escape to exit
+    </div>
+  </Html>
+)}
+```
+
+- [ ] **Step 3: Add Escape handler in App.tsx**
+
+In the keyboard handler section of `App.tsx`, add:
+
+```typescript
+if (e.key === 'Escape' && useSceneStore.getState().possessVolumeId) {
+  useSceneStore.getState().exitPossessMode();
+  e.preventDefault();
+  return;
+}
+```
+
+- [ ] **Step 4: Wire Possess button in CameraVolumeEditor**
+
+In `CameraVolumeEditor.tsx`, add the button that was specified in Task 4:
+
+```tsx
+<button
+  style={{ ...styles.btn, background: possessVolumeId === volume.id ? '#00cccc' : undefined }}
+  onClick={() => {
+    if (possessVolumeId === volume.id) exitPossessMode();
+    else enterPossessMode(volume.id);
+  }}
+>
+  {possessVolumeId === volume.id ? 'Exit Preview' : 'Possess Camera'}
+</button>
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `cd tools && pnpm --filter bricklayer build 2>&1 | head -20`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/App.tsx \
+        tools/apps/bricklayer/src/store/useSceneStore.ts \
+        tools/apps/bricklayer/src/viewport/Viewport.tsx \
+        tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx
+git commit -m "feat(bricklayer): add possess camera preview mode"
+```
+
+---
+
+### Task 9: Scene Export — camera_zones Block
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/lib/sceneExport.ts`
+
+- [ ] **Step 1: Add camera_zones export**
+
+In `exportSceneJson()`, after the VFX instances export block (around line 230), add:
+
+```typescript
+  // Camera zones
+  if (state.cameraVolumes.length > 0 || state.cameraTriggers.length > 0 || state.cameraRails.length > 0) {
+    const cameraZones: Record<string, unknown> = {};
+
+    if (Object.keys(state.cameraDefaultParams).length > 0) {
+      cameraZones.default_params = state.cameraDefaultParams;
+    }
+    if (state.cameraShowDebugVolumes) {
+      cameraZones.show_debug_volumes = true;
+    }
+
+    if (state.cameraVolumes.length > 0) {
+      cameraZones.volumes = state.cameraVolumes.map((v) => {
+        const out: Record<string, unknown> = {
+          id: v.id,
+          shape: v.shape,
+        };
+        // Only include non-default params
+        const p = v.params;
+        const params: Record<string, unknown> = {};
+        if (p.mode !== 'free_look') params.mode = p.mode;
+        if (p.priority !== 0) params.priority = p.priority;
+        if (p.blend_time !== 1.0) params.blend_time = p.blend_time;
+        if (!p.allow_user_orbit) params.allow_user_orbit = false;
+        if (p.pitch_min !== -60) params.pitch_min = p.pitch_min;
+        if (p.pitch_max !== 10) params.pitch_max = p.pitch_max;
+        if (p.yaw_min !== -180) params.yaw_min = p.yaw_min;
+        if (p.yaw_max !== 180) params.yaw_max = p.yaw_max;
+        if (p.fov !== 45) params.fov = p.fov;
+        if (p.orbit_distance !== 10) params.orbit_distance = p.orbit_distance;
+        if (p.offset[0] !== 0 || p.offset[1] !== 5 || p.offset[2] !== -10) params.offset = p.offset;
+        if (p.fixed_position) params.fixed_position = p.fixed_position;
+        if (p.rail_id) params.rail_id = p.rail_id;
+        if (Object.keys(params).length > 0) out.params = params;
+        return out;
+      });
+    }
+
+    if (state.cameraTriggers.length > 0) {
+      cameraZones.triggers = state.cameraTriggers.map((t) => {
+        const out: Record<string, unknown> = {
+          shape: t.shape,
+          to_zone: t.to_zone,
+        };
+        if (t.from_zone) out.from_zone = t.from_zone;
+        if (t.blend_override >= 0) out.blend_override = t.blend_override;
+        return out;
+      });
+    }
+
+    if (state.cameraRails.length > 0) {
+      cameraZones.rails = state.cameraRails.map((r) => {
+        const out: Record<string, unknown> = {
+          id: r.id,
+          control_points: r.control_points,
+        };
+        if (r.target_points && r.target_points.length > 0) {
+          out.target_points = r.target_points;
+        }
+        return out;
+      });
+    }
+
+    scene.camera_zones = cameraZones;
+  }
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd tools && pnpm --filter bricklayer build 2>&1 | head -20`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/lib/sceneExport.ts
+git commit -m "feat(bricklayer): export camera_zones block in scene JSON"
+```
+
+---
+
+### Task 10: Integration Test — Full Workflow
+
+**Files:** No new files — manual verification.
+
+- [ ] **Step 1: Build Bricklayer**
+
+Run: `cd tools && pnpm --filter bricklayer build`
+
+Expected: Clean build, no errors.
+
+- [ ] **Step 2: Start Bricklayer dev server**
+
+Run: `cd tools/apps/bricklayer && pnpm dev`
+
+Open in browser. Verify:
+1. Camera section appears in Project Tree
+2. Click "+ Volume" adds a volume, selects it
+3. Volume appears as cyan wireframe in viewport
+4. Properties panel shows volume editor with all fields
+5. Changing shape type (AABB ↔ Sphere) updates the gizmo
+6. TransformControls appear for dragging
+7. Number inputs and gizmo stay in sync
+8. Click "+ Rail" creates a rail with yellow spline
+9. Click "+ Trigger" creates a trigger with magenta wireframe
+10. Possess Camera button switches viewport to zone perspective
+
+- [ ] **Step 3: Test scene export**
+
+Create a scene with camera zones, export via File > Export Scene JSON. Verify the output contains a valid `camera_zones` block matching the Phase 1 schema.
+
+- [ ] **Step 4: Test with engine**
+
+Load the exported scene in the demo app:
+
+```bash
+./build/macos-debug/gseurat_demo --scene path/to/exported_scene.json
+```
+
+Verify the camera zones work at runtime.
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add -u
+git commit -m "fix(bricklayer): integration test fixes"
+```

--- a/docs/superpowers/specs/2026-04-07-camera-bricklayer-editor-design.md
+++ b/docs/superpowers/specs/2026-04-07-camera-bricklayer-editor-design.md
@@ -1,0 +1,386 @@
+# Camera Zone Editor for Bricklayer — Phase 2
+
+**Date:** 2026-04-07
+**Status:** Draft
+**Scope:** Phase 2 of 3 — Bricklayer editor UI for camera volumes, triggers, and rails. Builds on Phase 1 runtime engine (PR #180).
+
+## Problem
+
+Phase 1 delivered the C++ runtime pipeline for camera zones, but camera zone data must currently be hand-written in JSON. For 3DGS scenes, hiding splat backsides and density falloff requires millimeter-precision boundary placement — impossible without spatial feedback. Level designers need interactive tools to place, resize, and preview camera zones directly in the 3D viewport.
+
+## Solution
+
+Extend Bricklayer with a camera zone editing system following the established entity pattern (store + panel + gizmo). Three entity types: volumes, triggers, and rails. Interactive gizmos for translation and scaling. Frustum wireframe visualization with semi-transparent constraint surfaces. A "Possess Camera" preview mode that temporarily switches the viewport to the zone's restricted camera perspective.
+
+## Data Model
+
+### Shared Shape Type
+
+```typescript
+// Shared between volumes and triggers — mirrors C++ VolumeShape variant
+interface CameraShape {
+  type: 'aabb' | 'sphere';
+  center: [number, number, number];
+  half_extents?: [number, number, number];  // AABB only
+  radius?: number;                           // Sphere only
+}
+```
+
+Extracting this as a shared type ensures clean 1:1 mapping to the C++ `std::variant<CamAABB, CamSphere>` and leaves room to add `'capsule'` or `'convex_hull'` in the future without structural changes.
+
+### Camera Zone Params
+
+```typescript
+interface CameraZoneParams {
+  mode: 'free_look' | 'rail_follow' | 'cinematic_rail' | 'fixed_point' | 'side_scroll';
+  priority: number;          // 0 = auto (smallest volume wins), >0 = manual override
+  blend_time: number;        // seconds
+  allow_user_orbit: boolean;
+  pitch_min: number;         // degrees
+  pitch_max: number;
+  yaw_min: number;           // -180..180 = unrestricted
+  yaw_max: number;
+  fov: number;               // degrees
+  orbit_distance: number;    // free_look mode
+  offset: [number, number, number];
+  fixed_position?: [number, number, number];  // fixed_point mode
+  rail_id?: string;          // rail_follow / cinematic_rail modes
+}
+```
+
+Default values match the Phase 1 C++ `CameraParams` defaults: `mode: 'free_look'`, `priority: 0`, `blend_time: 1.0`, `allow_user_orbit: true`, `pitch_min: -60`, `pitch_max: 10`, `yaw_min: -180`, `yaw_max: 180`, `fov: 45`, `orbit_distance: 10`, `offset: [0, 5, -10]`.
+
+### Entity Types
+
+```typescript
+interface CameraZoneVolume {
+  id: string;
+  name: string;
+  shape: CameraShape;
+  params: CameraZoneParams;
+}
+
+interface CameraZoneTrigger {
+  id: string;
+  shape: CameraShape;
+  from_zone?: string;   // volume ID, undefined = any direction
+  to_zone: string;      // volume ID
+  blend_override: number; // -1 = use target zone's blend_time
+}
+
+interface CameraZoneRail {
+  id: string;
+  name: string;
+  control_points: [number, number, number][];
+  target_points?: [number, number, number][];
+}
+
+// Top-level camera zone configuration
+interface CameraZonesConfig {
+  default_params: Partial<CameraZoneParams>;
+  show_debug_volumes: boolean;  // export flag for C++ debug visualization
+}
+```
+
+### Priority Resolution (Designer Reference)
+
+When multiple volumes overlap, the runtime resolves which zone's rules apply:
+
+1. **Manual priority** (`priority > 0`) always beats auto (`priority == 0`).
+2. Among manual: highest priority wins.
+3. Among auto: smallest volume wins (product of half_extents for AABB, r³ for Sphere).
+4. Tie-break: lowest entity ID (deterministic, stable).
+
+Designers can ignore priority entirely for most layouts — the "smallest volume wins" heuristic handles nested volumes intuitively. Only set manual priority when the heuristic produces wrong results.
+
+## Store Integration
+
+Add to `useSceneStore.ts` state:
+
+```typescript
+// Camera zone entities
+cameraVolumes: CameraZoneVolume[];
+cameraTriggers: CameraZoneTrigger[];
+cameraRails: CameraZoneRail[];
+cameraDefaultParams: Partial<CameraZoneParams>;
+cameraShowDebugVolumes: boolean;
+```
+
+Actions follow the established entity pattern:
+
+```typescript
+// Volumes
+addCameraVolume: (position?: [number, number, number]) => void;
+updateCameraVolume: (id: string, patch: Partial<CameraZoneVolume>) => void;
+removeCameraVolume: (id: string) => void;
+
+// Triggers
+addCameraTrigger: (position?: [number, number, number]) => void;
+updateCameraTrigger: (id: string, patch: Partial<CameraZoneTrigger>) => void;
+removeCameraTrigger: (id: string) => void;
+
+// Rails
+addCameraRail: () => void;
+updateCameraRail: (id: string, patch: Partial<CameraZoneRail>) => void;
+removeCameraRail: (id: string) => void;
+addRailControlPoint: (railId: string, point: [number, number, number]) => void;
+removeRailControlPoint: (railId: string, index: number) => void;
+updateRailControlPoint: (railId: string, index: number, point: [number, number, number]) => void;
+
+// Default params
+updateCameraDefaultParams: (patch: Partial<CameraZoneParams>) => void;
+setCameraShowDebugVolumes: (show: boolean) => void;
+```
+
+ID generation: `genId('camvol')`, `genId('camtrig')`, `genId('camrail')`.
+
+Default new volume: AABB, center at viewport focus or `[0, 2, 0]`, half_extents `[5, 5, 5]`, free_look mode.
+
+## Project Tree
+
+Add a **Camera** section under Scene in `ProjectTree.tsx`:
+
+```
+▼ Scene
+  ▼ Objects (3)
+  ▼ Lights (2)
+  ▼ Emitters (1)
+  ▼ VFX (0)
+  ▼ Camera                    ← new section
+    ▼ Volumes (3)
+      • courtyard
+      • corridor
+      • tower_top
+    ▼ Triggers (1)
+      • courtyard → corridor
+    ▼ Rails (1)
+      • corridor_cam
+    [+ Volume] [+ Trigger] [+ Rail]
+```
+
+- Selecting an item sets `selectedEntity` with type `'camera_volume'`, `'camera_trigger'`, or `'camera_rail'`.
+- Tree selection syncs with viewport click selection (bidirectional).
+- Trigger display name: `from_zone → to_zone` (or `* → to_zone` if from_zone is undefined).
+- Each item has a delete button (x icon) on hover.
+
+## Properties Panel
+
+Three editor components, conditionally rendered in `ScenePropertiesPanel.tsx` based on `selectedEntity.type`:
+
+### CameraVolumeEditor
+
+| Field | Input Type | Condition |
+|-------|-----------|-----------|
+| Name | text | always |
+| Shape Type | dropdown: AABB / Sphere | always |
+| Center | Vec3Input | always (synced with gizmo) |
+| Half Extents | Vec3Input | AABB only (synced with scale gizmo) |
+| Radius | NumberInput with drag | Sphere only (synced with scale gizmo) |
+| Mode | dropdown (5 modes) | always |
+| Priority | NumberInput | always |
+| Blend Time | NumberInput (seconds) | always |
+| Allow User Orbit | checkbox | always |
+| Pitch Min / Max | NumberInput pair (degrees) | always |
+| Yaw Min / Max | NumberInput pair (degrees) | always |
+| FOV | NumberInput (degrees) | always |
+| Orbit Distance | NumberInput | free_look mode |
+| Offset | Vec3Input | free_look / side_scroll |
+| Fixed Position | Vec3Input | fixed_point mode |
+| Rail | dropdown of rail IDs | rail_follow / cinematic_rail |
+| **[Possess Camera]** | button | always |
+
+Mode-dependent fields hide/show based on mode selection. All numeric inputs use the existing `NumberInput` component with drag-to-scrub.
+
+### CameraTriggerEditor
+
+| Field | Input Type |
+|-------|-----------|
+| Shape Type | dropdown: AABB / Sphere |
+| Center | Vec3Input (synced with gizmo) |
+| Half Extents / Radius | Vec3Input or NumberInput |
+| From Zone | dropdown: volume IDs + "Any" |
+| To Zone | dropdown: volume IDs |
+| Blend Override | NumberInput (-1 = use target default) |
+
+### CameraRailEditor
+
+| Field | Input Type |
+|-------|-----------|
+| Name | text |
+| Control Points | ordered list of Vec3Inputs, each with [x] remove button |
+| [+ Add Point] | button (appends default point) |
+| Target Points | optional ordered list (toggle to enable) |
+
+Each control point is editable via Vec3Input. Stretch goal: click-to-place in viewport.
+
+## Viewport Gizmos
+
+### CameraZoneMarkers.tsx
+
+**Volumes:**
+- **AABB:** Wireframe box using `EdgesGeometry` on `BoxGeometry(2*hx, 2*hy, 2*hz)`. Color: `#00cccc` (cyan) when not selected, `#00ffff` (bright cyan) when selected. Semi-transparent fill (`MeshBasicMaterial` with `opacity: 0.08`, `transparent: true`) to show the volume as a region, not just edges.
+- **Sphere:** Wireframe sphere using `EdgesGeometry` on `SphereGeometry(radius, 24, 16)`. Same color scheme + semi-transparent fill.
+- **Click to select:** Invisible solid mesh matching volume shape for raycasting. `onPointerDown` → `setSelectedEntity({ type: 'camera_volume', id })`.
+- **Label:** drei `Html` component showing volume name when selected, positioned above the center.
+
+**Triggers:**
+- Same wireframe rendering as volumes but in **magenta** (`#cc00cc` / `#ff00ff`).
+- Typically thinner volumes (small half_extents in one axis) placed at doorways.
+
+**Rails:**
+- drei `Line` component through control_points in **yellow** (`#cccc00`).
+- Small spheres (`SphereGeometry(0.3)`) at each control point, clickable for selection.
+- If `target_points` present: second dashed line in **orange** (`#cc8800`).
+
+### Transform Gizmos (drei TransformControls)
+
+When a camera volume is selected:
+
+1. **Translation mode:** drei `TransformControls` with `mode="translate"` attached to the volume center group. On change: update `shape.center` in store via `updateCameraVolume(id, { shape: { ...shape, center: [x,y,z] } })`.
+
+2. **Scale mode:** A second `TransformControls` with `mode="scale"` on a child group. For AABB: axes map to `half_extents` components. For Sphere: uniform scale maps to `radius`. The gizmo's scale is initialized from the current extents/radius so dragging feels 1:1.
+
+3. **Mode toggle:** Keyboard shortcut `W` = translate, `R` = scale (matching Blender/Unity convention). Or a small toolbar overlay near the gizmo.
+
+**Bidirectional sync:** Gizmo drag → `onObjectChange` callback → store update → React re-render → panel values update. Panel number edit → store update → React re-render → gizmo position/scale updates. Both paths go through the same `updateCameraVolume` action.
+
+Triggers and rail control points also get translate gizmos when selected.
+
+### Camera Frustum Gizmo
+
+When a camera volume is selected, render a frustum visualization:
+
+**Origin:** Computed from the zone's mode:
+- `free_look`: orbit position at `orbit_distance` from center + offset, using current azimuth=0 / elevation=0 as default viewing direction.
+- `fixed_point`: `fixed_position`.
+- `rail_follow`: first control point of the referenced rail.
+- `side_scroll`: center + offset.
+- `cinematic_rail`: first control point of the referenced rail.
+
+**Frustum geometry:**
+- Four edges from the camera position outward forming the FOV pyramid, clipped at a display distance of ~10 units.
+- Near plane and far plane quads as thin wireframe rectangles.
+
+**Pitch/Yaw constraint visualization:**
+- Render the allowed rotation range as **semi-transparent fan surfaces** using `THREE.ShapeGeometry` or `THREE.RingGeometry`.
+- Pitch limits: vertical arc segments showing the elevation range (like a protractor viewed from the side).
+- Yaw limits: horizontal arc segments showing the azimuth range (like a compass rose viewed from above).
+- Surface color: `#00ffff` with `opacity: 0.15` — visible enough to show the "walls" of the constraint but not obscuring the scene.
+- When pitch/yaw limits change via panel sliders, the fan surfaces open/close in real-time.
+
+**Fixed-point camera icon:**
+- In `fixed_point` mode, render a small camera sprite (`THREE.Sprite` with a camera icon texture or a simple geometric camera shape built from boxes/cones) at `fixed_position`.
+- A dashed line connects the camera icon to the volume center (the look-at target direction).
+
+## Possess Mode (Camera Preview)
+
+### Activation
+
+A **"Possess Camera"** button in the CameraVolumeEditor panel. Also bindable to a keyboard shortcut (e.g., `Numpad 0` or a toolbar button in the viewport).
+
+### Behavior
+
+1. **Enter possess mode:**
+   - Store the current editor camera state: `{ position, target, azimuth, elevation, distance }`.
+   - Smoothly interpolate (`THREE.Vector3.lerp` / `THREE.Quaternion.slerp`) from the editor camera to the zone's camera position/target over 0.5 seconds.
+   - Apply orbit control constraints: `controls.minPolarAngle` / `maxPolarAngle` from pitch limits, `controls.minAzimuthAngle` / `maxAzimuthAngle` from yaw limits.
+   - If the mode is `fixed_point`, lock position and only allow rotation.
+   - Display a prominent banner: **"PREVIEW MODE — Escape to exit"** with a semi-transparent dark background at the top of the viewport.
+
+2. **While in possess mode:**
+   - Mouse orbit is restricted to the zone's pitch/yaw limits.
+   - **Rotation damping near limits:** As the camera angle approaches within 5° of a limit, increase damping (multiply rotation delta by `max(0, (distance_to_limit - 1°) / 4°)`) so the camera decelerates smoothly into the wall rather than hitting a hard stop. This simulates the feel the player will experience at runtime.
+   - Camera position stays inside the volume (for free_look: orbit stays within boundary; for fixed_point: position is locked).
+   - Panel editing is still active — changing pitch/yaw limits updates the constraints in real-time while in preview.
+
+3. **Exit possess mode:**
+   - Press Escape or click the "Possess Camera" button again.
+   - Smoothly interpolate back to the saved editor camera state over 0.5 seconds.
+   - Restore default orbit control constraints (no limits).
+
+### Non-functional: No Bridge Required
+
+Possess mode operates entirely within Bricklayer's Three.js viewport. It does NOT require communication with the C++ engine or a second render pass. The preview shows the Three.js scene (voxel terrain, gizmos) from the zone's camera perspective — not the actual GS-rendered output. This is sufficient for verifying spatial constraints. True GS rendering verification requires running the demo app with `--scene`.
+
+## Scene Export
+
+### Export (`sceneExport.ts`)
+
+Add `camera_zones` block to the exported scene JSON:
+
+```typescript
+if (store.cameraVolumes.length > 0 || store.cameraTriggers.length > 0 || store.cameraRails.length > 0) {
+  scene.camera_zones = {
+    default_params: store.cameraDefaultParams,
+    show_debug_volumes: store.cameraShowDebugVolumes,
+    volumes: store.cameraVolumes.map(v => ({
+      id: v.id,
+      shape: v.shape,
+      params: v.params,
+    })),
+    triggers: store.cameraTriggers.map(t => ({
+      shape: t.shape,
+      ...(t.from_zone ? { from_zone: t.from_zone } : {}),
+      to_zone: t.to_zone,
+      blend_override: t.blend_override,
+    })),
+    rails: store.cameraRails.map(r => ({
+      id: r.id,
+      control_points: r.control_points,
+      ...(r.target_points ? { target_points: r.target_points } : {}),
+    })),
+  };
+}
+```
+
+### Import (`loadProject` in `useSceneStore.ts`)
+
+Parse `camera_zones` from saved BricklayerFile:
+
+```typescript
+if (data.scene.camera_zones) {
+  const cz = data.scene.camera_zones;
+  cameraVolumes = cz.volumes ?? [];
+  cameraTriggers = cz.triggers ?? [];
+  cameraRails = cz.rails ?? [];
+  cameraDefaultParams = cz.default_params ?? {};
+  cameraShowDebugVolumes = cz.show_debug_volumes ?? false;
+}
+```
+
+### Debug Volume Flag
+
+`show_debug_volumes: boolean` is exported in the `camera_zones` block. The C++ runtime (Phase 1) ignores unknown fields, so this is forward-compatible. When the C++ side adds debug visualization support, it reads this flag to decide whether to render wireframe volumes in development builds.
+
+## Files Changed
+
+| File | Change | New/Modify |
+|------|--------|------------|
+| `tools/apps/bricklayer/src/store/types.ts` | CameraShape, CameraZoneParams, CameraZoneVolume, CameraZoneTrigger, CameraZoneRail, CameraZonesConfig types | Modify |
+| `tools/apps/bricklayer/src/store/useSceneStore.ts` | Camera zone state + add/update/remove actions + save/load | Modify |
+| `tools/apps/bricklayer/src/panels/ProjectTree.tsx` | Camera section with Volumes/Triggers/Rails sub-trees | Modify |
+| `tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx` | Route to camera entity editors | Modify |
+| `tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx` | Volume parameter editing + Possess button | New |
+| `tools/apps/bricklayer/src/panels/CameraTriggerEditor.tsx` | Trigger parameter editing | New |
+| `tools/apps/bricklayer/src/panels/CameraRailEditor.tsx` | Rail control point editing | New |
+| `tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx` | Volume/trigger wireframes + labels | New |
+| `tools/apps/bricklayer/src/viewport/CameraRailMarkers.tsx` | Rail spline + control point spheres | New |
+| `tools/apps/bricklayer/src/viewport/CameraFrustumGizmo.tsx` | FOV pyramid + pitch/yaw constraint fans | New |
+| `tools/apps/bricklayer/src/viewport/CameraPossessMode.tsx` | Preview mode overlay + camera control override | New |
+| `tools/apps/bricklayer/src/viewport/Viewport.tsx` | Include new marker/gizmo components | Modify |
+| `tools/apps/bricklayer/src/lib/sceneExport.ts` | Export camera_zones block | Modify |
+| `tools/apps/bricklayer/src/App.tsx` | Possess mode keyboard shortcut (Numpad 0) | Modify |
+
+## Known Limitations
+
+### No GS Rendering in Preview
+
+Possess mode shows the Three.js viewport (voxel mesh, wireframes) from the zone camera's perspective — not the actual Gaussian splat rendering. Designers must run the demo app to see true GS output. This is acceptable because the primary goal of possess mode is verifying spatial constraints (angle limits, volume boundaries), not visual quality.
+
+### No Undo for Gizmo Drags
+
+The current undo/redo system snapshots voxel + collision data. Gizmo-driven camera zone edits are tracked via store mutations but not integrated into the undo stack. This matches the existing behavior for light/emitter gizmo edits. Adding camera zone undo is a future enhancement.
+
+### Rail Drawing Deferred to Phase 2 Stretch / Phase 3
+
+Rail control points are edited via Vec3Input fields in the panel. Interactive click-to-place in the viewport is a stretch goal. The data structure supports it — only the UI interaction is deferred.

--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -264,6 +264,15 @@ export function App() {
       const store = useSceneStore.getState();
       const meta = e.metaKey || e.ctrlKey;
 
+      // Escape: exit possess/preview mode first
+      if (e.key === 'Escape') {
+        if (store.possessVolumeId) {
+          store.exitPossessMode();
+          e.preventDefault();
+          return;
+        }
+      }
+
       // Ctrl/Cmd+S: save project
       if (meta && e.key === 's') {
         e.preventDefault();

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -242,5 +242,61 @@ export function exportSceneJson(state: SceneStoreState): object {
     scene.nav_zones = state.navZoneNames;
   }
 
+  // Camera zones
+  const { cameraVolumes, cameraTriggers, cameraRails, cameraDefaultParams, cameraShowDebugVolumes } = state;
+  if (cameraVolumes.length > 0 || cameraTriggers.length > 0 || cameraRails.length > 0) {
+    const cameraZones: Record<string, unknown> = {};
+
+    if (Object.keys(cameraDefaultParams).length > 0) {
+      cameraZones.default_params = cameraDefaultParams;
+    }
+    if (cameraShowDebugVolumes) {
+      cameraZones.show_debug_volumes = true;
+    }
+
+    if (cameraVolumes.length > 0) {
+      cameraZones.volumes = cameraVolumes.map((v) => {
+        const out: Record<string, unknown> = { id: v.id, shape: v.shape };
+        // Only export non-default params
+        const p = v.params;
+        const params: Record<string, unknown> = {};
+        if (p.mode !== 'free_look') params.mode = p.mode;
+        if (p.priority !== 0) params.priority = p.priority;
+        if (p.blend_time !== 1.0) params.blend_time = p.blend_time;
+        if (!p.allow_user_orbit) params.allow_user_orbit = false;
+        if (p.pitch_min !== -60) params.pitch_min = p.pitch_min;
+        if (p.pitch_max !== 10) params.pitch_max = p.pitch_max;
+        if (p.yaw_min !== -180) params.yaw_min = p.yaw_min;
+        if (p.yaw_max !== 180) params.yaw_max = p.yaw_max;
+        if (p.fov !== 45) params.fov = p.fov;
+        if (p.orbit_distance !== 10) params.orbit_distance = p.orbit_distance;
+        if (p.offset[0] !== 0 || p.offset[1] !== 5 || p.offset[2] !== -10) params.offset = p.offset;
+        if (p.fixed_position) params.fixed_position = p.fixed_position;
+        if (p.rail_id) params.rail_id = p.rail_id;
+        if (Object.keys(params).length > 0) out.params = params;
+        return out;
+      });
+    }
+
+    if (cameraTriggers.length > 0) {
+      cameraZones.triggers = cameraTriggers.map((t) => {
+        const out: Record<string, unknown> = { shape: t.shape, to_zone: t.to_zone };
+        if (t.from_zone) out.from_zone = t.from_zone;
+        if (t.blend_override >= 0) out.blend_override = t.blend_override;
+        return out;
+      });
+    }
+
+    if (cameraRails.length > 0) {
+      cameraZones.rails = cameraRails.map((r) => {
+        const out: Record<string, unknown> = { id: r.id, control_points: r.control_points };
+        if (r.target_points && r.target_points.length > 0) out.target_points = r.target_points;
+        return out;
+      });
+    }
+
+    scene.camera_zones = cameraZones;
+  }
+
   return scene;
 }

--- a/tools/apps/bricklayer/src/panels/CameraRailEditor.tsx
+++ b/tools/apps/bricklayer/src/panels/CameraRailEditor.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import { Vec3Input } from '../components/Vec3Input.js';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { CameraZoneRail } from '../store/types.js';
+import { panelStyles } from '../styles/panel.js';
+
+const styles = { ...panelStyles };
+
+export function CameraRailEditor({ rail }: { rail: CameraZoneRail }) {
+  const updateCameraRail = useSceneStore((s) => s.updateCameraRail);
+  const removeCameraRail = useSceneStore((s) => s.removeCameraRail);
+  const addRailControlPoint = useSceneStore((s) => s.addRailControlPoint);
+  const removeRailControlPoint = useSceneStore((s) => s.removeRailControlPoint);
+  const updateRailControlPoint = useSceneStore((s) => s.updateRailControlPoint);
+
+  const [targetEnabled, setTargetEnabled] = useState(
+    rail.target_points !== undefined && rail.target_points.length > 0,
+  );
+
+  const update = (patch: Partial<CameraZoneRail>) => updateCameraRail(rail.id, patch);
+
+  const handleToggleTargets = (enabled: boolean) => {
+    setTargetEnabled(enabled);
+    if (!enabled) {
+      update({ target_points: undefined });
+    } else {
+      update({ target_points: rail.target_points ?? [] });
+    }
+  };
+
+  const removeTargetPoint = (index: number) => {
+    const pts = (rail.target_points ?? []).filter((_, i) => i !== index);
+    update({ target_points: pts });
+  };
+
+  const updateTargetPoint = (index: number, point: [number, number, number]) => {
+    const pts = [...(rail.target_points ?? [])];
+    pts[index] = point;
+    update({ target_points: pts });
+  };
+
+  const addTargetPoint = () => {
+    const pts = [...(rail.target_points ?? [])];
+    pts.push([0, 0, 0]);
+    update({ target_points: pts });
+  };
+
+  return (
+    <div>
+      <div style={{ ...styles.row, marginBottom: 12 }}>
+        <span style={{ ...styles.label, flex: 1 }}>Camera Rail</span>
+        <button style={styles.btnDanger} onClick={() => removeCameraRail(rail.id)}>Remove</button>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Name</span>
+        <input
+          type="text"
+          value={rail.name}
+          onChange={(e) => update({ name: e.target.value })}
+          style={styles.input}
+        />
+      </div>
+
+      {/* Control Points */}
+      <div style={{ marginBottom: 8 }}>
+        <div style={{ ...styles.row, marginBottom: 4 }}>
+          <span style={{ ...styles.label, flex: 1 }}>Control Points ({rail.control_points.length})</span>
+          <button
+            style={{ padding: '2px 8px', background: '#2a2a5a', border: '1px solid #444', borderRadius: 3, color: '#77f', cursor: 'pointer', fontSize: 12 }}
+            onClick={() => addRailControlPoint(rail.id, [0, 0, 0])}
+          >+ Add Point</button>
+        </div>
+        {rail.control_points.map((pt, i) => (
+          <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 4 }}>
+            <span style={{ fontSize: 10, color: '#666', minWidth: 18, textAlign: 'right' }}>{i + 1}</span>
+            <div style={{ flex: 1 }}>
+              <Vec3Input
+                value={pt}
+                onChange={(v) => updateRailControlPoint(rail.id, i, v)}
+              />
+            </div>
+            <button
+              style={{ padding: '0 4px', border: 'none', background: 'transparent', color: '#844', cursor: 'pointer', fontSize: 13, lineHeight: '1', flexShrink: 0 }}
+              onClick={() => removeRailControlPoint(rail.id, i)}
+            >&times;</button>
+          </div>
+        ))}
+      </div>
+
+      {/* Target Points */}
+      <div style={styles.section}>
+        <label style={{ fontSize: 12, color: '#ddd', display: 'flex', alignItems: 'center', gap: 6 }}>
+          <input
+            type="checkbox"
+            checked={targetEnabled}
+            onChange={(e) => handleToggleTargets(e.target.checked)}
+          />
+          Use Target Points
+        </label>
+      </div>
+
+      {targetEnabled && (
+        <div style={{ marginBottom: 8 }}>
+          <div style={{ ...styles.row, marginBottom: 4 }}>
+            <span style={{ ...styles.label, flex: 1 }}>Target Points ({(rail.target_points ?? []).length})</span>
+            <button
+              style={{ padding: '2px 8px', background: '#2a2a5a', border: '1px solid #444', borderRadius: 3, color: '#77f', cursor: 'pointer', fontSize: 12 }}
+              onClick={addTargetPoint}
+            >+ Add Point</button>
+          </div>
+          {(rail.target_points ?? []).map((pt, i) => (
+            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 4 }}>
+              <span style={{ fontSize: 10, color: '#666', minWidth: 18, textAlign: 'right' }}>{i + 1}</span>
+              <div style={{ flex: 1 }}>
+                <Vec3Input
+                  value={pt}
+                  onChange={(v) => updateTargetPoint(i, v)}
+                />
+              </div>
+              <button
+                style={{ padding: '0 4px', border: 'none', background: 'transparent', color: '#844', cursor: 'pointer', fontSize: 13, lineHeight: '1', flexShrink: 0 }}
+                onClick={() => removeTargetPoint(i)}
+              >&times;</button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/panels/CameraTriggerEditor.tsx
+++ b/tools/apps/bricklayer/src/panels/CameraTriggerEditor.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { NumberInput } from '../components/NumberInput.js';
+import { Vec3Input } from '../components/Vec3Input.js';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { CameraZoneTrigger } from '../store/types.js';
+import { panelStyles } from '../styles/panel.js';
+
+const styles = { ...panelStyles };
+
+export function CameraTriggerEditor({ trigger }: { trigger: CameraZoneTrigger }) {
+  const updateCameraTrigger = useSceneStore((s) => s.updateCameraTrigger);
+  const removeCameraTrigger = useSceneStore((s) => s.removeCameraTrigger);
+  const cameraVolumes = useSceneStore((s) => s.cameraVolumes);
+
+  const update = (patch: Partial<CameraZoneTrigger>) => updateCameraTrigger(trigger.id, patch);
+
+  const shapeType = trigger.shape.type;
+
+  return (
+    <div>
+      <div style={{ ...styles.row, marginBottom: 12 }}>
+        <span style={{ ...styles.label, flex: 1 }}>Camera Trigger</span>
+        <button style={styles.btnDanger} onClick={() => removeCameraTrigger(trigger.id)}>Remove</button>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Shape Type</span>
+        <select
+          style={styles.select}
+          value={shapeType}
+          onChange={(e) => {
+            const newType = e.target.value;
+            update({
+              shape: newType === 'sphere'
+                ? { type: 'sphere', center: trigger.shape.center, radius: (trigger.shape as any).radius ?? 5 }
+                : { type: 'aabb', center: trigger.shape.center, half_extents: (trigger.shape as any).half_extents ?? [5, 5, 5] },
+            });
+          }}
+        >
+          <option value="aabb">AABB</option>
+          <option value="sphere">Sphere</option>
+        </select>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Center</span>
+        <Vec3Input
+          value={trigger.shape.center}
+          onChange={(v) => update({ shape: { ...trigger.shape, center: v } })}
+        />
+      </div>
+
+      {shapeType === 'aabb' && (
+        <div style={styles.section}>
+          <span style={styles.label}>Half Extents</span>
+          <Vec3Input
+            value={(trigger.shape as any).half_extents ?? [5, 5, 5]}
+            onChange={(v) => update({ shape: { ...trigger.shape, half_extents: v } as any })}
+          />
+        </div>
+      )}
+
+      {shapeType === 'sphere' && (
+        <div style={styles.section}>
+          <span style={styles.label}>Radius</span>
+          <NumberInput
+            value={(trigger.shape as any).radius ?? 5}
+            min={0.1}
+            step={0.5}
+            onChange={(v) => update({ shape: { ...trigger.shape, radius: v } as any })}
+            style={styles.input}
+          />
+        </div>
+      )}
+
+      <div style={styles.section}>
+        <span style={styles.label}>From Zone</span>
+        <select
+          style={styles.select}
+          value={trigger.from_zone ?? ''}
+          onChange={(e) => update({ from_zone: e.target.value || undefined })}
+        >
+          <option value="">Any</option>
+          {cameraVolumes.map((v) => (
+            <option key={v.id} value={v.id}>{v.name || v.id}</option>
+          ))}
+        </select>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>To Zone</span>
+        <select
+          style={styles.select}
+          value={trigger.to_zone}
+          onChange={(e) => update({ to_zone: e.target.value })}
+        >
+          <option value="">(none)</option>
+          {cameraVolumes.map((v) => (
+            <option key={v.id} value={v.id}>{v.name || v.id}</option>
+          ))}
+        </select>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Blend Override</span>
+        <NumberInput
+          value={trigger.blend_override}
+          step={0.1}
+          onChange={(v) => update({ blend_override: v })}
+          style={styles.input}
+        />
+        <span style={{ fontSize: 10, color: '#666', marginTop: 2 }}>-1 = use volume default</span>
+      </div>
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx
+++ b/tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx
@@ -11,7 +11,9 @@ export function CameraVolumeEditor({ volume }: { volume: CameraZoneVolume }) {
   const updateCameraVolume = useSceneStore((s) => s.updateCameraVolume);
   const removeCameraVolume = useSceneStore((s) => s.removeCameraVolume);
   const cameraRails = useSceneStore((s) => s.cameraRails);
+  const possessVolumeId = useSceneStore((s) => s.possessVolumeId);
   const enterPossessMode = useSceneStore((s) => s.enterPossessMode);
+  const exitPossessMode = useSceneStore((s) => s.exitPossessMode);
 
   const update = (patch: Partial<CameraZoneVolume>) => updateCameraVolume(volume.id, patch);
   const updateParams = (patch: Partial<CameraZoneVolume['params']>) =>
@@ -237,10 +239,18 @@ export function CameraVolumeEditor({ volume }: { volume: CameraZoneVolume }) {
 
       <div style={{ marginTop: 12 }}>
         <button
-          style={{ ...styles.btn, width: '100%' }}
-          onClick={() => enterPossessMode(volume.id)}
+          style={{
+            ...styles.btn,
+            width: '100%',
+            background: possessVolumeId === volume.id ? '#00cccc' : undefined,
+            color: possessVolumeId === volume.id ? '#000' : undefined,
+          }}
+          onClick={() => {
+            if (possessVolumeId === volume.id) exitPossessMode();
+            else enterPossessMode(volume.id);
+          }}
         >
-          Possess Camera
+          {possessVolumeId === volume.id ? '✖ Exit Preview' : '👁 Possess Camera'}
         </button>
       </div>
     </div>

--- a/tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx
+++ b/tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import { NumberInput } from '../components/NumberInput.js';
+import { Vec3Input } from '../components/Vec3Input.js';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { CameraZoneVolume } from '../store/types.js';
+import { panelStyles } from '../styles/panel.js';
+
+const styles = { ...panelStyles };
+
+export function CameraVolumeEditor({ volume }: { volume: CameraZoneVolume }) {
+  const updateCameraVolume = useSceneStore((s) => s.updateCameraVolume);
+  const removeCameraVolume = useSceneStore((s) => s.removeCameraVolume);
+  const cameraRails = useSceneStore((s) => s.cameraRails);
+  const enterPossessMode = useSceneStore((s) => s.enterPossessMode);
+
+  const update = (patch: Partial<CameraZoneVolume>) => updateCameraVolume(volume.id, patch);
+  const updateParams = (patch: Partial<CameraZoneVolume['params']>) =>
+    update({ params: { ...volume.params, ...patch } });
+
+  const shapeType = volume.shape.type;
+  const mode = volume.params.mode;
+
+  return (
+    <div>
+      <div style={{ ...styles.row, marginBottom: 12 }}>
+        <span style={{ ...styles.label, flex: 1 }}>Camera Volume</span>
+        <button style={styles.btnDanger} onClick={() => removeCameraVolume(volume.id)}>Remove</button>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Name</span>
+        <input
+          type="text"
+          value={volume.name}
+          onChange={(e) => update({ name: e.target.value })}
+          style={styles.input}
+        />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Shape Type</span>
+        <select
+          style={styles.select}
+          value={shapeType}
+          onChange={(e) => {
+            const newType = e.target.value;
+            update({
+              shape: newType === 'sphere'
+                ? { type: 'sphere', center: volume.shape.center, radius: (volume.shape as any).radius ?? 5 }
+                : { type: 'aabb', center: volume.shape.center, half_extents: (volume.shape as any).half_extents ?? [5, 5, 5] },
+            });
+          }}
+        >
+          <option value="aabb">AABB</option>
+          <option value="sphere">Sphere</option>
+        </select>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Center</span>
+        <Vec3Input
+          value={volume.shape.center}
+          onChange={(v) => update({ shape: { ...volume.shape, center: v } })}
+        />
+      </div>
+
+      {shapeType === 'aabb' && (
+        <div style={styles.section}>
+          <span style={styles.label}>Half Extents</span>
+          <Vec3Input
+            value={(volume.shape as any).half_extents ?? [5, 5, 5]}
+            onChange={(v) => update({ shape: { ...volume.shape, half_extents: v } as any })}
+          />
+        </div>
+      )}
+
+      {shapeType === 'sphere' && (
+        <div style={styles.section}>
+          <span style={styles.label}>Radius</span>
+          <NumberInput
+            value={(volume.shape as any).radius ?? 5}
+            min={0.1}
+            step={0.5}
+            onChange={(v) => update({ shape: { ...volume.shape, radius: v } as any })}
+            style={styles.input}
+          />
+        </div>
+      )}
+
+      <div style={styles.section}>
+        <span style={styles.label}>Mode</span>
+        <select
+          style={styles.select}
+          value={mode}
+          onChange={(e) => updateParams({ mode: e.target.value as any })}
+        >
+          <option value="free_look">Free Look</option>
+          <option value="rail_follow">Rail Follow</option>
+          <option value="cinematic_rail">Cinematic Rail</option>
+          <option value="fixed_point">Fixed Point</option>
+          <option value="side_scroll">Side Scroll</option>
+        </select>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Priority</span>
+        <NumberInput
+          value={volume.params.priority}
+          step={1}
+          onChange={(v) => updateParams({ priority: v })}
+          style={styles.input}
+        />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Blend Time</span>
+        <NumberInput
+          value={volume.params.blend_time}
+          min={0}
+          step={0.1}
+          onChange={(v) => updateParams({ blend_time: v })}
+          style={styles.input}
+        />
+      </div>
+
+      <div style={styles.section}>
+        <label style={{ fontSize: 12, color: '#ddd', display: 'flex', alignItems: 'center', gap: 6 }}>
+          <input
+            type="checkbox"
+            checked={volume.params.allow_user_orbit}
+            onChange={(e) => updateParams({ allow_user_orbit: e.target.checked })}
+          />
+          Allow User Orbit
+        </label>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Pitch Min / Max</span>
+        <div style={styles.row}>
+          <NumberInput
+            label="Min"
+            value={volume.params.pitch_min}
+            step={1}
+            onChange={(v) => updateParams({ pitch_min: v })}
+            style={styles.input}
+          />
+          <NumberInput
+            label="Max"
+            value={volume.params.pitch_max}
+            step={1}
+            onChange={(v) => updateParams({ pitch_max: v })}
+            style={styles.input}
+          />
+        </div>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Yaw Min / Max</span>
+        <div style={styles.row}>
+          <NumberInput
+            label="Min"
+            value={volume.params.yaw_min}
+            step={1}
+            onChange={(v) => updateParams({ yaw_min: v })}
+            style={styles.input}
+          />
+          <NumberInput
+            label="Max"
+            value={volume.params.yaw_max}
+            step={1}
+            onChange={(v) => updateParams({ yaw_max: v })}
+            style={styles.input}
+          />
+        </div>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>FOV</span>
+        <NumberInput
+          value={volume.params.fov}
+          min={10}
+          max={150}
+          step={1}
+          onChange={(v) => updateParams({ fov: v })}
+          style={styles.input}
+        />
+      </div>
+
+      {mode === 'free_look' && (
+        <div style={styles.section}>
+          <span style={styles.label}>Orbit Distance</span>
+          <NumberInput
+            value={volume.params.orbit_distance}
+            min={0.1}
+            step={0.5}
+            onChange={(v) => updateParams({ orbit_distance: v })}
+            style={styles.input}
+          />
+        </div>
+      )}
+
+      {(mode === 'free_look' || mode === 'side_scroll') && (
+        <div style={styles.section}>
+          <span style={styles.label}>Offset</span>
+          <Vec3Input
+            value={volume.params.offset}
+            onChange={(v) => updateParams({ offset: v })}
+          />
+        </div>
+      )}
+
+      {mode === 'fixed_point' && (
+        <div style={styles.section}>
+          <span style={styles.label}>Fixed Position</span>
+          <Vec3Input
+            value={volume.params.fixed_position ?? [0, 10, 0]}
+            onChange={(v) => updateParams({ fixed_position: v })}
+          />
+        </div>
+      )}
+
+      {(mode === 'rail_follow' || mode === 'cinematic_rail') && (
+        <div style={styles.section}>
+          <span style={styles.label}>Rail</span>
+          <select
+            style={styles.select}
+            value={volume.params.rail_id ?? ''}
+            onChange={(e) => updateParams({ rail_id: e.target.value || undefined })}
+          >
+            <option value="">(none)</option>
+            {cameraRails.map((r) => (
+              <option key={r.id} value={r.id}>{r.name || r.id}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div style={{ marginTop: 12 }}>
+        <button
+          style={{ ...styles.btn, width: '100%' }}
+          onClick={() => enterPossessMode(volume.id)}
+        >
+          Possess Camera
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/tools/apps/bricklayer/src/panels/ProjectTree.tsx
+++ b/tools/apps/bricklayer/src/panels/ProjectTree.tsx
@@ -181,6 +181,15 @@ export function ProjectTree() {
   const updateVfxInstance = useSceneStore((st) => st.updateVfxInstance);
   const removeVfxInstance = useSceneStore((st) => st.removeVfxInstance);
   const collisionGridData = useSceneStore((st) => st.collisionGridData);
+  const cameraVolumes = useSceneStore((st) => st.cameraVolumes);
+  const cameraTriggers = useSceneStore((st) => st.cameraTriggers);
+  const cameraRails = useSceneStore((st) => st.cameraRails);
+  const addCameraVolume = useSceneStore((st) => st.addCameraVolume);
+  const addCameraTrigger = useSceneStore((st) => st.addCameraTrigger);
+  const addCameraRail = useSceneStore((st) => st.addCameraRail);
+  const removeCameraVolume = useSceneStore((st) => st.removeCameraVolume);
+  const removeCameraTrigger = useSceneStore((st) => st.removeCameraTrigger);
+  const removeCameraRail = useSceneStore((st) => st.removeCameraRail);
 
   const [sceneOpen, setSceneOpen] = useState(true);
   const [gameObjOpen, setGameObjOpen] = useState(true);
@@ -189,6 +198,10 @@ export function ProjectTree() {
   const [emitterOpen, setEmitterOpen] = useState(true);
   const [animOpen, setAnimOpen] = useState(true);
   const [vfxOpen, setVfxOpen] = useState(true);
+  const [cameraOpen, setCameraOpen] = useState(false);
+  const [camVolOpen, setCamVolOpen] = useState(true);
+  const [camTrigOpen, setCamTrigOpen] = useState(true);
+  const [camRailOpen, setCamRailOpen] = useState(true);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   const click = (node: NavigationNode) => {
@@ -441,6 +454,78 @@ export function ProjectTree() {
                 </>}
               />
             ))}
+          </TreeNode>
+
+          {/* Camera Zones */}
+          <TreeNode
+            icon="\u25A1" label="Camera" count={cameraVolumes.length + cameraTriggers.length + cameraRails.length}
+            arrow={cameraOpen ? '\u25BE' : '\u25B8'}
+            isActive={isActive({ kind: 'scene_category', category: 'camera_zones' as any })}
+            onClick={() => { setCameraOpen(!cameraOpen); click({ kind: 'scene_category', category: 'camera_zones' as any }); }}
+            isOpen={cameraOpen}
+          >
+            {/* Volumes */}
+            <TreeNode
+              icon="\u25A1" label="Volumes" count={cameraVolumes.length}
+              arrow={camVolOpen ? '\u25BE' : '\u25B8'}
+              isActive={false}
+              onClick={() => setCamVolOpen(!camVolOpen)}
+              actions={addBtn(() => addCameraVolume(getCameraTarget().xyz))}
+              isOpen={camVolOpen}
+            >
+              {cameraVolumes.map((v) => (
+                <TreeNode
+                  key={v.id}
+                  icon="\u25A1"
+                  label={v.name || v.id.slice(0, 12)}
+                  isActive={isActive({ kind: 'scene_item', entityType: 'camera_volume', entityId: v.id })}
+                  onClick={() => click({ kind: 'scene_item', entityType: 'camera_volume', entityId: v.id })}
+                  actions={removeBtn(() => removeCameraVolume(v.id))}
+                />
+              ))}
+            </TreeNode>
+
+            {/* Triggers */}
+            <TreeNode
+              icon="\u25B6" label="Triggers" count={cameraTriggers.length}
+              arrow={camTrigOpen ? '\u25BE' : '\u25B8'}
+              isActive={false}
+              onClick={() => setCamTrigOpen(!camTrigOpen)}
+              actions={addBtn(() => addCameraTrigger(getCameraTarget().xyz))}
+              isOpen={camTrigOpen}
+            >
+              {cameraTriggers.map((t) => (
+                <TreeNode
+                  key={t.id}
+                  icon="\u25B6"
+                  label={`${t.from_zone ? t.from_zone : '*'} \u2192 ${t.to_zone}`}
+                  isActive={isActive({ kind: 'scene_item', entityType: 'camera_trigger', entityId: t.id })}
+                  onClick={() => click({ kind: 'scene_item', entityType: 'camera_trigger', entityId: t.id })}
+                  actions={removeBtn(() => removeCameraTrigger(t.id))}
+                />
+              ))}
+            </TreeNode>
+
+            {/* Rails */}
+            <TreeNode
+              icon="\u21C4" label="Rails" count={cameraRails.length}
+              arrow={camRailOpen ? '\u25BE' : '\u25B8'}
+              isActive={false}
+              onClick={() => setCamRailOpen(!camRailOpen)}
+              actions={addBtn(() => addCameraRail())}
+              isOpen={camRailOpen}
+            >
+              {cameraRails.map((r) => (
+                <TreeNode
+                  key={r.id}
+                  icon="\u21C4"
+                  label={r.name || r.id.slice(0, 12)}
+                  isActive={isActive({ kind: 'scene_item', entityType: 'camera_rail', entityId: r.id })}
+                  onClick={() => click({ kind: 'scene_item', entityType: 'camera_rail', entityId: r.id })}
+                  actions={removeBtn(() => removeCameraRail(r.id))}
+                />
+              ))}
+            </TreeNode>
           </TreeNode>
 
           {/* Player */}

--- a/tools/apps/bricklayer/src/panels/ProjectTree.tsx
+++ b/tools/apps/bricklayer/src/panels/ProjectTree.tsx
@@ -35,6 +35,10 @@ const icons: Record<string, string> = {
   vfx: '\u2605',         // ★
   backgrounds: '\u25A1', // □
   file: '\u25C7',        // ◇
+  camera: '\u25CE',      // ◎
+  volume: '\u25A2',      // ▢
+  trigger: '\u26A1',     // ⚡
+  rail: '\u21C4',        // ⇄
 };
 
 // ── Styles ──
@@ -458,7 +462,7 @@ export function ProjectTree() {
 
           {/* Camera Zones */}
           <TreeNode
-            icon="\u25A1" label="Camera" count={cameraVolumes.length + cameraTriggers.length + cameraRails.length}
+            icon={icons.camera} label="Camera" count={cameraVolumes.length + cameraTriggers.length + cameraRails.length}
             arrow={cameraOpen ? '\u25BE' : '\u25B8'}
             isActive={isActive({ kind: 'scene_category', category: 'camera_zones' as any })}
             onClick={() => { setCameraOpen(!cameraOpen); click({ kind: 'scene_category', category: 'camera_zones' as any }); }}
@@ -466,7 +470,7 @@ export function ProjectTree() {
           >
             {/* Volumes */}
             <TreeNode
-              icon="\u25A1" label="Volumes" count={cameraVolumes.length}
+              icon={icons.volume} label="Volumes" count={cameraVolumes.length}
               arrow={camVolOpen ? '\u25BE' : '\u25B8'}
               isActive={false}
               onClick={() => setCamVolOpen(!camVolOpen)}
@@ -476,7 +480,7 @@ export function ProjectTree() {
               {cameraVolumes.map((v) => (
                 <TreeNode
                   key={v.id}
-                  icon="\u25A1"
+                  icon={icons.volume}
                   label={v.name || v.id.slice(0, 12)}
                   isActive={isActive({ kind: 'scene_item', entityType: 'camera_volume', entityId: v.id })}
                   onClick={() => click({ kind: 'scene_item', entityType: 'camera_volume', entityId: v.id })}
@@ -487,7 +491,7 @@ export function ProjectTree() {
 
             {/* Triggers */}
             <TreeNode
-              icon="\u25B6" label="Triggers" count={cameraTriggers.length}
+              icon={icons.trigger} label="Triggers" count={cameraTriggers.length}
               arrow={camTrigOpen ? '\u25BE' : '\u25B8'}
               isActive={false}
               onClick={() => setCamTrigOpen(!camTrigOpen)}
@@ -497,7 +501,7 @@ export function ProjectTree() {
               {cameraTriggers.map((t) => (
                 <TreeNode
                   key={t.id}
-                  icon="\u25B6"
+                  icon={icons.trigger}
                   label={`${t.from_zone ? t.from_zone : '*'} \u2192 ${t.to_zone}`}
                   isActive={isActive({ kind: 'scene_item', entityType: 'camera_trigger', entityId: t.id })}
                   onClick={() => click({ kind: 'scene_item', entityType: 'camera_trigger', entityId: t.id })}
@@ -508,7 +512,7 @@ export function ProjectTree() {
 
             {/* Rails */}
             <TreeNode
-              icon="\u21C4" label="Rails" count={cameraRails.length}
+              icon={icons.rail} label="Rails" count={cameraRails.length}
               arrow={camRailOpen ? '\u25BE' : '\u25B8'}
               isActive={false}
               onClick={() => setCamRailOpen(!camRailOpen)}
@@ -518,7 +522,7 @@ export function ProjectTree() {
               {cameraRails.map((r) => (
                 <TreeNode
                   key={r.id}
-                  icon="\u21C4"
+                  icon={icons.rail}
                   label={r.name || r.id.slice(0, 12)}
                   isActive={isActive({ kind: 'scene_item', entityType: 'camera_rail', entityId: r.id })}
                   onClick={() => click({ kind: 'scene_item', entityType: 'camera_rail', entityId: r.id })}

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -15,6 +15,9 @@ import type {
   VfxInstanceData,
 } from '../store/types.js';
 import { panelStyles } from '../styles/panel.js';
+import { CameraVolumeEditor } from './CameraVolumeEditor.js';
+import { CameraTriggerEditor } from './CameraTriggerEditor.js';
+import { CameraRailEditor } from './CameraRailEditor.js';
 
 const styles = { ...panelStyles };
 
@@ -1491,6 +1494,9 @@ export function ScenePropertiesPanel() {
   const gsAnimations = useSceneStore((s) => s.gsAnimations);
   const vfxInstances = useSceneStore((s) => s.vfxInstances);
   const player = useSceneStore((s) => s.player);
+  const cameraVolumes = useSceneStore((s) => s.cameraVolumes);
+  const cameraTriggers = useSceneStore((s) => s.cameraTriggers);
+  const cameraRails = useSceneStore((s) => s.cameraRails);
 
   if (!selectedEntity) {
     return <div style={styles.empty}>Select an entity in the scene tree</div>;
@@ -1534,6 +1540,24 @@ export function ScenePropertiesPanel() {
 
   if (selectedEntity.type === 'player') {
     return <PlayerProperties player={player} />;
+  }
+
+  if (selectedEntity.type === 'camera_volume') {
+    const vol = cameraVolumes.find((v) => v.id === selectedEntity.id);
+    if (!vol) return <div style={styles.empty}>Camera volume not found</div>;
+    return <CameraVolumeEditor volume={vol} />;
+  }
+
+  if (selectedEntity.type === 'camera_trigger') {
+    const trig = cameraTriggers.find((t) => t.id === selectedEntity.id);
+    if (!trig) return <div style={styles.empty}>Camera trigger not found</div>;
+    return <CameraTriggerEditor trigger={trig} />;
+  }
+
+  if (selectedEntity.type === 'camera_rail') {
+    const rail = cameraRails.find((r) => r.id === selectedEntity.id);
+    if (!rail) return <div style={styles.empty}>Camera rail not found</div>;
+    return <CameraRailEditor rail={rail} />;
   }
 
   return <div style={styles.empty}>Unknown entity type</div>;

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -308,6 +308,67 @@ export interface VfxInstanceData {
 }
 
 
+// ── Camera Zone Types (Phase 2) ──
+
+export interface CameraShape {
+  type: 'aabb' | 'sphere';
+  center: [number, number, number];
+  half_extents?: [number, number, number];  // AABB only
+  radius?: number;                           // Sphere only
+}
+
+export interface CameraZoneParams {
+  mode: 'free_look' | 'rail_follow' | 'cinematic_rail' | 'fixed_point' | 'side_scroll';
+  priority: number;
+  blend_time: number;
+  allow_user_orbit: boolean;
+  pitch_min: number;
+  pitch_max: number;
+  yaw_min: number;
+  yaw_max: number;
+  fov: number;
+  orbit_distance: number;
+  offset: [number, number, number];
+  fixed_position?: [number, number, number];
+  rail_id?: string;
+}
+
+export const DEFAULT_CAMERA_ZONE_PARAMS: CameraZoneParams = {
+  mode: 'free_look',
+  priority: 0,
+  blend_time: 1.0,
+  allow_user_orbit: true,
+  pitch_min: -60,
+  pitch_max: 10,
+  yaw_min: -180,
+  yaw_max: 180,
+  fov: 45,
+  orbit_distance: 10,
+  offset: [0, 5, -10],
+};
+
+export interface CameraZoneVolume {
+  id: string;
+  name: string;
+  shape: CameraShape;
+  params: CameraZoneParams;
+}
+
+export interface CameraZoneTrigger {
+  id: string;
+  shape: CameraShape;
+  from_zone?: string;
+  to_zone: string;
+  blend_override: number;
+}
+
+export interface CameraZoneRail {
+  id: string;
+  name: string;
+  control_points: [number, number, number][];
+  target_points?: [number, number, number][];
+}
+
 export interface CollisionGridData {
   width: number;
   height: number;
@@ -399,5 +460,10 @@ export interface BricklayerFile {
     gsParticleEmitters?: GsParticleEmitterData[];
     gsAnimations?: GsAnimationGroupData[];
     vfxInstances?: VfxInstanceData[];
+    cameraVolumes?: CameraZoneVolume[];
+    cameraTriggers?: CameraZoneTrigger[];
+    cameraRails?: CameraZoneRail[];
+    cameraDefaultParams?: Partial<CameraZoneParams>;
+    cameraShowDebugVolumes?: boolean;
   };
 }

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -28,7 +28,12 @@ import type {
   AssetEntry,
   NavigationNode,
   ColorPalette,
+  CameraZoneVolume,
+  CameraZoneTrigger,
+  CameraZoneRail,
+  CameraZoneParams,
 } from './types.js';
+import { DEFAULT_CAMERA_ZONE_PARAMS } from './types.js';
 import { voxelKey, parseKey, floodFill3D, brushPositions } from '../lib/voxelUtils.js';
 import { extractColorsFromImage as extractColorsFromImageData } from '../lib/colorExtract.js';
 
@@ -234,6 +239,13 @@ export interface SceneStoreState {
   gaussianSplat: GaussianSplatConfig;
   collisionGridData: CollisionGridData | null;
   navZoneNames: string[];
+  cameraVolumes: CameraZoneVolume[];
+  cameraTriggers: CameraZoneTrigger[];
+  cameraRails: CameraZoneRail[];
+  cameraDefaultParams: Partial<CameraZoneParams>;
+  cameraShowDebugVolumes: boolean;
+  possessVolumeId: string | null;
+  savedEditorCamera: { position: [number,number,number]; target: [number,number,number] } | null;
 
   // Editor state
   mode: BricklayerMode;
@@ -298,6 +310,22 @@ export interface SceneStoreState {
   addVfxInstance: (data: VfxInstanceData) => void;
   updateVfxInstance: (id: string, patch: Partial<VfxInstanceData>) => void;
   removeVfxInstance: (id: string) => void;
+  addCameraVolume: (position?: [number, number, number]) => void;
+  updateCameraVolume: (id: string, patch: Partial<CameraZoneVolume>) => void;
+  removeCameraVolume: (id: string) => void;
+  addCameraTrigger: (position?: [number, number, number]) => void;
+  updateCameraTrigger: (id: string, patch: Partial<CameraZoneTrigger>) => void;
+  removeCameraTrigger: (id: string) => void;
+  addCameraRail: () => void;
+  updateCameraRail: (id: string, patch: Partial<CameraZoneRail>) => void;
+  removeCameraRail: (id: string) => void;
+  addRailControlPoint: (railId: string, point: [number, number, number]) => void;
+  removeRailControlPoint: (railId: string, index: number) => void;
+  updateRailControlPoint: (railId: string, index: number, point: [number, number, number]) => void;
+  updateCameraDefaultParams: (patch: Partial<CameraZoneParams>) => void;
+  setCameraShowDebugVolumes: (show: boolean) => void;
+  enterPossessMode: (volumeId: string) => void;
+  exitPossessMode: () => void;
   updatePlayer: (patch: Partial<PlayerData>) => void;
   addBackgroundLayer: () => void;
   updateBackgroundLayer: (id: string, patch: Partial<BackgroundLayer>) => void;
@@ -484,6 +512,13 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   gaussianSplat: defaultGaussianSplat(),
   collisionGridData: null,
   navZoneNames: [],
+  cameraVolumes: [],
+  cameraTriggers: [],
+  cameraRails: [],
+  cameraDefaultParams: {},
+  cameraShowDebugVolumes: false,
+  possessVolumeId: null,
+  savedEditorCamera: null,
 
   mode: 'terrain',
   selectedEntity: null,
@@ -772,6 +807,105 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   removeVfxInstance: (id) => set({
     vfxInstances: get().vfxInstances.filter((v) => v.id !== id), isDirty: true,
   }),
+
+  // ── Camera Zone actions ──
+  addCameraVolume: (pos?) => {
+    const volumes = get().cameraVolumes;
+    const volume: CameraZoneVolume = {
+      id: genId('camvol'),
+      name: `Volume ${volumes.length + 1}`,
+      shape: {
+        type: 'aabb',
+        center: pos ?? [0, 2, 0],
+        half_extents: [5, 5, 5],
+      },
+      params: { ...DEFAULT_CAMERA_ZONE_PARAMS },
+    };
+    set({ cameraVolumes: [...volumes, volume], isDirty: true });
+  },
+  updateCameraVolume: (id, patch) => set({
+    cameraVolumes: get().cameraVolumes.map((v) => (v.id === id ? { ...v, ...patch } : v)), isDirty: true,
+  }),
+  removeCameraVolume: (id) => set({
+    cameraVolumes: get().cameraVolumes.filter((v) => v.id !== id), isDirty: true,
+  }),
+
+  addCameraTrigger: (pos?) => {
+    const trigger: CameraZoneTrigger = {
+      id: genId('camtrig'),
+      shape: {
+        type: 'aabb',
+        center: pos ?? [0, 2, 0],
+        half_extents: [1, 3, 3],
+      },
+      to_zone: '',
+      blend_override: -1,
+    };
+    set({ cameraTriggers: [...get().cameraTriggers, trigger], isDirty: true });
+  },
+  updateCameraTrigger: (id, patch) => set({
+    cameraTriggers: get().cameraTriggers.map((t) => (t.id === id ? { ...t, ...patch } : t)), isDirty: true,
+  }),
+  removeCameraTrigger: (id) => set({
+    cameraTriggers: get().cameraTriggers.filter((t) => t.id !== id), isDirty: true,
+  }),
+
+  addCameraRail: () => {
+    const rails = get().cameraRails;
+    const rail: CameraZoneRail = {
+      id: genId('camrail'),
+      name: `Rail ${rails.length + 1}`,
+      control_points: [
+        [0, 5, -10],
+        [0, 5, 0],
+        [0, 5, 10],
+      ],
+    };
+    set({ cameraRails: [...rails, rail], isDirty: true });
+  },
+  updateCameraRail: (id, patch) => set({
+    cameraRails: get().cameraRails.map((r) => (r.id === id ? { ...r, ...patch } : r)), isDirty: true,
+  }),
+  removeCameraRail: (id) => set({
+    cameraRails: get().cameraRails.filter((r) => r.id !== id), isDirty: true,
+  }),
+  addRailControlPoint: (railId, point) => set({
+    cameraRails: get().cameraRails.map((r) =>
+      r.id === railId ? { ...r, control_points: [...r.control_points, point] } : r
+    ), isDirty: true,
+  }),
+  removeRailControlPoint: (railId, index) => set({
+    cameraRails: get().cameraRails.map((r) =>
+      r.id === railId
+        ? { ...r, control_points: r.control_points.filter((_, i) => i !== index) }
+        : r
+    ), isDirty: true,
+  }),
+  updateRailControlPoint: (railId, index, point) => set({
+    cameraRails: get().cameraRails.map((r) =>
+      r.id === railId
+        ? { ...r, control_points: r.control_points.map((p, i) => (i === index ? point : p)) }
+        : r
+    ), isDirty: true,
+  }),
+
+  updateCameraDefaultParams: (patch) => set({
+    cameraDefaultParams: { ...get().cameraDefaultParams, ...patch }, isDirty: true,
+  }),
+  setCameraShowDebugVolumes: (show) => set({ cameraShowDebugVolumes: show }),
+
+  enterPossessMode: (volumeId) => {
+    const s = get();
+    const camera = s.gaussianSplat.camera;
+    set({
+      possessVolumeId: volumeId,
+      savedEditorCamera: {
+        position: [...camera.position] as [number, number, number],
+        target: [...camera.target] as [number, number, number],
+      },
+    });
+  },
+  exitPossessMode: () => set({ possessVolumeId: null, savedEditorCamera: null }),
 
   updatePlayer: (patch) => set({ player: { ...get().player, ...patch }, isDirty: true }),
 
@@ -1165,6 +1299,11 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
         gsParticleEmitters: s.gsParticleEmitters,
         gsAnimations: s.gsAnimations,
         vfxInstances: s.vfxInstances.length > 0 ? s.vfxInstances : undefined,
+        cameraVolumes: s.cameraVolumes.length > 0 ? s.cameraVolumes : undefined,
+        cameraTriggers: s.cameraTriggers.length > 0 ? s.cameraTriggers : undefined,
+        cameraRails: s.cameraRails.length > 0 ? s.cameraRails : undefined,
+        cameraDefaultParams: Object.keys(s.cameraDefaultParams).length > 0 ? s.cameraDefaultParams : undefined,
+        cameraShowDebugVolumes: s.cameraShowDebugVolumes || undefined,
       },
     };
   },
@@ -1248,6 +1387,13 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       gsParticleEmitters: data.scene.gsParticleEmitters ?? [],
       gsAnimations: data.scene.gsAnimations ?? [],
       vfxInstances: data.scene.vfxInstances ?? [],
+      cameraVolumes: data.scene.cameraVolumes ?? [],
+      cameraTriggers: data.scene.cameraTriggers ?? [],
+      cameraRails: data.scene.cameraRails ?? [],
+      cameraDefaultParams: data.scene.cameraDefaultParams ?? {},
+      cameraShowDebugVolumes: data.scene.cameraShowDebugVolumes ?? false,
+      possessVolumeId: null,
+      savedEditorCamera: null,
       player: data.scene.player,
       backgroundLayers: data.scene.backgroundLayers,
       torchEmitter: data.scene.torchEmitter,

--- a/tools/apps/bricklayer/src/viewport/CameraFrustumGizmo.tsx
+++ b/tools/apps/bricklayer/src/viewport/CameraFrustumGizmo.tsx
@@ -1,0 +1,230 @@
+import React, { useMemo } from 'react';
+import * as THREE from 'three';
+import { Line } from '@react-three/drei';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { CameraZoneVolume, CameraZoneParams } from '../store/types.js';
+
+const DISPLAY_DIST = 8;
+const ASPECT = 9 / 16; // 16:9 assumed
+
+/** Build arc points in the XY plane (local) sweeping from startDeg to endDeg at radius r */
+function arcPoints(startDeg: number, endDeg: number, radius: number, steps = 24): THREE.Vector3[] {
+  const pts: THREE.Vector3[] = [];
+  const startRad = startDeg * Math.PI / 180;
+  const endRad = endDeg * Math.PI / 180;
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const angle = startRad + t * (endRad - startRad);
+    pts.push(new THREE.Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, 0));
+  }
+  return pts;
+}
+
+/** Build a fan shape (origin + arc) as a ShapeGeometry */
+function buildFanGeometry(startDeg: number, endDeg: number, radius: number): THREE.BufferGeometry {
+  const shape = new THREE.Shape();
+  shape.moveTo(0, 0);
+  const arc = arcPoints(startDeg, endDeg, radius);
+  shape.moveTo(arc[0].x, arc[0].y);
+  arc.forEach((p) => shape.lineTo(p.x, p.y));
+  shape.lineTo(0, 0);
+  return new THREE.ShapeGeometry(shape);
+}
+
+function FrustumGizmo({ volume }: { volume: CameraZoneVolume }) {
+  const { params, shape } = volume;
+  const cameraRails = useSceneStore((s) => s.cameraRails);
+
+  const cameraOrigin = useMemo(() => {
+    const center = shape.center;
+    const offset = params.offset ?? [0, 5, -10];
+
+    switch (params.mode) {
+      case 'fixed_point': {
+        if (params.fixed_position) return new THREE.Vector3(...params.fixed_position);
+        // Fall through to free_look default
+        break;
+      }
+      case 'rail_follow':
+      case 'cinematic_rail': {
+        if (params.rail_id) {
+          const rail = cameraRails.find((r) => r.id === params.rail_id);
+          if (rail && rail.control_points.length > 0) {
+            return new THREE.Vector3(...rail.control_points[0]);
+          }
+        }
+        break;
+      }
+      case 'side_scroll': {
+        return new THREE.Vector3(
+          center[0] + offset[0],
+          center[1] + offset[1],
+          center[2] + offset[2],
+        );
+      }
+      default:
+        break;
+    }
+
+    // free_look default: center + offset + orbit at azimuth=0, elevation=0
+    const orbitDist = params.orbit_distance ?? 10;
+    return new THREE.Vector3(
+      center[0] + offset[0],
+      center[1] + offset[1],
+      center[2] + offset[2] + orbitDist,
+    );
+  }, [params, shape.center, cameraRails]);
+
+  const frustumData = useMemo(() => {
+    const fov = params.fov ?? 45;
+    const halfFovRad = (fov / 2) * Math.PI / 180;
+    const halfW = Math.tan(halfFovRad) * DISPLAY_DIST;
+    const halfH = halfW * ASPECT;
+
+    const origin = cameraOrigin;
+    const forward = new THREE.Vector3(0, 0, -1); // camera looks -Z in local space
+
+    // 4 corner directions (camera local: X right, Y up, Z back)
+    const corners: [number, number, number][] = [
+      [-halfW, halfH, -DISPLAY_DIST],
+      [halfW, halfH, -DISPLAY_DIST],
+      [halfW, -halfH, -DISPLAY_DIST],
+      [-halfW, -halfH, -DISPLAY_DIST],
+    ];
+
+    return { origin, corners, forward };
+  }, [params.fov, cameraOrigin]);
+
+  const { origin, corners } = frustumData;
+
+  // Frustum edge lines: origin → each corner, plus the near rect connecting corners
+  const frustumLines = useMemo(() => {
+    const o = [origin.x, origin.y, origin.z] as [number, number, number];
+    const lines: { points: [number, number, number][]; }[] = [
+      // 4 rays from origin to corners
+      { points: [o, corners[0]] },
+      { points: [o, corners[1]] },
+      { points: [o, corners[2]] },
+      { points: [o, corners[3]] },
+      // near rect
+      { points: [corners[0], corners[1], corners[2], corners[3], corners[0]] },
+    ];
+    return lines;
+  }, [origin, corners]);
+
+  // Pitch constraint fan (vertical arc in YZ plane at camera origin)
+  const pitchFanGeo = useMemo(() => {
+    const pMin = params.pitch_min ?? -60;
+    const pMax = params.pitch_max ?? 10;
+    const isDefault = pMin <= -90 && pMax >= 90;
+    if (isDefault) return null;
+    return buildFanGeometry(pMin, pMax, DISPLAY_DIST * 0.6);
+  }, [params.pitch_min, params.pitch_max]);
+
+  // Yaw constraint fan (horizontal arc in XZ plane at camera origin)
+  const yawFanGeo = useMemo(() => {
+    const yMin = params.yaw_min ?? -180;
+    const yMax = params.yaw_max ?? 180;
+    const isDefault = yMin <= -180 && yMax >= 180;
+    if (isDefault) return null;
+    return buildFanGeometry(yMin, yMax, DISPLAY_DIST * 0.6);
+  }, [params.yaw_min, params.yaw_max]);
+
+  const isFixedPoint = params.mode === 'fixed_point';
+  const volumeCenter = new THREE.Vector3(...shape.center);
+
+  return (
+    <group>
+      {/* Frustum lines */}
+      {frustumLines.map((line, i) => (
+        <Line
+          key={i}
+          points={line.points}
+          color="#00ffff"
+          lineWidth={1.5}
+          opacity={0.7}
+          transparent
+        />
+      ))}
+
+      {/* Pitch constraint fan — rotated to stand vertical (XZ → XY) */}
+      {pitchFanGeo && (
+        <mesh
+          geometry={pitchFanGeo}
+          position={[origin.x, origin.y, origin.z]}
+          rotation={[0, Math.PI / 2, 0]}
+        >
+          <meshBasicMaterial
+            color="#00ffff"
+            opacity={0.12}
+            transparent
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      )}
+
+      {/* Yaw constraint fan — flat on XZ plane */}
+      {yawFanGeo && (
+        <mesh
+          geometry={yawFanGeo}
+          position={[origin.x, origin.y, origin.z]}
+          rotation={[-Math.PI / 2, 0, 0]}
+        >
+          <meshBasicMaterial
+            color="#00ffff"
+            opacity={0.12}
+            transparent
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      )}
+
+      {/* Camera icon for fixed_point mode */}
+      {isFixedPoint && (
+        <group position={[origin.x, origin.y, origin.z]}>
+          {/* Camera body */}
+          <mesh>
+            <boxGeometry args={[0.8, 0.5, 0.5]} />
+            <meshBasicMaterial color="#00ffff" opacity={0.8} transparent />
+          </mesh>
+          {/* Lens cone */}
+          <mesh position={[0.65, 0, 0]} rotation={[0, 0, -Math.PI / 2]}>
+            <coneGeometry args={[0.3, 0.4, 12]} />
+            <meshBasicMaterial color="#00ffff" opacity={0.8} transparent />
+          </mesh>
+          {/* Dashed line from camera icon to volume center */}
+          <Line
+            points={[
+              [0, 0, 0],
+              [
+                volumeCenter.x - origin.x,
+                volumeCenter.y - origin.y,
+                volumeCenter.z - origin.z,
+              ],
+            ]}
+            color="#00cccc"
+            lineWidth={1}
+            opacity={0.4}
+            transparent
+            dashed
+            dashScale={3}
+          />
+        </group>
+      )}
+    </group>
+  );
+}
+
+export function CameraFrustumGizmo() {
+  const cameraVolumes = useSceneStore((s) => s.cameraVolumes);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const showGizmos = useSceneStore((s) => s.showGizmos);
+
+  if (!showGizmos) return null;
+  if (!selectedEntity || selectedEntity.type !== 'camera_volume') return null;
+
+  const volume = cameraVolumes.find((v) => v.id === selectedEntity.id);
+  if (!volume) return null;
+
+  return <FrustumGizmo volume={volume} />;
+}

--- a/tools/apps/bricklayer/src/viewport/CameraRailMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/CameraRailMarkers.tsx
@@ -1,0 +1,178 @@
+import React, { useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { Html, Line, TransformControls } from '@react-three/drei';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { CameraZoneRail } from '../store/types.js';
+
+function RailMarker({ rail, isSelected, selectedPointIndex, onSelect, onSelectPoint, onMovePoint }: {
+  rail: CameraZoneRail;
+  isSelected: boolean;
+  selectedPointIndex: number | null;
+  onSelect: () => void;
+  onSelectPoint: (index: number) => void;
+  onMovePoint: (index: number, pos: [number, number, number]) => void;
+}) {
+  const pointRefs = useRef<(THREE.Mesh | null)[]>([]);
+
+  const curvePoints = useMemo(() => {
+    if (rail.control_points.length < 2) return null;
+    const curve = new THREE.CatmullRomCurve3(
+      rail.control_points.map((p) => new THREE.Vector3(p[0], p[1], p[2])),
+      false,
+      'catmullrom',
+    );
+    return curve.getPoints(64).map((p) => [p.x, p.y, p.z] as [number, number, number]);
+  }, [rail.control_points]);
+
+  const targetCurvePoints = useMemo(() => {
+    if (!rail.target_points || rail.target_points.length < 2) return null;
+    const curve = new THREE.CatmullRomCurve3(
+      rail.target_points.map((p) => new THREE.Vector3(p[0], p[1], p[2])),
+      false,
+      'catmullrom',
+    );
+    return curve.getPoints(64).map((p) => [p.x, p.y, p.z] as [number, number, number]);
+  }, [rail.target_points]);
+
+  const lineColor = isSelected ? '#ffff00' : '#cccc00';
+  const lineWidth = isSelected ? 3 : 1.5;
+
+  return (
+    <group>
+      {/* Main rail spline */}
+      {curvePoints && (
+        <Line
+          points={curvePoints}
+          color={lineColor}
+          lineWidth={lineWidth}
+          opacity={isSelected ? 1.0 : 0.6}
+          transparent
+        />
+      )}
+
+      {/* Target points spline (dashed orange) */}
+      {targetCurvePoints && (
+        <Line
+          points={targetCurvePoints}
+          color="#ff8800"
+          lineWidth={isSelected ? 2 : 1}
+          opacity={isSelected ? 0.8 : 0.4}
+          transparent
+          dashed
+          dashScale={2}
+        />
+      )}
+
+      {/* Control point spheres */}
+      {rail.control_points.map((pt, i) => {
+        const isPointSelected = isSelected && selectedPointIndex === i;
+        const pointMesh = (
+          <mesh
+            key={i}
+            ref={(el) => { pointRefs.current[i] = el; }}
+            position={[pt[0], pt[1], pt[2]]}
+            onPointerDown={(e) => {
+              e.stopPropagation();
+              onSelect();
+              onSelectPoint(i);
+            }}
+          >
+            <sphereGeometry args={[isPointSelected ? 0.45 : 0.3, 12, 8]} />
+            <meshBasicMaterial
+              color={isPointSelected ? '#ffffff' : (isSelected ? '#ffff00' : '#cccc00')}
+            />
+          </mesh>
+        );
+
+        if (isPointSelected && pointRefs.current[i]) {
+          return (
+            <TransformControls
+              key={`tc-${i}`}
+              object={pointRefs.current[i]!}
+              mode="translate"
+              onObjectChange={(e) => {
+                const pos = (e as { target?: { object?: THREE.Object3D } })?.target?.object?.position;
+                if (pos) onMovePoint(i, [pos.x, pos.y, pos.z]);
+              }}
+            />
+          );
+        }
+
+        return pointMesh;
+      })}
+
+      {/* Rail name label */}
+      {isSelected && rail.control_points.length > 0 && (
+        <Html position={[
+          rail.control_points[0][0],
+          rail.control_points[0][1] + 1.5,
+          rail.control_points[0][2],
+        ]} center>
+          <div style={{
+            background: 'rgba(0,0,0,0.7)', color: '#ffff00',
+            padding: '1px 5px', borderRadius: 3, fontSize: 10, whiteSpace: 'nowrap',
+          }}>
+            {rail.name}
+          </div>
+        </Html>
+      )}
+
+      {/* Invisible click zone at first control point when not selected */}
+      {!isSelected && rail.control_points.length > 0 && (
+        <mesh
+          position={[
+            rail.control_points[0][0],
+            rail.control_points[0][1],
+            rail.control_points[0][2],
+          ]}
+          onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}
+        >
+          <sphereGeometry args={[1.0, 8, 8]} />
+          <meshBasicMaterial visible={false} />
+        </mesh>
+      )}
+    </group>
+  );
+}
+
+export function CameraRailMarkers() {
+  const cameraRails = useSceneStore((s) => s.cameraRails);
+  const showGizmos = useSceneStore((s) => s.showGizmos);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
+  const updateRailControlPoint = useSceneStore((s) => s.updateRailControlPoint);
+
+  // Track which control point index is selected for the active rail
+  const selectedPointIndex = useMemo(() => {
+    if (!selectedEntity || selectedEntity.type !== 'camera_rail') return null;
+    // Store the selected point index in the entity id as "railId:pointIndex"
+    const parts = selectedEntity.id.split(':');
+    if (parts.length === 2) return parseInt(parts[1], 10);
+    return null;
+  }, [selectedEntity]);
+
+  const selectedRailId = useMemo(() => {
+    if (!selectedEntity || selectedEntity.type !== 'camera_rail') return null;
+    return selectedEntity.id.split(':')[0];
+  }, [selectedEntity]);
+
+  if (!showGizmos) return null;
+
+  return (
+    <group>
+      {cameraRails.map((rail) => (
+        <RailMarker
+          key={rail.id}
+          rail={rail}
+          isSelected={selectedRailId === rail.id}
+          selectedPointIndex={selectedRailId === rail.id ? selectedPointIndex : null}
+          onSelect={() => setSelectedEntity({ type: 'camera_rail', id: rail.id })}
+          onSelectPoint={(index) =>
+            setSelectedEntity({ type: 'camera_rail', id: `${rail.id}:${index}` })
+          }
+          onMovePoint={(index, pos) => updateRailControlPoint(rail.id, index, pos)}
+        />
+      ))}
+    </group>
+  );
+}

--- a/tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx
@@ -1,0 +1,217 @@
+import React, { useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { Html, TransformControls } from '@react-three/drei';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { CameraZoneVolume, CameraZoneTrigger, CameraShape } from '../store/types.js';
+
+function ShapeWireframe({ shape, color }: { shape: CameraShape; color: string }) {
+  const edgesGeo = useMemo(() => {
+    if (shape.type === 'aabb') {
+      const [hx, hy, hz] = shape.half_extents ?? [2, 2, 2];
+      return new THREE.EdgesGeometry(new THREE.BoxGeometry(2 * hx, 2 * hy, 2 * hz));
+    } else {
+      const r = shape.radius ?? 2;
+      return new THREE.EdgesGeometry(new THREE.SphereGeometry(r, 24, 16));
+    }
+  }, [shape]);
+
+  return (
+    <lineSegments geometry={edgesGeo}>
+      <lineBasicMaterial color={color} />
+    </lineSegments>
+  );
+}
+
+function ShapeFill({ shape }: { shape: CameraShape }) {
+  if (shape.type === 'aabb') {
+    const [hx, hy, hz] = shape.half_extents ?? [2, 2, 2];
+    return (
+      <mesh>
+        <boxGeometry args={[2 * hx, 2 * hy, 2 * hz]} />
+        <meshBasicMaterial color="#00ccff" opacity={0.08} transparent side={THREE.DoubleSide} />
+      </mesh>
+    );
+  } else {
+    const r = shape.radius ?? 2;
+    return (
+      <mesh>
+        <sphereGeometry args={[r, 24, 16]} />
+        <meshBasicMaterial color="#00ccff" opacity={0.08} transparent side={THREE.DoubleSide} />
+      </mesh>
+    );
+  }
+}
+
+function VolumeMarker({ volume, isSelected, onSelect, onMove }: {
+  volume: CameraZoneVolume;
+  isSelected: boolean;
+  onSelect: () => void;
+  onMove: (pos: [number, number, number]) => void;
+}) {
+  const groupRef = useRef<THREE.Group>(null);
+  const { shape } = volume;
+  const edgeColor = isSelected ? '#00ffff' : '#00cccc80';
+  const center = shape.center;
+
+  const hitSize = useMemo(() => {
+    if (shape.type === 'aabb') {
+      return Math.max(...(shape.half_extents ?? [2, 2, 2]));
+    }
+    return shape.radius ?? 2;
+  }, [shape]);
+
+  const markerGroup = (
+    <group ref={groupRef} position={[center[0], center[1], center[2]]}>
+      {/* Invisible hit mesh */}
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
+        <sphereGeometry args={[Math.max(hitSize, 1.5), 12, 12]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+      {/* Wireframe edges */}
+      <ShapeWireframe shape={shape} color={edgeColor} />
+      {/* Semi-transparent fill */}
+      <ShapeFill shape={shape} />
+      {/* Label when selected */}
+      {isSelected && (
+        <Html position={[0, hitSize + 1.2, 0]} center>
+          <div style={{
+            background: 'rgba(0,0,0,0.7)', color: '#00ffff',
+            padding: '1px 5px', borderRadius: 3, fontSize: 10, whiteSpace: 'nowrap',
+          }}>
+            {volume.name}
+          </div>
+        </Html>
+      )}
+    </group>
+  );
+
+  if (isSelected && groupRef.current) {
+    return (
+      <TransformControls
+        object={groupRef.current}
+        mode="translate"
+        onObjectChange={(e) => {
+          const pos = (e as { target?: { object?: THREE.Object3D } })?.target?.object?.position;
+          if (pos) onMove([pos.x, pos.y, pos.z]);
+        }}
+      >
+        {markerGroup}
+      </TransformControls>
+    );
+  }
+
+  return markerGroup;
+}
+
+function TriggerMarker({ trigger, isSelected, onSelect, onMove }: {
+  trigger: CameraZoneTrigger;
+  isSelected: boolean;
+  onSelect: () => void;
+  onMove: (pos: [number, number, number]) => void;
+}) {
+  const groupRef = useRef<THREE.Group>(null);
+  const { shape } = trigger;
+  const edgeColor = isSelected ? '#ff00ff' : '#cc00cc80';
+  const center = shape.center;
+
+  const hitSize = useMemo(() => {
+    if (shape.type === 'aabb') {
+      return Math.max(...(shape.half_extents ?? [2, 2, 2]));
+    }
+    return shape.radius ?? 2;
+  }, [shape]);
+
+  const fillGeo = useMemo(() => {
+    if (shape.type === 'aabb') {
+      const [hx, hy, hz] = shape.half_extents ?? [2, 2, 2];
+      return <boxGeometry args={[2 * hx, 2 * hy, 2 * hz]} />;
+    } else {
+      const r = shape.radius ?? 2;
+      return <sphereGeometry args={[r, 24, 16]} />;
+    }
+  }, [shape]);
+
+  const markerGroup = (
+    <group ref={groupRef} position={[center[0], center[1], center[2]]}>
+      {/* Invisible hit mesh */}
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
+        <sphereGeometry args={[Math.max(hitSize, 1.5), 12, 12]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+      {/* Wireframe edges */}
+      <ShapeWireframe shape={shape} color={edgeColor} />
+      {/* Semi-transparent fill */}
+      <mesh>
+        {fillGeo}
+        <meshBasicMaterial color="#ff00ff" opacity={0.08} transparent side={THREE.DoubleSide} />
+      </mesh>
+      {/* Label when selected */}
+      {isSelected && (
+        <Html position={[0, hitSize + 1.2, 0]} center>
+          <div style={{
+            background: 'rgba(0,0,0,0.7)', color: '#ff00ff',
+            padding: '1px 5px', borderRadius: 3, fontSize: 10, whiteSpace: 'nowrap',
+          }}>
+            Trigger → {trigger.to_zone}
+          </div>
+        </Html>
+      )}
+    </group>
+  );
+
+  if (isSelected && groupRef.current) {
+    return (
+      <TransformControls
+        object={groupRef.current}
+        mode="translate"
+        onObjectChange={(e) => {
+          const pos = (e as { target?: { object?: THREE.Object3D } })?.target?.object?.position;
+          if (pos) onMove([pos.x, pos.y, pos.z]);
+        }}
+      >
+        {markerGroup}
+      </TransformControls>
+    );
+  }
+
+  return markerGroup;
+}
+
+export function CameraZoneMarkers() {
+  const cameraVolumes = useSceneStore((s) => s.cameraVolumes);
+  const cameraTriggers = useSceneStore((s) => s.cameraTriggers);
+  const showGizmos = useSceneStore((s) => s.showGizmos);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
+  const updateCameraVolume = useSceneStore((s) => s.updateCameraVolume);
+  const updateCameraTrigger = useSceneStore((s) => s.updateCameraTrigger);
+
+  if (!showGizmos) return null;
+
+  return (
+    <group>
+      {cameraVolumes.map((volume) => (
+        <VolumeMarker
+          key={volume.id}
+          volume={volume}
+          isSelected={selectedEntity?.type === 'camera_volume' && selectedEntity.id === volume.id}
+          onSelect={() => setSelectedEntity({ type: 'camera_volume', id: volume.id })}
+          onMove={(pos) => updateCameraVolume(volume.id, {
+            shape: { ...volume.shape, center: pos },
+          })}
+        />
+      ))}
+      {cameraTriggers.map((trigger) => (
+        <TriggerMarker
+          key={trigger.id}
+          trigger={trigger}
+          isSelected={selectedEntity?.type === 'camera_trigger' && selectedEntity.id === trigger.id}
+          onSelect={() => setSelectedEntity({ type: 'camera_trigger', id: trigger.id })}
+          onMove={(pos) => updateCameraTrigger(trigger.id, {
+            shape: { ...trigger.shape, center: pos },
+          })}
+        />
+      ))}
+    </group>
+  );
+}

--- a/tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx
@@ -4,7 +4,7 @@ import { Html, TransformControls } from '@react-three/drei';
 import { useSceneStore } from '../store/useSceneStore.js';
 import type { CameraZoneVolume, CameraZoneTrigger, CameraShape } from '../store/types.js';
 
-function ShapeWireframe({ shape, color }: { shape: CameraShape; color: string }) {
+function ShapeWireframe({ shape, color, opacity = 1 }: { shape: CameraShape; color: string; opacity?: number }) {
   const edgesGeo = useMemo(() => {
     if (shape.type === 'aabb') {
       const [hx, hy, hz] = shape.half_extents ?? [2, 2, 2];
@@ -17,7 +17,7 @@ function ShapeWireframe({ shape, color }: { shape: CameraShape; color: string })
 
   return (
     <lineSegments geometry={edgesGeo}>
-      <lineBasicMaterial color={color} />
+      <lineBasicMaterial color={color} transparent opacity={opacity} />
     </lineSegments>
   );
 }
@@ -50,7 +50,8 @@ function VolumeMarker({ volume, isSelected, onSelect, onMove }: {
 }) {
   const groupRef = useRef<THREE.Group>(null);
   const { shape } = volume;
-  const edgeColor = isSelected ? '#00ffff' : '#00cccc80';
+  const edgeColor = isSelected ? '#00ffff' : '#00cccc';
+  const edgeOpacity = isSelected ? 1.0 : 0.5;
   const center = shape.center;
 
   const hitSize = useMemo(() => {
@@ -68,7 +69,7 @@ function VolumeMarker({ volume, isSelected, onSelect, onMove }: {
         <meshBasicMaterial visible={false} />
       </mesh>
       {/* Wireframe edges */}
-      <ShapeWireframe shape={shape} color={edgeColor} />
+      <ShapeWireframe shape={shape} color={edgeColor} opacity={edgeOpacity} />
       {/* Semi-transparent fill */}
       <ShapeFill shape={shape} />
       {/* Label when selected */}
@@ -111,7 +112,8 @@ function TriggerMarker({ trigger, isSelected, onSelect, onMove }: {
 }) {
   const groupRef = useRef<THREE.Group>(null);
   const { shape } = trigger;
-  const edgeColor = isSelected ? '#ff00ff' : '#cc00cc80';
+  const edgeColor = isSelected ? '#ff00ff' : '#cc00cc';
+  const edgeOpacity = isSelected ? 1.0 : 0.5;
   const center = shape.center;
 
   const hitSize = useMemo(() => {
@@ -139,7 +141,7 @@ function TriggerMarker({ trigger, isSelected, onSelect, onMove }: {
         <meshBasicMaterial visible={false} />
       </mesh>
       {/* Wireframe edges */}
-      <ShapeWireframe shape={shape} color={edgeColor} />
+      <ShapeWireframe shape={shape} color={edgeColor} opacity={edgeOpacity} />
       {/* Semi-transparent fill */}
       <mesh>
         {fillGeo}

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -410,16 +410,7 @@ function SceneContent() {
               TWO: 1,
             }}
           />
-          <Html fullscreen style={{ pointerEvents: 'none' }}>
-            <div style={{
-              position: 'absolute', top: 0, left: 0, right: 0,
-              background: 'rgba(0,0,0,0.75)', color: '#00ffff',
-              textAlign: 'center', padding: '8px 0', fontSize: '14px', fontWeight: 'bold',
-              letterSpacing: '1px', zIndex: 1000,
-            }}>
-              PREVIEW MODE — Press Escape to exit
-            </div>
-          </Html>
+          {/* Banner rendered outside Canvas in Viewport() wrapper */}
         </>
       ) : (
         <OrbitControls
@@ -449,14 +440,27 @@ function SceneContent() {
 export function Viewport() {
   const gridWidth = useSceneStore((s) => s.gridWidth);
   const gridDepth = useSceneStore((s) => s.gridDepth);
+  const possessVolumeId = useSceneStore((s) => s.possessVolumeId);
 
   return (
-    <Canvas
-      camera={{ position: [gridWidth / 2, 30, gridDepth + 20], fov: 50 }}
-      style={{ background: '#16162a' }}
-      onContextMenu={(e) => e.preventDefault()}
-    >
-      <SceneContent />
-    </Canvas>
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <Canvas
+        camera={{ position: [gridWidth / 2, 30, gridDepth + 20], fov: 50 }}
+        style={{ background: '#16162a' }}
+        onContextMenu={(e) => e.preventDefault()}
+      >
+        <SceneContent />
+      </Canvas>
+      {possessVolumeId && (
+        <div style={{
+          position: 'absolute', top: 0, left: 0, right: 0,
+          background: 'rgba(0,0,0,0.75)', color: '#00ffff',
+          textAlign: 'center', padding: '8px 0', fontSize: '14px', fontWeight: 'bold',
+          letterSpacing: '1px', zIndex: 10, pointerEvents: 'none',
+        }}>
+          PREVIEW MODE — Press Escape to exit
+        </div>
+      )}
+    </div>
   );
 }

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -14,6 +14,9 @@ import { GsAnimationMarkers } from './GsAnimationMarkers.js';
 import { VfxInstanceMarkers } from './VfxInstanceMarkers.js';
 import { VfxRenderer } from './VfxRenderer.js';
 import { PlayerMarker } from './PlayerMarker.js';
+import { CameraZoneMarkers } from './CameraZoneMarkers.js';
+import { CameraRailMarkers } from './CameraRailMarkers.js';
+import { CameraFrustumGizmo } from './CameraFrustumGizmo.js';
 import { CollisionOverlay } from './CollisionOverlay.js';
 import { useSceneStore } from '../store/useSceneStore.js';
 
@@ -303,6 +306,9 @@ function SceneContent() {
       <VfxInstanceMarkers />
       <VfxRenderer />
       <PlayerMarker />
+      <CameraZoneMarkers />
+      <CameraRailMarkers />
+      <CameraFrustumGizmo />
       <CollisionOverlay />
       <TeleportPlane />
       <GrabPlane />

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -271,7 +271,77 @@ function SceneContent() {
   const showGrid = useSceneStore((s) => s.showGrid);
   const grabMode = useSceneStore((s) => s.grabMode);
   const orbitLocked = useSceneStore((s) => s.orbitLocked);
+  const possessVolumeId = useSceneStore((s) => s.possessVolumeId);
+  const cameraVolumes = useSceneStore((s) => s.cameraVolumes);
+  const cameraRails = useSceneStore((s) => s.cameraRails);
   const controlsRef = useRef<OrbitControlsRef | null>(null);
+
+  // Compute possess mode camera constraints
+  const possessData = React.useMemo(() => {
+    if (!possessVolumeId) return null;
+    const volume = cameraVolumes.find((v) => v.id === possessVolumeId);
+    if (!volume) return null;
+
+    const { params, shape } = volume;
+    const center = shape.center;
+    const offset = params.offset ?? [0, 5, -10];
+    const orbitDist = params.orbit_distance ?? 10;
+
+    // Compute camera position based on mode (same logic as CameraFrustumGizmo)
+    let camPos: [number, number, number];
+    switch (params.mode) {
+      case 'fixed_point': {
+        if (params.fixed_position) {
+          camPos = [...params.fixed_position] as [number, number, number];
+        } else {
+          camPos = [center[0] + offset[0], center[1] + offset[1], center[2] + offset[2] + orbitDist];
+        }
+        break;
+      }
+      case 'rail_follow':
+      case 'cinematic_rail': {
+        if (params.rail_id) {
+          const rail = cameraRails.find((r) => r.id === params.rail_id);
+          if (rail && rail.control_points.length > 0) {
+            camPos = [...rail.control_points[0]] as [number, number, number];
+            break;
+          }
+        }
+        camPos = [center[0] + offset[0], center[1] + offset[1], center[2] + offset[2] + orbitDist];
+        break;
+      }
+      case 'side_scroll': {
+        camPos = [center[0] + offset[0], center[1] + offset[1], center[2] + offset[2]];
+        break;
+      }
+      default: {
+        // free_look: center + offset + orbit at orbit_distance
+        camPos = [center[0] + offset[0], center[1] + offset[1], center[2] + offset[2] + orbitDist];
+        break;
+      }
+    }
+
+    // Convert pitch/yaw limits from degrees to polar/azimuth angles for OrbitControls
+    // OrbitControls polar: 0 = top, π/2 = equator, π = bottom
+    // pitch in degrees: 0 = horizon, positive = up, negative = down
+    // polar = π/2 - pitch_in_radians
+    const pitchMinRad = (params.pitch_min ?? -60) * Math.PI / 180;
+    const pitchMaxRad = (params.pitch_max ?? 10) * Math.PI / 180;
+    const minPolar = Math.PI / 2 - pitchMaxRad;
+    const maxPolar = Math.PI / 2 - pitchMinRad;
+
+    const minAzimuth = (params.yaw_min ?? -180) * Math.PI / 180;
+    const maxAzimuth = (params.yaw_max ?? 180) * Math.PI / 180;
+
+    return {
+      target: center as [number, number, number],
+      camPos,
+      minPolar,
+      maxPolar,
+      minAzimuth,
+      maxAzimuth,
+    };
+  }, [possessVolumeId, cameraVolumes, cameraRails]);
 
   return (
     <>
@@ -313,25 +383,65 @@ function SceneContent() {
       <TeleportPlane />
       <GrabPlane />
 
-      <OrbitControls
-        ref={(r: OrbitControlsRef | null) => {
-          controlsRef.current = r;
-          orbitControlsRef = r;
-        }}
-        enabled={!grabMode && !orbitLocked}
-        target={[gridWidth / 2, 0, gridDepth / 2]}
-        makeDefault
-        screenSpacePanning
-        mouseButtons={{
-          LEFT: 0,
-          MIDDLE: 1,
-          RIGHT: 2,
-        }}
-        touches={{
-          ONE: 0,
-          TWO: 1,
-        }}
-      />
+      {possessData ? (
+        <>
+          <OrbitControls
+            ref={(r: OrbitControlsRef | null) => {
+              controlsRef.current = r;
+              orbitControlsRef = r;
+            }}
+            enabled={!grabMode}
+            target={possessData.target}
+            minPolarAngle={possessData.minPolar}
+            maxPolarAngle={possessData.maxPolar}
+            minAzimuthAngle={possessData.minAzimuth}
+            maxAzimuthAngle={possessData.maxAzimuth}
+            enableDamping
+            dampingFactor={0.1}
+            makeDefault
+            screenSpacePanning={false}
+            mouseButtons={{
+              LEFT: 0,
+              MIDDLE: 1,
+              RIGHT: 2,
+            }}
+            touches={{
+              ONE: 0,
+              TWO: 1,
+            }}
+          />
+          <Html fullscreen style={{ pointerEvents: 'none' }}>
+            <div style={{
+              position: 'absolute', top: 0, left: 0, right: 0,
+              background: 'rgba(0,0,0,0.75)', color: '#00ffff',
+              textAlign: 'center', padding: '8px 0', fontSize: '14px', fontWeight: 'bold',
+              letterSpacing: '1px', zIndex: 1000,
+            }}>
+              PREVIEW MODE — Press Escape to exit
+            </div>
+          </Html>
+        </>
+      ) : (
+        <OrbitControls
+          ref={(r: OrbitControlsRef | null) => {
+            controlsRef.current = r;
+            orbitControlsRef = r;
+          }}
+          enabled={!grabMode && !orbitLocked}
+          target={[gridWidth / 2, 0, gridDepth / 2]}
+          makeDefault
+          screenSpacePanning
+          mouseButtons={{
+            LEFT: 0,
+            MIDDLE: 1,
+            RIGHT: 2,
+          }}
+          touches={{
+            ONE: 0,
+            TWO: 1,
+          }}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Camera zone editing in Bricklayer with interactive viewport gizmos
- Three entity types: volumes (AABB/Sphere), triggers, and rails (Catmull-Rom spline)
- Draggable TransformControls for volume center translation and positioning
- Frustum visualization with semi-transparent pitch/yaw constraint fans
- Possess Camera preview mode — switches viewport to zone's restricted perspective with rotation damping near limits
- Bidirectional sync between property panel inputs and viewport gizmos
- Scene export produces `camera_zones` JSON block matching Phase 1 runtime schema
- Project Tree with Camera section (Volumes/Triggers/Rails sub-trees)

## New files
- `panels/CameraVolumeEditor.tsx` — volume parameter editor + possess button
- `panels/CameraTriggerEditor.tsx` — trigger parameter editor
- `panels/CameraRailEditor.tsx` — rail control point editor
- `viewport/CameraZoneMarkers.tsx` — volume/trigger wireframe gizmos + TransformControls
- `viewport/CameraRailMarkers.tsx` — spline line + control point spheres
- `viewport/CameraFrustumGizmo.tsx` — FOV pyramid + constraint fans + camera icon

## Modified files
- `store/types.ts` — CameraShape, CameraZoneParams, Volume, Trigger, Rail types
- `store/useSceneStore.ts` — state, 18 actions, save/load
- `panels/ProjectTree.tsx` — Camera section
- `panels/ScenePropertiesPanel.tsx` — routing to camera editors
- `viewport/Viewport.tsx` — markers + possess mode OrbitControls override
- `lib/sceneExport.ts` — camera_zones export block
- `App.tsx` — Escape key for possess mode exit

## Test plan
- [x] Bricklayer builds clean (pnpm --filter bricklayer build)
- [x] C++ engine builds clean (28/29 tests pass, 1 pre-existing failure)
- [ ] Visual verification: open Bricklayer, add volumes/triggers/rails, verify gizmos
- [ ] Possess mode: enter/exit, verify angle constraints
- [ ] Export scene, load in engine with --scene flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)