### PR TITLE
docs: update READMEs for Phase 0.0 unified project layout

### DIFF
--- a/tools/apps/bricklayer/README.md
+++ b/tools/apps/bricklayer/README.md
@@ -197,6 +197,7 @@ Texture-based parallax backgrounds — texture, Z-depth, parallax factor, quad d
 - **Export Scene** — engine-format JSON
 - **Export PLY** — voxel terrain to PLY
 - **Open in Staging** — push current scene over the bridge
+- **Connect Bridge to Project Root…** — Phase 0.0: prompts for the project's absolute disk path and POSTs it to the bridge's `/api/project/root` endpoint, so the engine resolves relative asset paths under the same root the editors are saving to.
 
 ### Auto-Sync to Staging
 
@@ -204,12 +205,33 @@ Toggle in **View → Auto-Sync Staging**. Bricklayer fingerprints scene structur
 
 ## Project Format
 
-`BricklayerFile` JSON with versioning:
+`BricklayerFile` JSON v2 (Phase 0.0):
 
+- **`asset_registry`** — top-level field indexing characters / VFX / textures / audio / maps by stable IDs (`#walker` etc.). Synthesized from legacy v1 `assets[]` on first load.
 - Multi-terrain entries (voxel + collision per terrain)
-- Asset registry (PLY / texture / audio / VFX) with metadata
 - Unified scene data (objects, lights, portals, player, emitters, animations, VFX, cameras)
 - Component schemas for extensibility
+
+Asset references in entity fields use either the registry-ID form (`#walker`) or a project-relative path (`assets/characters/walker/walker.manifest.json`). Bare filenames and absolute paths are forbidden — `exportSceneJson` runs a `validateScenePaths` check and logs warnings for any violations during the migration window.
+
+### Project layout on disk (Phase 0.0)
+
+When saved to a directory, Bricklayer writes under the unified GSeurat project layout:
+
+```
+my_project/
+├── tools_data/
+│   └── bricklayer/
+│       └── scene.bricklayer       # editor state
+└── assets/
+    ├── scenes/{slug}.json         # engine-format scene JSON
+    ├── maps/{slug}.ply            # terrain Gaussian cloud
+    ├── vfx/presets/{name}.vfx.json  # VFX instance presets
+    ├── characters/{id}/...        # referenced via the asset_registry
+    └── textures/...
+```
+
+`loadProject` reads `tools_data/bricklayer/scene.bricklayer` first and falls back to a legacy root-level `scene.bricklayer` with a warning. The ZIP fallback paths (`saveProjectAsZip`/`loadProjectFromZip`) are unchanged.
 
 ## Integration
 

--- a/tools/apps/echidna/README.md
+++ b/tools/apps/echidna/README.md
@@ -133,11 +133,23 @@ When gizmos are enabled in Animate mode:
 
 ### File Menu
 
+**Unified project workspace** (Phase 0.0):
+
+- **Set Project Root…** — pick a project directory via the File System Access API. The handle is persisted via IndexedDB and re-acquired on next launch (you only pick once per project).
+- **Save to Project** — save the current `.echidna` file under `tools_data/echidna_saves/{id}.echidna` in the project root.
+- **Export Character to Project** — write the engine-ready PLY + manifest under `assets/characters/{id}/{id}.ply` and `assets/characters/{id}/{id}.manifest.json`. The engine resolves these paths via the bridge's project-root mechanism.
+
+**Legacy download/upload** (still available as a safety net):
+
 - **New Project** — preset sizes 32–256 or custom 8–1024
-- **Save** / **Save As…** — `.echidna` JSON v2 format
+- **Save** / **Save As…** — `.echidna` JSON v3 format (browser download)
 - **Load** — file picker
 - **Resize Grid** — expand or contract grid
 - **Import** — `.ply`, `.vox`, `.obj`
+
+### Persistent character `id`
+
+Each character has a stable `id` slug that's set on the **first save** and never changes thereafter. Renaming the character via the editor does not relocate files. The `id` is derived from `characterName` via `slugifyCharacterId` (lowercase, whitespace → underscore, strip non-`[a-z0-9_-]`, fallback `'character'`).
 
 ### Import Formats
 
