### PR TITLE
feat(melies): Connect Bridge to Project Root menu action (Phase 0.1 #5)

### DIFF
--- a/tools/apps/melies/src/App.tsx
+++ b/tools/apps/melies/src/App.tsx
@@ -153,6 +153,33 @@ function MenuBar({ onImportScene }: { onImportScene?: () => void }) {
     setFileOpen(false);
   };
 
+  const handleConnectBridgeToProject = async () => {
+    const projectPath = window.prompt(
+      'Project root absolute path on disk:\n\n' +
+        'This tells the bridge (and engine) where your project lives so relative ' +
+        'asset paths can be resolved. Example: /Users/you/MyGameProject',
+      '',
+    );
+    if (!projectPath) return;
+    try {
+      const res = await fetch('http://localhost:9101/api/project/root', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path: projectPath }),
+      });
+      if (res.ok) {
+        const body = (await res.json()) as { activeProjectDir?: string };
+        console.info(`[melies] Bridge connected to project root: ${body.activeProjectDir}`);
+      } else {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        console.error(`[melies] Bridge rejected path: ${body.error ?? res.statusText}`);
+      }
+    } catch (e) {
+      console.error('[melies] Failed to reach bridge:', e);
+    }
+    setFileOpen(false);
+  };
+
   // ── Auto-sync to Staging (debounced) ──
   const stagingAutoSync = useVfxStore((s) => s.stagingAutoSync);
   const autoSyncTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -228,6 +255,7 @@ function MenuBar({ onImportScene }: { onImportScene?: () => void }) {
               { label: 'Export .vfx.json', action: handleExportVfx },
               { label: 'Import Scene PLY...', action: () => { onImportScene?.(); setFileOpen(false); } },
               { label: 'Open in Staging', action: handleOpenInStaging },
+              { label: 'Connect Bridge to Project Root…', action: handleConnectBridgeToProject },
             ].map((item) => (
               <div key={item.label} onClick={item.action}
                 style={{ padding: '6px 16px', cursor: 'pointer', fontSize: 12, color: T.text }}


### PR DESCRIPTION
## Summary
- Adds a File menu entry **Connect Bridge to Project Root…** to Méliès, mirroring the existing Bricklayer action
- Handler is a near-direct copy of Bricklayer's `handleConnectBridgeToProject` — `window.prompt` for the absolute path → `POST http://localhost:9101/api/project/root` → log success/failure to console

## Why
Méliès's *Open in Staging* / *Auto-Sync* sends a scene JSON containing relative `gaussian_splat.ply_file: 'scene/{name}.ply'`. The engine's `resolve_asset_path` only joins relative paths against the project root if `set_project_root` has been called on the bridge. Until now the only way to do that was via Bricklayer's menu, so Méliès's preview only worked if the user had previously connected the bridge through Bricklayer pointing at the same directory. This unblocks Méliès standalone usage.

This is Phase 0.1 cleanup item #5. Item #2 will replace the manual prompt with IDB-cached auto-fill.

## Test plan
- [x] `pnpm build` (Méliès) — `tsc && vite build` clean
- [ ] Manual: open Méliès, File → Connect Bridge to Project Root… → enter `/Users/you/MyGameProject` → bridge logs `activeProjectDir`
- [ ] Manual: with bridge connected, Open in Staging → engine resolves relative `scene/foo.ply` against project root
- [ ] Manual: cancel the prompt → no request sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)