### PR TITLE
feat(bricklayer): Phase 0.0 schema v2 + asset registry + path validator [Tasks 17-23]

### DIFF
--- a/tools/apps/bricklayer/package.json
+++ b/tools/apps/bricklayer/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@gseurat/asset-types": "workspace:*",
@@ -31,6 +32,7 @@
     "@types/three": "^0.170.0",
     "@vitejs/plugin-react": "^4.2.0",
     "typescript": "^5.4.0",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/tools/apps/bricklayer/package.json
+++ b/tools/apps/bricklayer/package.json
@@ -12,6 +12,7 @@
     "@gseurat/asset-types": "workspace:*",
     "@gseurat/engine-client": "workspace:*",
     "@gseurat/test-harness": "workspace:*",
+    "@gseurat/project-root": "workspace:*",
     "@gseurat/simulation-wasm": "workspace:*",
     "@gseurat/vfx-utils": "workspace:*",
     "@gseurat/ui-kit": "workspace:*",

--- a/tools/apps/bricklayer/src/lib/__tests__/migrateBricklayerFile.test.ts
+++ b/tools/apps/bricklayer/src/lib/__tests__/migrateBricklayerFile.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { migrateBricklayerFile } from '../migrateBricklayerFile';
+
+describe('migrateBricklayerFile', () => {
+  it('upgrades v1 with no assets to v2 with empty registry', () => {
+    const v1 = {
+      version: 1,
+      gridWidth: 32,
+      gridDepth: 32,
+      voxels: [],
+      collision: [],
+      scene: {},
+    };
+    const v2 = migrateBricklayerFile(v1);
+    expect(v2.version).toBe(2);
+    expect(v2.asset_registry.version).toBe(1);
+    expect(Object.keys(v2.asset_registry.characters)).toEqual([]);
+    expect(Object.keys(v2.asset_registry.maps)).toEqual([]);
+  });
+
+  it('synthesizes registry entries from v1 flat assets[]', () => {
+    const v1 = {
+      version: 1,
+      gridWidth: 32,
+      gridDepth: 32,
+      voxels: [],
+      collision: [],
+      assets: [
+        { id: 'house', name: 'House', type: 'ply', path: 'assets/maps/house.ply' },
+        { id: 'sky', name: 'Sky', type: 'texture', path: 'assets/textures/sky.png' },
+        { id: 'beep', name: 'Beep', type: 'audio', path: 'assets/audio/beep.wav' },
+      ],
+      scene: {},
+    };
+    const v2 = migrateBricklayerFile(v1);
+    expect(v2.asset_registry.maps.house?.file).toBe('assets/maps/house.ply');
+    expect(v2.asset_registry.textures.sky?.file).toBe('assets/textures/sky.png');
+    expect(v2.asset_registry.audio.beep?.file).toBe('assets/audio/beep.wav');
+  });
+
+  it('synthesizes character entries when ply path lives under assets/characters/', () => {
+    const v1 = {
+      version: 1,
+      gridWidth: 32, gridDepth: 32, voxels: [], collision: [],
+      assets: [
+        { id: 'walker', name: 'Walker', type: 'ply', path: 'assets/characters/walker/walker.ply' },
+      ],
+      scene: {},
+    };
+    const v2 = migrateBricklayerFile(v1);
+    expect(v2.asset_registry.characters.walker?.ply).toBe('assets/characters/walker/walker.ply');
+    expect(v2.asset_registry.characters.walker?.manifest).toBe('assets/characters/walker/walker.manifest.json');
+    // Maps should NOT contain it
+    expect(v2.asset_registry.maps.walker).toBeUndefined();
+  });
+
+  it('skips assets with non-asset paths', () => {
+    const v1 = {
+      version: 1,
+      gridWidth: 32, gridDepth: 32, voxels: [], collision: [],
+      assets: [
+        { id: 'evil', name: 'Evil', type: 'ply', path: '/abs/evil.ply' },           // absolute
+        { id: 'bare', name: 'Bare', type: 'ply', path: 'walker.ply' },              // bare filename
+      ],
+      scene: {},
+    };
+    const v2 = migrateBricklayerFile(v1);
+    expect(Object.keys(v2.asset_registry.maps)).toEqual([]);
+    expect(Object.keys(v2.asset_registry.characters)).toEqual([]);
+  });
+
+  it('passes v2 through unchanged', () => {
+    const v2 = {
+      version: 2,
+      asset_registry: {
+        version: 1,
+        characters: {},
+        vfx: {},
+        textures: {},
+        audio: {},
+        maps: {},
+      },
+      gridWidth: 32,
+      gridDepth: 32,
+      voxels: [],
+      collision: [],
+      scene: {},
+    };
+    const result = migrateBricklayerFile(v2);
+    expect(result.version).toBe(2);
+    expect(result.asset_registry).toEqual(v2.asset_registry);
+  });
+
+  it('throws on unknown version', () => {
+    expect(() => migrateBricklayerFile({ version: 99, scene: {} })).toThrow(/unknown.*version|version 99/i);
+  });
+
+  it('throws on non-object input', () => {
+    expect(() => migrateBricklayerFile(null)).toThrow();
+    expect(() => migrateBricklayerFile(42)).toThrow();
+  });
+
+  it('preserves voxels, collision, and scene through migration', () => {
+    const v1 = {
+      version: 1,
+      gridWidth: 16, gridDepth: 24,
+      voxels: [{ x: 1, y: 2, z: 3, r: 100, g: 100, b: 100, a: 255 }],
+      collision: ['some-string'],
+      scene: { ambientColor: [0.5, 0.5, 0.5, 1.0] },
+    };
+    const v2 = migrateBricklayerFile(v1);
+    expect(v2.gridWidth).toBe(16);
+    expect(v2.gridDepth).toBe(24);
+    expect(v2.voxels).toHaveLength(1);
+    expect(v2.collision).toEqual(['some-string']);
+    expect(v2.scene).toEqual({ ambientColor: [0.5, 0.5, 0.5, 1.0] });
+  });
+});