@@ -192,6 +204,10 @@ All imports configure grid size (8–1024).
 - `bone_index` (optional uchar) — skinning index
 
 Surface voxels only — fully-interior voxels are culled.
+
+### Echidna save file (`.echidna`)
+
+JSON v3 with `id` (persistent slug), `characterName`, `gridWidth`/`gridDepth`, `voxels`, `parts`, `poses`, `animations`. Legacy v1/v2 files are auto-migrated on load via `migrateEchidnaFile`.
 
 ### Character Manifest (`.manifest.json`)
 

--- a/tools/apps/melies/README.md
+++ b/tools/apps/melies/README.md
@@ -161,18 +161,29 @@ Toggle in **View → Auto-Sync Staging**. Debounced 2s live sync — edits strea
 }
 ```
 
-### Project Layout
+### Project Layout (Phase 0.0)
+
+Méliès saves under the unified GSeurat project layout, sharing one project root with Echidna and Bricklayer:
 
 ```
 my_project/
-├── project.json
-├── effects/
-│   ├── preset_1.vfx.json
-│   └── preset_2.vfx.json
-└── scene/
-    ├── scene1.ply
-    └── scene2.ply
+├── tools_data/
+│   └── melies_projects/
+│       └── {slug}.json          # editor state (project.json equivalent)
+├── assets/
+│   ├── vfx/
+│   │   └── presets/
+│   │       ├── particle_burst.vfx.json   # engine-ready VFX presets
+│   │       └── explosion.vfx.json
+│   └── scenes/
+│       ├── scene1.ply           # PLY scenes (still under scene/ legacy dir)
+│       └── scene2.ply
+└── scene/                       # legacy PLY import location (unchanged)
 ```
+
+The `{slug}.json` filename is derived from the project name via `slugifyProjectName` (lowercase, whitespace → underscore, strip non-`[a-z0-9_-]`, fallback `'project'`).
+
+`loadProject` reads from `tools_data/melies_projects/{slug}.json` first and falls back to a legacy root-level `project.json` with a console warning if the new path doesn't exist.
 
 ## Keyboard Shortcuts
 

--- a/tools/packages/project-root/README.md
+++ b/tools/packages/project-root/README.md
@@ -1,0 +1,184 @@
+# @gseurat/project-root
+
+Shared TypeScript package defining the canonical project layout, asset registry, path validation, FSAPI helpers, and IndexedDB-backed directory handle persistence used by Bricklayer, Méliès, Echidna, and the Bridge server.
+
+This package is the single source of truth for **where files go** under a GSeurat project root. It was introduced in **Phase 0.0** of the toolchain refactor.
+
+## Modules
+
+### `layout.ts` — canonical directory layout
+
+```ts
+import { PROJECT_LAYOUT, ASSET_KINDS, isAssetPath, isToolsDataPath } from '@gseurat/project-root';
+
+PROJECT_LAYOUT.assets.characters     // 'assets/characters'
+PROJECT_LAYOUT.assets.vfxPresets     // 'assets/vfx/presets'
+PROJECT_LAYOUT.assets.scenes         // 'assets/scenes'
+PROJECT_LAYOUT.assets.maps           // 'assets/maps'
+PROJECT_LAYOUT.toolsData.bricklayer  // 'tools_data/bricklayer'
+PROJECT_LAYOUT.toolsData.melies      // 'tools_data/melies_projects'
+PROJECT_LAYOUT.toolsData.echidnaSaves // 'tools_data/echidna_saves'
+
+ASSET_KINDS  // ['characters', 'vfx', 'scenes', 'maps', 'textures', 'audio'] as const
+
+isAssetPath('assets/characters/walker/walker.ply')   // true
+isAssetPath('assets/../evil/foo')                    // false (segment-aware traversal check)
+isToolsDataPath('tools_data/bricklayer/scene.bricklayer') // true
+```
+
+### `paths.ts` — asset reference parser & validator
+
+Asset references come in two forms: `#id` (looked up against the registry) or `assets/...` (project-relative path). Both are first-class.
+
+```ts
+import { toAssetPath, parseAssetRef, isAssetRef, validateAssetRef } from '@gseurat/project-root';
+
+toAssetPath('characters', 'walker', 'walker.ply')
+// → 'assets/characters/walker/walker.ply'
+
+parseAssetRef('#walker')
+// → { kind: 'id', id: 'walker' }
+
+parseAssetRef('assets/characters/walker/walker.manifest.json')
+// → { kind: 'path', path: 'assets/characters/walker/walker.manifest.json' }
+
+parseAssetRef('walker.ply')                   // throws: bare filename
+parseAssetRef('/Users/foo/walker.ply')        // throws: absolute path
+parseAssetRef('assets/')                      // throws: needs at least 2 segments
+parseAssetRef('assets/foo/../../etc/passwd')  // throws: traversal
+
+isAssetRef(s)        // boolean wrapper
+validateAssetRef(s)  // null if valid, error message if invalid
+```
+
+### `registry.ts` — asset registry data model
+
+Bricklayer's `BricklayerFile` v2 stores a top-level `AssetRegistry` indexing assets by stable ID. The registry is **immutable** — `register*` functions return a new registry (Zustand-friendly).
+
+```ts
+import {
+  createEmptyRegistry,
+  registerCharacter, registerVfx, registerTexture, registerAudio, registerMap,
+  resolveRef,
+  type AssetRegistry, type RefKind,
+} from '@gseurat/project-root';
+
+let reg = createEmptyRegistry();
+reg = registerCharacter(reg, 'walker', {
+  ply: 'assets/characters/walker/walker.ply',
+  manifest: 'assets/characters/walker/walker.manifest.json',
+});
+reg = registerVfx(reg, 'explosion', { file: 'assets/vfx/presets/explosion.vfx.json' });
+
+resolveRef('#walker', 'character', reg)
+// → 'assets/characters/walker/walker.manifest.json'  (returns manifest, not PLY)
+
+resolveRef('assets/maps/town.ply', 'map', reg)
+// → 'assets/maps/town.ply'  (path refs pass through)
+
+resolveRef('#missing', 'character', reg)
+// throws: unknown id "missing" in the character registry
+```
+
+### `fs.ts` — FileSystemDirectoryHandle helpers
+
+Thin wrappers over the File System Access API with segment-aware traversal guards. The async functions accept any `FileSystemDirectoryHandle` (real browser FSAPI or an in-memory mock for tests).
+
+```ts
+import { ensureSubdir, writeFileAtPath, readFileAtPath, fileExistsAtPath } from '@gseurat/project-root';
+
+const root: FileSystemDirectoryHandle = await window.showDirectoryPicker({ mode: 'readwrite' });
+
+await ensureSubdir(root, 'assets/characters/walker');
+// recursively creates assets/, assets/characters/, assets/characters/walker/
+
+await writeFileAtPath(root, 'assets/characters/walker/walker.ply', plyBytes);
+// accepts string | Uint8Array | Blob
+// creates intermediate directories on the fly
+// overwrites existing content
+
+const blob = await readFileAtPath(root, 'assets/scenes/town.json');
+// strict — throws if any segment is missing
+
+const exists = await fileExistsAtPath(root, 'assets/scenes/town.json');
+// boolean — propagates traversal errors instead of returning false
+```
+
+### `handle.ts` — IndexedDB-backed directory handle persistence
+
+Each editor (`echidna`, `melies`, `bricklayer`) keeps its picked project root in IndexedDB so it survives page reloads. The browser still requires a permission re-grant on the next session — usually silent if the user previously approved.
+
+```ts
+import {
+  saveProjectRootHandle,
+  loadProjectRootHandle,
+  ensureHandlePermission,
+  restoreProjectRoot,
+  clearProjectRootHandle,
+} from '@gseurat/project-root';
+
+// On user "Set Project Root…" action:
+const handle = await window.showDirectoryPicker({ mode: 'readwrite' });
+await saveProjectRootHandle('echidna', handle);
+
+// On editor bootstrap (App.tsx useEffect):
+const restored = await restoreProjectRoot('echidna');
+if (restored) {
+  // Restored handle has read/write permission. Use directly.
+}
+
+// Lower-level if you need finer control:
+const stored = await loadProjectRootHandle('echidna');
+if (stored && (await ensureHandlePermission(stored))) { /* ... */ }
+```
+
+## Canonical project layout (Phase 0.0 contract)
+
+```
+{ProjectRoot}/
+├── assets/                    # engine-ready files (read by the C++ engine)
+│   ├── characters/{id}/{id}.ply  + {id}.manifest.json
+│   ├── vfx/presets/{slug}.vfx.json
+│   ├── scenes/{slug}.json     # engine scene JSON exported by Bricklayer
+│   ├── maps/{slug}.ply        # terrain Gaussian clouds
+│   ├── textures/...
+│   ├── audio/...
+│   └── components/*.schema.json  # editor schema definitions
+└── tools_data/                # editor-only state (engine never reads this)
+    ├── bricklayer/scene.bricklayer
+    ├── melies_projects/{slug}.json
+    ├── echidna_saves/{id}.echidna
+    └── cache/
+```
+
+The engine learns about the project root via the bridge endpoint `POST /api/project/root`, which forwards a `set_project_root` command over the Unix socket. After that, `gseurat::resolve_asset_path` (C++) joins relative scene/PLY paths against the project root before opening files.
+
+## Development
+
+```bash
+pnpm --filter @gseurat/project-root test         # 69 tests
+pnpm --filter @gseurat/project-root exec tsc --noEmit
+pnpm --filter @gseurat/project-root build        # tsc → dist/
+```
+
+## Tests
+
+| Module | Test count |
+|---|---|
+| `layout` | 9 |
+| `paths` | 22 |
+| `registry` | 18 |
+| `fs` | 20 (with in-memory FSAPI mock) |
+| `handle` | 0 — browser-runtime only, exercised by editor integration |
+| **Total** | **69** |
+
+## Consumers
+
+- **`@gseurat/echidna`** — uses `PROJECT_LAYOUT.toolsData.echidnaSaves`, `toAssetPath('characters', ...)`, `restoreProjectRoot('echidna')` in App bootstrap
+- **`@gseurat/melies`** — uses `PROJECT_LAYOUT.toolsData.melies` and `PROJECT_LAYOUT.assets.vfxPresets`
+- **`@gseurat/bricklayer`** — embeds `AssetRegistry` in `BricklayerFile`, uses `validateAssetRef`/`resolveRef` in scene export
+- **`@gseurat/bridge`** — currently does not import the package directly (it shares the same conceptual layout via the engine's `resolve_asset_path` C++ function), but matches the `assets/scenes`, `assets/textures`, `assets/characters` subdirectories in its asset endpoints
+
+## Why "pure" register functions
+
+The `register*` functions return a new `AssetRegistry` instead of mutating in place because Bricklayer's Zustand store relies on reference identity for re-renders. A mutating API would silently fail to trigger React updates. The cost is one object spread per registration; the benefit is that the API is safe to drop into any immutable state container without ceremony.


### PR DESCRIPTION
## Summary

Bring all editor READMEs in sync with the Phase 0.0 Foundation work that just merged across PRs #201–#207.

## What changed

| File | Update |
|---|---|
| **\`tools/apps/echidna/README.md\`** | New File menu actions (Set Project Root… / Save to Project / Export Character to Project), persistent \`characterId\` semantics, \`.echidna\` v3 schema note |
| **\`tools/apps/melies/README.md\`** | New project layout block — \`tools_data/melies_projects/{slug}.json\` for editor state and \`assets/vfx/presets/{slug}.vfx.json\` for VFX presets, with legacy root-level \`project.json\` fallback documented |
| **\`tools/apps/bricklayer/README.md\`** | New "Connect Bridge to Project Root…" menu action, \`BricklayerFile\` v2 with top-level \`asset_registry\`, asset-ref contract (#id or assets/...), new save paths block, \`validateScenePaths\` warning behavior |
| **\`tools/packages/project-root/README.md\`** | **New file** — covers all 5 modules (layout, paths, registry, fs, handle), the canonical layout contract diagram, the test count breakdown, the consumer list, and the rationale for pure (immutable) \`register*\` functions (Zustand compatibility) |

## What's NOT in this PR

- No code changes
- The plan file (\`docs/superpowers/plans/2026-04-10-phase-0-foundation.md\`) is left as-is — historical record
- CLAUDE.md unchanged — instructional, not a feature manifest

## Test plan

- [ ] Read each README and confirm the diff makes sense
- [ ] Spot-check that the directory diagrams in melies/bricklayer/project-root are consistent with each other
- [ ] No broken markdown links

🤖 Generated with [Claude Code](https://claude.com/claude-code)