### PR TITLE
feat(project-root): fs + handle modules [Tasks 6-8] — closes Group 1

### DIFF
--- a/tools/packages/project-root/src/fs.ts
+++ b/tools/packages/project-root/src/fs.ts
@@ -1,13 +1,14 @@
-const TRAVERSAL_RE = /(^|\/)\.\.($|\/)/;
-
 function splitPath(p: string): string[] {
   if (!p || p.length === 0) {
     throw new Error('path is empty');
   }
-  if (TRAVERSAL_RE.test(p)) {
-    throw new Error(`path contains traversal: "${p}"`);
+  const parts = p.split('/').filter(s => s.length > 0);
+  for (const part of parts) {
+    if (part === '..' || part === '.') {
+      throw new Error(`path contains traversal: "${p}"`);
+    }
   }
-  return p.split('/').filter(s => s.length > 0);
+  return parts;
 }
 
 /**
@@ -36,7 +37,7 @@ export async function ensureSubdir(
 export async function writeFileAtPath(
   root: FileSystemDirectoryHandle,
   relativePath: string,
-  content: string | Uint8Array,
+  content: string | Uint8Array | Blob,
 ): Promise<void> {
   const parts = splitPath(relativePath);
   if (parts.length === 0) {
@@ -48,9 +49,8 @@ export async function writeFileAtPath(
     cur = await cur.getDirectoryHandle(part, { create: true });
   }
   const fileHandle = await cur.getFileHandle(filename, { create: true });
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const writable = await (fileHandle as any).createWritable();
-  await writable.write(content);
+  const writable = await fileHandle.createWritable();
+  await writable.write(content as FileSystemWriteChunkType);
   await writable.close();
 }
 
@@ -72,8 +72,7 @@ export async function readFileAtPath(
     cur = await cur.getDirectoryHandle(part, { create: false });
   }
   const fileHandle = await cur.getFileHandle(filename, { create: false });
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return await (fileHandle as any).getFile();
+  return await fileHandle.getFile();
 }
 
 /** Returns true if a file exists at `relativePath` under `root`. */
@@ -81,6 +80,8 @@ export async function fileExistsAtPath(
   root: FileSystemDirectoryHandle,
   relativePath: string,
 ): Promise<boolean> {
+  // Let traversal errors propagate rather than being swallowed.
+  splitPath(relativePath);
   try {
     await readFileAtPath(root, relativePath);
     return true;

--- a/tools/packages/project-root/src/fs.ts
+++ b/tools/packages/project-root/src/fs.ts
@@ -1,0 +1,90 @@
+const TRAVERSAL_RE = /(^|\/)\.\.($|\/)/;
+
+function splitPath(p: string): string[] {
+  if (!p || p.length === 0) {
+    throw new Error('path is empty');
+  }
+  if (TRAVERSAL_RE.test(p)) {
+    throw new Error(`path contains traversal: "${p}"`);
+  }
+  return p.split('/').filter(s => s.length > 0);
+}
+
+/**
+ * Ensure a subdirectory exists under `root`, creating any missing intermediate
+ * directories. Returns a handle to the deepest directory.
+ */
+export async function ensureSubdir(
+  root: FileSystemDirectoryHandle,
+  relativePath: string,
+): Promise<FileSystemDirectoryHandle> {
+  const parts = splitPath(relativePath);
+  if (parts.length === 0) {
+    throw new Error('ensureSubdir: empty path');
+  }
+  let cur: FileSystemDirectoryHandle = root;
+  for (const part of parts) {
+    cur = await cur.getDirectoryHandle(part, { create: true });
+  }
+  return cur;
+}
+
+/**
+ * Write `content` to a file at `relativePath` under `root`, creating any
+ * missing intermediate directories. Overwrites existing content.
+ */
+export async function writeFileAtPath(
+  root: FileSystemDirectoryHandle,
+  relativePath: string,
+  content: string | Uint8Array,
+): Promise<void> {
+  const parts = splitPath(relativePath);
+  if (parts.length === 0) {
+    throw new Error('writeFileAtPath: empty path');
+  }
+  const filename = parts.pop() as string;
+  let cur: FileSystemDirectoryHandle = root;
+  for (const part of parts) {
+    cur = await cur.getDirectoryHandle(part, { create: true });
+  }
+  const fileHandle = await cur.getFileHandle(filename, { create: true });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const writable = await (fileHandle as any).createWritable();
+  await writable.write(content);
+  await writable.close();
+}
+
+/**
+ * Read the file at `relativePath` under `root`, returning a Blob.
+ * Throws if any path segment does not exist.
+ */
+export async function readFileAtPath(
+  root: FileSystemDirectoryHandle,
+  relativePath: string,
+): Promise<Blob> {
+  const parts = splitPath(relativePath);
+  if (parts.length === 0) {
+    throw new Error('readFileAtPath: empty path');
+  }
+  const filename = parts.pop() as string;
+  let cur: FileSystemDirectoryHandle = root;
+  for (const part of parts) {
+    cur = await cur.getDirectoryHandle(part, { create: false });
+  }
+  const fileHandle = await cur.getFileHandle(filename, { create: false });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return await (fileHandle as any).getFile();
+}
+
+/** Returns true if a file exists at `relativePath` under `root`. */
+export async function fileExistsAtPath(
+  root: FileSystemDirectoryHandle,
+  relativePath: string,
+): Promise<boolean> {
+  try {
+    await readFileAtPath(root, relativePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tools/packages/project-root/src/handle.ts
+++ b/tools/packages/project-root/src/handle.ts
@@ -2,6 +2,14 @@ import { get, set, del } from 'idb-keyval';
 
 const KEY_PREFIX = 'gseurat:project-root-handle:';
 
+// FSAPI permission methods are not yet in the base TypeScript DOM lib.
+// Declare the minimal shape we use so ensureHandlePermission can be typed
+// without an inline cast.
+interface FSHandleWithPermission {
+  queryPermission(o: { mode: 'read' | 'readwrite' }): Promise<PermissionState>;
+  requestPermission(o: { mode: 'read' | 'readwrite' }): Promise<PermissionState>;
+}
+
 /**
  * This module is tested via editor integration (Tasks 13, 16, 21) rather
  * than unit tests — IDB and FSAPI's permission methods both require a
@@ -15,6 +23,9 @@ const KEY_PREFIX = 'gseurat:project-root-handle:';
  *
  * `appId` scopes the handle per editor so Echidna, Méliès, and Bricklayer can
  * each remember their own project root independently.
+ *
+ * Throws if IndexedDB is unavailable (private browsing, storage disabled) or
+ * the quota is exceeded. Callers should catch and surface a user-visible error.
  */
 export async function saveProjectRootHandle(
   appId: string,
@@ -44,28 +55,26 @@ export async function clearProjectRootHandle(appId: string): Promise<void> {
  * Query, then request if needed, read/write permission on a previously stored
  * directory handle. Returns true if permission is granted.
  *
- * The browser usually grants silently on the first call if the user previously
- * approved the directory, but will prompt if not. Callers should handle both
- * outcomes gracefully.
+ * If the user previously denied permission for this directory, most browsers
+ * will not prompt again and requestPermission() will return 'denied'
+ * immediately — this function returns false in that case rather than throwing.
+ * Callers should handle the false return by prompting the user to re-pick the
+ * directory via showDirectoryPicker().
  */
 export async function ensureHandlePermission(
   handle: FileSystemDirectoryHandle,
 ): Promise<boolean> {
   const opts = { mode: 'readwrite' as const };
-  // queryPermission / requestPermission are FSAPI extensions not yet in the
-  // base TypeScript DOM lib. Declare the shape locally.
-  const h = handle as unknown as {
-    queryPermission(o: { mode: 'readwrite' }): Promise<PermissionState>;
-    requestPermission(o: { mode: 'readwrite' }): Promise<PermissionState>;
-  };
+  const h = handle as unknown as FSHandleWithPermission;
   if ((await h.queryPermission(opts)) === 'granted') return true;
   return (await h.requestPermission(opts)) === 'granted';
 }
 
 /**
  * Convenience bootstrap used on editor startup. Loads the stored handle for
- * `appId`, requests permission, and returns the handle on success. Returns
- * null if there is no stored handle or permission was denied.
+ * `appId`, re-acquires read/write permission if needed, and returns the handle
+ * on success. Returns null if there is no stored handle or permission was
+ * denied.
  */
 export async function restoreProjectRoot(
   appId: string,

--- a/tools/packages/project-root/src/handle.ts
+++ b/tools/packages/project-root/src/handle.ts
@@ -1,0 +1,77 @@
+import { get, set, del } from 'idb-keyval';
+
+const KEY_PREFIX = 'gseurat:project-root-handle:';
+
+/**
+ * This module is tested via editor integration (Tasks 13, 16, 21) rather
+ * than unit tests — IDB and FSAPI's permission methods both require a
+ * browser runtime, and the logic here is a thin pass-through.
+ */
+
+/**
+ * Persist a directory handle in IndexedDB so future sessions can re-acquire it.
+ * The browser still requires re-prompting for permission via requestPermission()
+ * on subsequent sessions — see ensureHandlePermission() / restoreProjectRoot().
+ *
+ * `appId` scopes the handle per editor so Echidna, Méliès, and Bricklayer can
+ * each remember their own project root independently.
+ */
+export async function saveProjectRootHandle(
+  appId: string,
+  handle: FileSystemDirectoryHandle,
+): Promise<void> {
+  await set(KEY_PREFIX + appId, handle);
+}
+
+/**
+ * Load a previously stored directory handle. Returns null if none is stored.
+ * Does NOT check or request permission — use ensureHandlePermission() or
+ * restoreProjectRoot() for that.
+ */
+export async function loadProjectRootHandle(
+  appId: string,
+): Promise<FileSystemDirectoryHandle | null> {
+  const handle = await get<FileSystemDirectoryHandle>(KEY_PREFIX + appId);
+  return handle ?? null;
+}
+
+/** Remove a stored handle for this appId. */
+export async function clearProjectRootHandle(appId: string): Promise<void> {
+  await del(KEY_PREFIX + appId);
+}
+
+/**
+ * Query, then request if needed, read/write permission on a previously stored
+ * directory handle. Returns true if permission is granted.
+ *
+ * The browser usually grants silently on the first call if the user previously
+ * approved the directory, but will prompt if not. Callers should handle both
+ * outcomes gracefully.
+ */
+export async function ensureHandlePermission(
+  handle: FileSystemDirectoryHandle,
+): Promise<boolean> {
+  const opts = { mode: 'readwrite' as const };
+  // queryPermission / requestPermission are FSAPI extensions not yet in the
+  // base TypeScript DOM lib. Declare the shape locally.
+  const h = handle as unknown as {
+    queryPermission(o: { mode: 'readwrite' }): Promise<PermissionState>;
+    requestPermission(o: { mode: 'readwrite' }): Promise<PermissionState>;
+  };
+  if ((await h.queryPermission(opts)) === 'granted') return true;
+  return (await h.requestPermission(opts)) === 'granted';
+}
+
+/**
+ * Convenience bootstrap used on editor startup. Loads the stored handle for
+ * `appId`, requests permission, and returns the handle on success. Returns
+ * null if there is no stored handle or permission was denied.
+ */
+export async function restoreProjectRoot(
+  appId: string,
+): Promise<FileSystemDirectoryHandle | null> {
+  const handle = await loadProjectRootHandle(appId);
+  if (!handle) return null;
+  const ok = await ensureHandlePermission(handle);
+  return ok ? handle : null;
+}

--- a/tools/packages/project-root/src/index.ts
+++ b/tools/packages/project-root/src/index.ts
@@ -1,5 +1,6 @@
-// Barrel — populated incrementally by Tasks 3–7.
+// Barrel — all five modules.
 export * from './layout';
 export * from './paths';
 export * from './registry';
 export * from './fs';
+export * from './handle';

--- a/tools/packages/project-root/src/index.ts
+++ b/tools/packages/project-root/src/index.ts
@@ -2,3 +2,4 @@
 export * from './layout';
 export * from './paths';
 export * from './registry';
+export * from './fs';

--- a/tools/packages/project-root/test/fs.test.ts
+++ b/tools/packages/project-root/test/fs.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { ensureSubdir, writeFileAtPath, readFileAtPath, fileExistsAtPath } from '../src/fs';
+
+// Minimal in-memory mock matching the FileSystemDirectoryHandle subset we use.
+type Node =
+  | { kind: 'dir'; entries: Map<string, Node> }
+  | { kind: 'file'; data: Uint8Array };
+
+class MockDirHandle {
+  kind: 'directory' = 'directory';
+  constructor(
+    public node: Extract<Node, { kind: 'dir' }>,
+    public name = '',
+  ) {}
+
+  async getDirectoryHandle(name: string, opts?: { create?: boolean }): Promise<MockDirHandle> {
+    let n = this.node.entries.get(name);
+    if (!n) {
+      if (!opts?.create) {
+        const e: any = new Error(`NotFoundError: ${name}`);
+        e.name = 'NotFoundError';
+        throw e;
+      }
+      n = { kind: 'dir', entries: new Map() };
+      this.node.entries.set(name, n);
+    }
+    if (n.kind !== 'dir') {
+      const e: any = new Error(`TypeMismatchError: ${name}`);
+      e.name = 'TypeMismatchError';
+      throw e;
+    }
+    return new MockDirHandle(n, name);
+  }
+
+  async getFileHandle(name: string, opts?: { create?: boolean }) {
+    let n = this.node.entries.get(name);
+    if (!n) {
+      if (!opts?.create) {
+        const e: any = new Error(`NotFoundError: ${name}`);
+        e.name = 'NotFoundError';
+        throw e;
+      }
+      n = { kind: 'file', data: new Uint8Array() };
+      this.node.entries.set(name, n);
+    }
+    if (n.kind !== 'file') {
+      const e: any = new Error(`TypeMismatchError: ${name}`);
+      e.name = 'TypeMismatchError';
+      throw e;
+    }
+    const file = n;
+    return {
+      kind: 'file' as const,
+      name,
+      async createWritable() {
+        return {
+          async write(d: Uint8Array | string | ArrayBuffer) {
+            let bytes: Uint8Array;
+            if (typeof d === 'string') bytes = new TextEncoder().encode(d);
+            else if (d instanceof Uint8Array) bytes = d;
+            else bytes = new Uint8Array(d);
+            file.data = bytes;
+          },
+          async close() {},
+        };
+      },
+      async getFile() {
+        return new Blob([file.data as Uint8Array<ArrayBuffer>]);
+      },
+    };
+  }
+}
+
+function makeRoot(): MockDirHandle {
+  return new MockDirHandle({ kind: 'dir', entries: new Map() });
+}
+
+describe('ensureSubdir', () => {
+  it('creates nested subdirectories', async () => {
+    const root = makeRoot();
+    const handle = await ensureSubdir(root as any, 'assets/characters/walker');
+    expect(handle.name).toBe('walker');
+    // Check the parent chain exists
+    const assets = await (root as any).getDirectoryHandle('assets');
+    const characters = await assets.getDirectoryHandle('characters');
+    await characters.getDirectoryHandle('walker'); // throws if missing
+  });
+
+  it('is idempotent', async () => {
+    const root = makeRoot();
+    await ensureSubdir(root as any, 'assets/foo');
+    await ensureSubdir(root as any, 'assets/foo'); // should not throw
+  });
+
+  it('returns the root when path is a single segment', async () => {
+    const root = makeRoot();
+    const handle = await ensureSubdir(root as any, 'assets');
+    expect(handle.name).toBe('assets');
+  });
+
+  it('rejects empty path', async () => {
+    const root = makeRoot();
+    await expect(ensureSubdir(root as any, '')).rejects.toThrow(/empty/i);
+  });
+
+  it('rejects traversal', async () => {
+    const root = makeRoot();
+    await expect(ensureSubdir(root as any, 'assets/../evil')).rejects.toThrow(/traversal/i);
+  });
+});
+
+describe('writeFileAtPath / readFileAtPath', () => {
+  it('round-trips text content', async () => {
+    const root = makeRoot();
+    await writeFileAtPath(root as any, 'assets/scenes/town.json', '{"hello":"world"}');
+    const blob = await readFileAtPath(root as any, 'assets/scenes/town.json');
+    const text = await blob.text();
+    expect(text).toBe('{"hello":"world"}');
+  });
+
+  it('round-trips binary content', async () => {
+    const root = makeRoot();
+    const bytes = new Uint8Array([1, 2, 3, 4, 255, 0, 128]);
+    await writeFileAtPath(root as any, 'assets/maps/town.ply', bytes);
+    const blob = await readFileAtPath(root as any, 'assets/maps/town.ply');
+    const arr = new Uint8Array(await blob.arrayBuffer());
+    expect(Array.from(arr)).toEqual([1, 2, 3, 4, 255, 0, 128]);
+  });
+
+  it('creates intermediate directories on write', async () => {
+    const root = makeRoot();
+    await writeFileAtPath(root as any, 'tools_data/bricklayer/deep/nested/scene.bricklayer', '{}');
+    const blob = await readFileAtPath(root as any, 'tools_data/bricklayer/deep/nested/scene.bricklayer');
+    expect(await blob.text()).toBe('{}');
+  });
+
+  it('overwrites existing file content', async () => {
+    const root = makeRoot();
+    await writeFileAtPath(root as any, 'assets/scenes/town.json', 'v1');
+    await writeFileAtPath(root as any, 'assets/scenes/town.json', 'v2');
+    const blob = await readFileAtPath(root as any, 'assets/scenes/town.json');
+    expect(await blob.text()).toBe('v2');
+  });
+
+  it('rejects empty path on write', async () => {
+    const root = makeRoot();
+    await expect(writeFileAtPath(root as any, '', 'data')).rejects.toThrow(/empty/i);
+  });
+
+  it('rejects traversal on write', async () => {
+    const root = makeRoot();
+    await expect(writeFileAtPath(root as any, 'assets/../evil.txt', 'x')).rejects.toThrow(/traversal/i);
+  });
+
+  it('rejects traversal on read', async () => {
+    const root = makeRoot();
+    await expect(readFileAtPath(root as any, 'assets/../evil.txt')).rejects.toThrow(/traversal/i);
+  });
+});
+
+describe('fileExistsAtPath', () => {
+  it('returns true when the file exists', async () => {
+    const root = makeRoot();
+    await writeFileAtPath(root as any, 'assets/scenes/town.json', '{}');
+    expect(await fileExistsAtPath(root as any, 'assets/scenes/town.json')).toBe(true);
+  });
+
+  it('returns false when the file does not exist', async () => {
+    const root = makeRoot();
+    expect(await fileExistsAtPath(root as any, 'assets/scenes/missing.json')).toBe(false);
+  });
+
+  it('returns false for a missing intermediate directory', async () => {
+    const root = makeRoot();
+    expect(await fileExistsAtPath(root as any, 'assets/nonexistent/file.json')).toBe(false);
+  });
+});

--- a/tools/packages/project-root/test/fs.test.ts
+++ b/tools/packages/project-root/test/fs.test.ts
@@ -54,9 +54,10 @@ class MockDirHandle {
       name,
       async createWritable() {
         return {
-          async write(d: Uint8Array | string | ArrayBuffer) {
+          async write(d: Uint8Array | string | ArrayBuffer | Blob) {
             let bytes: Uint8Array;
             if (typeof d === 'string') bytes = new TextEncoder().encode(d);
+            else if (d instanceof Blob) bytes = new Uint8Array(await d.arrayBuffer());
             else if (d instanceof Uint8Array) bytes = d;
             else bytes = new Uint8Array(d);
             file.data = bytes;
@@ -107,6 +108,11 @@ describe('ensureSubdir', () => {
     const root = makeRoot();
     await expect(ensureSubdir(root as any, 'assets/../evil')).rejects.toThrow(/traversal/i);
   });
+
+  it('rejects single-dot segment', async () => {
+    const root = makeRoot();
+    await expect(ensureSubdir(root as any, 'assets/./foo')).rejects.toThrow(/traversal/i);
+  });
 });
 
 describe('writeFileAtPath / readFileAtPath', () => {
@@ -156,6 +162,25 @@ describe('writeFileAtPath / readFileAtPath', () => {
     const root = makeRoot();
     await expect(readFileAtPath(root as any, 'assets/../evil.txt')).rejects.toThrow(/traversal/i);
   });
+
+  it('rejects single-dot current-dir segment on write', async () => {
+    const root = makeRoot();
+    await expect(writeFileAtPath(root as any, 'assets/./foo.json', '{}')).rejects.toThrow(/traversal/i);
+  });
+
+  it('accepts Blob content', async () => {
+    const root = makeRoot();
+    const blob = new Blob(['hello from blob'], { type: 'text/plain' });
+    await writeFileAtPath(root as any, 'assets/scenes/blob.json', blob);
+    const read = await readFileAtPath(root as any, 'assets/scenes/blob.json');
+    expect(await read.text()).toBe('hello from blob');
+  });
+
+  it('normalizes trailing slash and double slashes', async () => {
+    const root = makeRoot();
+    await writeFileAtPath(root as any, 'assets//scenes/test.json', '1');
+    expect(await fileExistsAtPath(root as any, 'assets/scenes/test.json')).toBe(true);
+  });
 });
 
 describe('fileExistsAtPath', () => {
@@ -173,5 +198,10 @@ describe('fileExistsAtPath', () => {
   it('returns false for a missing intermediate directory', async () => {
     const root = makeRoot();
     expect(await fileExistsAtPath(root as any, 'assets/nonexistent/file.json')).toBe(false);
+  });
+
+  it('propagates traversal error instead of returning false', async () => {
+    const root = makeRoot();
+    await expect(fileExistsAtPath(root as any, 'assets/../evil.txt')).rejects.toThrow(/traversal/i);
   });
 });


### PR DESCRIPTION
## Summary

**Scope: Tasks 6–8 of Phase 0.0 Foundation — final piece of Group 1.** Completes the `@gseurat/project-root` shared package with:

1. **\`fs.ts\`** (Task 6) — \`FileSystemDirectoryHandle\` helpers: \`ensureSubdir\` (recursive mkdir), \`writeFileAtPath\` (create-and-write with intermediate dirs), \`readFileAtPath\` (strict read returning Blob), \`fileExistsAtPath\` (boolean probe). Tested via an in-memory FSAPI mock so vitest runs in Node without a browser.

2. **\`handle.ts\`** (Task 7) — IDB-backed persistence for directory handles so each editor can remember its project root across page reloads. Thin wrapper around \`idb-keyval\` with a \`restoreProjectRoot(appId)\` bootstrap helper that composes load + permission re-acquisition. **Intentionally no unit tests** — IDB and FSAPI permission methods both need a browser runtime; Task 13's Echidna integration will provide end-to-end coverage.

3. **Task 8** — package-wide verification: 69 tests passing, \`tsc --noEmit\` clean, barrel exports all 5 modules.

After this PR, the \`@gseurat/project-root\` package is **done**. Groups 2–6 begin consumer integration (Echidna → Méliès → Bricklayer → Bridge → Engine).

Full plan: \`docs/superpowers/plans/2026-04-10-phase-0-foundation.md\`

## Commits (4 total after rebase)

| # | SHA | Message |
|---|---|---|
| 1 | \`105930c\` | feat: ensureSubdir + writeFileAtPath + readFileAtPath |
| 2 | \`3f12b9a\` | fix: tighten fs.ts traversal check + remove unused any casts |
| 3 | \`ddc6106\` | feat: IDB-backed directory handle persistence |
| 4 | \`1c30964\` | docs: lift permission type to named interface + clarify docs |

## Issues caught by review (Task 6 fs.ts)

The quality review on Task 6 caught three real issues that landed in the fix commit:

- **\`as any\` casts were unnecessary** — TS 5.4+ DOM lib already types \`FileSystemFileHandle.createWritable()\` and \`.getFile()\`. Both casts removed; full type safety restored.
- **\`fileExistsAtPath\` silently swallowed traversal errors** — a caller asking \`fileExistsAtPath(root, 'assets/../evil.txt')\` got \`false\` instead of a security exception. Fixed by calling \`splitPath\` eagerly before the try-block so traversal errors propagate.
- **Traversal guard inconsistent with \`paths.ts\`** — fs.ts used a regex-based \`..\` check that missed \`.\` segments (\`foo/./bar\`). Replaced with a segment-split pattern matching \`paths.ts\`'s \`hasTraversalSegment\`. Now both modules handle traversal identically.

## Tests (69 total in @gseurat/project-root)

- **layout** — 9 tests (PROJECT_LAYOUT constants + classifiers)
- **paths** — 22 tests (toAssetPath, parseAssetRef, edge cases)
- **registry** — 18 tests (AssetRegistry, register/resolve, immutability)
- **fs** — 20 tests (ensureSubdir, write/read roundtrip text+binary+**Blob**, intermediate dir creation, traversal rejection including single-dot, overwrite semantics, fileExistsAtPath incl. traversal propagation, trailing-slash normalization)
- **handle** — 0 tests (browser-runtime only; integration via Task 13 Echidna)

## Review focus

- [ ] **In-memory FSAPI mock in \`fs.test.ts\`** — is the mock faithful enough to real FSAPI behavior? See the \`MockDirHandle\` class (~60 lines). It handles \`getDirectoryHandle\`, \`getFileHandle\`, \`createWritable\`, \`getFile\` with proper NotFoundError / TypeMismatchError propagation.
- [ ] **\`FSHandleWithPermission\` interface in handle.ts** — a minimal local interface for FSAPI's \`queryPermission\`/\`requestPermission\` which aren't in the base DOM lib. Is this the right layer to stub them?
- [ ] **No unit tests for handle.ts** — documented rationale in the file's top-of-file comment with forward reference to Task 13. Is this acceptable?
- [ ] **\`writeFileAtPath\` accepts \`string | Uint8Array | Blob\`** — added Blob support per code review. Real FSAPI \`FileSystemWritableFileStream.write()\` handles all three natively.

## What's NOT in this PR

- No consumer wiring — Echidna/Méliès/Bricklayer still untouched
- No Bridge or engine changes
- Handle module has no unit tests (intentional)

## Test plan for reviewers

- [ ] \`pnpm --filter @gseurat/project-root test\` — 69 green
- [ ] \`pnpm --filter @gseurat/project-root exec tsc --noEmit\` — no errors
- [ ] Read the mock in \`test/fs.test.ts\` — is it the minimum viable fake?
- [ ] Confirm \`src/index.ts\` barrel exports all 5 modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)