### PR TITLE
feat(echidna): Phase 0.0 FSAPI integration [Tasks 9-14]

### DIFF
--- a/tools/apps/echidna/package.json
+++ b/tools/apps/echidna/package.json
@@ -18,6 +18,7 @@
     "@react-three/drei": "^9.117.0",
     "@gseurat/engine-client": "workspace:*",
     "@gseurat/asset-types": "workspace:*",
+    "@gseurat/project-root": "workspace:*",
     "@gseurat/ui-kit": "workspace:*",
     "@gseurat/test-harness": "workspace:*"
   },

--- a/tools/apps/echidna/src/App.tsx
+++ b/tools/apps/echidna/src/App.tsx
@@ -114,7 +114,7 @@ export function App() {
     (async () => {
       try {
         const handle = await restoreProjectRoot('echidna');
-        if (handle) {
+        if (handle && !useCharacterStore.getState().projectRootHandle) {
           useCharacterStore.getState().setProjectRootHandle(handle);
           console.info(`[echidna] Restored project root: ${handle.name}`);
         }

--- a/tools/apps/echidna/src/App.tsx
+++ b/tools/apps/echidna/src/App.tsx
@@ -8,6 +8,7 @@ import { AnimateRightPanel } from './panels/AnimateRightPanel.js';
 import { Timeline } from './panels/Timeline.js';
 import { useCharacterStore } from './store/useCharacterStore.js';
 import type { ToolType } from './store/types.js';
+import { restoreProjectRoot } from '@gseurat/project-root';
 
 const styles: Record<string, React.CSSProperties> = {
   root: {
@@ -107,6 +108,22 @@ export function App() {
   // Keep refs in sync for drag callbacks
   leftRef.current = leftWidth;
   rightRef.current = rightWidth;
+
+  // Bootstrap: restore project root handle from IDB on startup
+  useEffect(() => {
+    (async () => {
+      try {
+        const handle = await restoreProjectRoot('echidna');
+        if (handle) {
+          useCharacterStore.getState().setProjectRootHandle(handle);
+          console.info(`[echidna] Restored project root: ${handle.name}`);
+        }
+      } catch (e) {
+        // Silently ignore — user can pick the root again via File → Set Project Root…
+        console.info('[echidna] No project root to restore');
+      }
+    })();
+  }, []);
 
   const handleLeftDrag = useCallback((delta: number) => {
     setLeftWidth(Math.max(150, Math.min(400, leftRef.current + delta)));

--- a/tools/apps/echidna/src/__tests__/echidnaFile.test.ts
+++ b/tools/apps/echidna/src/__tests__/echidnaFile.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { migrateEchidnaFile, slugifyCharacterId, ECHIDNA_FILE_VERSION, type EchidnaFile } from '../store/types.js';
+
+describe('slugifyCharacterId', () => {
+  it('lowercases and replaces whitespace with underscores', () => {
+    expect(slugifyCharacterId('Walker Bot')).toBe('walker_bot');
+    expect(slugifyCharacterId('  Hello   World  ')).toBe('hello_world');
+  });
+  it('strips characters outside [a-z0-9_-]', () => {
+    expect(slugifyCharacterId('Cat/Dog#1')).toBe('catdog1');
+    expect(slugifyCharacterId('  Déjà Vu  ')).toBe('dj_vu');  // strips accented + ends up no-underscore run
+  });
+  it('preserves hyphens and underscores', () => {
+    expect(slugifyCharacterId('cool-guy_v2')).toBe('cool-guy_v2');
+  });
+  it('falls back to "character" when empty or all stripped', () => {
+    expect(slugifyCharacterId('')).toBe('character');
+    expect(slugifyCharacterId('   ')).toBe('character');
+    expect(slugifyCharacterId('###')).toBe('character');
+  });
+});
+
+describe('migrateEchidnaFile', () => {
+  it('adds id by slugifying characterName for legacy v2 file with no id', () => {
+    const old = {
+      version: 2,
+      characterName: 'Walker Bot',
+      gridWidth: 32,
+      gridDepth: 32,
+      voxels: [],
+      parts: [],
+      poses: {},
+    };
+    const migrated = migrateEchidnaFile(old);
+    expect(migrated.version).toBe(ECHIDNA_FILE_VERSION);
+    expect(migrated.version).toBe(3);
+    expect(migrated.id).toBe('walker_bot');
+  });
+
+  it('preserves an existing id on current-version file', () => {
+    const file = {
+      version: 3,
+      id: 'walker',
+      characterName: 'Walker Bot',
+      gridWidth: 32,
+      gridDepth: 32,
+      voxels: [],
+      parts: [],
+      poses: {},
+    };
+    const migrated = migrateEchidnaFile(file);
+    expect(migrated.id).toBe('walker');
+    expect(migrated.characterName).toBe('Walker Bot');
+  });
+
+  it('migrates even when characterName is missing, falling back to "character"', () => {
+    const old = { version: 2, gridWidth: 32, gridDepth: 32, voxels: [], parts: [], poses: {} };
+    const migrated = migrateEchidnaFile(old);
+    expect(migrated.id).toBe('character');
+  });
+
+  it('preserves animations field when present', () => {
+    const old = {
+      version: 2,
+      characterName: 'Walker',
+      gridWidth: 32,
+      gridDepth: 32,
+      voxels: [],
+      parts: [],
+      poses: {},
+      animations: { walk: { duration: 1.0, keyframes: [] } },
+    };
+    const migrated = migrateEchidnaFile(old);
+    expect(migrated.animations).toEqual({ walk: { duration: 1.0, keyframes: [] } });
+  });
+
+  it('throws on null/undefined/non-object input', () => {
+    expect(() => migrateEchidnaFile(null)).toThrow();
+    expect(() => migrateEchidnaFile(undefined)).toThrow();
+    expect(() => migrateEchidnaFile(42)).toThrow();
+    expect(() => migrateEchidnaFile('string')).toThrow();
+  });
+});

--- a/tools/apps/echidna/src/__tests__/projectFs.test.ts
+++ b/tools/apps/echidna/src/__tests__/projectFs.test.ts
@@ -1,0 +1,42 @@
+// Unit tests for pure path builders. The async save/load/export functions
+// that wrap FSAPI are exercised by Task 13's MenuBar integration (too thin
+// to unit-test without duplicating the in-memory mock from project-root).
+
+import { describe, it, expect } from 'vitest';
+import {
+  echidnaSavePath,
+  characterPlyPath,
+  characterManifestPath,
+} from '../lib/projectFs';
+
+describe('Echidna project path helpers', () => {
+  describe('echidnaSavePath', () => {
+    it('places .echidna files under tools_data/echidna_saves', () => {
+      expect(echidnaSavePath('walker')).toBe('tools_data/echidna_saves/walker.echidna');
+    });
+
+    it('appends .echidna extension to the id', () => {
+      expect(echidnaSavePath('walker_bot')).toBe('tools_data/echidna_saves/walker_bot.echidna');
+    });
+  });
+
+  describe('characterPlyPath', () => {
+    it('places PLY under assets/characters/{id}/{id}.ply', () => {
+      expect(characterPlyPath('walker')).toBe('assets/characters/walker/walker.ply');
+    });
+
+    it('works for hyphenated ids', () => {
+      expect(characterPlyPath('cool-guy_v2')).toBe('assets/characters/cool-guy_v2/cool-guy_v2.ply');
+    });
+  });
+
+  describe('characterManifestPath', () => {
+    it('places manifest under assets/characters/{id}/{id}.manifest.json', () => {
+      expect(characterManifestPath('walker')).toBe('assets/characters/walker/walker.manifest.json');
+    });
+
+    it('works for hyphenated ids', () => {
+      expect(characterManifestPath('cool-guy_v2')).toBe('assets/characters/cool-guy_v2/cool-guy_v2.manifest.json');
+    });
+  });
+});

--- a/tools/apps/echidna/src/lib/projectFs.ts
+++ b/tools/apps/echidna/src/lib/projectFs.ts
@@ -1,0 +1,85 @@
+import {
+  PROJECT_LAYOUT,
+  toAssetPath,
+  ensureSubdir,
+  writeFileAtPath,
+  readFileAtPath,
+} from '@gseurat/project-root';
+import { migrateEchidnaFile, type EchidnaFile } from '../store/types';
+
+/* ----- path builders ----- */
+
+/**
+ * Returns the project-relative path for an Echidna project save file.
+ * Example: `echidnaSavePath('walker')` → `'tools_data/echidna_saves/walker.echidna'`.
+ */
+export function echidnaSavePath(id: string): string {
+  return `${PROJECT_LAYOUT.toolsData.echidnaSaves}/${id}.echidna`;
+}
+
+/**
+ * Returns the project-relative path for a character's PLY file.
+ * Example: `characterPlyPath('walker')` → `'assets/characters/walker/walker.ply'`.
+ */
+export function characterPlyPath(id: string): string {
+  return toAssetPath('characters', id, `${id}.ply`);
+}
+
+/**
+ * Returns the project-relative path for a character's manifest JSON.
+ * Example: `characterManifestPath('walker')` → `'assets/characters/walker/walker.manifest.json'`.
+ */
+export function characterManifestPath(id: string): string {
+  return toAssetPath('characters', id, `${id}.manifest.json`);
+}
+
+/* ----- save / load / export ----- */
+
+/**
+ * Save an Echidna project file to `tools_data/echidna_saves/{id}.echidna`.
+ * Creates the directory if needed.
+ */
+export async function saveEchidnaProject(
+  root: FileSystemDirectoryHandle,
+  file: EchidnaFile,
+): Promise<void> {
+  await ensureSubdir(root, PROJECT_LAYOUT.toolsData.echidnaSaves);
+  const path = echidnaSavePath(file.id);
+  const json = JSON.stringify(file, null, 2);
+  await writeFileAtPath(root, path, json);
+}
+
+/**
+ * Load an Echidna project file from `tools_data/echidna_saves/{id}.echidna`.
+ * Routes through `migrateEchidnaFile` so legacy files are migrated on read.
+ */
+export async function loadEchidnaProject(
+  root: FileSystemDirectoryHandle,
+  id: string,
+): Promise<EchidnaFile> {
+  const blob = await readFileAtPath(root, echidnaSavePath(id));
+  const text = await blob.text();
+  return migrateEchidnaFile(JSON.parse(text));
+}
+
+/**
+ * Export a character's PLY and manifest to `assets/characters/{id}/`.
+ * Creates the character subdirectory if needed. Returns the written paths.
+ */
+export async function exportCharacterToProject(
+  root: FileSystemDirectoryHandle,
+  id: string,
+  ply: Blob | Uint8Array,
+  manifestJson: string,
+): Promise<{ plyPath: string; manifestPath: string }> {
+  await ensureSubdir(root, `${PROJECT_LAYOUT.assets.characters}/${id}`);
+  const plyPath = characterPlyPath(id);
+  const manifestPath = characterManifestPath(id);
+
+  // writeFileAtPath accepts string | Uint8Array | Blob per the shared package
+  // — just pass the PLY through unchanged.
+  await writeFileAtPath(root, plyPath, ply);
+  await writeFileAtPath(root, manifestPath, manifestJson);
+
+  return { plyPath, manifestPath };
+}

--- a/tools/apps/echidna/src/panels/MenuBar.tsx
+++ b/tools/apps/echidna/src/panels/MenuBar.tsx
@@ -13,6 +13,16 @@ import { ResizeGridDialog } from './ResizeGridDialog.js';
 import { ExportDialog } from './ExportDialog.js';
 import { ImportDialog } from './ImportDialog.js';
 import type { ImportOptions } from './ImportDialog.js';
+import {
+  saveProjectRootHandle,
+  ensureHandlePermission,
+  restoreProjectRoot,
+} from '@gseurat/project-root';
+import {
+  saveEchidnaProject,
+  exportCharacterToProject,
+  echidnaSavePath,
+} from '../lib/projectFs.js';
 
 const BRIDGE_REST_URL = 'http://localhost:9101';
 
@@ -481,8 +491,131 @@ export function MenuBar() {
     }
   }, [showToast]);
 
+  const handlePickProjectRoot = useCallback(async () => {
+    try {
+      // @ts-expect-error - showDirectoryPicker is FSAPI extension not in lib.dom
+      const handle: FileSystemDirectoryHandle = await window.showDirectoryPicker({ mode: 'readwrite' });
+      await saveProjectRootHandle('echidna', handle);
+      useCharacterStore.getState().setProjectRootHandle(handle);
+      showToast(`Project root set: ${handle.name}`, 'success');
+    } catch (e) {
+      // User canceled or denied permission
+      if ((e as Error).name !== 'AbortError') {
+        console.error('[echidna] Failed to set project root:', e);
+        showToast('Failed to set project root', 'error');
+      }
+    }
+  }, [showToast]);
+
+  const handleSaveToProject = useCallback(async () => {
+    const s = useCharacterStore.getState();
+    let handle = s.projectRootHandle;
+    if (!handle) {
+      try {
+        // @ts-expect-error - showDirectoryPicker is FSAPI extension
+        handle = await window.showDirectoryPicker({ mode: 'readwrite' }) as FileSystemDirectoryHandle;
+        await saveProjectRootHandle('echidna', handle);
+        s.setProjectRootHandle(handle);
+      } catch (e) {
+        if ((e as Error).name !== 'AbortError') {
+          console.error('[echidna] Cannot pick project root:', e);
+          showToast('Cannot pick project root', 'error');
+        }
+        return;
+      }
+    } else {
+      const ok = await ensureHandlePermission(handle);
+      if (!ok) {
+        showToast('Project root permission denied', 'error');
+        return;
+      }
+    }
+
+    const id = s.ensureCharacterId();
+    const file = s.saveProject();
+    try {
+      await saveEchidnaProject(handle, file);
+      showToast(`Saved to ${echidnaSavePath(id)}`, 'success');
+    } catch (e) {
+      console.error('[echidna] Save failed:', e);
+      showToast('Save to project failed', 'error');
+    }
+  }, [showToast]);
+
+  const handleExportCharacterToProject = useCallback(async () => {
+    const s = useCharacterStore.getState();
+    if (s.voxels.size === 0) {
+      showToast('No voxels to export', 'error');
+      return;
+    }
+
+    // Ensure project root handle is available
+    let handle = s.projectRootHandle;
+    if (!handle) {
+      handle = await restoreProjectRoot('echidna');
+      if (!handle) {
+        showToast('No project root set — use File → Set Project Root… first', 'error');
+        return;
+      }
+      s.setProjectRootHandle(handle);
+    } else {
+      const ok = await ensureHandlePermission(handle);
+      if (!ok) {
+        showToast('Project root permission denied', 'error');
+        return;
+      }
+    }
+
+    const id = s.ensureCharacterId();
+
+    // Build PLY
+    const ply = exportPly(s.voxels, s.gridWidth, s.gridDepth, s.characterParts);
+
+    // Build manifest with bone joints centered to match PLY centering
+    // (same logic as pushToStaging — see lines ~436-447 above)
+    const halfW = s.gridWidth / 2;
+    let maxY = 0;
+    for (const [key] of s.voxels.entries()) {
+      const y = parseInt(key.split(',')[1], 10);
+      if (y > maxY) maxY = y;
+    }
+    const halfH = maxY / 2;
+    const centeredParts = s.characterParts.map((p) => ({
+      ...p,
+      joint: [p.joint[0] - halfW, p.joint[1] - halfH, p.joint[2]] as [number, number, number],
+    }));
+    const manifest = buildManifest(
+      id,
+      `${id}.ply`,
+      1.0,
+      centeredParts,
+      s.characterPoses,
+      s.animations,
+    );
+
+    showToast('Exporting character…', 'loading');
+
+    try {
+      const { plyPath, manifestPath } = await exportCharacterToProject(
+        handle,
+        id,
+        ply,
+        JSON.stringify(manifest, null, 2),
+      );
+      console.info(`[echidna] Exported ${plyPath} + ${manifestPath}`);
+      showToast(`Exported ${id} to project`, 'success');
+    } catch (e) {
+      console.error('[echidna] Export failed:', e);
+      showToast('Export to project failed', 'error');
+    }
+  }, [showToast]);
+
   const fileItems = [
     { label: 'New', shortcut: '\u2318N', action: handleNew },
+    { separator: true as const },
+    { label: 'Set Project Root\u2026', action: handlePickProjectRoot },
+    { label: 'Save to Project', action: handleSaveToProject },
+    { label: 'Export Character to Project', action: handleExportCharacterToProject },
     { separator: true as const },
     { label: 'Save', shortcut: '\u2318S', action: handleSave },
     { label: 'Save As...', shortcut: '\u21e7\u2318S', action: handleSaveAs },

--- a/tools/apps/echidna/src/panels/MenuBar.tsx
+++ b/tools/apps/echidna/src/panels/MenuBar.tsx
@@ -558,6 +558,12 @@ export function MenuBar() {
         return;
       }
       s.setProjectRootHandle(handle);
+      // After restoring from IDB, we still need to verify/request permission.
+      const ok = await ensureHandlePermission(handle);
+      if (!ok) {
+        showToast('Project root permission denied', 'error');
+        return;
+      }
     } else {
       const ok = await ensureHandlePermission(handle);
       if (!ok) {

--- a/tools/apps/echidna/src/store/types.ts
+++ b/tools/apps/echidna/src/store/types.ts
@@ -70,10 +70,13 @@ export interface ClipboardEntry {
   color: [number, number, number, number];
 }
 
-// ── File format (v2) ──
+// ── File format (v3) ──
+
+export const ECHIDNA_FILE_VERSION = 3;
 
 export interface EchidnaFile {
   version: number;
+  id: string;            // persistent slug, immutable after first save
   characterName: string;
   gridWidth: number;
   gridDepth: number;
@@ -81,6 +84,50 @@ export interface EchidnaFile {
   parts: BodyPart[];
   poses: Record<string, PoseData>;
   animations?: Record<string, AnimationClip>;
+}
+
+/**
+ * Slugify a character name into a stable ID usable as a directory name.
+ * Rules: lowercase, trim, collapse whitespace runs to single underscores,
+ * strip characters outside [a-z0-9_-], fall back to "character" if empty.
+ */
+export function slugifyCharacterId(name: string): string {
+  const cleaned = name
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_-]/g, '');
+  return cleaned.length > 0 ? cleaned : 'character';
+}
+
+/**
+ * Migrate a raw parsed JSON object to the current EchidnaFile shape.
+ * - Adds a persistent `id` (slugified from characterName) if missing.
+ * - Bumps version to ECHIDNA_FILE_VERSION.
+ * - Throws on non-object input.
+ *
+ * Does NOT attempt to validate voxel/part/pose structure — the store
+ * loader handles those. This migration is specifically about schema v2 → v3.
+ */
+export function migrateEchidnaFile(raw: any): EchidnaFile {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('migrateEchidnaFile: expected an object');
+  }
+  const id: string = typeof raw.id === 'string' && raw.id.length > 0
+    ? raw.id
+    : slugifyCharacterId(typeof raw.characterName === 'string' ? raw.characterName : '');
+
+  return {
+    version: ECHIDNA_FILE_VERSION,
+    id,
+    characterName: raw.characterName ?? '',
+    gridWidth: raw.gridWidth ?? 32,
+    gridDepth: raw.gridDepth ?? 32,
+    voxels: Array.isArray(raw.voxels) ? raw.voxels : [],
+    parts: Array.isArray(raw.parts) ? raw.parts : [],
+    poses: raw.poses && typeof raw.poses === 'object' ? raw.poses : {},
+    animations: raw.animations,
+  };
 }
 
 // ── Undo snapshot ──

--- a/tools/apps/echidna/src/store/types.ts
+++ b/tools/apps/echidna/src/store/types.ts
@@ -72,7 +72,7 @@ export interface ClipboardEntry {
 
 // ── File format (v3) ──
 
-export const ECHIDNA_FILE_VERSION = 3;
+export const ECHIDNA_FILE_VERSION = 3 as const;
 
 export interface EchidnaFile {
   version: number;
@@ -126,7 +126,9 @@ export function migrateEchidnaFile(raw: any): EchidnaFile {
     voxels: Array.isArray(raw.voxels) ? raw.voxels : [],
     parts: Array.isArray(raw.parts) ? raw.parts : [],
     poses: raw.poses && typeof raw.poses === 'object' ? raw.poses : {},
-    animations: raw.animations,
+    animations: raw.animations && typeof raw.animations === 'object' && !Array.isArray(raw.animations)
+      ? raw.animations
+      : undefined,
   };
 }
 

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -13,6 +13,7 @@ import type {
   ClipboardEntry,
   PlaybackMode,
 } from './types.js';
+import { slugifyCharacterId, ECHIDNA_FILE_VERSION } from './types.js';
 import { voxelKey, parseKey, floodFill3D, extrudeLayer } from '../lib/voxelUtils.js';
 
 function makeSnapshot(voxels: Map<VoxelKey, Voxel>, parts: BodyPart[]): Snapshot {
@@ -740,7 +741,8 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       voxelArr.push({ x, y, z, r: vox.color[0], g: vox.color[1], b: vox.color[2], a: vox.color[3] });
     }
     return {
-      version: 2,
+      version: ECHIDNA_FILE_VERSION,
+      id: slugifyCharacterId(s.characterName),
       characterName: s.characterName,
       gridWidth: s.gridWidth,
       gridDepth: s.gridDepth,

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -13,7 +13,7 @@ import type {
   ClipboardEntry,
   PlaybackMode,
 } from './types.js';
-import { slugifyCharacterId, ECHIDNA_FILE_VERSION } from './types.js';
+import { migrateEchidnaFile, slugifyCharacterId, ECHIDNA_FILE_VERSION } from './types.js';
 import { voxelKey, parseKey, floodFill3D, extrudeLayer } from '../lib/voxelUtils.js';
 
 function makeSnapshot(voxels: Map<VoxelKey, Voxel>, parts: BodyPart[]): Snapshot {
@@ -112,6 +112,8 @@ export interface CharacterStoreState {
   playbackSpeed: number;
 
   // File
+  characterId: string;
+  projectRootHandle: FileSystemDirectoryHandle | null;
   currentFilename: string | null;
 
   // Undo / redo
@@ -199,8 +201,10 @@ export interface CharacterStoreState {
   newCharacter: (gridSize?: number) => void;
   resizeGrid: (size: number) => void;
   saveProject: () => EchidnaFile;
-  loadProject: (data: EchidnaFile) => void;
+  loadProject: (raw: any) => void;
   setCurrentFilename: (name: string | null) => void;
+  setProjectRootHandle: (h: FileSystemDirectoryHandle | null) => void;
+  ensureCharacterId: () => string;
 
   // Actions – new tools and clipboard
   setXrayMode: (v: boolean) => void;
@@ -251,6 +255,8 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
   isPlaying: false,
   playbackSpeed: 1,
 
+  characterId: '',
+  projectRootHandle: null,
   currentFilename: null,
 
   undoStack: [],
@@ -688,10 +694,19 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   // ── File actions ──
   setCurrentFilename: (name) => set({ currentFilename: name }),
+  setProjectRootHandle: (h) => set({ projectRootHandle: h }),
+  ensureCharacterId: () => {
+    const s = get();
+    if (s.characterId.length > 0) return s.characterId;
+    const id = slugifyCharacterId(s.characterName);
+    set({ characterId: id });
+    return id;
+  },
 
   newCharacter: (gridSize?: number) => {
     const size = gridSize ?? 32;
     set({
+      characterId: '',
       voxels: new Map(),
       gridWidth: size,
       gridDepth: size,
@@ -735,6 +750,10 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   saveProject: () => {
     const s = get();
+    const id = s.characterId || slugifyCharacterId(s.characterName);
+    if (!s.characterId) {
+      set({ characterId: id });
+    }
     const voxelArr: EchidnaFile['voxels'] = [];
     for (const [key, vox] of s.voxels) {
       const [x, y, z] = parseKey(key);
@@ -742,7 +761,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     }
     return {
       version: ECHIDNA_FILE_VERSION,
-      id: slugifyCharacterId(s.characterName),
+      id,
       characterName: s.characterName,
       gridWidth: s.gridWidth,
       gridDepth: s.gridDepth,
@@ -753,7 +772,12 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     };
   },
 
-  loadProject: (data) => {
+  loadProject: (raw) => {
+    const data = migrateEchidnaFile(raw);
+    const wasLegacy = (raw?.version ?? 0) < ECHIDNA_FILE_VERSION;
+    if (wasLegacy) {
+      console.warn(`[echidna] Loaded legacy v${raw?.version} file; migrated to v${ECHIDNA_FILE_VERSION}`);
+    }
     const voxels = new Map<VoxelKey, Voxel>();
     for (const v of data.voxels) {
       voxels.set(voxelKey(v.x, v.y, v.z), { color: [v.r, v.g, v.b, v.a] });
@@ -778,6 +802,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       }
     }
     set({
+      characterId: data.id,
       voxels,
       gridWidth: data.gridWidth,
       gridDepth: data.gridDepth,

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -749,11 +749,8 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
   },
 
   saveProject: () => {
+    const id = get().ensureCharacterId();
     const s = get();
-    const id = s.characterId || slugifyCharacterId(s.characterName);
-    if (!s.characterId) {
-      set({ characterId: id });
-    }
     const voxelArr: EchidnaFile['voxels'] = [];
     for (const [key, vox] of s.voxels) {
       const [x, y, z] = parseKey(key);
@@ -776,7 +773,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     const data = migrateEchidnaFile(raw);
     const wasLegacy = (raw?.version ?? 0) < ECHIDNA_FILE_VERSION;
     if (wasLegacy) {
-      console.warn(`[echidna] Loaded legacy v${raw?.version} file; migrated to v${ECHIDNA_FILE_VERSION}`);
+      console.warn(`[echidna] Loaded legacy v${raw?.version} file "${data.characterName}" (id: ${data.id}); migrated to v${ECHIDNA_FILE_VERSION}`);
     }
     const voxels = new Map<VoxelKey, Voxel>();
     for (const v of data.voxels) {

--- a/tools/apps/echidna/vite.config.ts
+++ b/tools/apps/echidna/vite.config.ts
@@ -11,4 +11,9 @@ export default defineConfig({
   server: {
     port: 5179,
   },
-});
+  test: {
+    resolve: {
+      conditions: ['source'],
+    },
+  },
+} as any);

--- a/tools/packages/project-root/package.json
+++ b/tools/packages/project-root/package.json
@@ -8,8 +8,8 @@
   "exports": {
     ".": {
       "source": "./src/index.ts",
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/src/index.js",
+      "types": "./dist/src/index.d.ts"
     }
   },
   "scripts": {

--- a/tools/pnpm-lock.yaml
+++ b/tools/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       '@gseurat/engine-client':
         specifier: workspace:*
         version: link:../../packages/engine-client
+      '@gseurat/project-root':
+        specifier: workspace:*
+        version: link:../../packages/project-root
       '@gseurat/test-harness':
         specifier: workspace:*
         version: link:../../packages/test-harness


### PR DESCRIPTION
## Summary

**Scope: Tasks 9–14 of Phase 0.0 Foundation — Group 2 (Echidna FSAPI integration).** First consumer of \`@gseurat/project-root\`. Echidna gains the ability to:

1. **Pick a project root directory** via FSAPI \`showDirectoryPicker\` (persisted to IndexedDB)
2. **Save \`.echidna\` files** to \`tools_data/echidna_saves/\` instead of browser downloads
3. **Export PLY + manifest** to \`assets/characters/{id}/\` instead of separate downloads
4. **Restore the project root on startup** so the user only picks once per project
5. **Track a persistent \`characterId\`** that's slugified on first save and immutable thereafter (renaming the character does NOT relocate files)

The legacy download/upload menu entries remain intact as a safety net.

Full plan: \`docs/superpowers/plans/2026-04-10-phase-0-foundation.md\`

## Commits (9 total after rebase)

| # | SHA | Message |
|---|---|---|
| 1 | \`463ea4c\` | feat: persistent id field + slugify + migration to v3 |
| 2 | \`3d2b9af\` | fix: guard migrateEchidnaFile animations field + as const version |
| 3 | \`117757b\` | feat: persistent characterId + projectRootHandle state |
| 4 | \`6b1f1db\` | refactor: dedupe id minting + add name to migration warning |
| 5 | \`977075a\` | build: add @gseurat/project-root workspace dependency |
| 6 | \`74d5df3\` | feat: projectFs adapter for project-root package |
| 7 | \`ad0032d\` | feat: FSAPI menu actions for project root + bootstrap restore |
| 8 | \`06230a2\` | fix: permission check on export restore + bootstrap race guard |
| 9 | \`389c576\` | build: update pnpm-lock for @gseurat/project-root workspace link |

## Issues caught by review (highlights)

| Task | Issue caught + fixed |
|---|---|
| 9 | \`migrateEchidnaFile\` passed \`animations\` through unguarded; corrupt files would crash downstream |
| 9 | \`ECHIDNA_FILE_VERSION\` widened to \`number\` instead of literal \`3\` |
| 10 | \`saveProject\` duplicated id-minting logic instead of calling \`ensureCharacterId()\` |
| 12 | \`@gseurat/project-root\` exports map referenced \`./dist/index.js\` but tsc with \`rootDir: "."\` actually emits to \`./dist/src/index.js\` — broke vitest resolution |
| 12 | Echidna's vitest 4 needed \`test.resolve.conditions: ['source']\` because vitest 4 bundles its own vite@7 that doesn't inherit top-level conditions from vite@5 |
| 13 | \`handleExportCharacterToProject\` IDB-restore branch skipped \`ensureHandlePermission\`, would throw \`NotAllowedError\` on first export after page reload |
| 13 | Bootstrap effect could overwrite a user-picked project root if IDB read finishes after the user already picked one |

## Tests

- **65 tests passing** in @gseurat/echidna across 9 test files
- New: 9 echidnaFile tests (slugify + migrate edge cases) + 6 projectFs tests (path builders)
- Pre-existing: 50 (voxel utils, PLY/OBJ/VOX import/export, easing, manifest export)
- All unit-tested with vitest. Async FSAPI wrappers covered by integration in Task 13's MenuBar wiring (manual browser smoke test deferred to Group 6 end-to-end)

## What's NOT in this PR

- No Méliès / Bricklayer / Bridge / Engine changes
- Async FSAPI write/read wrappers (\`saveEchidnaProject\`, \`loadEchidnaProject\`, \`exportCharacterToProject\`) have no automated browser tests yet — they'll be exercised by Task 31's end-to-end smoke
- Echidna's legacy download/upload menu entries are preserved unchanged

## Review focus

- [ ] **\`EchidnaFile.id\` persistence semantics** — locked on first save, not affected by character rename. Is that the right policy?
- [ ] **\`projectFs.ts\` adapter pattern** — does this thin wrapper layer over \`@gseurat/project-root\` look right, or should the editor call the shared package directly?
- [ ] **\`@gseurat/project-root\` exports path fix** (\`dist/src/index.js\`) — sustainable, or should we restructure with \`rootDir: "src"\` so emitted layout is \`dist/index.js\`?
- [ ] **MenuBar handler patterns** — three new handlers, all using \`useCharacterStore.getState()\` imperatively. Consistent with existing Echidna style?
- [ ] **Bootstrap race guard** — \`if (handle && !useCharacterStore.getState().projectRootHandle)\` — sufficient, or should there be a flag to indicate "user has interacted with this session"?

## Test plan for reviewers

- [ ] \`pnpm --filter @gseurat/echidna test --run\` — 65 green
- [ ] \`pnpm --filter @gseurat/echidna exec tsc --noEmit\` — clean
- [ ] \`pnpm --filter @gseurat/echidna build\` — succeeds
- [ ] Read \`projectFs.ts\` and confirm it stays a thin adapter
- [ ] Spot-check the MenuBar diff — three new handlers, three new menu items, legacy entries untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)