### PR TITLE
fix(camera): preserve facing direction on teleport in camera review

### DIFF
--- a/include/gseurat/engine/camera_zone_system.hpp
+++ b/include/gseurat/engine/camera_zone_system.hpp
@@ -57,6 +57,10 @@ public:
     /// True while blending between two zones.
     bool is_transitioning() const { return transitioning_; }
 
+    /// Set orbit azimuth/elevation from an existing camera position+target.
+    /// Use before teleport to preserve the camera's current facing direction.
+    void set_orbit_from_camera(glm::vec3 cam_pos, glm::vec3 cam_target);
+
 private:
     // Stage 1: Zone resolution
     int resolve_zone(glm::vec3 player_pos);

--- a/src/engine/camera_zone_system.cpp
+++ b/src/engine/camera_zone_system.cpp
@@ -34,6 +34,22 @@ float CameraZoneSystem::nearest_t_on_spline(const SplinePath& path,
     return best_t;
 }
 
+// ── set_orbit_from_camera ────────────────────────────────────────────────────
+
+void CameraZoneSystem::set_orbit_from_camera(glm::vec3 cam_pos, glm::vec3 cam_target) {
+    // Inverse of the spherical-to-cartesian in evaluate_vcam (free_look):
+    //   x = dist * cos(el) * sin(az)
+    //   y = dist * sin(el)
+    //   z = dist * cos(el) * cos(az)
+    glm::vec3 offset = cam_pos - cam_target;
+    float dist = std::sqrt(offset.x * offset.x + offset.y * offset.y + offset.z * offset.z);
+    if (dist < 1e-6f) return;  // degenerate — keep current angles
+
+    glm::vec3 dir = offset / dist;
+    orbit_azimuth_ = std::atan2(dir.x, dir.z);
+    orbit_elevation_ = std::asin(std::clamp(dir.y, -1.0f, 1.0f));
+}
+
 // ── load_from_data ──────────────────────────────────────────────────────────
 
 void CameraZoneSystem::load_from_data(

--- a/src/staging/camera_review_state.cpp
+++ b/src/staging/camera_review_state.cpp
@@ -179,12 +179,20 @@ void CameraReviewState::update(float dt, const InputManager& input,
 // ── Teleport / injected movement ─────────────────────────────────────────────
 
 void CameraReviewState::teleport(float x, float z) {
+    // Preserve camera facing direction before moving the player.
+    CameraState cam = zone_system_.current_state();
+    zone_system_.set_orbit_from_camera(cam.position, cam.target);
+
     player_pos_.x = x;
     player_pos_.z = z;
     player_vel_ = glm::vec3{0.0f};
 }
 
 void CameraReviewState::teleport(float x, float y, float z) {
+    // Preserve camera facing direction before moving the player.
+    CameraState cam = zone_system_.current_state();
+    zone_system_.set_orbit_from_camera(cam.position, cam.target);
+
     player_pos_.x = x;
     player_pos_.y = y;
     player_pos_.z = z;

--- a/tests/test_camera_zone_system.cpp
+++ b/tests/test_camera_zone_system.cpp
@@ -446,6 +446,64 @@ void test_constraint_pitch_clamp() {
           "constraint pitch: pitch does not go below pitch_min=-20 after extreme input");
 }
 
+// ── Test 12: set_orbit_from_camera preserves facing direction ────────────
+
+void test_set_orbit_from_camera() {
+    std::printf("set_orbit_from_camera:\n");
+
+    gseurat::CameraZoneSystem sys;
+    gseurat::CameraParams defaults;
+    defaults.mode = gseurat::CameraMode::free_look;
+    defaults.fov = 45.0f;
+    defaults.orbit_distance = 10.0f;
+    defaults.allow_user_orbit = false;
+    defaults.pitch_min = -89.0f;
+    defaults.pitch_max = 89.0f;
+    defaults.blend_time = 0.0f;
+
+    // Large sphere so position clamping doesn't interfere.
+    gseurat::CameraVolume vol;
+    vol.shape = gseurat::CamSphere{{0.0f, 0.0f, 0.0f}, 200.0f};
+    vol.params = defaults;
+    vol.params.priority = 0;
+
+    std::vector<std::pair<int, gseurat::CameraVolume>> volumes = {{1, vol}};
+    sys.load_from_data(volumes, {}, {}, defaults);
+
+    // Converge at origin with default azimuth (0 = camera at +Z).
+    converge(sys, {0.0f, 0.0f, 0.0f}, 240);
+
+    auto before = sys.current_state();
+    // Default: camera at +Z relative to target.
+    check(before.position.z > before.target.z,
+          "set_orbit: default camera is at +Z of target");
+
+    // Simulate a camera that was facing from +X (camera at +X, looking at origin).
+    // This corresponds to azimuth = pi/2.
+    glm::vec3 fake_cam_pos = {10.0f, 3.0f, 0.0f};
+    glm::vec3 fake_cam_target = {0.0f, 0.0f, 0.0f};
+    sys.set_orbit_from_camera(fake_cam_pos, fake_cam_target);
+
+    // Run frames to let spring converge with new orbit angles.
+    converge(sys, {0.0f, 0.0f, 0.0f}, 240);
+
+    auto after = sys.current_state();
+    // Camera should now be at +X relative to target (not +Z).
+    check(std::fabs(after.position.x - after.target.x) > 3.0f,
+          "set_orbit: camera has significant X offset after set_orbit_from_camera");
+    check(std::fabs(after.position.z - after.target.z) < 3.0f,
+          "set_orbit: camera Z offset is small (no longer at +Z default)");
+
+    // Test with camera looking from -Z (azimuth = pi, camera at -Z).
+    glm::vec3 neg_z_cam = {0.0f, 2.0f, -10.0f};
+    sys.set_orbit_from_camera(neg_z_cam, fake_cam_target);
+    converge(sys, {0.0f, 0.0f, 0.0f}, 240);
+
+    auto after2 = sys.current_state();
+    check(after2.position.z < after2.target.z,
+          "set_orbit: camera at -Z after set from -Z direction");
+}
+
 // ── Main ────────────────────────────────────────────────────────────────────
 
 int main() {
@@ -462,6 +520,7 @@ int main() {
     test_smoothstep_position_blend();
     test_constraint_position_clamp();
     test_constraint_pitch_clamp();
+    test_set_orbit_from_camera();
 
     std::printf("\n=== Results: %d passed, %d failed ===\n", passed, failed);
     return failed > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary
- Add `set_orbit_from_camera()` to `CameraZoneSystem` — extracts orbit azimuth/elevation from an existing camera position+target (inverse of the spherical-to-cartesian formula in `evaluate_vcam`)
- Call it from both `CameraReviewState::teleport()` overloads before moving the player, so the camera facing direction is preserved instead of snapping to the default azimuth 0 (+Z/backward)
- Fixes all teleport sources: "Go to Volume" button, right-click teleport, and socket `camera_review_teleport` command

## Test plan
- [x] New test (Test 12) with 4 assertions: verifies +X and -Z facing directions after `set_orbit_from_camera`
- [x] All 33 camera zone system tests pass
- [x] Full build succeeds (243 targets)
- [ ] Manual: In Staging, activate camera review on a scene with a rail + volume. Walk along rail, then click "Go to Volume" — camera should preserve facing direction instead of snapping backward

🤖 Generated with [Claude Code](https://claude.com/claude-code)