### PR TITLE
feat(gs): add Pixel Art mode with blendable intensity

### DIFF
--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -114,6 +114,8 @@ public:
     void set_effect_time(float t) { time_ = t; }
     void set_toon_bands(int bands) { toon_bands_ = bands; }
     int toon_bands() const { return toon_bands_; }
+    void set_pixel_art_intensity(float v) { pixel_art_intensity_ = glm::clamp(v, 0.0f, 1.0f); }
+    float pixel_art_intensity() const { return pixel_art_intensity_; }
     void set_light_mode(int mode) { light_mode_ = mode; }
     int light_mode() const { return light_mode_; }
     void set_light_dir(const glm::vec3& d) { light_dir_ = d; }
@@ -339,6 +341,7 @@ private:
     // Visual effect state
     float time_ = 0.0f;
     int toon_bands_ = 0;          // 0 = off, 3/4/5 = band count
+    float pixel_art_intensity_ = 0.0f; // 0.0 = off, 1.0 = full retro pixel art
     int light_mode_ = 0;          // 0 = off, 1 = directional, 2 = point
     glm::vec3 light_dir_{0.5f, 1.0f, 0.7f};
     float light_intensity_ = 1.0f;

--- a/shaders/gs_preprocess.comp
+++ b/shaders/gs_preprocess.comp
@@ -476,9 +476,13 @@ void main() {
     float half_w = float(params.x) * 0.5;
     float half_h = float(params.y) * 0.5;
 
-    float a = cov2d_full[0][0] * half_w * half_w + 0.3;
+    // Pixel art mode: covariance minimum bound ensures splats cover at least 1 pixel
+    float pixel_art = point_light_params.y;  // 0.0 = off, 1.0 = full retro
+    float cov_min_bound = pixel_art * 1.0;   // adds 1.0 to diagonal at full intensity
+
+    float a = cov2d_full[0][0] * half_w * half_w + 0.3 + cov_min_bound;
     float b = cov2d_full[0][1] * half_w * half_h;
-    float c = cov2d_full[1][1] * half_h * half_h + 0.3;
+    float c = cov2d_full[1][1] * half_h * half_h + 0.3 + cov_min_bound;
 
     // Compute inverse of 2D covariance for conic representation
     float det = a * c - b * b;
@@ -515,6 +519,16 @@ void main() {
         sort_entries[idx].key = 0xFFFF;
         sort_entries[idx].index = projected_offset + idx;
         return;
+    }
+
+    // Pixel art mode: snap screen coords to pixel grid + enforce minimum radius
+    if (pixel_art > 0.0) {
+        vec2 raw = vec2(screen_x, screen_y);
+        vec2 snapped = floor(raw) + 0.5;
+        vec2 final_pos = mix(raw, snapped, pixel_art);
+        screen_x = final_pos.x;
+        screen_y = final_pos.y;
+        radius_px = max(radius_px, mix(radius_px, 2.0, pixel_art));
     }
 
     // Write projected splat

--- a/shaders/gs_render.comp
+++ b/shaders/gs_render.comp
@@ -129,6 +129,15 @@ void main() {
         if (power > 0.0) continue;  // shouldn't happen, but safety check
 
         float gaussian_alpha = exp(power);
+
+        // Pixel art mode: hard-threshold alpha to kill soft Gaussian tails
+        float pixel_art = point_light_params.y;  // 0.0 = off, 1.0 = full retro
+        if (pixel_art > 0.0) {
+            float smooth_a = gaussian_alpha * opacity;
+            float hard_a = step(0.3, smooth_a);
+            gaussian_alpha = mix(smooth_a, hard_a, pixel_art) / max(opacity, 1e-6);
+        }
+
         float alpha = min(0.99, opacity * gaussian_alpha);
 
         if (alpha < 1.0 / 255.0) continue;  // negligible contribution

--- a/src/demo/gs_demo_state.cpp
+++ b/src/demo/gs_demo_state.cpp
@@ -28,6 +28,7 @@ void GsDemoState::on_enter(AppBase& app) {
     app.gs_terrain().parallax_active = false;
     app.renderer().set_gs_skip_chunk_cull(false);
     app.renderer().gs_renderer().set_skip_sort(false);
+    app.renderer().gs_renderer().set_pixel_art_intensity(0.5f);
 
     // Sync local scale from scene-loaded value
     scale_multiplier_ = app.renderer().gs_renderer().scale_multiplier();

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1292,7 +1292,7 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
                                         actor_rotation_.z, actor_rotation_.w);
 
     // Point lights — flat arrays matching shader layout
-    uniforms.point_light_params = glm::vec4(static_cast<float>(point_lights_.size()), 0, 0, 0);
+    uniforms.point_light_params = glm::vec4(static_cast<float>(point_lights_.size()), pixel_art_intensity_, 0, 0);
     for (size_t i = 0; i < point_lights_.size() && i < kMaxGsPointLights; i++) {
         uniforms.pl_pos_rad[i] = point_lights_[i].position_and_radius;
         uniforms.pl_color[i] = point_lights_[i].color;

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -681,6 +681,11 @@ void StagingState::draw_gs_params(AppBase& app) {
         gs.set_toon_bands(toon);
     }
 
+    float pixel_intensity = gs.pixel_art_intensity();
+    if (ImGui::SliderFloat("Pixel Art", &pixel_intensity, 0.0f, 1.0f, "%.2f", ImGuiSliderFlags_NoInput)) {
+        gs.set_pixel_art_intensity(pixel_intensity);
+    }
+
     ImGui::Separator();
 
     int budget = static_cast<int>(app.renderer().gs_gaussian_budget());


### PR DESCRIPTION
## Summary
- **Screen-space snapping** in `gs_preprocess.comp`: locks splat centers to pixel grid with blendable intensity, plus covariance minimum bound to prevent sub-pixel flickering
- **Hard alpha thresholding** in `gs_render.comp`: kills soft Gaussian tails via `mix(smooth, step(0.3, smooth), intensity)` for sharp pixel-sprite edges
- **Float intensity** (0.0–1.0) via `point_light_params.y` enables smooth "demake" transitions between photorealistic and retro styles
- **Staging UI**: "Pixel Art" slider in GS Parameters panel
- **Demo default**: intensity set to 0.5

## Test plan
- [ ] Build succeeds (`cmake --build --preset macos-debug`)
- [ ] Run demo — splats appear sharper with grid-locked centers at default 0.5
- [ ] Staging: drag "Pixel Art" slider from 0.0 to 1.0 — smooth transition from standard 3DGS to full retro
- [ ] Verify composability with toon shading and lighting modes
- [ ] Verify no visual artifacts at intensity extremes (0.0 and 1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)