### PR TITLE
feat(project-root): layout + paths + registry modules [Tasks 3-5]

### DIFF
--- a/tools/packages/project-root/src/index.ts
+++ b/tools/packages/project-root/src/index.ts
@@ -1,2 +1,2 @@
-// Barrel — populated in Tasks 3–7
-export {};
+// Barrel — populated incrementally by Tasks 3–7.
+export * from './layout';

--- a/tools/packages/project-root/src/index.ts
+++ b/tools/packages/project-root/src/index.ts
@@ -1,3 +1,4 @@
 // Barrel — populated incrementally by Tasks 3–7.
 export * from './layout';
 export * from './paths';
+export * from './registry';

--- a/tools/packages/project-root/src/index.ts
+++ b/tools/packages/project-root/src/index.ts
@@ -1,2 +1,3 @@
 // Barrel — populated incrementally by Tasks 3–7.
 export * from './layout';
+export * from './paths';

--- a/tools/packages/project-root/src/layout.ts
+++ b/tools/packages/project-root/src/layout.ts
@@ -1,0 +1,37 @@
+export const PROJECT_LAYOUT = {
+  assets: {
+    characters: 'assets/characters',
+    vfx:        'assets/vfx',
+    vfxPresets: 'assets/vfx/presets',
+    scenes:     'assets/scenes',
+    maps:       'assets/maps',
+    textures:   'assets/textures',
+    audio:      'assets/audio',
+    components: 'assets/components',
+  },
+  toolsData: {
+    bricklayer:   'tools_data/bricklayer',
+    melies:       'tools_data/melies_projects',
+    echidnaSaves: 'tools_data/echidna_saves',
+    cache:        'tools_data/cache',
+  },
+} as const;
+
+export const ASSET_KINDS = [
+  'characters',
+  'vfx',
+  'scenes',
+  'maps',
+  'textures',
+  'audio',
+] as const;
+
+export type AssetKind = typeof ASSET_KINDS[number];
+
+export function isAssetPath(p: string): boolean {
+  return p.startsWith('assets/') && !p.includes('..');
+}
+
+export function isToolsDataPath(p: string): boolean {
+  return p.startsWith('tools_data/') && !p.includes('..');
+}

--- a/tools/packages/project-root/src/layout.ts
+++ b/tools/packages/project-root/src/layout.ts
@@ -17,6 +17,9 @@ export const PROJECT_LAYOUT = {
   },
 } as const;
 
