### PR TITLE
docs(melies,echidna): add comprehensive READMEs

### DIFF
--- a/tools/apps/echidna/README.md
+++ b/tools/apps/echidna/README.md
@@ -1,0 +1,280 @@
+# Echidna
+
+Web-based voxel character editor for the GSeurat engine. Sculpt voxel models, rig them with bones, author keyframe animations, and export PLY + character manifests that the engine renders as 3D Gaussian splat characters with GPU skinning.
+
+## Quick Start
+
+```bash
+pnpm --filter @gseurat/echidna dev
+```
+
+Open <http://localhost:5179>. The bridge server (port 9100/9101) and a running Staging instance are required for live preview / Auto-Sync.
+
+## Modes
+
+Echidna has two top-level modes accessible from the menu bar:
+
+- **BUILD** — voxel sculpting, palette, body parts
+- **ANIMATE** — bone hierarchy, poses, keyframe animations, timeline playback
+
+The 3-panel layout (left tools / center viewport / right inspector) is shared between modes; panels are resizable (150–500px).
+
+## Build Mode
+
+### Tools
+
+| Key | Tool | Purpose |
+|-----|------|---------|
+| `V` | Place | Add voxels (with ghost preview) |
+| `B` | Paint | Recolor existing voxels |
+| `E` | Erase | Remove voxels |
+| `I` | Eyedropper | Sample voxel color |
+| `G` | Fill | 3D flood fill by connected color |
+| `X` | Extrude | Copy + offset voxel layer vertically |
+| `S` | Box select | Rectangular 3D selection |
+| `L` | Lasso select | Freehand 2D selection |
+
+### Color & Brush
+
+- Hex picker with live preview
+- 12 preset swatches (skin tones, browns, grays, RGB, purple, orange)
+- Brush size 1–8 (`[` / `]`)
+
+### Build Panel (right)
+
+- **Y-Clip** — slice view at adjustable Y for interior editing
+- **Y-Level Lock** — constrain painting to a fixed height
+- **Mirror X / Mirror Z** — symmetric placement (live)
+- **Toggles**: Grid, Gizmos, Color by Part, X-Ray (`T`)
+
+### Selection & Clipboard
+
+- Box select / lasso select
+- `Cmd/Ctrl+C` copy
+- Paste at cursor
+- `Del` / `Backspace` delete
+- `Esc` clear selection
+
+## Animate Mode
+
+### Bones (Left Panel)
+
+- Tree view of skeletal hierarchy
+- Drag-to-reparent with circular-dependency protection
+- Inline add / remove
+- Root bone label
+
+### Animations List (Left Panel)
+
+- All animation clips in the project
+- Add / remove / select active
+- **Root Motion** badge (RM) on clips with translation enabled
+
+### Bone Properties (Right Panel)
+
+- Joint position X/Y/Z spinners
+- Parent assignment dropdown
+- **Auto-Center Joint** — snap joint to voxel centroid for the part
+- Voxel count per bone
+
+### Keyframe Editor (Right Panel)
+
+- Animation duration slider (0.1s minimum)
+- Keyframe list (time / pose / easing)
+- Add keyframe at current playback time
+- Quick "create pose + keyframe" action
+- **Easing per keyframe**: linear, ease-in-out, bounce, elastic, step, custom (cubic Bezier)
+- **Root position** (when root motion enabled) — drives world translation
+- **Per-bone Euler XYZ rotations** for the active keyframe (degrees)
+
+### Timeline (Bottom Panel)
+
+- **Playback**: play / pause (`Space`), stop, current/duration display, speed slider 0.1×–3.0×
+- **Scrub track**: click to seek, drag to scrub, keyframe dots, playhead
+- **Modes**: Loop / Ping-Pong / Once
+- **Onion skinning**: ghost frames from adjacent keyframes
+
+## Body Parts (Build Mode, Parts Panel)
+
+- Character name editor
+- Hierarchical parts tree with depth indentation
+- Add part (text input + Enter)
+- Per-part editor: ID, parent dropdown, joint XYZ, voxel count, delete
+
+## Poses (Build Mode, Pose Panel)
+
+- Named pose list
+- Create pose (text + button)
+- Per-pose editor:
+  - **Preview** checkbox — visualize pose on character in viewport
+  - Per-bone Euler rotations XYZ (degrees, live update)
+
+## 3D Viewport
+
+- React Three Fiber + Three.js perspective camera (FOV 50°)
+- OrbitControls — left pan, middle/scroll zoom, right rotate, screen-space panning
+- **Auto-frame** on first voxel placement
+- Grid (configurable, fade distance 200u)
+- Ground plane at Y = −0.5 (click to place at Y = 0)
+- **Mirror plane** overlay (red X / blue Z) when active
+- **Ghost voxel** preview cube under the cursor (Place tool)
+
+## Joint Gizmos
+
+When gizmos are enabled in Animate mode:
+
+- Draggable spheres per bone (white / yellow selected / orange dragging)
+- Horizontal-plane drag constraint with live coordinate label
+- Integer snapping on drop
+- White lines connecting child joint to parent joint
+- When pose preview is on, gizmos show FK-computed posed positions
+
+## File Operations
+
+### File Menu
+
+- **New Project** — preset sizes 32–256 or custom 8–1024
+- **Save** / **Save As…** — `.echidna` JSON v2 format
+- **Load** — file picker
+- **Resize Grid** — expand or contract grid
+- **Import** — `.ply`, `.vox`, `.obj`
+
+### Import Formats
+
+- **`.vox`** (MagicaVoxel) — each model becomes a separate body part, palette colors preserved
+- **`.ply`** — voxelize point cloud, optional companion `.manifest.json` for bones/poses
+- **`.obj`** — voxelize mesh vertices with configurable resolution (8–256)
+
+All imports configure grid size (8–1024).
+
+### Export
+
+- **PLY+Manifest** — recommended for engine use
+- **Posed PLY** — bake current pose into PLY (no skinning needed)
+- **Density**: 1× / 2× / 3× / 4× sub-Gaussian subdivisions (1, 8, 27, 64 Gaussians per voxel)
+- **Include `bone_index`** checkbox for skinning support
+
+## Keyboard Shortcuts
+
+### File
+| Key | Action |
+|-----|--------|
+| `Cmd/Ctrl+N` | New project |
+| `Cmd/Ctrl+S` | Save |
+| `Cmd/Ctrl+Shift+S` | Save As… |
+| `Cmd/Ctrl+O` | Open |
+
+### Edit
+| Key | Action |
+|-----|--------|
+| `Cmd/Ctrl+Z` | Undo (50-step history) |
+| `Cmd/Ctrl+Shift+Z` / `Cmd/Ctrl+Y` | Redo |
+| `Cmd/Ctrl+C` | Copy selection |
+| `Del` / `Backspace` | Delete selection |
+| `Esc` | Clear selection |
+
+### Build Tools
+`V` Place · `B` Paint · `E` Erase · `I` Eyedropper · `G` Fill · `X` Extrude · `S` Box select · `L` Lasso select · `[` / `]` brush size · `T` x-ray
+
+### Animate
+`Space` Play/Pause · `S` Box select
+
+## Export Format
+
+### PLY (binary little-endian)
+
+3D Gaussian splat properties:
+- `x, y, z` — position (centered at grid midpoint)
+- `f_dc_0/1/2` — diffuse color (linear sRGB)
+- `opacity`
+- `scale_0/1/2` — log-scale Gaussian size
+- `rot_0/1/2/3` — quaternion
+- `bone_index` (optional uchar) — skinning index
+
+Surface voxels only — fully-interior voxels are culled.
+
+### Character Manifest (`.manifest.json`)
+
+```json
+{
+  "name": "walker",
+  "ply_file": "walker.ply",
+  "scale": 1.0,
+  "bones": [{ "id": "spine", "parent": "root", "joint": [0, 1, 0] }],
+  "poses": {
+    "idle": { "bone_rotations": { ... }, "root_position": [0, 0, 0] }
+  },
+  "animations": {
+    "walk": {
+      "duration": 1.0,
+      "looping": true,
+      "root_motion": true,
+      "keyframes": [
+        { "time": 0, "pose": "idle", "easing": "linear" }
+      ]
+    }
+  }
+}
+```
+
+## Engine Integration
+
+### Bridge REST API (`http://localhost:9101`)
+
+- `POST /api/characters/{charId}/file/{filename}` — binary PLY upload
+- `POST /api/characters/{charId}/manifest` — JSON metadata upload
+
+### Auto-Sync to Staging
+
+Toggle in **View → Auto-Sync Staging**. Debounced 2s after voxel/part changes — uploads PLY + manifest live for in-engine preview.
+
+### Preview in Staging
+
+**File → Preview in Staging** constructs a minimal scene JSON with a Gaussian splat camera + the character + animation manifest, then loads it in the running Staging app via WebSocket.
+
+## Animation System
+
+### Poses
+
+Per-bone Euler rotations + optional root position offset. Snapshots that animations interpolate between.
+
+### Clips
+
+- Name + duration
+- Time-ordered keyframe sequence
+- Playback mode: loop / ping-pong / once
+- Optional root motion flag
+
+### Keyframes
+
+- Time (seconds)
+- Reference pose name
+- Easing function (linear, ease-in-out, bounce, elastic, step, custom Bezier)
+- Optional per-part filter (animate only specific bones)
+
+### Playback
+
+- SLERP per-bone rotation interpolation
+- Easing applied between keyframes
+- Speed multiplier 0.1×–3.0×
+- Onion-skin ghost frames during scrub
+
+### Forward Kinematics
+
+Recursive transform accumulation through the bone hierarchy, used for both pose preview and posed PLY export.
+
+## Build
+
+```bash
+pnpm --filter @gseurat/echidna build
+```
+
+Outputs to `tools/apps/echidna/dist/`.
+
+## Tests
+
+```bash
+pnpm --filter @gseurat/echidna test
+```
+
+Vitest covers voxel ops, PLY export/import, OBJ/VOX import, easing functions, and manifest export.