--- a/tools/apps/bricklayer/src/lib/__tests__/sceneExport.test.ts
+++ b/tools/apps/bricklayer/src/lib/__tests__/sceneExport.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { validateScenePaths, type ScenePathError } from '../sceneExport';
+import { createEmptyRegistry, registerCharacter } from '@gseurat/project-root';
+
+describe('validateScenePaths', () => {
+  it('passes a clean scene with relative asset paths', () => {
+    const reg = createEmptyRegistry();
+    const scene = {
+      game_objects: [{ id: 'a', ply_file: 'assets/maps/house.ply' }],
+      vfx_instances: [{ vfx_file: 'assets/vfx/presets/explosion.vfx.json' }],
+      gaussian_splat: { ply_file: 'assets/maps/town.ply' },
+    } as any;
+    const errs = validateScenePaths(scene, reg);
+    expect(errs).toEqual([]);
+  });
+
+  it('resolves #id refs against the registry', () => {
+    let reg = createEmptyRegistry();
+    reg = registerCharacter(reg, 'walker', {
+      ply: 'assets/characters/walker/walker.ply',
+      manifest: 'assets/characters/walker/walker.manifest.json',
+    });
+    const scene = {
+      game_objects: [{
+        id: 'a',
+        components: { CharacterModel: { manifest: '#walker' } },
+      }],
+    } as any;
+    const errs = validateScenePaths(scene, reg);
+    expect(errs).toEqual([]);
+  });
+
+  it('rejects bare filenames in ply_file', () => {
+    const scene = { game_objects: [{ id: 'a', ply_file: 'walker.ply' }] } as any;
+    const errs = validateScenePaths(scene, createEmptyRegistry());
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs[0].field).toContain('ply_file');
+    expect(errs[0].message).toMatch(/bare filename/i);
+  });
+
+  it('rejects absolute paths', () => {
+    const scene = { game_objects: [{ id: 'a', ply_file: '/Users/foo/walker.ply' }] } as any;
+    const errs = validateScenePaths(scene, createEmptyRegistry());
+    expect(errs[0].message).toMatch(/absolute/i);
+  });
+
+  it('rejects unknown #id in CharacterModel.manifest', () => {
+    const scene = {
+      game_objects: [{ id: 'a', components: { CharacterModel: { manifest: '#nope' } } }],
+    } as any;
+    const errs = validateScenePaths(scene, createEmptyRegistry());
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs[0].message).toMatch(/unknown id/i);
+  });
+
+  it('validates vfx_instances[i].vfx_file', () => {
+    const scene = {
+      vfx_instances: [{ vfx_file: 'walker.vfx.json' }],
+    } as any;
+    const errs = validateScenePaths(scene, createEmptyRegistry());
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs[0].field).toContain('vfx_instances[0].vfx_file');
+  });
+
+  it('validates gaussian_splat.ply_file', () => {
+    const scene = { gaussian_splat: { ply_file: 'town.ply' } } as any;
+    const errs = validateScenePaths(scene, createEmptyRegistry());
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs[0].field).toBe('gaussian_splat.ply_file');
+  });
+
+  it('validates gaussian_splat.background_image', () => {
+    const scene = { gaussian_splat: { background_image: 'sky.png' } } as any;
+    const errs = validateScenePaths(scene, createEmptyRegistry());
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs[0].field).toBe('gaussian_splat.background_image');
+  });
+
+  it('validates background_layers[i].texture', () => {
+    const scene = {
+      background_layers: [{ texture: 'sky.png' }, { texture: 'assets/textures/ground.png' }],
+    } as any;
+    const errs = validateScenePaths(scene, createEmptyRegistry());
+    expect(errs.length).toBe(1);
+    expect(errs[0].field).toBe('background_layers[0].texture');
+  });
+
+  it('skips empty/missing optional fields', () => {
+    const scene = {
+      game_objects: [{ id: 'a' }, { id: 'b', ply_file: '' }],
+      vfx_instances: [],
+    } as any;
+    const errs = validateScenePaths(scene, createEmptyRegistry());
+    expect(errs).toEqual([]);
+  });
+
+  it('reports multiple errors in a single scene', () => {
+    const scene = {
+      game_objects: [
+        { id: 'a', ply_file: 'walker.ply' },
+        { id: 'b', ply_file: '/abs/foo.ply' },
+      ],
+      vfx_instances: [{ vfx_file: 'bare.vfx.json' }],
+    } as any;
+    const errs = validateScenePaths(scene, createEmptyRegistry());
+    expect(errs.length).toBe(3);
+  });
+});

