### PR TITLE
fix(melies): prompt for project name on first save (Phase 0.1 #1)

### DIFF
--- a/tools/apps/melies/src/App.tsx
+++ b/tools/apps/melies/src/App.tsx
@@ -14,6 +14,36 @@ import { LayerProperties } from './panels/LayerProperties.js';
 import { PresetSettings } from './panels/PresetSettings.js';
 import { T, inputStyle, selectStyle, layerColor } from './styles/theme.js';
 
+/**
+ * Save the current project, prompting the user for a real project name on
+ * the first save so we don't silently overwrite tools_data/melies_projects/
+ * untitled.json (Phase 0.1 #1). Returns true if a save was attempted, false
+ * if the user cancelled the prompt.
+ */
+async function saveProjectWithNamePrompt(): Promise<boolean> {
+  const store = useVfxStore.getState();
+  const currentName = store.ensureProjectName();
+  if (currentName === 'Untitled') {
+    const input = window.prompt('Project name:', '');
+    if (input == null) return false;
+    const trimmed = input.trim();
+    if (trimmed.length === 0) return false;
+    store.setProjectName(trimmed);
+  }
+  if (hasFileSystemAccess()) {
+    let handle = store.projectHandle;
+    if (!handle) {
+      handle = await openProjectDirectory();
+      if (!handle) return false;
+      store.setProjectHandle(handle);
+    }
+    await saveProject(handle);
+  } else {
+    downloadProject();
+  }
+  return true;
+}
+
 // ═══════════════════════════════════════════════════════════════
 // MenuBar
 // ═══════════════════════════════════════════════════════════════
@@ -26,18 +56,7 @@ function MenuBar({ onImportScene }: { onImportScene?: () => void }) {
   const ref = useRef<HTMLDivElement>(null);
 
   const handleSaveProject = async () => {
-    const store = useVfxStore.getState();
-    if (hasFileSystemAccess()) {
-      let handle = store.projectHandle;
-      if (!handle) {
-        handle = await openProjectDirectory();
-        if (!handle) return;
-        store.setProjectHandle(handle);
-      }
-      await saveProject(handle);
-    } else {
-      downloadProject();
-    }
+    await saveProjectWithNamePrompt();
     setFileOpen(false);
   };
 
@@ -823,18 +842,7 @@ export function App() {
       if (meta) {
         if (e.key === 's') {
           e.preventDefault();
-          const store = useVfxStore.getState();
-          if (hasFileSystemAccess()) {
-            let handle = store.projectHandle;
-            if (!handle) {
-              handle = await openProjectDirectory();
-              if (!handle) return;
-              store.setProjectHandle(handle);
-            }
-            await saveProject(handle);
-          } else {
-            downloadProject();
-          }
+          await saveProjectWithNamePrompt();
         } else if (e.key === 'o') {
           e.preventDefault();
           if (hasFileSystemAccess()) {

--- a/tools/apps/melies/src/store/__tests__/useVfxStore.test.ts
+++ b/tools/apps/melies/src/store/__tests__/useVfxStore.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useVfxStore } from '../useVfxStore';
+
+describe('useVfxStore — ensureProjectName', () => {
+  beforeEach(() => {
+    useVfxStore.setState({ projectName: 'Untitled' });
+  });
+
+  it('returns the existing name when set to a real value', () => {
+    useVfxStore.setState({ projectName: 'Forest Demo' });
+    expect(useVfxStore.getState().ensureProjectName()).toBe('Forest Demo');
+    expect(useVfxStore.getState().projectName).toBe('Forest Demo');
+  });
+
+  it('returns "Untitled" and stores it when name is empty', () => {
+    useVfxStore.setState({ projectName: '' });
+    expect(useVfxStore.getState().ensureProjectName()).toBe('Untitled');
+    expect(useVfxStore.getState().projectName).toBe('Untitled');
+  });
+
+  it('returns "Untitled" when name is whitespace-only', () => {
+    useVfxStore.setState({ projectName: '   ' });
+    expect(useVfxStore.getState().ensureProjectName()).toBe('Untitled');
+    expect(useVfxStore.getState().projectName).toBe('Untitled');
+  });
+
+  it('returns "Untitled" when projectName is the default — caller must prompt', () => {
+    expect(useVfxStore.getState().ensureProjectName()).toBe('Untitled');
+  });
+
+  it('treats names containing "Untitled" as user-set if differing from the default', () => {
+    useVfxStore.setState({ projectName: 'Untitled v2' });
+    expect(useVfxStore.getState().ensureProjectName()).toBe('Untitled v2');
+  });
+});

--- a/tools/apps/melies/src/store/useVfxStore.ts
+++ b/tools/apps/melies/src/store/useVfxStore.ts
@@ -54,6 +54,14 @@ export interface VfxStoreState {
   // Actions — project
   setProjectHandle: (handle: FileSystemDirectoryHandle | null) => void;
   setProjectName: (name: string) => void;
+  /**
+   * Returns the current project name, normalising empty/whitespace values
+   * to 'Untitled'. Callers should treat 'Untitled' as the default sentinel
+   * meaning "no real name yet" and prompt the user before saving so we don't
+   * silently overwrite tools_data/melies_projects/untitled.json.
+   * Mirrors Echidna's `ensureCharacterId` pattern.
+   */
+  ensureProjectName: () => string;
   saveProjectData: () => VfxProject;
   loadProjectData: (data: VfxProject) => void;
 
@@ -116,6 +124,12 @@ export const useVfxStore = create<VfxStoreState>((set, get) => ({
 
   setProjectHandle: (handle) => set({ projectHandle: handle }),
   setProjectName: (name) => set({ projectName: name }),
+  ensureProjectName: () => {
+    const current = get().projectName;
+    if (current && current.trim().length > 0) return current;
+    set({ projectName: 'Untitled' });
+    return 'Untitled';
+  },
 
   saveProjectData: () => ({
     version: VFX_PROJECT_VERSION,


### PR DESCRIPTION
## Summary
- Adds `ensureProjectName()` action to `useVfxStore` mirroring Echidna's `ensureCharacterId` pattern
- Extracts a shared `saveProjectWithNamePrompt()` helper used by both the File menu Save Project action and the Cmd+S keyboard shortcut
- Prompts via `window.prompt` when the name is still the `'Untitled'` default; aborts cleanly on cancel/empty input

## Why
Méliès previously saved fresh projects to `tools_data/melies_projects/untitled.json` without ever asking for a real name, so creating a second project after saving would silently overwrite the first. This is Phase 0.1 cleanup item #1 from the post-Phase-0.0 review.

## Test plan
- [x] 5 new unit tests in `useVfxStore.test.ts` covering: existing name passthrough, empty/whitespace normalisation, default sentinel, "Untitled v2" treated as user-set
- [x] `pnpm test` — 15/15 pass
- [x] `pnpm build` — `tsc && vite build` clean
- [ ] Manual: open Méliès, click Save Project on a fresh session → prompt appears
- [ ] Manual: cancel the prompt → no file is written
- [ ] Manual: enter a name → saves to `tools_data/melies_projects/{slug}.json`
- [ ] Manual: second save uses the same name without re-prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)