--- a/tools/apps/melies/README.md
+++ b/tools/apps/melies/README.md
@@ -1,0 +1,225 @@
+# Méliès
+
+Web-based VFX editor for the GSeurat engine. Author particle effects, animations, lights, and PLY-based objects as reusable presets that load into Bricklayer scenes and play back live in Staging.
+
+## Quick Start
+
+```bash
+pnpm --filter @gseurat/melies dev
+```
+
+Open <http://localhost:5181>. The bridge server (port 9100/9101) and a running Staging instance are required for "Open in Staging" / Auto-Sync.
+
+## Workspace Layout
+
+- **Menu Bar** (top) — File / Edit / View
+- **Left Sidebar** — VFX tree: scenes + presets with their layers
+- **Center Viewport** — 3D preview with gizmos and Gaussian point cloud
+- **Right Sidebar** — context-aware properties (layer or preset settings)
+- **Timeline** (bottom) — playback scrubber with per-layer track bars
+
+## VFX Element Types
+
+Méliès composes a preset out of four element types:
+
+### Object (PLY)
+
+Loads a Gaussian point cloud as a static prop in the preset.
+
+- `ply_file` — path (project-relative or absolute)
+- `position`, `scale`
+- Region (sphere or box) — defines the volume animation layers can target
+- No timeline — always visible while the preset is active
+
+### Emitter
+
+Spawns particles using a WASM-powered ParticleEmitter.
+
+**Core parameters**: spawn rate, lifetime min/max, velocity min/max, acceleration, color start/end, scale min/max + end factor, opacity start/end, emission, burst duration.
+
+**Spawn region**: box (center + half_extents) or sphere (radius).
+
+**Spline path** (optional):
+- `emitter_path` — emitter moves along a Catmull-Rom spline (`emitter_speed` cycles/sec)
+- `particle_path` — particles route along the spline (`path_spread`, `align_to_tangent`)
+
+**Built-in presets**: `dust_puff`, `spark_shower`, `magic_spiral`, `fire`, `smoke`, `rain`, `snow`, `leaves`, `fireflies`, `steam`, `waterfall_mist`, `rain_drops`. Any preset can be overridden field-by-field.
+
+**Timeline**: `start`, `duration`, `loop`.
+
+### Animation
+
+Applies WASM-powered Gaussian transformations to point clouds within a region.
+
+**Effect types**: `detach`, `float`, `orbit`, `dissolve`, `reform`, `pulse`, `vortex`, `wave`, `scatter`.
+
+**Parameters** (effect-dependent, all with easing): rotations, expansion, height rise, opacity end, scale end, velocity, noise, wave speed, pulse frequency, gravity.
+
+**Easing**: 11 functions × 3 directions — `linear`, `quad`, `cubic`, `quart`, `quint`, `sine`, `expo`, `circ`, `back`, `elastic`, `bounce` (each in/out/in_out).
+
+**Reform system**: optional second phase reforms the original shape (`reform_enabled`, `reform_lifetime`).
+
+**Region**: sphere (radius) or box (half_extents) — only affects Gaussians inside.
+
+**Timeline**: `start`, `duration`, `loop`.
+
+### Light
+
+Adds a point light to the scene for Staging rendering.
+
+- `color`, `intensity`, `radius`, `position`
+- No timeline — always on while the preset is active
+
+## Timeline Editor
+
+- **Playback**: play/pause, stop, time display (MM:SS.SS), duration auto-derived
+- **Scrubber**: click to seek, drag to scrub, white playhead
+- **Track bars** (color-coded): emitter pink, animation cyan, light yellow
+- **Drag interactions**: drag bar body to move, drag edges to resize start/duration
+- **Snap**: 0.05s grid
+
+## VFX Tree (Left Sidebar)
+
+**Scenes** — registered PLY files. Click to set active, `+` to load, `×` to remove.
+
+**Presets** — expandable per-preset:
+- `+` Emitter / `+` Animation / `+` Light buttons
+- Per-layer: icon, name, mute (eye), solo (S), remove (×)
+
+## Properties Panel
+
+Context-aware right panel switches between **Layer Mode** and **Preset Settings Mode**.
+
+**Common layer fields**: name, type, position, start, duration, loop.
+
+**Type-specific editors**: PLY picker (object), spawn region + 18 emitter params + spline editor, animation effect dropdown + easing-aware param sliders, light color/intensity/radius.
+
+**Preset settings**: name, duration override, derived duration info.
+
+## 3D Viewport
+
+- React Three Fiber + Three.js with OrbitControls (pan / rotate / zoom)
+- Gaussian point cloud with shader-based color and scale attributes
+- **Gizmos** (selectable):
+
+  | Type | Marker | Color |
+  |------|--------|-------|
+  | Object | Octahedron | white / gray |
+  | Emitter | Sphere + spawn region outline | pink |
+  | Animation | Wireframe region | cyan |
+  | Light | Sphere | yellow |
+  | Spline | Curve + control handles | green / orange |
+
+- **Toggles**: View → Show Gizmos, Show Point Cloud
+
+## File Operations
+
+### File Menu
+
+- **New VFX**
+- **Open Project…** — File System Access API directory or `.json` upload
+- **Save Project** — directory or download
+- **Import .vfx.json…**
+- **Export .vfx.json**
+- **Import Scene PLY…**
+- **Open in Staging** — push current preset over the bridge
+
+### Auto-Sync to Staging
+
+Toggle in **View → Auto-Sync Staging**. Debounced 2s live sync — edits stream to Staging without manual export.
+
+## File Format
+
+### Project (`project.json`)
+
+```json
+{
+  "version": 2,
+  "presets": [...],
+  "scenes": [...],
+  "activeSceneId": "..."
+}
+```
+
+### Preset (`.vfx.json`)
+
+```json
+{
+  "name": "My Effect",
+  "duration": 3.0,
+  "elements": [
+    {
+      "name": "burst",
+      "type": "emitter",
+      "position": [0, 1, 0],
+      "start": 0,
+      "duration": 1,
+      "loop": false,
+      "emitter": { ... }
+    }
+  ]
+}
+```
+
+### Project Layout
+
+```
+my_project/
+├── project.json
+├── effects/
+│   ├── preset_1.vfx.json
+│   └── preset_2.vfx.json
+└── scene/
+    ├── scene1.ply
+    └── scene2.ply
+```
+
+## Keyboard Shortcuts
+
+### Always Active
+| Key | Action |
+|-----|--------|
+| `Cmd/Ctrl+S` | Save project |
+| `Cmd/Ctrl+O` | Open project |
+| `Cmd/Ctrl+D` | Duplicate selected layer |
+
+### Playback (when not typing)
+| Key | Action |
+|-----|--------|
+| `Space` | Play / Pause |
+| `Esc` | Stop (reset to 0) |
+| `Del` / `Backspace` | Remove selected layer |
+| `Home` / `,` | Seek to start |
+| `End` / `.` | Seek to end |
+| `←` / `→` | Seek ±0.1s |
+| `Shift+←` / `Shift+→` | Nudge selected layer ±0.05s |
+
+## Layer Visibility
+
+- **Mute** (eye) — hide layer during playback
+- **Solo** (S) — isolate layer, mute all others
+- WASM simulation respects per-layer visibility
+
+## Bricklayer Integration
+
+Méliès presets get loaded as **VFX Instances** in Bricklayer scenes:
+
+1. Author preset in Méliès → save as `.vfx.json`
+2. In Bricklayer, add a VFX Instance referencing the preset path
+3. Bricklayer writes the file via the bridge before pushing the scene
+4. Staging plays back the preset live
+
+## Build
+
+```bash
+pnpm --filter @gseurat/melies build
+```
+
+Outputs to `tools/apps/melies/dist/`.
+
+## Notes & Limitations
+
+- Animation effects target scene point clouds or object PLY clouds — not emitter particles
+- Spline gizmo is read-only in the viewport (edit via properties panel)
+- No undo/redo system yet
+- Schema v2 with v1 migration support (legacy `layers` → `elements`)


### PR DESCRIPTION
## Summary
- Adds `tools/apps/melies/README.md` documenting the VFX editor: element types, timeline editor, file format, Bricklayer integration
- Adds `tools/apps/echidna/README.md` documenting the voxel character editor: BUILD/ANIMATE modes, rigging, animation system, import/export, engine integration
- Follows the same structure as the recently-merged Bricklayer README

## Test plan
- [ ] Render check on GitHub — markdown formatting and tables look correct
- [ ] Spot-check accuracy: hotkeys, ports (5181 / 5179), package names

🤖 Generated with [Claude Code](https://claude.com/claude-code)