--- a/tools/apps/bricklayer/src/lib/migrateBricklayerFile.ts
+++ b/tools/apps/bricklayer/src/lib/migrateBricklayerFile.ts
@@ -1,0 +1,81 @@
+import {
+  createEmptyRegistry,
+  registerCharacter,
+  registerTexture,
+  registerAudio,
+  registerMap,
+  type AssetRegistry,
+} from '@gseurat/project-root';
+import type { BricklayerFile } from '../store/types.js';
+import { BRICKLAYER_FILE_VERSION } from '../store/types.js';
+
+interface LegacyAssetEntry {
+  id: string;
+  name: string;
+  type: 'ply' | 'texture' | 'audio';
+  path: string;
+}
+
+function buildRegistryFromLegacyAssets(entries: LegacyAssetEntry[] | undefined): AssetRegistry {
+  let reg = createEmptyRegistry();
+  if (!Array.isArray(entries)) return reg;
+  for (const e of entries) {
+    if (!e || typeof e.path !== 'string' || !e.path.startsWith('assets/')) continue;
+    if (e.type === 'ply') {
+      // Heuristic: if under characters/, treat as a character; else as a map.
+      if (e.path.startsWith('assets/characters/')) {
+        reg = registerCharacter(reg, e.id, {
+          ply: e.path,
+          manifest: e.path.replace(/\.ply$/, '.manifest.json'),
+        });
+      } else {
+        reg = registerMap(reg, e.id, { file: e.path });
+      }
+    } else if (e.type === 'texture') {
+      reg = registerTexture(reg, e.id, { file: e.path });
+    } else if (e.type === 'audio') {
+      reg = registerAudio(reg, e.id, { file: e.path });
+    }
+  }
+  return reg;
+}
+
+/**
+ * Migrate a parsed BricklayerFile JSON object to the current schema version.
+ *
+ * - v1 → v2: synthesize an `asset_registry` from the legacy flat `assets[]`
+ *   array, preserving the original `assets` field for diagnostic purposes.
+ * - v2: pass through unchanged.
+ *
+ * Throws on non-object input or unknown version numbers.
+ */
+export function migrateBricklayerFile(raw: any): BricklayerFile {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('migrateBricklayerFile: expected an object');
+  }
+  const ver = raw.version ?? 1;
+  if (ver !== 1 && ver !== 2) {
+    throw new Error(`migrateBricklayerFile: unknown file version ${ver}`);
+  }
+  if (ver === 2) {
+    return raw as BricklayerFile;
+  }
+
+  console.warn('[bricklayer] Loaded v1 file; migrating to v2 in memory.');
+  const registry = buildRegistryFromLegacyAssets(raw.assets);
+
+  return {
+    version: BRICKLAYER_FILE_VERSION,
+    asset_registry: registry,
+    gridWidth: raw.gridWidth ?? 128,
+    gridDepth: raw.gridDepth ?? 96,
+    voxels: raw.voxels ?? [],
+    collision: raw.collision ?? [],
+    collisionGridData: raw.collisionGridData,
+    nav_zone_names: raw.nav_zone_names,
+    color_palettes: raw.color_palettes,
+    terrains: raw.terrains,
+    assets: raw.assets,
+    scene: raw.scene ?? {},
+  };
+}