+// Note: 'components' is intentionally excluded. It holds editor schema JSON
+// (schemas/*.schema.json), not engine-facing runtime assets. Consumers that
+// need the components directory should use PROJECT_LAYOUT.assets.components directly.
 export const ASSET_KINDS = [
   'characters',
   'vfx',
@@ -29,9 +32,11 @@ export const ASSET_KINDS = [
 export type AssetKind = typeof ASSET_KINDS[number];
 
 export function isAssetPath(p: string): boolean {
-  return p.startsWith('assets/') && !p.includes('..');
+  const segments = p.split('/');
+  return segments[0] === 'assets' && !segments.includes('..');
 }
 
 export function isToolsDataPath(p: string): boolean {
-  return p.startsWith('tools_data/') && !p.includes('..');
+  const segments = p.split('/');
+  return segments[0] === 'tools_data' && !segments.includes('..');
 }

--- a/tools/packages/project-root/src/paths.ts
+++ b/tools/packages/project-root/src/paths.ts
@@ -1,0 +1,96 @@
+import type { AssetKind } from './layout';
+
+export type AssetRef =
+  | { kind: 'id'; id: string }
+  | { kind: 'path'; path: string };
+
+const PART_SEPARATOR_RE = /[/\\]/;
+
+/**
+ * Build an asset path like `assets/characters/walker/walker.ply`.
+ * All parts are joined with `/`. Each part must be non-empty, contain no
+ * separators, and not be a traversal segment.
+ */
+export function toAssetPath(kind: AssetKind, ...parts: string[]): string {
+  if (parts.length === 0) {
+    throw new Error(`toAssetPath: at least one part required for kind=${kind}`);
+  }
+  for (const p of parts) {
+    if (p.length === 0) {
+      throw new Error(`toAssetPath: empty part not allowed (kind=${kind})`);
+    }
+    if (PART_SEPARATOR_RE.test(p)) {
+      throw new Error(`toAssetPath: part contains separator: "${p}"`);
+    }
+    if (p === '..' || p === '.') {
+      throw new Error(`toAssetPath: traversal segment not allowed: "${p}"`);
+    }
+  }
+  return `assets/${kind}/${parts.join('/')}`;
+}
+
+function hasTraversalSegment(s: string): boolean {
+  const segments = s.split(/[/\\]/);
+  return segments.includes('..') || segments.includes('.');
+}
+
+function isAbsolute(s: string): boolean {
+  if (s.startsWith('/')) return true;
+  // Windows drive letter: C:/foo, D:\foo
+  if (/^[A-Za-z]:[/\\]/.test(s)) return true;
+  return false;
+}
+
+/**
+ * Parse an asset reference string into its discriminated-union form.
+ * Accepts `#id` (registry ID) or `assets/...` (project-relative path).
+ * Throws on any other form or on traversal.
+ */
+export function parseAssetRef(s: string): AssetRef {
+  if (typeof s !== 'string' || s.length === 0) {
+    throw new Error('parseAssetRef: empty');
+  }
+  if (s.startsWith('#')) {
+    const id = s.slice(1);
+    if (id.length === 0 || PART_SEPARATOR_RE.test(id)) {
+      throw new Error(`parseAssetRef: invalid id: "${s}"`);
+    }
+    return { kind: 'id', id };
+  }
+  if (isAbsolute(s)) {
+    throw new Error(`parseAssetRef: absolute path not allowed: "${s}"`);
+  }
+  if (hasTraversalSegment(s)) {
+    throw new Error(`parseAssetRef: traversal not allowed: "${s}"`);
+  }
+  if (s.startsWith('tools_data/')) {
+    throw new Error(`parseAssetRef: not an asset path (tools_data): "${s}"`);
+  }
+  if (!s.startsWith('assets/')) {
+    throw new Error(`parseAssetRef: bare filename not allowed: "${s}"`);
+  }
+  return { kind: 'path', path: s };
+}
+
+/** Returns true if `s` is a valid asset ref (`#id` or `assets/...`). */
+export function isAssetRef(s: string): boolean {
+  try {
+    parseAssetRef(s);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns null if `s` is a valid asset ref, or a human-readable error message.
+ * Useful for validators that want to report why a ref was rejected.
+ */
+export function validateAssetRef(s: string): string | null {
+  try {
+    parseAssetRef(s);
+    return null;
+  } catch (e) {
+    return (e as Error).message;
+  }
+}

--- a/tools/packages/project-root/src/paths.ts
+++ b/tools/packages/project-root/src/paths.ts
@@ -22,16 +22,20 @@ export function toAssetPath(kind: AssetKind, ...parts: string[]): string {
     if (PART_SEPARATOR_RE.test(p)) {
       throw new Error(`toAssetPath: part contains separator: "${p}"`);
     }
-    if (p === '..' || p === '.') {
+    if (isTraversalSegment(p)) {
       throw new Error(`toAssetPath: traversal segment not allowed: "${p}"`);
     }
   }
   return `assets/${kind}/${parts.join('/')}`;
 }
 
+function isTraversalSegment(segment: string): boolean {
+  return segment === '..' || segment === '.';
+}
+
 function hasTraversalSegment(s: string): boolean {
   const segments = s.split(/[/\\]/);
-  return segments.includes('..') || segments.includes('.');
+  return segments.some(isTraversalSegment);
 }
 
 function isAbsolute(s: string): boolean {
@@ -48,7 +52,7 @@ function isAbsolute(s: string): boolean {
  */
 export function parseAssetRef(s: string): AssetRef {
   if (typeof s !== 'string' || s.length === 0) {
-    throw new Error('parseAssetRef: empty');
+    throw new Error('parseAssetRef: expected "#id" or "assets/..." but got empty string');
   }
   if (s.startsWith('#')) {
     const id = s.slice(1);
@@ -68,6 +72,13 @@ export function parseAssetRef(s: string): AssetRef {
   }
   if (!s.startsWith('assets/')) {
     throw new Error(`parseAssetRef: bare filename not allowed: "${s}"`);
+  }
+  // assets/ must be followed by {kind}/{name} at minimum
+  const afterAssets = s.slice('assets/'.length);
+  if (afterAssets.length === 0 || !afterAssets.includes('/')) {
+    throw new Error(
+      `parseAssetRef: path must be "assets/{kind}/{name}" with at least two segments, got: "${s}"`
+    );
   }
   return { kind: 'path', path: s };
 }
@@ -91,6 +102,6 @@ export function validateAssetRef(s: string): string | null {
     parseAssetRef(s);
     return null;
   } catch (e) {
-    return (e as Error).message;
+    return e instanceof Error ? e.message : String(e);
   }
 }

--- a/tools/packages/project-root/src/registry.ts
+++ b/tools/packages/project-root/src/registry.ts
@@ -35,40 +35,70 @@ export function registerCharacter(
   reg: AssetRegistry,
   id: string,
   entry: { ply: string; manifest: string },
-): void {
-  reg.characters[id] = { id, ply: entry.ply, manifest: entry.manifest };
+): AssetRegistry {
+  return {
+    ...reg,
+    characters: {
+      ...reg.characters,
+      [id]: { id, ply: entry.ply, manifest: entry.manifest },
+    },
+  };
 }
 
 export function registerVfx(
   reg: AssetRegistry,
   id: string,
   entry: { file: string },
-): void {
-  reg.vfx[id] = { id, file: entry.file };
+): AssetRegistry {
+  return {
+    ...reg,
+    vfx: {
+      ...reg.vfx,
+      [id]: { id, file: entry.file },
+    },
+  };
 }
 
 export function registerTexture(
   reg: AssetRegistry,
   id: string,
   entry: { file: string },
-): void {
-  reg.textures[id] = { id, file: entry.file };
+): AssetRegistry {
+  return {
+    ...reg,
+    textures: {
+      ...reg.textures,
+      [id]: { id, file: entry.file },
+    },
+  };
 }
 
 export function registerAudio(
   reg: AssetRegistry,
   id: string,
   entry: { file: string },
-): void {
-  reg.audio[id] = { id, file: entry.file };
+): AssetRegistry {
+  return {
+    ...reg,
+    audio: {
+      ...reg.audio,
+      [id]: { id, file: entry.file },
+    },
+  };
 }
 
 export function registerMap(
   reg: AssetRegistry,
   id: string,
   entry: { file: string },
-): void {
-  reg.maps[id] = { id, file: entry.file };
+): AssetRegistry {
+  return {
+    ...reg,
+    maps: {
+      ...reg.maps,
+      [id]: { id, file: entry.file },
+    },
+  };
 }
 
 export type RefKind = 'character' | 'vfx' | 'texture' | 'audio' | 'map';
@@ -89,28 +119,32 @@ export function resolveRef(ref: string, kind: RefKind, reg: AssetRegistry): stri
   switch (kind) {
     case 'character': {
       const e = reg.characters[parsed.id];
-      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in characters`);
+      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in the character registry`);
       return e.manifest;
     }
     case 'vfx': {
       const e = reg.vfx[parsed.id];
-      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in vfx`);
+      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in the vfx registry`);
       return e.file;
     }
     case 'texture': {
       const e = reg.textures[parsed.id];
-      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in textures`);
+      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in the texture registry`);
       return e.file;
     }
     case 'audio': {
       const e = reg.audio[parsed.id];
-      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in audio`);
+      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in the audio registry`);
       return e.file;
     }
     case 'map': {
       const e = reg.maps[parsed.id];
-      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in maps`);
+      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in the map registry`);
       return e.file;
+    }
+    default: {
+      const _exhaustive: never = kind;
+      throw new Error(`resolveRef: unhandled kind: ${_exhaustive}`);
     }
   }
 }

