### PR TITLE
feat(echidna): Connect Bridge to Project Root menu action (Phase 0.1 #6)

### DIFF
--- a/tools/apps/echidna/src/panels/MenuBar.tsx
+++ b/tools/apps/echidna/src/panels/MenuBar.tsx
@@ -491,6 +491,35 @@ export function MenuBar() {
     }
   }, [showToast]);
 
+  const handleConnectBridgeToProject = useCallback(async () => {
+    const projectPath = window.prompt(
+      'Project root absolute path on disk:\n\n' +
+        'This tells the bridge (and engine) where your project lives so relative ' +
+        'asset paths can be resolved. Example: /Users/you/MyGameProject',
+      '',
+    );
+    if (!projectPath) return;
+    try {
+      const res = await fetch(`${BRIDGE_REST_URL}/api/project/root`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path: projectPath }),
+      });
+      if (res.ok) {
+        const body = (await res.json()) as { activeProjectDir?: string };
+        console.info(`[echidna] Bridge connected to project root: ${body.activeProjectDir}`);
+        showToast(`Bridge → ${body.activeProjectDir}`, 'success');
+      } else {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        console.error(`[echidna] Bridge rejected path: ${body.error ?? res.statusText}`);
+        showToast(`Bridge rejected: ${body.error ?? res.statusText}`, 'error', 5000);
+      }
+    } catch (e) {
+      console.error('[echidna] Failed to reach bridge:', e);
+      showToast('Failed to reach bridge', 'error');
+    }
+  }, [showToast]);
+
   const handlePickProjectRoot = useCallback(async () => {
     try {
       // @ts-expect-error - showDirectoryPicker is FSAPI extension not in lib.dom
@@ -635,6 +664,7 @@ export function MenuBar() {
     { label: 'Export PLY...', action: handleExportPly },
     { label: 'Export Manifest...', action: handleExportManifest },
     { separator: true as const },
+    { label: 'Connect Bridge to Project Root\u2026', action: handleConnectBridgeToProject },
     { label: 'Preview in Staging', action: handlePreviewInStaging },
   ];
 


### PR DESCRIPTION
## Summary
- Adds a File menu entry **Connect Bridge to Project Root…** to Echidna, near *Preview in Staging*
- Same `window.prompt` → `POST /api/project/root` flow as Bricklayer / Méliès
- Uses Echidna's existing `showToast` helper for success/error feedback (matches local idioms)

## Why
Echidna's `handlePreviewInStaging` works around the missing project-root state by uploading PLY/manifest via REST. When `activeProjectDir` is unset on the bridge, those files get written to `<ENGINE_DIR_FALLBACK>/assets/characters/{id}/...` (the engine's own checkout directory) instead of the user's project. The engine still renders correctly, but litters the wrong location.

It also creates a duplication risk: if the user has already done *Export Character to Project* (which writes via FSAPI), then clicks *Preview in Staging*, the bridge writes a SECOND copy via REST. If `activeProjectDir` matches the project root, it overwrites (harmless). If they don't match, two divergent copies exist.

This menu action is the minimal fix — it lets the user point the bridge at their project so both paths land in the same place. Phase 0.1 #2 will remove the manual prompt entirely via IDB-cached auto-fill.

This is Phase 0.1 cleanup item #6.

## Test plan
- [x] `pnpm build` (Echidna) — `tsc && vite build` clean
- [ ] Manual: Echidna File → Connect Bridge to Project Root… → enter `/Users/you/MyGameProject` → toast `Bridge → ...`
- [ ] Manual: Preview in Staging now writes character files into the connected project root
- [ ] Manual: cancel the prompt → no request sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)