--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -3,6 +3,13 @@ import { useSceneStore, BUILTIN_SCHEMAS } from '../store/useSceneStore.js';
 import { exportSceneJson } from './sceneExport.js';
 import { exportPly } from './plyExport.js';
 import type { BricklayerFile, ComponentSchema } from '../store/types.js';
+import {
+  PROJECT_LAYOUT,
+  toAssetPath,
+  ensureSubdir,
+  writeFileAtPath,
+  readFileAtPath,
+} from '@gseurat/project-root';
 
 /**
  * Check if the File System Access API is available.
@@ -24,65 +31,84 @@ export async function openProjectDirectory(): Promise<FileSystemDirectoryHandle 
   }
 }
 
+/* ----- path builders ----- */
+
+/**
+ * Slugify a name into a stable filename fragment.
+ * Same rules as echidna/melies — lowercase, trim, whitespace → underscore,
+ * strip [^a-z0-9_-], fallback if empty.
+ */
+function slugify(name: string, fallback = 'project'): string {
+  const cleaned = name.toLowerCase().trim().replace(/\s+/g, '_').replace(/[^a-z0-9_-]/g, '');
+  return cleaned.length > 0 ? cleaned : fallback;
+}
+
+/** Returns the project-relative path for the Bricklayer save file. */
+export function bricklayerSavePath(): string {
+  return `${PROJECT_LAYOUT.toolsData.bricklayer}/scene.bricklayer`;
+}
+
+/** Returns the project-relative path for the engine scene JSON. */
+export function engineScenePath(projectName: string): string {
+  return toAssetPath('scenes', `${slugify(projectName)}.json`);
+}
+
+/** Returns the project-relative path for the terrain PLY. */
+export function terrainPlyPath(projectName: string): string {
+  return toAssetPath('maps', `${slugify(projectName)}.ply`);
+}
+
+/** Returns the project-relative path for a VFX preset file. */
+export function vfxPresetPath(presetName: string): string {
+  return `${PROJECT_LAYOUT.assets.vfxPresets}/${slugify(presetName, 'preset')}.vfx.json`;
+}
+
 /**
  * Save the current project to the project directory.
+ *
+ * New structure (Phase 0):
+ * <project-root>/
+ * ├── tools_data/bricklayer/scene.bricklayer   # Bricklayer save file
+ * ├── assets/scenes/{slug}.json                # engine scene JSON
+ * ├── assets/maps/{slug}.ply                   # terrain PLY
+ * ├── assets/vfx/presets/{slug}.vfx.json       # VFX instance presets
+ * └── assets/**                                # imported asset blobs
  */
 export async function saveProject(handle: FileSystemDirectoryHandle): Promise<void> {
   const store = useSceneStore.getState();
+  const projectName = store.projectName || 'project';
+
+  // 1. Bricklayer save file under tools_data/bricklayer/
   const data = store.saveProject();
   const json = JSON.stringify(data, null, 2);
+  await ensureSubdir(handle, PROJECT_LAYOUT.toolsData.bricklayer);
+  await writeFileAtPath(handle, bricklayerSavePath(), json);
 
-  // Write bricklayer project file
-  const fileHandle = await handle.getFileHandle('scene.bricklayer', { create: true });
-  const writable = await fileHandle.createWritable();
-  await writable.write(json);
-  await writable.close();
-
-  // Write engine scene.json
+  // 2. Engine scene JSON under assets/scenes/
   const sceneJson = JSON.stringify(exportSceneJson(store), null, 2);
-  const sceneHandle = await handle.getFileHandle(`${store.projectName || 'scene'}.json`, { create: true });
-  const sw = await sceneHandle.createWritable();
-  await sw.write(sceneJson);
-  await sw.close();
+  await ensureSubdir(handle, PROJECT_LAYOUT.assets.scenes);
+  await writeFileAtPath(handle, engineScenePath(projectName), sceneJson);
 
-  // Write terrain PLY to assets/maps/
+  // 3. Terrain PLY under assets/maps/
   if (store.voxels.size > 0) {
-    const assetsDir = await handle.getDirectoryHandle('assets', { create: true });
-    const mapsDir = await assetsDir.getDirectoryHandle('maps', { create: true });
     const plyBlob = exportPly(store.voxels, store.gridWidth, store.gridDepth);
-    const plyHandle = await mapsDir.getFileHandle(`${store.projectName || 'map'}.ply`, { create: true });
-    const pw = await plyHandle.createWritable();
-    await pw.write(plyBlob);
-    await pw.close();
+    await ensureSubdir(handle, PROJECT_LAYOUT.assets.maps);
+    await writeFileAtPath(handle, terrainPlyPath(projectName), plyBlob);
   }
 
-  // Write asset blobs to assets/ directory
+  // 4. Asset blobs from assetBlobs Map (paths already under assets/)
   if (store.assetBlobs.size > 0) {
-    const assetsDir = await handle.getDirectoryHandle('assets', { create: true });
     for (const [path, blob] of store.assetBlobs) {
-      const name = path.startsWith('assets/') ? path.slice(7) : path;
-      // Create subdirectories if needed (e.g., "props/house.ply")
-      const parts = name.split('/');
-      let dir = assetsDir;
-      for (let i = 0; i < parts.length - 1; i++) {
-        dir = await dir.getDirectoryHandle(parts[i], { create: true });
-      }
-      const assetHandle = await dir.getFileHandle(parts[parts.length - 1], { create: true });
-      const w = await assetHandle.createWritable();
-      await w.write(blob);
-      await w.close();
+      // Only write paths that are under assets/ for safety
+      if (!path.startsWith('assets/')) continue;
+      await writeFileAtPath(handle, path, blob);
     }
   }
 
-  // Write VFX instance files to assets/vfx/ with edited names
+  // 5. VFX instance preset files under assets/vfx/presets/
   if (store.vfxInstances.length > 0) {
-    const assetsDir = await handle.getDirectoryHandle('assets', { create: true });
-    const vfxDir = await assetsDir.getDirectoryHandle('vfx', { create: true });
-    const updatedBlobs = new Map(store.assetBlobs);
+    await ensureSubdir(handle, PROJECT_LAYOUT.assets.vfxPresets);
     for (const inst of store.vfxInstances) {
-      // Use the Bricklayer-edited name for the filename
-      const fileName = `${inst.name.replace(/\s+/g, '_').toLowerCase()}.vfx.json`;
-      const newPath = `assets/vfx/${fileName}`;
       // Re-serialize the preset data (applies any name edits)
       const out: Record<string, unknown> = {
         name: inst.name,
@@ -91,14 +117,10 @@ export async function saveProject(handle: FileSystemDirectoryHandle): Promise<vo
       if (inst.vfx_preset.duration !== undefined) out.duration = inst.vfx_preset.duration;
       if (inst.vfx_preset.category) out.category = inst.vfx_preset.category;
       const vfxJson = JSON.stringify(out, null, 2);
-      const fh = await vfxDir.getFileHandle(fileName, { create: true });
-      const w = await fh.createWritable();
-      await w.write(vfxJson);
-      await w.close();
-      // Update vfx_file path if name changed
+      const newPath = vfxPresetPath(inst.name);
+      await writeFileAtPath(handle, newPath, vfxJson);
+      // Update vfx_file path if name/path changed
       if (inst.vfx_file !== newPath) {
-        // Remove old blob entry
-        updatedBlobs.delete(inst.vfx_file);
         store.updateVfxInstance(inst.id, { vfx_file: newPath });
       }
     }
@@ -107,12 +129,23 @@ export async function saveProject(handle: FileSystemDirectoryHandle): Promise<vo
 
 /**
  * Load a project from the project directory.
+ * Reads from tools_data/bricklayer/scene.bricklayer (new layout).
+ * Falls back to root-level scene.bricklayer for back-compat with old saves.
  */
 export async function loadProject(handle: FileSystemDirectoryHandle): Promise<boolean> {
   try {
-    const fileHandle = await handle.getFileHandle('scene.bricklayer');
-    const file = await fileHandle.getFile();
-    const text = await file.text();
+    let text: string;
+    try {
+      // New path: tools_data/bricklayer/scene.bricklayer
+      const blob = await readFileAtPath(handle, bricklayerSavePath());
+      text = await blob.text();
+    } catch {
+      // Legacy fallback: root-level scene.bricklayer
+      console.warn('[bricklayer] No scene.bricklayer at new path, falling back to legacy root');
+      const fh = await handle.getFileHandle('scene.bricklayer');
+      const legacy = await fh.getFile();
+      text = await legacy.text();
+    }
     const data = JSON.parse(text) as BricklayerFile;
     useSceneStore.getState().loadProject(data);
 

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -1,4 +1,98 @@
 import type { SceneStoreState } from '../store/useSceneStore.js';
+import { parseAssetRef, resolveRef, type AssetRegistry, type RefKind } from '@gseurat/project-root';
+
+export interface ScenePathError {
+  field: string;
+  value: string;
+  message: string;
+}
+
+function validateRef(
+  field: string,
+  value: unknown,
+  kind: RefKind,
+  reg: AssetRegistry,
+  out: ScenePathError[],
+): void {
+  // Skip empty/missing fields — they're not errors at validation time.
+  if (typeof value !== 'string' || value.length === 0) return;
+
+  try {
+    parseAssetRef(value);
+  } catch (e) {
+    out.push({ field, value, message: (e as Error).message });
+    return;
+  }
+  // For #id refs, additionally verify the id resolves in the registry
+  if (value.startsWith('#')) {
+    try {
+      resolveRef(value, kind, reg);
+    } catch (e) {
+      out.push({ field, value, message: (e as Error).message });
+    }
+  }
+}
+
+/**
+ * Walk an exported engine scene JSON and validate every asset path field.
+ * Returns a list of errors (empty if all valid). Does NOT throw — callers
+ * decide how to handle violations.
+ *
+ * Validates:
+ * - game_objects[i].ply_file (map)
+ * - game_objects[i].components.CharacterModel.manifest (character)
+ * - vfx_instances[i].vfx_file (vfx)
+ * - gaussian_splat.ply_file (map)
+ * - gaussian_splat.background_image (texture)
+ * - background_layers[i].texture (texture)
+ */
+export function validateScenePaths(scene: any, reg: AssetRegistry): ScenePathError[] {
+  const errs: ScenePathError[] = [];
+
+  if (Array.isArray(scene?.game_objects)) {
+    for (let i = 0; i < scene.game_objects.length; i++) {
+      const go = scene.game_objects[i];
+      validateRef(`game_objects[${i}].ply_file`, go?.ply_file, 'map', reg, errs);
+      const cm = go?.components?.CharacterModel;
+      if (cm) {
+        validateRef(
+          `game_objects[${i}].components.CharacterModel.manifest`,
+          cm.manifest,
+          'character',
+          reg,
+          errs,
+        );
+      }
+    }
+  }
+
+  if (Array.isArray(scene?.vfx_instances)) {
+    for (let i = 0; i < scene.vfx_instances.length; i++) {
+      const v = scene.vfx_instances[i];
+      validateRef(`vfx_instances[${i}].vfx_file`, v?.vfx_file, 'vfx', reg, errs);
+    }
+  }
+
+  if (scene?.gaussian_splat) {
+    validateRef('gaussian_splat.ply_file', scene.gaussian_splat.ply_file, 'map', reg, errs);
+    validateRef(
+      'gaussian_splat.background_image',
+      scene.gaussian_splat.background_image,
+      'texture',
+      reg,
+      errs,
+    );
+  }
+
+  if (Array.isArray(scene?.background_layers)) {
+    for (let i = 0; i < scene.background_layers.length; i++) {
+      const b = scene.background_layers[i];
+      validateRef(`background_layers[${i}].texture`, b?.texture, 'texture', reg, errs);
+    }
+  }
+
+  return errs;
+}
 
 export function exportSceneJson(state: SceneStoreState): object {
   const scene: Record<string, unknown> = {
@@ -296,6 +390,15 @@ export function exportSceneJson(state: SceneStoreState): object {
     }
 
     scene.camera_zones = cameraZones;
+  }
+
+  // Phase 0.0 migration window: validate but don't throw.
+  const pathErrors = validateScenePaths(scene, state.asset_registry);
+  if (pathErrors.length > 0) {
+    console.warn(`[bricklayer] Scene export has ${pathErrors.length} path issue(s):`);
+    for (const e of pathErrors) {
+      console.warn(`  ${e.field}: ${e.value} — ${e.message}`);
+    }
   }
 
   return scene;

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -1,3 +1,5 @@
+import type { AssetRegistry } from '@gseurat/project-root';
+
 // ── Voxel ──
 
 export interface Voxel {
@@ -429,8 +431,11 @@ export interface Snapshot {
   collisionGridData: CollisionGridData | null;
 }
 
+export const BRICKLAYER_FILE_VERSION = 2 as const;
+
 export interface BricklayerFile {
-  version: number;
+  version: 2;
+  asset_registry: AssetRegistry;
   gridWidth: number;
   gridDepth: number;
   voxels: { x: number; y: number; z: number; r: number; g: number; b: number; a: number }[];

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -1,4 +1,7 @@
 import { create } from 'zustand';
+import { migrateBricklayerFile } from '../lib/migrateBricklayerFile.js';
+import { createEmptyRegistry, type AssetRegistry } from '@gseurat/project-root';
+import { BRICKLAYER_FILE_VERSION } from './types.js';
 import type {
   Voxel,
   VoxelKey,
@@ -184,6 +187,7 @@ export interface SceneStoreState {
   terrains: TerrainEntry[];
   currentTerrainId: string;
   assets: AssetEntry[];
+  asset_registry: AssetRegistry;
   assetBlobs: Map<string, Blob>;
   activeNode: NavigationNode | null;
 
@@ -401,7 +405,7 @@ export interface SceneStoreState {
   newScene: (width: number, depth: number) => void;
   importImage: (imageData: ImageData, mode: 'flat' | 'luminance' | 'depth', maxHeight: number, depthMap?: Float32Array, budget?: number) => void;
   saveProject: () => BricklayerFile;
-  loadProject: (data: BricklayerFile) => void;
+  loadProject: (data: any) => void;
 }
 
 function mirrorPositions(
@@ -464,6 +468,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   terrains: [],
   currentTerrainId: '',
   assets: [],
+  asset_registry: createEmptyRegistry(),
   assetBlobs: new Map(),
   activeNode: null,
   isDirty: false,
@@ -1303,7 +1308,8 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       voxelArr.push({ x, y, z, r: vox.color[0], g: vox.color[1], b: vox.color[2], a: vox.color[3] });
     }
     return {
-      version: 1,
+      version: BRICKLAYER_FILE_VERSION,
+      asset_registry: s.asset_registry,
       gridWidth: s.gridWidth,
       gridDepth: s.gridDepth,
       voxels: voxelArr,
@@ -1340,7 +1346,8 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     };
   },
 
-  loadProject: (data) => {
+  loadProject: (raw) => {
+    const data = migrateBricklayerFile(raw);
     const voxels = new Map<VoxelKey, Voxel>();
     for (const v of data.voxels) {
       voxels.set(voxelKey(v.x, v.y, v.z), { color: [v.r, v.g, v.b, v.a] });
@@ -1376,6 +1383,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       activePaletteIndex: 0,
       terrains: data.terrains ?? [],
       assets: data.assets ?? [],
+      asset_registry: data.asset_registry,
       ambientColor: data.scene.ambientColor,
       godRaysIntensity: data.scene.godRaysIntensity ?? 0,
       staticLights: migratedLights,

--- a/tools/apps/bricklayer/vite.config.ts
+++ b/tools/apps/bricklayer/vite.config.ts
@@ -11,4 +11,9 @@ export default defineConfig({
   server: {
     port: 5180,
   },
-});
+  test: {
+    resolve: {
+      conditions: ['source'],
+    },
+  },
+} as any);

--- a/tools/pnpm-lock.yaml
+++ b/tools/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@gseurat/engine-client':
         specifier: workspace:*
         version: link:../../packages/engine-client
+      '@gseurat/project-root':
+        specifier: workspace:*
+        version: link:../../packages/project-root
       '@gseurat/simulation-wasm':
         specifier: workspace:*
         version: link:../../packages/simulation-wasm

--- a/tools/pnpm-lock.yaml
+++ b/tools/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       vite:
         specifier: ^5.4.0
         version: 5.4.21(@types/node@20.19.35)
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@20.19.35)(tsx@4.21.0)
 
   apps/bridge:
     dependencies:


### PR DESCRIPTION
## Summary

**Scope: Tasks 17–23 of Phase 0.0 Foundation — Group 4 (Bricklayer schema v2 + asset registry).** This is the **TS-only pause-point** of the whole plan: after this lands, all three editors (Echidna / Méliès / Bricklayer) save under the unified project layout. Groups 5–6 (Bridge + Engine path resolution) can be scheduled independently.

### What changes

1. **\`BricklayerFile\` schema v2** with top-level \`asset_registry: AssetRegistry\` field
2. **\`migrateBricklayerFile\`** synthesizes the registry from legacy flat \`assets[]\` array (heuristic: PLY paths under \`assets/characters/*\` → character entries with synthesized manifest paths; other PLY paths → maps)
3. **\`useSceneStore\`** routes \`loadProject\` through migration and emits v2 on save
4. **\`projectIO.ts\`** writes via \`@gseurat/project-root\` helpers to canonical paths:
   - \`tools_data/bricklayer/scene.bricklayer\` (was: root)
   - \`assets/scenes/{slug}.json\` (was: root)
   - \`assets/maps/{slug}.ply\` (unchanged)
   - \`assets/vfx/presets/{slug}.vfx.json\` (was: \`assets/vfx/{name}.vfx.json\`)
   - Asset blobs under their stored \`assets/...\` paths (unchanged)
5. **\`validateScenePaths\`** in \`sceneExport.ts\` — walks the engine-format scene JSON and reports asset reference violations (bare filenames, absolute paths, unknown \`#id\` lookups). Called by \`exportSceneJson\` to log warnings; does NOT throw during the migration window.
6. **Vitest infrastructure** added to Bricklayer (first tests in this package).

Full plan: \`docs/superpowers/plans/2026-04-10-phase-0-foundation.md\`

## Commits (4 total)

| # | SHA | Message |
|---|---|---|
| 1 | \`0c9ced2\` | build: add @gseurat/project-root workspace dependency |
| 2 | \`3c9ece9\` | feat: BricklayerFile v2 with asset_registry + migration (Tasks 18+19+20 combined) |
| 3 | \`3e047da\` | feat: save under new project layout via @gseurat/project-root |
| 4 | \`3d1645e\` | feat: scene export path validator + warning on issues |

## Why Tasks 18+19+20 are one commit

Schema bump, migration, and store wiring are tightly coupled — the type widening in Task 18 alone breaks compilation, so they must land together. The combined commit preserves the full scene-unpacking logic in \`loadProject\` (verified: 25+ scene fields still set, line count grew by only +2).

## Tests (19 total in @gseurat/bricklayer)

- **8 migration tests** — empty registry, character heuristic, map/texture/audio synthesis, invalid path rejection, v2 passthrough, version validation, voxel/scene preservation
- **11 sceneExport validator tests** — clean scene, ID resolution, bare filename rejection, absolute path rejection, unknown ID rejection, every validated field, multi-error reports

## What's NOT in this PR

- No Bridge or Engine changes (Group 5 + Group 6 will follow)
- No browser-integration testing — async FSAPI wrappers covered by the shared \`@gseurat/project-root\` helpers' own tests + manual smoke at Task 31
- ZIP fallback functions (\`saveProjectAsZip\`/\`loadProjectFromZip\`) intentionally left unchanged
- The \`exportSceneJson\` validator currently only **warns** — strict enforcement is deferred until the migration window closes

## Pause-point milestone

After this PR merges, the **TS-only milestone is complete**:
- All three editors (Echidna, Méliès, Bricklayer) save to the canonical layout
- The shared \`@gseurat/project-root\` package has 69 tests
- Each editor has its own test suite (Echidna 65, Méliès 10, Bricklayer 19)
- 163 TypeScript tests passing across the toolchain

The remaining work (Groups 5–6, Tasks 24–31) wires the bridge endpoint and engine \`set_project_root\` command so Staging can resolve relative paths under the user-picked project root. That work can be scheduled independently.

## Review focus

- [ ] **\`migrateBricklayerFile\` heuristic** — PLY paths under \`assets/characters/*\` get \`registerCharacter\` with synthesized manifest path. Aggressive enough? Too aggressive?
- [ ] **\`loadProject\` preservation** — verify the scene field unpacking is intact (the riskiest part of this PR; the spec reviewer confirmed all 25+ fields are still set)
- [ ] **Validator placement** — \`exportSceneJson\` warns but does not throw. Comfortable with that for the migration window?
- [ ] **\`vfxPresetPath\` slug change** — Bricklayer's VFX presets now go to \`assets/vfx/presets/\` (was \`assets/vfx/\`), matching Méliès. This means existing projects' VFX file references in the registry won't auto-update — they'll need to be saved through Bricklayer once to migrate.

## Test plan for reviewers

- [ ] \`pnpm --filter @gseurat/bricklayer test --run\` — 19 green
- [ ] \`pnpm --filter @gseurat/bricklayer exec tsc --noEmit\` — clean
- [ ] \`pnpm --filter @gseurat/bricklayer build\` — succeeds
- [ ] Spot-check the migration logic: does the character heuristic do what you'd expect?
- [ ] Read the validator test cases — every reachable asset reference field is exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)