--- a/tools/packages/project-root/src/registry.ts
+++ b/tools/packages/project-root/src/registry.ts
@@ -1,0 +1,116 @@
+import { parseAssetRef } from './paths';
+
+export interface CharacterEntry {
+  id: string;
+  ply: string;       // assets/characters/{id}/{id}.ply
+  manifest: string;  // assets/characters/{id}/{id}.manifest.json
+}
+
+export interface FileEntry {
+  id: string;
+  file: string;
+}
+
+export interface AssetRegistry {
+  version: 1;
+  characters: Record<string, CharacterEntry>;
+  vfx:        Record<string, FileEntry>;
+  textures:   Record<string, FileEntry>;
+  audio:      Record<string, FileEntry>;
+  maps:       Record<string, FileEntry>;
+}
+
+export function createEmptyRegistry(): AssetRegistry {
+  return {
+    version: 1,
+    characters: {},
+    vfx: {},
+    textures: {},
+    audio: {},
+    maps: {},
+  };
+}
+
+export function registerCharacter(
+  reg: AssetRegistry,
+  id: string,
+  entry: { ply: string; manifest: string },
+): void {
+  reg.characters[id] = { id, ply: entry.ply, manifest: entry.manifest };
+}
+
+export function registerVfx(
+  reg: AssetRegistry,
+  id: string,
+  entry: { file: string },
+): void {
+  reg.vfx[id] = { id, file: entry.file };
+}
+
+export function registerTexture(
+  reg: AssetRegistry,
+  id: string,
+  entry: { file: string },
+): void {
+  reg.textures[id] = { id, file: entry.file };
+}
+
+export function registerAudio(
+  reg: AssetRegistry,
+  id: string,
+  entry: { file: string },
+): void {
+  reg.audio[id] = { id, file: entry.file };
+}
+
+export function registerMap(
+  reg: AssetRegistry,
+  id: string,
+  entry: { file: string },
+): void {
+  reg.maps[id] = { id, file: entry.file };
+}
+
+export type RefKind = 'character' | 'vfx' | 'texture' | 'audio' | 'map';
+
+/**
+ * Resolve an asset ref to its canonical project-relative file path.
+ * - For `#id` refs, looks up the entry in the registry.
+ *   - Characters resolve to their **manifest** file (not the PLY).
+ *   - Other kinds resolve to their single `file` field.
+ * - For `assets/...` path refs, returns the path unchanged (pass-through).
+ * - Throws on bare filenames, absolute paths, traversal, unknown ids, etc.
+ */
+export function resolveRef(ref: string, kind: RefKind, reg: AssetRegistry): string {
+  const parsed = parseAssetRef(ref);
+  if (parsed.kind === 'path') {
+    return parsed.path;
+  }
+  switch (kind) {
+    case 'character': {
+      const e = reg.characters[parsed.id];
+      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in characters`);
+      return e.manifest;
+    }
+    case 'vfx': {
+      const e = reg.vfx[parsed.id];
+      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in vfx`);
+      return e.file;
+    }
+    case 'texture': {
+      const e = reg.textures[parsed.id];
+      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in textures`);
+      return e.file;
+    }
+    case 'audio': {
+      const e = reg.audio[parsed.id];
+      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in audio`);
+      return e.file;
+    }
+    case 'map': {
+      const e = reg.maps[parsed.id];
+      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in maps`);
+      return e.file;
+    }
+  }
+}

--- a/tools/packages/project-root/test/layout.test.ts
+++ b/tools/packages/project-root/test/layout.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { PROJECT_LAYOUT, ASSET_KINDS, isToolsDataPath, isAssetPath } from '../src/layout';
+
+describe('PROJECT_LAYOUT', () => {
+  it('exposes asset subdirs', () => {
+    expect(PROJECT_LAYOUT.assets.characters).toBe('assets/characters');
+    expect(PROJECT_LAYOUT.assets.vfx).toBe('assets/vfx');
+    expect(PROJECT_LAYOUT.assets.vfxPresets).toBe('assets/vfx/presets');
+    expect(PROJECT_LAYOUT.assets.scenes).toBe('assets/scenes');
+    expect(PROJECT_LAYOUT.assets.maps).toBe('assets/maps');
+    expect(PROJECT_LAYOUT.assets.textures).toBe('assets/textures');
+    expect(PROJECT_LAYOUT.assets.audio).toBe('assets/audio');
+    expect(PROJECT_LAYOUT.assets.components).toBe('assets/components');
+  });
+
+  it('exposes tools_data subdirs', () => {
+    expect(PROJECT_LAYOUT.toolsData.bricklayer).toBe('tools_data/bricklayer');
+    expect(PROJECT_LAYOUT.toolsData.melies).toBe('tools_data/melies_projects');
+    expect(PROJECT_LAYOUT.toolsData.echidnaSaves).toBe('tools_data/echidna_saves');
+    expect(PROJECT_LAYOUT.toolsData.cache).toBe('tools_data/cache');
+  });
+
+  it('lists asset kinds', () => {
+    expect(ASSET_KINDS).toContain('characters');
+    expect(ASSET_KINDS).toContain('vfx');
+    expect(ASSET_KINDS).toContain('maps');
+  });
+});
+
+describe('classifiers', () => {
+  it('isAssetPath', () => {
+    expect(isAssetPath('assets/characters/walker/walker.ply')).toBe(true);
+    expect(isAssetPath('tools_data/bricklayer/scene.bricklayer')).toBe(false);
+    expect(isAssetPath('walker.ply')).toBe(false);
+  });
+
+  it('isToolsDataPath', () => {
+    expect(isToolsDataPath('tools_data/echidna_saves/walker.echidna')).toBe(true);
+    expect(isToolsDataPath('assets/scenes/town.json')).toBe(false);
+  });
+});

--- a/tools/packages/project-root/test/layout.test.ts
+++ b/tools/packages/project-root/test/layout.test.ts
@@ -38,4 +38,23 @@ describe('classifiers', () => {
     expect(isToolsDataPath('tools_data/echidna_saves/walker.echidna')).toBe(true);
     expect(isToolsDataPath('assets/scenes/town.json')).toBe(false);
   });
+
+  it('isAssetPath rejects path traversal segments', () => {
+    expect(isAssetPath('assets/../evil/foo')).toBe(false);
+    expect(isAssetPath('assets/foo/../../etc/passwd')).toBe(false);
+  });
+
+  it('isAssetPath accepts dots inside a path segment', () => {
+    expect(isAssetPath('assets/characters/walker..v2/walker.ply')).toBe(true);
+    expect(isAssetPath('assets/maps/region..north.json')).toBe(true);
+  });
+
+  it('isToolsDataPath rejects path traversal segments', () => {
+    expect(isToolsDataPath('tools_data/../evil')).toBe(false);
+    expect(isToolsDataPath('tools_data/foo/../../etc')).toBe(false);
+  });
+
+  it('isToolsDataPath accepts dots inside a path segment', () => {
+    expect(isToolsDataPath('tools_data/echidna_saves/walker..v2.echidna')).toBe(true);
+  });
 });

--- a/tools/packages/project-root/test/paths.test.ts
+++ b/tools/packages/project-root/test/paths.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toAssetPath,
+  validateAssetRef,
+  parseAssetRef,
+  isAssetRef,
+  type AssetRef,
+} from '../src/paths';
+
+describe('toAssetPath', () => {
+  it('builds character paths', () => {
+    expect(toAssetPath('characters', 'walker', 'walker.ply'))
+      .toBe('assets/characters/walker/walker.ply');
+  });
+
+  it('builds vfx preset paths', () => {
+    expect(toAssetPath('vfx', 'presets', 'explosion.vfx.json'))
+      .toBe('assets/vfx/presets/explosion.vfx.json');
+  });
+
+  it('rejects empty parts', () => {
+    expect(() => toAssetPath('characters', '')).toThrow(/empty/i);
+  });
+
+  it('rejects parts with separators', () => {
+    expect(() => toAssetPath('characters', 'foo/bar')).toThrow(/separator/i);
+  });
+
+  it('rejects traversal', () => {
+    expect(() => toAssetPath('characters', '..', 'evil')).toThrow(/traversal/i);
+  });
+});
+
+describe('parseAssetRef / isAssetRef', () => {
+  it('recognizes ID refs', () => {
+    expect(parseAssetRef('#walker')).toEqual({ kind: 'id', id: 'walker' });
+    expect(isAssetRef('#walker')).toBe(true);
+  });
+
+  it('recognizes path refs', () => {
+    expect(parseAssetRef('assets/characters/walker/walker.ply'))
+      .toEqual({ kind: 'path', path: 'assets/characters/walker/walker.ply' });
+    expect(isAssetRef('assets/characters/walker/walker.ply')).toBe(true);
+  });
+
+  it('rejects bare filenames', () => {
+    expect(() => parseAssetRef('walker.ply')).toThrow(/bare filename/i);
+    expect(isAssetRef('walker.ply')).toBe(false);
+  });
+
+  it('rejects absolute paths (unix)', () => {
+    expect(() => parseAssetRef('/Users/foo/walker.ply')).toThrow(/absolute/i);
+    expect(isAssetRef('/Users/foo/walker.ply')).toBe(false);
+  });
+
+  it('rejects absolute paths (windows)', () => {
+    expect(() => parseAssetRef('C:/foo/walker.ply')).toThrow(/absolute/i);
+    expect(() => parseAssetRef('D:\\foo\\walker.ply')).toThrow(/absolute/i);
+  });
+
+  it('rejects traversal', () => {
+    expect(() => parseAssetRef('assets/../evil')).toThrow(/traversal/i);
+    expect(() => parseAssetRef('assets/foo/../../etc/passwd')).toThrow(/traversal/i);
+  });
+
+  it('accepts dots inside a path segment', () => {
+    // walker..v2 is a legitimate directory name, not traversal
+    expect(isAssetRef('assets/characters/walker..v2/walker.ply')).toBe(true);
+  });
+
+  it('rejects tools_data paths as asset refs', () => {
+    expect(() => parseAssetRef('tools_data/bricklayer/scene.bricklayer')).toThrow(/asset path/i);
+  });
+
+  it('rejects empty id after hash', () => {
+    expect(() => parseAssetRef('#')).toThrow(/invalid id/i);
+  });
+
+  it('rejects id containing separator', () => {
+    expect(() => parseAssetRef('#foo/bar')).toThrow(/invalid id/i);
+  });
+
+  it('rejects empty string', () => {
+    expect(() => parseAssetRef('')).toThrow(/empty/i);
+  });
+});
+
+describe('validateAssetRef', () => {
+  it('returns null for valid', () => {
+    expect(validateAssetRef('#walker')).toBeNull();
+    expect(validateAssetRef('assets/foo/bar.ply')).toBeNull();
+  });
+
+  it('returns error message for invalid', () => {
+    expect(validateAssetRef('walker.ply')).toMatch(/bare filename/i);
+    expect(validateAssetRef('/abs/walker.ply')).toMatch(/absolute/i);
+  });
+});

--- a/tools/packages/project-root/test/paths.test.ts
+++ b/tools/packages/project-root/test/paths.test.ts
@@ -29,6 +29,10 @@ describe('toAssetPath', () => {
   it('rejects traversal', () => {
     expect(() => toAssetPath('characters', '..', 'evil')).toThrow(/traversal/i);
   });
+
+  it('rejects zero parts', () => {
+    expect(() => toAssetPath('characters' as any)).toThrow(/at least one/i);
+  });
 });
 
 describe('parseAssetRef / isAssetRef', () => {
@@ -61,6 +65,18 @@ describe('parseAssetRef / isAssetRef', () => {
   it('rejects traversal', () => {
     expect(() => parseAssetRef('assets/../evil')).toThrow(/traversal/i);
     expect(() => parseAssetRef('assets/foo/../../etc/passwd')).toThrow(/traversal/i);
+  });
+
+  it('rejects single-dot segment', () => {
+    expect(() => parseAssetRef('assets/./characters/walker.ply')).toThrow(/traversal/i);
+  });
+
+  it('rejects "assets/" with no further segments', () => {
+    expect(() => parseAssetRef('assets/')).toThrow(/at least two segments/i);
+  });
+
+  it('rejects "assets/kind" without a name', () => {
+    expect(() => parseAssetRef('assets/characters')).toThrow(/at least two segments/i);
   });
 
   it('accepts dots inside a path segment', () => {

--- a/tools/packages/project-root/test/registry.test.ts
+++ b/tools/packages/project-root/test/registry.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEmptyRegistry,
+  registerCharacter,
+  registerVfx,
+  registerTexture,
+  registerAudio,
+  registerMap,
+  resolveRef,
+  type AssetRegistry,
+} from '../src/registry';
+
+describe('AssetRegistry', () => {
+  it('starts empty with version 1', () => {
+    const r = createEmptyRegistry();
+    expect(r.version).toBe(1);
+    expect(Object.keys(r.characters)).toEqual([]);
+    expect(Object.keys(r.vfx)).toEqual([]);
+    expect(Object.keys(r.textures)).toEqual([]);
+    expect(Object.keys(r.audio)).toEqual([]);
+    expect(Object.keys(r.maps)).toEqual([]);
+  });
+
+  it('registers a character with ply and manifest', () => {
+    const r = createEmptyRegistry();
+    registerCharacter(r, 'walker', {
+      ply: 'assets/characters/walker/walker.ply',
+      manifest: 'assets/characters/walker/walker.manifest.json',
+    });
+    expect(r.characters.walker).toEqual({
+      id: 'walker',
+      ply: 'assets/characters/walker/walker.ply',
+      manifest: 'assets/characters/walker/walker.manifest.json',
+    });
+  });
+
+  it('registers vfx, textures, audio, and maps', () => {
+    const r = createEmptyRegistry();
+    registerVfx(r, 'explosion', { file: 'assets/vfx/presets/explosion.vfx.json' });
+    registerTexture(r, 'sky', { file: 'assets/textures/sky.png' });
+    registerAudio(r, 'boom', { file: 'assets/audio/boom.wav' });
+    registerMap(r, 'town', { file: 'assets/maps/town.ply' });
+
+    expect(r.vfx.explosion).toEqual({ id: 'explosion', file: 'assets/vfx/presets/explosion.vfx.json' });
+    expect(r.textures.sky).toEqual({ id: 'sky', file: 'assets/textures/sky.png' });
+    expect(r.audio.boom).toEqual({ id: 'boom', file: 'assets/audio/boom.wav' });
+    expect(r.maps.town).toEqual({ id: 'town', file: 'assets/maps/town.ply' });
+  });
+
+  it('register* overwrites an existing entry with the same id', () => {
+    const r = createEmptyRegistry();
+    registerVfx(r, 'explosion', { file: 'assets/vfx/presets/explosion_v1.vfx.json' });
+    registerVfx(r, 'explosion', { file: 'assets/vfx/presets/explosion_v2.vfx.json' });
+    expect(r.vfx.explosion.file).toBe('assets/vfx/presets/explosion_v2.vfx.json');
+  });
+});
+
+describe('resolveRef', () => {
+  it('returns character manifest path by id', () => {
+    const r = createEmptyRegistry();
+    registerCharacter(r, 'walker', {
+      ply: 'assets/characters/walker/walker.ply',
+      manifest: 'assets/characters/walker/walker.manifest.json',
+    });
+    expect(resolveRef('#walker', 'character', r))
+      .toBe('assets/characters/walker/walker.manifest.json');
+  });
+
+  it('returns vfx file path by id', () => {
+    const r = createEmptyRegistry();
+    registerVfx(r, 'explosion', { file: 'assets/vfx/presets/explosion.vfx.json' });
+    expect(resolveRef('#explosion', 'vfx', r))
+      .toBe('assets/vfx/presets/explosion.vfx.json');
+  });
+
+  it('returns texture path by id', () => {
+    const r = createEmptyRegistry();
+    registerTexture(r, 'sky', { file: 'assets/textures/sky.png' });
+    expect(resolveRef('#sky', 'texture', r)).toBe('assets/textures/sky.png');
+  });
+
+  it('returns audio path by id', () => {
+    const r = createEmptyRegistry();
+    registerAudio(r, 'boom', { file: 'assets/audio/boom.wav' });
+    expect(resolveRef('#boom', 'audio', r)).toBe('assets/audio/boom.wav');
+  });
+
+  it('returns map path by id', () => {
+    const r = createEmptyRegistry();
+    registerMap(r, 'town', { file: 'assets/maps/town.ply' });
+    expect(resolveRef('#town', 'map', r)).toBe('assets/maps/town.ply');
+  });
+
+  it('returns the path for a path-typed ref (passthrough)', () => {
+    const r = createEmptyRegistry();
+    expect(resolveRef('assets/characters/walker/walker.manifest.json', 'character', r))
+      .toBe('assets/characters/walker/walker.manifest.json');
+  });
+
+  it('throws on unknown id (characters)', () => {
+    const r = createEmptyRegistry();
+    expect(() => resolveRef('#missing', 'character', r)).toThrow(/unknown id.*characters/i);
+  });
+
+  it('throws on unknown id (vfx)', () => {
+    const r = createEmptyRegistry();
+    expect(() => resolveRef('#missing', 'vfx', r)).toThrow(/unknown id.*vfx/i);
+  });
+
+  it('rejects bare filenames (delegates to parseAssetRef)', () => {
+    const r = createEmptyRegistry();
+    expect(() => resolveRef('walker.ply', 'character', r)).toThrow(/bare filename/i);
+  });
+
+  it('rejects absolute paths', () => {
+    const r = createEmptyRegistry();
+    expect(() => resolveRef('/abs/walker.ply', 'character', r)).toThrow(/absolute/i);
+  });
+});
+
+describe('serialization round-trip', () => {
+  it('serializes and deserializes without loss', () => {
+    const r = createEmptyRegistry();
+    registerCharacter(r, 'walker', {
+      ply: 'assets/characters/walker/walker.ply',
+      manifest: 'assets/characters/walker/walker.manifest.json',
+    });
+    registerVfx(r, 'explosion', { file: 'assets/vfx/presets/explosion.vfx.json' });
+    const json = JSON.stringify(r);
+    const parsed: AssetRegistry = JSON.parse(json);
+    expect(parsed).toEqual(r);
+    expect(parsed.version).toBe(1);
+  });
+});

--- a/tools/packages/project-root/test/registry.test.ts
+++ b/tools/packages/project-root/test/registry.test.ts
@@ -22,8 +22,8 @@ describe('AssetRegistry', () => {
   });
 
   it('registers a character with ply and manifest', () => {
-    const r = createEmptyRegistry();
-    registerCharacter(r, 'walker', {
+    const r0 = createEmptyRegistry();
+    const r = registerCharacter(r0, 'walker', {
       ply: 'assets/characters/walker/walker.ply',
       manifest: 'assets/characters/walker/walker.manifest.json',
     });
@@ -32,14 +32,15 @@ describe('AssetRegistry', () => {
       ply: 'assets/characters/walker/walker.ply',
       manifest: 'assets/characters/walker/walker.manifest.json',
     });
+    expect(r0.characters.walker).toBeUndefined();  // original unchanged
   });
 
   it('registers vfx, textures, audio, and maps', () => {
-    const r = createEmptyRegistry();
-    registerVfx(r, 'explosion', { file: 'assets/vfx/presets/explosion.vfx.json' });
-    registerTexture(r, 'sky', { file: 'assets/textures/sky.png' });
-    registerAudio(r, 'boom', { file: 'assets/audio/boom.wav' });
-    registerMap(r, 'town', { file: 'assets/maps/town.ply' });
+    let r = createEmptyRegistry();
+    r = registerVfx(r, 'explosion', { file: 'assets/vfx/presets/explosion.vfx.json' });
+    r = registerTexture(r, 'sky', { file: 'assets/textures/sky.png' });
+    r = registerAudio(r, 'boom', { file: 'assets/audio/boom.wav' });
+    r = registerMap(r, 'town', { file: 'assets/maps/town.ply' });
 
     expect(r.vfx.explosion).toEqual({ id: 'explosion', file: 'assets/vfx/presets/explosion.vfx.json' });
     expect(r.textures.sky).toEqual({ id: 'sky', file: 'assets/textures/sky.png' });
@@ -48,17 +49,39 @@ describe('AssetRegistry', () => {
   });
 
   it('register* overwrites an existing entry with the same id', () => {
-    const r = createEmptyRegistry();
-    registerVfx(r, 'explosion', { file: 'assets/vfx/presets/explosion_v1.vfx.json' });
-    registerVfx(r, 'explosion', { file: 'assets/vfx/presets/explosion_v2.vfx.json' });
+    const r0 = createEmptyRegistry();
+    const r1 = registerVfx(r0, 'explosion', { file: 'assets/vfx/presets/explosion_v1.vfx.json' });
+    const r = registerVfx(r1, 'explosion', { file: 'assets/vfx/presets/explosion_v2.vfx.json' });
     expect(r.vfx.explosion.file).toBe('assets/vfx/presets/explosion_v2.vfx.json');
+  });
+
+  it('register* does not mutate the input registry', () => {
+    const r0 = createEmptyRegistry();
+    const r1 = registerVfx(r0, 'explosion', { file: 'assets/vfx/presets/explosion.vfx.json' });
+    expect(r0.vfx.explosion).toBeUndefined();  // original unchanged
+    expect(r1.vfx.explosion).toBeDefined();    // result has it
+    expect(r1).not.toBe(r0);                   // new object identity
+  });
+
+  it('registerCharacter overwrites an existing entry with new ply and manifest', () => {
+    const r0 = createEmptyRegistry();
+    const r1 = registerCharacter(r0, 'walker', {
+      ply: 'assets/characters/walker/walker_v1.ply',
+      manifest: 'assets/characters/walker/walker_v1.manifest.json',
+    });
+    const r2 = registerCharacter(r1, 'walker', {
+      ply: 'assets/characters/walker/walker_v2.ply',
+      manifest: 'assets/characters/walker/walker_v2.manifest.json',
+    });
+    expect(r2.characters.walker.ply).toBe('assets/characters/walker/walker_v2.ply');
+    expect(r2.characters.walker.manifest).toBe('assets/characters/walker/walker_v2.manifest.json');
   });
 });
 
 describe('resolveRef', () => {
   it('returns character manifest path by id', () => {
-    const r = createEmptyRegistry();
-    registerCharacter(r, 'walker', {
+    const r0 = createEmptyRegistry();
+    const r = registerCharacter(r0, 'walker', {
       ply: 'assets/characters/walker/walker.ply',
       manifest: 'assets/characters/walker/walker.manifest.json',
     });
@@ -67,27 +90,27 @@ describe('resolveRef', () => {
   });
 
   it('returns vfx file path by id', () => {
-    const r = createEmptyRegistry();
-    registerVfx(r, 'explosion', { file: 'assets/vfx/presets/explosion.vfx.json' });
+    const r0 = createEmptyRegistry();
+    const r = registerVfx(r0, 'explosion', { file: 'assets/vfx/presets/explosion.vfx.json' });
     expect(resolveRef('#explosion', 'vfx', r))
       .toBe('assets/vfx/presets/explosion.vfx.json');
   });
 
   it('returns texture path by id', () => {
-    const r = createEmptyRegistry();
-    registerTexture(r, 'sky', { file: 'assets/textures/sky.png' });
+    const r0 = createEmptyRegistry();
+    const r = registerTexture(r0, 'sky', { file: 'assets/textures/sky.png' });
     expect(resolveRef('#sky', 'texture', r)).toBe('assets/textures/sky.png');
   });
 
   it('returns audio path by id', () => {
-    const r = createEmptyRegistry();
-    registerAudio(r, 'boom', { file: 'assets/audio/boom.wav' });
+    const r0 = createEmptyRegistry();
+    const r = registerAudio(r0, 'boom', { file: 'assets/audio/boom.wav' });
     expect(resolveRef('#boom', 'audio', r)).toBe('assets/audio/boom.wav');
   });
 
   it('returns map path by id', () => {
-    const r = createEmptyRegistry();
-    registerMap(r, 'town', { file: 'assets/maps/town.ply' });
+    const r0 = createEmptyRegistry();
+    const r = registerMap(r0, 'town', { file: 'assets/maps/town.ply' });
     expect(resolveRef('#town', 'map', r)).toBe('assets/maps/town.ply');
   });
 
@@ -97,14 +120,21 @@ describe('resolveRef', () => {
       .toBe('assets/characters/walker/walker.manifest.json');
   });
 
+  it('passes path refs through without checking kind matches subdirectory', () => {
+    const r = createEmptyRegistry();
+    // A path ref is returned unchanged regardless of kind — kind only matters for #id lookups
+    expect(resolveRef('assets/textures/sky.png', 'character', r))
+      .toBe('assets/textures/sky.png');
+  });
+
   it('throws on unknown id (characters)', () => {
     const r = createEmptyRegistry();
-    expect(() => resolveRef('#missing', 'character', r)).toThrow(/unknown id.*characters/i);
+    expect(() => resolveRef('#missing', 'character', r)).toThrow(/unknown id.*character.*registry/i);
   });
 
   it('throws on unknown id (vfx)', () => {
     const r = createEmptyRegistry();
-    expect(() => resolveRef('#missing', 'vfx', r)).toThrow(/unknown id.*vfx/i);
+    expect(() => resolveRef('#missing', 'vfx', r)).toThrow(/unknown id.*vfx.*registry/i);
   });
 
   it('rejects bare filenames (delegates to parseAssetRef)', () => {
@@ -120,12 +150,12 @@ describe('resolveRef', () => {
 
 describe('serialization round-trip', () => {
   it('serializes and deserializes without loss', () => {
-    const r = createEmptyRegistry();
-    registerCharacter(r, 'walker', {
+    let r = createEmptyRegistry();
+    r = registerCharacter(r, 'walker', {
       ply: 'assets/characters/walker/walker.ply',
       manifest: 'assets/characters/walker/walker.manifest.json',
     });
-    registerVfx(r, 'explosion', { file: 'assets/vfx/presets/explosion.vfx.json' });
+    r = registerVfx(r, 'explosion', { file: 'assets/vfx/presets/explosion.vfx.json' });
     const json = JSON.stringify(r);
     const parsed: AssetRegistry = JSON.parse(json);
     expect(parsed).toEqual(r);


### PR DESCRIPTION
## Summary

**Scope: Tasks 3–5 of Phase 0.0 Foundation.** Adds the first three functional modules of the new `@gseurat/project-root` shared package:

1. **`layout.ts`** — `PROJECT_LAYOUT` constants (`assets/characters`, `assets/vfx/presets`, `tools_data/echidna_saves`, etc.) + `ASSET_KINDS` + segment-aware `isAssetPath` / `isToolsDataPath` classifiers
2. **`paths.ts`** — `toAssetPath(kind, ...parts)` builder + `parseAssetRef` / `isAssetRef` / `validateAssetRef` for the `#id` or `assets/...` ref format, with strict validation of absolute paths (unix + windows), traversal, bare filenames, and empty segments
3. **`registry.ts`** — `AssetRegistry` type + pure (immutable) `register*` helpers + `resolveRef(ref, kind, reg)` that delegates validation to `parseAssetRef` and looks up `#id`s in the registry

Builds on the scaffold from #201. Follow-up to merged main.

Full plan: \`docs/superpowers/plans/2026-04-10-phase-0-foundation.md\`

## Commits (TDD, 6 total)

Each feature commit has a fix commit that addresses issues caught by the code-quality review gate:

| # | SHA | Message |
|---|---|---|
| 1 | \`7b86c92\` | feat: canonical PROJECT_LAYOUT constants + classifiers |
| 2 | \`053d8c5\` | fix: segment-aware traversal check in classifiers |
| 3 | \`4df4ea5\` | feat: asset path builder + ref parser/validator |
| 4 | \`541cb01\` | fix: tighten parseAssetRef edge cases + dedupe traversal check |
| 5 | \`8b37823\` | feat: AssetRegistry types + register/resolve helpers |
| 6 | \`c4dbb27\` | refactor: pure (immutable) register* for Zustand compat |

## Issues caught by review (highlights)

- **Task 3**: substring \`..\` check would wrongly reject legitimate filenames like \`walker..v2\`; fixed by splitting on \`/\` first and checking segments
- **Task 4**: \`parseAssetRef('assets/')\` and \`parseAssetRef('assets/characters')\` passed validation despite being empty; added minimum-depth guard requiring \`assets/{kind}/{name}\`. Also duplicated traversal check between \`toAssetPath\` and \`hasTraversalSegment\`; extracted shared helper.
- **Task 5**: mutating \`register*\` functions would break Zustand's identity-based re-rendering in Bricklayer's future store integration (Tasks 20+). Converted to pure (spread-based) form returning a new registry. Also added exhaustiveness \`never\` guard in \`resolveRef\` switch so future \`RefKind\` additions become compile errors.

## Tests

- **49 tests passing** (9 layout + 22 paths + 18 registry)
- All strict TDD — test file written and failure verified before implementation
- Coverage includes edge cases: Windows absolute paths (\`C:/foo\` and \`D:\\\\foo\`), traversal segments, single-dot traversal, empty strings, empty IDs, cross-kind path passthrough, immutability invariants, register* overwrite semantics

## What's NOT in this PR

- \`fs.ts\` (Task 6) and \`handle.ts\` (Task 7) — next PR
- Any consumer wiring — Echidna / Méliès / Bricklayer unchanged
- Bridge or engine changes

## Review focus

- [ ] **API shape of \`register*\`** — the pure immutable form returns a new \`AssetRegistry\`; does this match how you'd want to use it in the Bricklayer store later?
- [ ] **Error message phrasing** — e.g. \`parseAssetRef: path must be "assets/{kind}/{name}" with at least two segments\`, \`resolveRef: unknown id "walker" in the character registry\` — are these the right UX for dev-facing errors?
- [ ] **\`resolveRef\` character → manifest\` decision** — consumers that need the PLY must access \`reg.characters[id].ply\` directly (documented in JSDoc)
- [ ] **\`AssetRef\` discriminated union** — \`{ kind: 'id' | 'path', ... }\` — workable for downstream code or would you prefer a string union?

## Test plan for reviewers

- [ ] \`pnpm --filter @gseurat/project-root test\` — 49 green
- [ ] \`pnpm --filter @gseurat/project-root exec tsc --noEmit\` — no errors
- [ ] Read the three \`src/*.ts\` modules — each is self-contained with clear single responsibility
- [ ] Spot-check the test files — they test actual behavior, not mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)