### PR TITLE
feat(bricklayer): auto-restore bridge project path on bootstrap (Phase 0.1 #2)

### DIFF
--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -4,6 +4,12 @@ import { MenuBar } from './panels/MenuBar.js';
 import { ImportDialog } from './panels/ImportDialog.js';
 import { ProjectTree } from './panels/ProjectTree.js';
 import { hasFileSystemAccess, saveProject as saveProjectDir, saveProjectAsZip } from './lib/projectIO.js';
+import {
+  restoreProjectRoot,
+  loadBridgePath,
+  matchBridgePath,
+} from '@gseurat/project-root';
+import { connectBridgeToPath } from './lib/bridgeConnection.js';
 import { TerrainLeftPanel } from './panels/TerrainLeftPanel.js';
 import { CollisionLeftPanel } from './panels/CollisionLeftPanel.js';
 import { TerrainRightPanel } from './panels/TerrainRightPanel.js';
@@ -254,6 +260,45 @@ export function App() {
 
   const handleRightDrag = useCallback((delta: number) => {
     setRightWidth((w) => Math.max(200, Math.min(600, w + delta)));
+  }, []);
+
+  // Bootstrap (Phase 0.1 #2): on first load, restore the previously-used
+  // FSAPI project handle from IDB and, if a cached bridge path is on file
+  // for that handle, automatically POST it so the engine can resolve
+  // relative asset paths without the user re-typing on every reload.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const handle = await restoreProjectRoot('bricklayer');
+        if (cancelled || !handle) return;
+        // Don't clobber a handle the user has already picked manually in
+        // the same session.
+        if (!useSceneStore.getState().projectHandle) {
+          useSceneStore.getState().setProjectHandle(handle);
+          useSceneStore.getState().setProjectName(handle.name);
+          console.info(`[bricklayer] Restored project root: ${handle.name}`);
+        }
+        // Auto-apply cached bridge path if it matches this handle.
+        const cached = await loadBridgePath('bricklayer');
+        if (cancelled) return;
+        const path = matchBridgePath(cached, handle.name);
+        if (!path) return;
+        const result = await connectBridgeToPath(path);
+        if (cancelled) return;
+        if (result.ok) {
+          useSceneStore.getState().setBridgeConnectedPath(result.activeProjectDir);
+          console.info(`[bricklayer] Bridge auto-connected: ${result.activeProjectDir}`);
+        } else {
+          console.warn(`[bricklayer] Bridge auto-connect failed: ${result.error}`);
+        }
+      } catch (e) {
+        console.warn('[bricklayer] Bootstrap failed:', e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {

--- a/tools/apps/bricklayer/src/lib/bridgeConnection.ts
+++ b/tools/apps/bricklayer/src/lib/bridgeConnection.ts
@@ -1,0 +1,49 @@
+/**
+ * Thin client wrapper around `POST /api/project/root` on the Bridge.
+ *
+ * Used by both:
+ *   - the File menu's "Connect Bridge to Project Root…" handler
+ *   - the App.tsx bootstrap that auto-applies a cached path on reload
+ *
+ * Phase 0.1 #2.
+ */
+
+const BRIDGE_REST_URL = 'http://localhost:9101';
+
+export type ConnectBridgeResult =
+  | { ok: true; activeProjectDir: string }
+  | { ok: false; error: string };
+
+/**
+ * POST the absolute path to the bridge so the engine's `set_project_root`
+ * can resolve relative asset paths. Returns a discriminated union — never
+ * throws on protocol-level failures so callers can react with toast / log.
+ */
+export async function connectBridgeToPath(
+  absolutePath: string,
+): Promise<ConnectBridgeResult> {
+  if (!absolutePath) {
+    return { ok: false, error: 'absolutePath is empty' };
+  }
+  try {
+    const res = await fetch(`${BRIDGE_REST_URL}/api/project/root`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ path: absolutePath }),
+    });
+    if (res.ok) {
+      const body = (await res.json()) as { activeProjectDir?: string };
+      return {
+        ok: true,
+        activeProjectDir: body.activeProjectDir ?? absolutePath,
+      };
+    }
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { ok: false, error: body.error ?? res.statusText };
+  } catch (e) {
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -7,6 +7,11 @@ import { computeFingerprint, isStructuralChange, type SceneFingerprint } from '.
 import { hasFileSystemAccess, openProjectDirectory, saveProject as saveProjectDir, loadProject as loadProjectDir, saveProjectAsZip, loadProjectFromZip, importAssetToProject } from '../lib/projectIO.js';
 import { sendBridgeCommand, sendBridgeCommands } from '@gseurat/engine-client';
 import type { BricklayerFile } from '../store/types.js';
+import {
+  saveProjectRootHandle,
+  saveBridgePath,
+} from '@gseurat/project-root';
+import { connectBridgeToPath } from '../lib/bridgeConnection.js';
 
 const styles: Record<string, React.CSSProperties> = {
   bar: {
@@ -155,6 +160,7 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
   const isDirty = useSceneStore((st) => st.isDirty);
   const projectName = useSceneStore((st) => st.projectName);
   const projectHandle = useSceneStore((st) => st.projectHandle);
+  const bridgeConnectedPath = useSceneStore((st) => st.bridgeConnectedPath);
 
   const closeMenu = useCallback(() => setOpenMenu(null), []);
   const toggleMenu = useCallback(
@@ -201,6 +207,11 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
       useSceneStore.getState().newScene(128, 96);
       useSceneStore.getState().setProjectHandle(handle);
       useSceneStore.getState().setProjectName(handle.name);
+      // Persist the handle so future sessions can auto-restore via App.tsx
+      // bootstrap (Phase 0.1 #2). Failure here is non-fatal.
+      saveProjectRootHandle('bricklayer', handle).catch((e) => {
+        console.warn('[bricklayer] saveProjectRootHandle failed:', e);
+      });
       await saveProjectDir(handle);
     } else if (!hasFileSystemAccess()) {
       useSceneStore.getState().newScene(128, 96);
@@ -215,6 +226,9 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
       if (handle) {
         useSceneStore.getState().setProjectHandle(handle);
         useSceneStore.getState().setProjectName(handle.name);
+        saveProjectRootHandle('bricklayer', handle).catch((e) => {
+          console.warn('[bricklayer] saveProjectRootHandle failed:', e);
+        });
         await loadProjectDir(handle);
       }
     } else {
@@ -258,6 +272,9 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
         if (newHandle) {
           useSceneStore.getState().setProjectHandle(newHandle);
           useSceneStore.getState().setProjectName(newHandle.name);
+          saveProjectRootHandle('bricklayer', newHandle).catch((e) => {
+            console.warn('[bricklayer] saveProjectRootHandle failed:', e);
+          });
           await saveProjectDir(newHandle);
           useSceneStore.getState().markClean();
         }
@@ -314,28 +331,34 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
   };
 
   const handleConnectBridgeToProject = async () => {
+    const currentHandle = useSceneStore.getState().projectHandle;
+    const currentBridgePath = useSceneStore.getState().bridgeConnectedPath;
+    const initial = currentBridgePath ?? '';
     const projectPath = window.prompt(
       'Project root absolute path on disk:\n\n' +
         'This tells the bridge (and engine) where your project lives so relative ' +
         'asset paths can be resolved. Example: /Users/you/MyGameProject',
-      '',
+      initial,
     );
     if (!projectPath) return;
-    try {
-      const res = await fetch('http://localhost:9101/api/project/root', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ path: projectPath }),
-      });
-      if (res.ok) {
-        const body = (await res.json()) as { activeProjectDir?: string };
-        console.info(`[bricklayer] Bridge connected to project root: ${body.activeProjectDir}`);
-      } else {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        console.error(`[bricklayer] Bridge rejected path: ${body.error ?? res.statusText}`);
+    const result = await connectBridgeToPath(projectPath);
+    if (result.ok) {
+      console.info(`[bricklayer] Bridge connected to project root: ${result.activeProjectDir}`);
+      useSceneStore.getState().setBridgeConnectedPath(result.activeProjectDir);
+      // Persist the {handleName, absolutePath} pair so future sessions can
+      // auto-apply it on bootstrap. Only persist when we actually have a
+      // FSAPI handle to key by — otherwise the auto-fill bootstrap has
+      // nothing to match against.
+      if (currentHandle) {
+        saveBridgePath('bricklayer', {
+          handleName: currentHandle.name,
+          absolutePath: result.activeProjectDir,
+        }).catch((e) => {
+          console.warn('[bricklayer] saveBridgePath failed:', e);
+        });
       }
-    } catch (e) {
-      console.error('[bricklayer] Failed to reach bridge:', e);
+    } else {
+      console.error(`[bricklayer] Bridge rejected path: ${result.error}`);
     }
   };
 
@@ -513,6 +536,24 @@ export function MenuBar({ onImport }: { onImport: () => void }) {
       <span style={styles.title}>
         Bricklayer{projectHandle ? ` \u2014 ${projectName}` : ''}
         {isDirty && <span style={{ color: '#fa0', marginLeft: 6 }}>{'\u25CF'}</span>}
+        <span
+          title={
+            bridgeConnectedPath
+              ? `Bridge connected to ${bridgeConnectedPath}`
+              : 'Bridge not connected — File → Connect Bridge to Project Root…'
+          }
+          style={{
+            marginLeft: 12,
+            padding: '2px 6px',
+            borderRadius: 3,
+            fontSize: 11,
+            color: bridgeConnectedPath ? '#7f7' : '#888',
+            background: bridgeConnectedPath ? '#1a3a1a' : '#2a2a2a',
+            border: `1px solid ${bridgeConnectedPath ? '#3a6a3a' : '#3a3a3a'}`,
+          }}
+        >
+          {bridgeConnectedPath ? 'Bridge \u25CF' : 'Bridge \u25CB'}
+        </span>
       </span>
     </div>
   );

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -184,6 +184,13 @@ export interface SceneStoreState {
   // Project management
   projectName: string;
   projectHandle: FileSystemDirectoryHandle | null;
+  /**
+   * Absolute disk path the bridge has been told about (Phase 0.1 #2). Set
+   * via Connect Bridge to Project Root… or restored automatically on
+   * bootstrap from `loadBridgePath`. Null when no bridge connection has
+   * been established this session.
+   */
+  bridgeConnectedPath: string | null;
   terrains: TerrainEntry[];
   currentTerrainId: string;
   assets: AssetEntry[];
@@ -352,6 +359,7 @@ export interface SceneStoreState {
   // Actions – project
   setProjectName: (name: string) => void;
   setProjectHandle: (handle: FileSystemDirectoryHandle | null) => void;
+  setBridgeConnectedPath: (path: string | null) => void;
   addTerrain: (terrain: TerrainEntry) => void;
   removeTerrain: (id: string) => void;
   switchTerrain: (id: string) => void;
@@ -465,6 +473,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
 
   projectName: 'Untitled',
   projectHandle: null,
+  bridgeConnectedPath: null,
   terrains: [],
   currentTerrainId: '',
   assets: [],
@@ -1038,6 +1047,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   // ── Project actions ──
   setProjectName: (name) => set({ projectName: name }),
   setProjectHandle: (handle) => set({ projectHandle: handle }),
+  setBridgeConnectedPath: (path) => set({ bridgeConnectedPath: path }),
   addTerrain: (terrain) => set({ terrains: [...get().terrains, terrain] }),
   removeTerrain: (id) => set({ terrains: get().terrains.filter((t) => t.id !== id) }),
   switchTerrain: (id) => set({ currentTerrainId: id }),

--- a/tools/packages/project-root/src/handle.ts
+++ b/tools/packages/project-root/src/handle.ts
@@ -1,6 +1,7 @@
 import { get, set, del } from 'idb-keyval';
 
 const KEY_PREFIX = 'gseurat:project-root-handle:';
+const BRIDGE_PATH_KEY_PREFIX = 'gseurat:bridge-project-path:';
 
 // FSAPI permission methods are not yet in the base TypeScript DOM lib.
 // Declare the minimal shape we use so ensureHandlePermission can be typed
@@ -83,4 +84,66 @@ export async function restoreProjectRoot(
   if (!handle) return null;
   const ok = await ensureHandlePermission(handle);
   return ok ? handle : null;
+}
+
+/**
+ * Persistent record of "the last absolute disk path the user typed when
+ * connecting the bridge for this project handle." The File System Access
+ * API hides the absolute path from JavaScript, so we cannot derive this — it
+ * has to be remembered between sessions.
+ *
+ * The pairing is keyed by `handleName` (the directory's basename) so a
+ * cached entry is only auto-applied when the user re-opens the *same*
+ * directory in a new session. Two unrelated projects that happen to share a
+ * basename will collide; we accept that risk for the convenience of skipping
+ * the manual prompt.
+ */
+export interface BridgePathRecord {
+  /** `FileSystemDirectoryHandle.name` at the time of persistence. */
+  handleName: string;
+  /** Absolute disk path the user typed in the Connect Bridge prompt. */
+  absolutePath: string;
+}
+
+/**
+ * Pure check used by the auto-fill bootstrap: returns the stored absolute
+ * path iff the cached record's handle name matches the currently restored
+ * handle name. Extracted so it can be unit-tested without IDB.
+ */
+export function matchBridgePath(
+  record: BridgePathRecord | null,
+  handleName: string,
+): string | null {
+  if (!record) return null;
+  if (record.handleName !== handleName) return null;
+  if (!record.absolutePath) return null;
+  return record.absolutePath;
+}
+
+/**
+ * Persist a `{handleName, absolutePath}` pair so future sessions can skip
+ * the manual Connect Bridge prompt for this project. `appId` scopes the
+ * record per editor.
+ */
+export async function saveBridgePath(
+  appId: string,
+  record: BridgePathRecord,
+): Promise<void> {
+  await set(BRIDGE_PATH_KEY_PREFIX + appId, record);
+}
+
+/**
+ * Load a previously stored bridge path record. Returns null if none is
+ * stored.
+ */
+export async function loadBridgePath(
+  appId: string,
+): Promise<BridgePathRecord | null> {
+  const record = await get<BridgePathRecord>(BRIDGE_PATH_KEY_PREFIX + appId);
+  return record ?? null;
+}
+
+/** Remove a stored bridge path record for this `appId`. */
+export async function clearBridgePath(appId: string): Promise<void> {
+  await del(BRIDGE_PATH_KEY_PREFIX + appId);
 }

--- a/tools/packages/project-root/test/handle.test.ts
+++ b/tools/packages/project-root/test/handle.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { matchBridgePath, type BridgePathRecord } from '../src/handle';
+
+describe('matchBridgePath', () => {
+  const record: BridgePathRecord = {
+    handleName: 'MyGameProject',
+    absolutePath: '/Users/me/MyGameProject',
+  };
+
+  it('returns the absolute path when handle names match', () => {
+    expect(matchBridgePath(record, 'MyGameProject')).toBe(
+      '/Users/me/MyGameProject',
+    );
+  });
+
+  it('returns null when no record is stored', () => {
+    expect(matchBridgePath(null, 'MyGameProject')).toBeNull();
+  });
+
+  it('returns null when handle names differ', () => {
+    expect(matchBridgePath(record, 'OtherProject')).toBeNull();
+  });
+
+  it('returns null when the stored absolute path is empty', () => {
+    expect(
+      matchBridgePath(
+        { handleName: 'MyGameProject', absolutePath: '' },
+        'MyGameProject',
+      ),
+    ).toBeNull();
+  });
+
+  it('is case-sensitive on handle name (matches FSAPI semantics)', () => {
+    expect(matchBridgePath(record, 'mygameproject')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- New `BridgePathRecord` type and `saveBridgePath` / `loadBridgePath` / `clearBridgePath` IDB helpers in `@gseurat/project-root`, plus a pure `matchBridgePath` function (testable without IDB)
- New `bridgeConnection.ts` adapter wrapping `POST /api/project/root` so the menu handler and the new bootstrap share one client
- Bricklayer's `handleNew` / `handleOpen` / `handleSave` now persist the FSAPI directory handle via `saveProjectRootHandle('bricklayer', ...)` (pre-existing gap — Bricklayer never persisted handles like Echidna does)
- New `App.tsx` bootstrap useEffect: restores the handle from IDB, looks up the cached bridge path, auto-POSTs on a `matchBridgePath` hit
- New `bridgeConnectedPath` state in `useSceneStore` plus a status indicator pill in the menu bar showing **Bridge ●** (connected, green) or **Bridge ○** (disconnected, gray), with the absolute path in the tooltip
- The Connect Bridge prompt now pre-fills with the currently connected path so editing it is one click instead of a re-type

## Why
The File System Access API hides absolute disk paths from JavaScript, so the Connect Bridge handler asked the user to type the path manually — and forced them to type it again on every browser reload. After this change, the first typed path is remembered, so any subsequent reload of Bricklayer with the same project handle auto-applies it with zero UI interaction. This is Phase 0.1 cleanup item #2.

## Test plan
- [x] `pnpm test` (project-root) — 74/74 pass (5 new for `matchBridgePath`)
- [x] `pnpm test` (bricklayer) — 19/19 pass
- [x] `pnpm build` (project-root) — clean
- [x] `pnpm build` (bricklayer) — clean
- [ ] Manual: open Bricklayer fresh → status pill shows **Bridge ○**
- [ ] Manual: File → Open Project → pick directory → status still **Bridge ○** (expected — not connected yet)
- [ ] Manual: File → Connect Bridge to Project Root… → enter `/Users/you/MyGameProject` → success → pill flips to **Bridge ●** with tooltip showing the path
- [ ] Manual: reload page → bootstrap restores the handle → bridge auto-connects → pill is **Bridge ●** without any interaction
- [ ] Manual: open a different project → cached path does NOT apply (handle name mismatch) → pill is **Bridge ○**

🤖 Generated with [Claude Code](https://claude.com/claude-code)