### PR TITLE
feat(echidna): Phase 0.3a schema + registry infrastructure

### DIFF
--- a/docs/superpowers/plans/2026-04-12-echidna-phase-03a-schema-registry.md
+++ b/docs/superpowers/plans/2026-04-12-echidna-phase-03a-schema-registry.md
@@ -1,0 +1,994 @@
+# Phase 0.3a — Schema + Registry Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add multi-asset support infrastructure to Echidna — EchidnaFile v4 with `kind` discriminator, `objects` kind in AssetRegistry, and store rename from Character → Asset.
+
+**Architecture:** Bottom-up approach: shared package changes first (layout, registry), then Echidna types, then store, then consumers. Each task is independently testable.
+
+**Tech Stack:** TypeScript, Zustand, Vitest, `@gseurat/project-root`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `tools/packages/project-root/src/layout.ts` | Modify | Add `objects` to PROJECT_LAYOUT and ASSET_KINDS |
+| `tools/packages/project-root/src/registry.ts` | Modify | Add `objects` field, `registerObject`, update `RefKind`, `resolveRef` |
+| `tools/packages/project-root/test/layout.test.ts` | Modify | Test `objects` in ASSET_KINDS |
+| `tools/packages/project-root/test/registry.test.ts` | Modify | Test `registerObject` + `resolveRef('object')` |
+| `tools/apps/echidna/src/store/types.ts` | Modify | EchidnaFile v4, Asset, AssetListEntry, EchidnaAssetKind, migration |
+| `tools/apps/echidna/src/lib/projectFs.ts` | Modify | Export functions for map/object PLY, update list return type |
+| `tools/apps/echidna/src/store/useCharacterStore.ts` | Modify | Rename character→asset throughout, newAsset(kind), save() branching |
+| `tools/apps/echidna/src/panels/CharactersPanel.tsx` | Rename→Modify | Becomes `AssetsPanel.tsx` |
+| `tools/apps/echidna/src/panels/*.tsx` | Modify | Update store selector names (character→asset) |
+| `tools/apps/echidna/src/viewport/*.tsx` | Modify | Update store selector names |
+| `tools/apps/echidna/src/App.tsx` | Modify | Update store selectors, component imports |
+| `tools/apps/echidna/src/__tests__/characterStore.test.ts` | Modify | Rename all character→asset references |
+| `tools/apps/echidna/src/__tests__/CharactersPanel.test.ts` | Rename→Modify | Becomes `AssetsPanel.test.ts` |
+| `tools/apps/echidna/src/__tests__/projectFs.test.ts` | Modify | Add export tests for map/object kinds |
+
+---
+
+### Task 1: PROJECT_LAYOUT + ASSET_KINDS — add `objects`
+
+**Files:**
+- Modify: `tools/packages/project-root/src/layout.ts`
+- Test: `tools/packages/project-root/test/layout.test.ts`
+
+- [ ] **Step 1: Write failing test for objects in ASSET_KINDS**
+
+In `tools/packages/project-root/test/layout.test.ts`, add:
+
+```typescript
+it('ASSET_KINDS includes objects', () => {
+  expect(ASSET_KINDS).toContain('objects');
+});
+
+it('PROJECT_LAYOUT.assets.objects is assets/objects', () => {
+  expect(PROJECT_LAYOUT.assets.objects).toBe('assets/objects');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tools && pnpm --filter @gseurat/project-root test -- --run --reporter verbose 2>&1 | tail -20`
+Expected: FAIL
+
+- [ ] **Step 3: Add objects to layout.ts**
+
+In `tools/packages/project-root/src/layout.ts`, add `objects` to `PROJECT_LAYOUT.assets`:
+
+```typescript
+export const PROJECT_LAYOUT = {
+  assets: {
+    characters: 'assets/characters',
+    vfx:        'assets/vfx',
+    vfxPresets: 'assets/vfx/presets',
+    scenes:     'assets/scenes',
+    maps:       'assets/maps',
+    textures:   'assets/textures',
+    audio:      'assets/audio',
+    components: 'assets/components',
+    objects:    'assets/objects',
+  },
+  toolsData: {
+    bricklayer:   'tools_data/bricklayer',
+    melies:       'tools_data/melies_projects',
+    echidnaSaves: 'tools_data/echidna_saves',
+    cache:        'tools_data/cache',
+  },
+} as const;
+```
+
+Add `'objects'` to `ASSET_KINDS`:
+
+```typescript
+export const ASSET_KINDS = [
+  'characters',
+  'vfx',
+  'scenes',
+  'maps',
+  'textures',
+  'audio',
+  'objects',
+] as const;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tools && pnpm --filter @gseurat/project-root test -- --run --reporter verbose 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/packages/project-root/src/layout.ts tools/packages/project-root/test/layout.test.ts
+git commit -m "feat(project-root): add objects to PROJECT_LAYOUT and ASSET_KINDS"
+```
+
+---
+
+### Task 2: AssetRegistry — add `objects` kind
+
+**Files:**
+- Modify: `tools/packages/project-root/src/registry.ts`
+- Test: `tools/packages/project-root/test/registry.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+In `tools/packages/project-root/test/registry.test.ts`:
+
+Add `registerObject` to the import:
+```typescript
+import {
+  createEmptyRegistry,
+  registerCharacter,
+  registerVfx,
+  registerTexture,
+  registerAudio,
+  registerMap,
+  registerObject,
+  resolveRef,
+  type AssetRegistry,
+} from '../src/registry';
+```
+
+Add to the `AssetRegistry` describe block:
+```typescript
+  it('starts empty with objects field', () => {
+    const r = createEmptyRegistry();
+    expect(Object.keys(r.objects)).toEqual([]);
+  });
+
+  it('registers an object', () => {
+    let r = createEmptyRegistry();
+    r = registerObject(r, 'crystal', { file: 'assets/objects/crystal.ply' });
+    expect(r.objects.crystal).toEqual({ id: 'crystal', file: 'assets/objects/crystal.ply' });
+  });
+```
+
+Add to the `resolveRef` describe block:
+```typescript
+  it('returns object path by id', () => {
+    const r0 = createEmptyRegistry();
+    const r = registerObject(r0, 'crystal', { file: 'assets/objects/crystal.ply' });
+    expect(resolveRef('#crystal', 'object', r)).toBe('assets/objects/crystal.ply');
+  });
+
+  it('throws on unknown object id', () => {
+    const r = createEmptyRegistry();
+    expect(() => resolveRef('#missing', 'object', r)).toThrow(/unknown id.*object.*registry/i);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tools && pnpm --filter @gseurat/project-root test -- --run --reporter verbose 2>&1 | tail -20`
+Expected: FAIL — `registerObject` does not exist yet
+
+- [ ] **Step 3: Add objects to registry.ts**
+
+Add `objects` field to `AssetRegistry`:
+```typescript
+export interface AssetRegistry {
+  version: 1;
+  characters: Record<string, CharacterEntry>;
+  vfx:        Record<string, FileEntry>;
+  textures:   Record<string, FileEntry>;
+  audio:      Record<string, FileEntry>;
+  maps:       Record<string, FileEntry>;
+  objects:    Record<string, FileEntry>;
+}
+```
+
+Update `createEmptyRegistry`:
+```typescript
+export function createEmptyRegistry(): AssetRegistry {
+  return {
+    version: 1,
+    characters: {},
+    vfx: {},
+    textures: {},
+    audio: {},
+    maps: {},
+    objects: {},
+  };
+}
+```
+
+Add `registerObject` function (after `registerMap`):
+```typescript
+export function registerObject(
+  reg: AssetRegistry,
+  id: string,
+  entry: { file: string },
+): AssetRegistry {
+  return {
+    ...reg,
+    objects: {
+      ...reg.objects,
+      [id]: { id, file: entry.file },
+    },
+  };
+}
+```
+
+Update `RefKind`:
+```typescript
+export type RefKind = 'character' | 'vfx' | 'texture' | 'audio' | 'map' | 'object';
+```
+
+Add `object` case to `resolveRef` (before `default`):
+```typescript
+    case 'object': {
+      const e = reg.objects[parsed.id];
+      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in the object registry`);
+      return e.file;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tools && pnpm --filter @gseurat/project-root test -- --run --reporter verbose 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Run build to ensure no type errors in consumers**
+
+Run: `cd tools && pnpm build 2>&1 | tail -20`
+
+Note: `createEmptyRegistry()` callers (Bricklayer) will now need `objects: {}` in their existing registry literals. The build will flag these. If any consumer constructs an `AssetRegistry` literal directly (not via `createEmptyRegistry()`), it will fail typecheck. Fix those by adding `objects: {}`.
+
+- [ ] **Step 6: Fix any consumer type errors from the new `objects` field**
+
+Search for `AssetRegistry` literals in `tools/apps/bricklayer/` and add `objects: {}` where needed. Also check `tools/apps/melies/` and any test files.
+
+- [ ] **Step 7: Run build again**
+
+Run: `cd tools && pnpm build 2>&1 | tail -10`
+Expected: Build succeeds
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tools/packages/project-root/src/registry.ts tools/packages/project-root/test/registry.test.ts
+# Also add any consumer files fixed in step 6
+git commit -m "feat(project-root): add objects kind to AssetRegistry"
+```
+
+---
+
+### Task 3: EchidnaFile v4 schema + migration
+
+**Files:**
+- Modify: `tools/apps/echidna/src/store/types.ts`
+- Test: `tools/apps/echidna/src/__tests__/characterStore.test.ts`
+
+- [ ] **Step 1: Write failing test for migration**
+
+In `tools/apps/echidna/src/__tests__/characterStore.test.ts`, add at the top level:
+
+```typescript
+import { migrateEchidnaFile, ECHIDNA_FILE_VERSION } from '../store/types';
+
+describe('migrateEchidnaFile v3 → v4', () => {
+  it('defaults kind to character for legacy v3 files', () => {
+    const raw = {
+      version: 3,
+      id: 'walker',
+      characterName: 'Walker',
+      gridWidth: 32,
+      gridDepth: 32,
+      voxels: [],
+      parts: [],
+      poses: {},
+    };
+    const result = migrateEchidnaFile(raw);
+    expect(result.version).toBe(4);
+    expect(result.kind).toBe('character');
+  });
+
+  it('preserves kind when already present', () => {
+    const raw = {
+      version: 4,
+      id: 'crystal',
+      kind: 'object',
+      characterName: 'Crystal',
+      gridWidth: 16,
+      gridDepth: 16,
+      voxels: [],
+      parts: [],
+      poses: {},
+      tags: ['prop'],
+    };
+    const result = migrateEchidnaFile(raw);
+    expect(result.kind).toBe('object');
+    expect(result.tags).toEqual(['prop']);
+  });
+
+  it('defaults tags to empty array', () => {
+    const raw = { version: 3, id: 'test', characterName: 'Test', voxels: [], parts: [], poses: {} };
+    const result = migrateEchidnaFile(raw);
+    expect(result.tags).toEqual([]);
+  });
+
+  it('ECHIDNA_FILE_VERSION is 4', () => {
+    expect(ECHIDNA_FILE_VERSION).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tools && pnpm --filter echidna test -- --run --reporter verbose 2>&1 | tail -20`
+Expected: FAIL — `kind` not on EchidnaFile, version is still 3
+
+- [ ] **Step 3: Update types.ts**
+
+In `tools/apps/echidna/src/store/types.ts`:
+
+Add `EchidnaAssetKind` type (after AppMode):
+```typescript
+export type EchidnaAssetKind = 'character' | 'map' | 'object';
+```
+
+Bump version:
+```typescript
+export const ECHIDNA_FILE_VERSION = 4 as const;
+```
+
+Update `EchidnaFile`:
+```typescript
+export interface EchidnaFile {
+  version: number;
+  id: string;
+  kind: EchidnaAssetKind;
+  characterName: string;
+  gridWidth: number;
+  gridDepth: number;
+  voxels: { x: number; y: number; z: number; r: number; g: number; b: number; a: number }[];
+  parts: BodyPart[];
+  poses: Record<string, PoseData>;
+  animations?: Record<string, AnimationClip>;
+  tags: string[];
+}
+```
+
+Update `migrateEchidnaFile`:
+```typescript
+export function migrateEchidnaFile(raw: any): EchidnaFile {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('migrateEchidnaFile: expected an object');
+  }
+  const id: string = typeof raw.id === 'string' && raw.id.length > 0
+    ? raw.id
+    : slugifyCharacterId(typeof raw.characterName === 'string' ? raw.characterName : '');
+
+  const kind: EchidnaAssetKind =
+    raw.kind === 'character' || raw.kind === 'map' || raw.kind === 'object'
+      ? raw.kind
+      : 'character';
+
+  return {
+    version: ECHIDNA_FILE_VERSION,
+    id,
+    kind,
+    characterName: raw.characterName ?? '',
+    gridWidth: raw.gridWidth ?? 32,
+    gridDepth: raw.gridDepth ?? 32,
+    voxels: Array.isArray(raw.voxels) ? raw.voxels : [],
+    parts: Array.isArray(raw.parts) ? raw.parts : [],
+    poses: raw.poses && typeof raw.poses === 'object' ? raw.poses : {},
+    animations: raw.animations && typeof raw.animations === 'object' && !Array.isArray(raw.animations)
+      ? raw.animations
+      : undefined,
+    tags: Array.isArray(raw.tags) ? raw.tags : [],
+  };
+}
+```
+
+Rename `Character` → `Asset`:
+```typescript
+export interface Asset {
+  id: string;
+  kind: EchidnaAssetKind;
+  characterName: string;
+  gridWidth: number;
+  gridDepth: number;
+  voxels: Map<VoxelKey, Voxel>;
+  characterParts: BodyPart[];
+  characterPoses: Record<string, PoseData>;
+  animations: Record<string, AnimationClip>;
+  tags: string[];
+  currentFilename: string | null;
+}
+```
+
+Rename `CharacterListEntry` → `AssetListEntry`:
+```typescript
+export interface AssetListEntry {
+  id: string;
+  kind: EchidnaAssetKind;
+  name: string;
+  lastModified: number;
+}
+```
+
+Keep old names as type aliases for incremental migration (removed in Task 5):
+```typescript
+/** @deprecated Use Asset */
+export type Character = Asset;
+/** @deprecated Use AssetListEntry */
+export type CharacterListEntry = AssetListEntry;
+```
+
+Rename `slugifyCharacterId` → `slugifyAssetId`:
+```typescript
+export function slugifyAssetId(name: string): string {
+  const cleaned = name
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_-]/g, '');
+  return cleaned.length > 0 ? cleaned : 'character';
+}
+
+/** @deprecated Use slugifyAssetId */
+export const slugifyCharacterId = slugifyAssetId;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tools && pnpm --filter echidna test -- --run --reporter verbose 2>&1 | tail -20`
+Expected: PASS (deprecated aliases keep existing code compiling)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/apps/echidna/src/store/types.ts tools/apps/echidna/src/__tests__/characterStore.test.ts
+git commit -m "feat(echidna): EchidnaFile v4 schema with kind discriminator + Asset type"
+```
+
+---
+
+### Task 4: projectFs.ts — export functions for map/object PLY
+
+**Files:**
+- Modify: `tools/apps/echidna/src/lib/projectFs.ts`
+- Test: `tools/apps/echidna/src/__tests__/projectFs.test.ts`
+
+- [ ] **Step 1: Write failing tests for map/object export**
+
+In `tools/apps/echidna/src/__tests__/projectFs.test.ts`, add:
+
+```typescript
+import { exportMapToProject, exportObjectToProject } from '../lib/projectFs';
+
+describe('exportMapToProject', () => {
+  it('writes PLY to assets/maps/{id}.ply', async () => {
+    const root = testing.makeRoot();
+    const ply = new Uint8Array([1, 2, 3]);
+    const result = await exportMapToProject(root as unknown as FileSystemDirectoryHandle, 'town', ply);
+    expect(result.plyPath).toBe('assets/maps/town.ply');
+
+    // Verify file exists
+    const assets = await root.getDirectoryHandle('assets');
+    const maps = await assets.getDirectoryHandle('maps');
+    const fh = await maps.getFileHandle('town.ply');
+    const file = await fh.getFile();
+    const buf = new Uint8Array(await file.arrayBuffer());
+    expect(buf).toEqual(ply);
+  });
+});
+
+describe('exportObjectToProject', () => {
+  it('writes PLY to assets/objects/{id}.ply', async () => {
+    const root = testing.makeRoot();
+    const ply = new Uint8Array([4, 5, 6]);
+    const result = await exportObjectToProject(root as unknown as FileSystemDirectoryHandle, 'crystal', ply);
+    expect(result.plyPath).toBe('assets/objects/crystal.ply');
+
+    const assets = await root.getDirectoryHandle('assets');
+    const objects = await assets.getDirectoryHandle('objects');
+    const fh = await objects.getFileHandle('crystal.ply');
+    const file = await fh.getFile();
+    const buf = new Uint8Array(await file.arrayBuffer());
+    expect(buf).toEqual(ply);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tools && pnpm --filter echidna test -- --run --reporter verbose 2>&1 | tail -20`
+Expected: FAIL — `exportMapToProject` and `exportObjectToProject` don't exist
+
+- [ ] **Step 3: Add export functions to projectFs.ts**
+
+In `tools/apps/echidna/src/lib/projectFs.ts`, update the import to use `AssetListEntry` and `EchidnaAssetKind`:
+
+```typescript
+import { migrateEchidnaFile, type EchidnaFile, type AssetListEntry, type EchidnaAssetKind } from '../store/types';
+```
+
+Add path builders:
+```typescript
+export function mapPlyPath(id: string): string {
+  return toAssetPath('maps', `${id}.ply`);
+}
+
+export function objectPlyPath(id: string): string {
+  return toAssetPath('objects', `${id}.ply`);
+}
+```
+
+Add export functions:
+```typescript
+export async function exportMapToProject(
+  root: FileSystemDirectoryHandle,
+  id: string,
+  ply: Blob | Uint8Array,
+): Promise<{ plyPath: string }> {
+  await ensureSubdir(root, PROJECT_LAYOUT.assets.maps);
+  const plyPath = mapPlyPath(id);
+  await writeFileAtPath(root, plyPath, ply);
+  return { plyPath };
+}
+
+export async function exportObjectToProject(
+  root: FileSystemDirectoryHandle,
+  id: string,
+  ply: Blob | Uint8Array,
+): Promise<{ plyPath: string }> {
+  await ensureSubdir(root, PROJECT_LAYOUT.assets.objects);
+  const plyPath = objectPlyPath(id);
+  await writeFileAtPath(root, plyPath, ply);
+  return { plyPath };
+}
+```
+
+Update `listEchidnaProjects` return type and populate `kind`:
+```typescript
+export async function listEchidnaProjects(
+  handle: FileSystemDirectoryHandle,
+): Promise<AssetListEntry[]> {
+```
+
+In the entries loop, change the push to include `kind`:
+```typescript
+      entries.push({
+        id: migrated.id,
+        kind: migrated.kind,
+        name: migrated.characterName,
+        lastModified: file.lastModified ?? 0,
+      });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tools && pnpm --filter echidna test -- --run --reporter verbose 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/apps/echidna/src/lib/projectFs.ts tools/apps/echidna/src/__tests__/projectFs.test.ts
+git commit -m "feat(echidna): add exportMapToProject and exportObjectToProject"
+```
+
+---
+
+### Task 5: Store rename — character → asset
+
+This is a large mechanical rename across the Zustand store and all 22 consumer files. The subagent should use search-and-replace.
+
+**Files:**
+- Modify: `tools/apps/echidna/src/store/useCharacterStore.ts`
+- Modify: `tools/apps/echidna/src/store/types.ts` (remove deprecated aliases)
+- Modify: `tools/apps/echidna/src/lib/projectFs.ts` (update import)
+- Modify: All panel/viewport/App files (22 files total)
+- Rename: `tools/apps/echidna/src/panels/CharactersPanel.tsx` → `tools/apps/echidna/src/panels/AssetsPanel.tsx`
+- Rename: `tools/apps/echidna/src/__tests__/CharactersPanel.test.ts` → `tools/apps/echidna/src/__tests__/AssetsPanel.test.ts`
+- Modify: `tools/apps/echidna/src/__tests__/characterStore.test.ts`
+
+- [ ] **Step 1: Perform the renames in useCharacterStore.ts**
+
+This is the core file. Apply these renames throughout `tools/apps/echidna/src/store/useCharacterStore.ts`:
+
+| Old | New |
+|-----|-----|
+| `import { ... Character, CharacterListEntry }` | `import { ... Asset, AssetListEntry }` |
+| `import { ... slugifyCharacterId }` | `import { ... slugifyAssetId }` |
+| `DEFAULT_CHARACTER` | `DEFAULT_ASSET` |
+| `character: Character \| null` | `asset: Asset \| null` |
+| `knownCharacters: CharacterListEntry[]` | `knownAssets: AssetListEntry[]` |
+| `newCharacter:` | `newAsset:` |
+| `openCharacter:` | `openAsset:` |
+| `listCharacters:` | `listAssets:` |
+| `deleteCharacter:` | `deleteAsset:` |
+| `renameCharacter:` | `renameAsset:` |
+| `duplicateCharacter:` | `duplicateAsset:` |
+| `requestOpenCharacter:` | `requestOpenAsset:` |
+| `ensureCharacterId` | `ensureAssetId` |
+| `ConfirmSwitch` info field `currentName` | stays `currentName` (no change) |
+| All `s.character` / `state.character` | `s.asset` / `state.asset` |
+| All `s.knownCharacters` / `state.knownCharacters` | `s.knownAssets` / `state.knownAssets` |
+| `slugifyCharacterId(` | `slugifyAssetId(` |
+
+Also update `DEFAULT_ASSET` to include `kind` and `tags`:
+```typescript
+const DEFAULT_ASSET: Asset = {
+  id: '',
+  kind: 'character',
+  characterName: 'Untitled',
+  gridWidth: 32,
+  gridDepth: 32,
+  voxels: new Map(),
+  characterParts: [],
+  characterPoses: {},
+  animations: {},
+  tags: [],
+  currentFilename: null,
+};
+```
+
+Update `CharacterStoreState` interface name to `AssetStoreState` (or keep as-is to reduce blast radius — implementer's judgment call; the important renames are the fields and actions).
+
+- [ ] **Step 2: Update newAsset to accept kind parameter**
+
+Change the signature:
+```typescript
+  newAsset: (kind: EchidnaAssetKind, gridSize?: number, name?: string) => void;
+```
+
+In the implementation, pass `kind` into the created asset:
+```typescript
+  newAsset: (kind, gridSize?, name?) => {
+    const size = gridSize ?? 32;
+    const charName = (name && name.trim().length > 0) ? name.trim() : 'Untitled';
+    const s = get();
+
+    const MAX_NEW_SUFFIX = 1000;
+    const baseId = slugifyAssetId(charName);
+    const existingIds = new Set(s.knownAssets.map((c) => c.id));
+    let newId = baseId;
+    let counter = 2;
+    while (existingIds.has(newId)) {
+      if (counter > MAX_NEW_SUFFIX) {
+        console.error(`[echidna] newAsset: > ${MAX_NEW_SUFFIX} collisions for base id "${baseId}"`);
+        return;
+      }
+      newId = `${baseId}_${counter}`;
+      counter += 1;
+    }
+
+    set({
+      asset: {
+        id: newId,
+        kind,
+        voxels: new Map(),
+        gridWidth: size,
+        gridDepth: size,
+        characterName: charName,
+        characterParts: [],
+        characterPoses: {},
+        animations: {},
+        tags: [],
+        currentFilename: null,
+      },
+      knownAssets: [
+        ...s.knownAssets,
+        { id: newId, kind, name: charName, lastModified: Date.now() },
+      ],
+      selectedPart: null,
+      selectedPose: null,
+      selectedAnimation: null,
+      previewPose: false,
+      undoStack: [],
+      redoStack: [],
+      playbackTime: 0,
+      isPlaying: false,
+      boxSelection: null,
+      colorByPart: false,
+      partColors: {},
+      dirty: true,
+    });
+  },
+```
+
+- [ ] **Step 3: Update save() to branch on asset.kind**
+
+In the `save()` method, after the `.echidna` source write succeeds, replace the engine-file export section with kind-branching:
+
+```typescript
+      // 2. Build engine-ready files based on asset kind
+      try {
+        if (s.asset.kind === 'character') {
+          const ply = exportPly(
+            s.asset.voxels,
+            s.asset.gridWidth,
+            s.asset.gridDepth,
+            s.asset.characterParts,
+          );
+          const manifest = buildManifest(
+            id,
+            `${id}.ply`,
+            1.0,
+            s.asset.characterParts,
+            s.asset.characterPoses,
+            s.asset.animations,
+          );
+          await exportCharacterToProject(handle, id, ply, JSON.stringify(manifest, null, 2));
+        } else if (s.asset.kind === 'map') {
+          const ply = exportPly(
+            s.asset.voxels,
+            s.asset.gridWidth,
+            s.asset.gridDepth,
+            s.asset.characterParts,
+          );
+          await exportMapToProject(handle, id, ply);
+        } else if (s.asset.kind === 'object') {
+          const ply = exportPly(
+            s.asset.voxels,
+            s.asset.gridWidth,
+            s.asset.gridDepth,
+            s.asset.characterParts,
+          );
+          await exportObjectToProject(handle, id, ply);
+        }
+      } catch (e) {
+        console.error('[echidna] save: partial write — engine files may be stale:', e);
+        return false;
+      }
+```
+
+Add imports for `exportMapToProject` and `exportObjectToProject` from `../lib/projectFs.js`.
+
+- [ ] **Step 4: Update saveProject() to include kind and tags**
+
+In the `saveProject()` method, add `kind` and `tags` to the returned DTO:
+
+```typescript
+    return {
+      version: ECHIDNA_FILE_VERSION,
+      id,
+      kind: char.kind,
+      characterName: char.characterName,
+      gridWidth: char.gridWidth,
+      gridDepth: char.gridDepth,
+      voxels: voxelArr,
+      parts: char.characterParts,
+      poses: char.characterPoses,
+      animations: Object.keys(char.animations).length > 0 ? char.animations : undefined,
+      tags: char.tags,
+    };
+```
+
+(Note: `char` here is the local variable after the null-throw guard — now renamed from `s.character` to `s.asset`.)
+
+- [ ] **Step 5: Update loadProject() to include kind and tags**
+
+In the `loadProject()` method, add `kind` and `tags` to the `set()` call:
+
+```typescript
+    set({
+      asset: {
+        id: data.id,
+        kind: data.kind,
+        voxels,
+        gridWidth: data.gridWidth,
+        gridDepth: data.gridDepth,
+        characterName: data.characterName,
+        characterParts: parts,
+        characterPoses: data.poses,
+        animations,
+        tags: data.tags,
+        currentFilename: null,
+      },
+      ...
+```
+
+- [ ] **Step 6: Remove deprecated aliases from types.ts**
+
+In `tools/apps/echidna/src/store/types.ts`, remove:
+```typescript
+/** @deprecated Use Asset */
+export type Character = Asset;
+/** @deprecated Use AssetListEntry */
+export type CharacterListEntry = AssetListEntry;
+/** @deprecated Use slugifyAssetId */
+export const slugifyCharacterId = slugifyAssetId;
+```
+
+- [ ] **Step 7: Rename CharactersPanel.tsx → AssetsPanel.tsx**
+
+```bash
+git mv tools/apps/echidna/src/panels/CharactersPanel.tsx tools/apps/echidna/src/panels/AssetsPanel.tsx
+```
+
+Update all internal references (`knownCharacters` → `knownAssets`, `character` → `asset`, etc.) and update the component export name from `CharactersPanel` to `AssetsPanel`.
+
+- [ ] **Step 8: Rename CharactersPanel.test.ts → AssetsPanel.test.ts**
+
+```bash
+git mv tools/apps/echidna/src/__tests__/CharactersPanel.test.ts tools/apps/echidna/src/__tests__/AssetsPanel.test.ts
+```
+
+Update all internal references.
+
+- [ ] **Step 9: Update all consumer files**
+
+These files read `s.character` / `s.knownCharacters` from the store and need mechanical updates:
+
+- `tools/apps/echidna/src/App.tsx` — selectors, imports (CharactersPanel→AssetsPanel), callbacks
+- `tools/apps/echidna/src/panels/MenuBar.tsx` — selectors, syncCharacterToStaging uses `s.asset`
+- `tools/apps/echidna/src/panels/BuildPanel.tsx` — selectors
+- `tools/apps/echidna/src/panels/PartsPanel.tsx` — selectors
+- `tools/apps/echidna/src/panels/PosePanel.tsx` — selectors
+- `tools/apps/echidna/src/panels/Timeline.tsx` — selectors
+- `tools/apps/echidna/src/panels/AnimateLeftPanel.tsx` — selectors
+- `tools/apps/echidna/src/panels/AnimateRightPanel.tsx` — selectors
+- `tools/apps/echidna/src/panels/ExportDialog.tsx` — selectors
+- `tools/apps/echidna/src/panels/ResizeGridDialog.tsx` — selectors
+- `tools/apps/echidna/src/panels/NewProjectDialog.tsx` — `newCharacter` → `newAsset('character', ...)`
+- `tools/apps/echidna/src/panels/EmptyProjectState.tsx` — if it references character
+- `tools/apps/echidna/src/viewport/CharacterViewport.tsx` — selectors
+- `tools/apps/echidna/src/viewport/VoxelMesh.tsx` — selectors
+- `tools/apps/echidna/src/viewport/MirrorPlane.tsx` — selectors
+- `tools/apps/echidna/src/viewport/JointGizmos.tsx` — selectors
+- `tools/apps/echidna/src/viewport/GroundPlane.tsx` — selectors
+
+The rename is mechanical: `useCharacterStore((s) => s.character` → `useCharacterStore((s) => s.asset`, `s.knownCharacters` → `s.knownAssets`, action names as per the rename table.
+
+- [ ] **Step 10: Update characterStore.test.ts**
+
+Apply the same renames throughout the test file. Every `character:` in `setState` becomes `asset:`, every `s.character?.id` becomes `s.asset?.id`, every `knownCharacters` becomes `knownAssets`, etc.
+
+Also update the `newCharacter` test block to call `newAsset('character', ...)` instead.
+
+- [ ] **Step 11: Add new test cases for map/object asset creation and save**
+
+In `tools/apps/echidna/src/__tests__/characterStore.test.ts`, add:
+
+```typescript
+describe('useCharacterStore.newAsset — kind parameter', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({ knownAssets: [], asset: null, dirty: false });
+  });
+
+  it('creates a map asset with no parts or poses', () => {
+    useCharacterStore.getState().newAsset('map', 64, 'Town');
+    const s = useCharacterStore.getState();
+    expect(s.asset?.kind).toBe('map');
+    expect(s.asset?.id).toBe('town');
+    expect(s.asset?.characterParts).toEqual([]);
+    expect(s.asset?.characterPoses).toEqual({});
+    expect(s.knownAssets[0].kind).toBe('map');
+  });
+
+  it('creates an object asset', () => {
+    useCharacterStore.getState().newAsset('object', 16, 'Crystal');
+    const s = useCharacterStore.getState();
+    expect(s.asset?.kind).toBe('object');
+    expect(s.asset?.id).toBe('crystal');
+    expect(s.knownAssets[0].kind).toBe('object');
+  });
+});
+
+describe('useCharacterStore.save — map kind', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({ _saving: false });
+  });
+
+  it('writes PLY to assets/maps/ without manifest', async () => {
+    const root = testing.makeRoot();
+    useCharacterStore.setState({
+      projectRootHandle: root as unknown as FileSystemDirectoryHandle,
+      asset: {
+        id: 'town',
+        kind: 'map',
+        characterName: 'Town',
+        gridWidth: 32,
+        gridDepth: 32,
+        voxels: new Map([['0,0,0', { color: [100, 150, 100, 255] }]]),
+        characterParts: [],
+        characterPoses: {},
+        animations: {},
+        tags: [],
+        currentFilename: null,
+      },
+      dirty: true,
+    });
+
+    const ok = await useCharacterStore.getState().save();
+    expect(ok).toBe(true);
+    expect(useCharacterStore.getState().dirty).toBe(false);
+
+    // PLY should exist at assets/maps/town.ply
+    const assets = await root.getDirectoryHandle('assets');
+    const maps = await assets.getDirectoryHandle('maps');
+    await maps.getFileHandle('town.ply');  // throws if missing
+
+    // No manifest or character directory should exist
+    let hasCharDir = true;
+    try {
+      const chars = await assets.getDirectoryHandle('characters');
+      await chars.getDirectoryHandle('town');
+    } catch {
+      hasCharDir = false;
+    }
+    expect(hasCharDir).toBe(false);
+  });
+});
+
+describe('useCharacterStore.save — object kind', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({ _saving: false });
+  });
+
+  it('writes PLY to assets/objects/ without manifest', async () => {
+    const root = testing.makeRoot();
+    useCharacterStore.setState({
+      projectRootHandle: root as unknown as FileSystemDirectoryHandle,
+      asset: {
+        id: 'crystal',
+        kind: 'object',
+        characterName: 'Crystal',
+        gridWidth: 16,
+        gridDepth: 16,
+        voxels: new Map([['0,0,0', { color: [200, 200, 255, 255] }]]),
+        characterParts: [],
+        characterPoses: {},
+        animations: {},
+        tags: ['prop'],
+        currentFilename: null,
+      },
+      dirty: true,
+    });
+
+    const ok = await useCharacterStore.getState().save();
+    expect(ok).toBe(true);
+
+    const assets = await root.getDirectoryHandle('assets');
+    const objects = await assets.getDirectoryHandle('objects');
+    await objects.getFileHandle('crystal.ply');
+  });
+});
+```
+
+- [ ] **Step 12: Run all tests**
+
+Run: `cd tools && pnpm --filter echidna test -- --run --reporter verbose 2>&1 | tail -30`
+Expected: all PASS
+
+- [ ] **Step 13: Run build**
+
+Run: `cd tools && pnpm build 2>&1 | tail -10`
+Expected: Build succeeds
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add -A tools/apps/echidna/
+git commit -m "feat(echidna): rename Character → Asset, add kind-based save branching"
+```
+
+---
+
+### Task 6: Final build verification
+
+- [ ] **Step 1: Run full project-root tests**
+
+Run: `cd tools && pnpm --filter @gseurat/project-root test -- --run --reporter verbose`
+Expected: all PASS
+
+- [ ] **Step 2: Run full echidna tests**
+
+Run: `cd tools && pnpm --filter echidna test -- --run --reporter verbose`
+Expected: all PASS
+
+- [ ] **Step 3: Run full build**
+
+Run: `cd tools && pnpm build 2>&1 | tail -20`
+Expected: Build succeeds

--- a/docs/superpowers/specs/2026-04-12-echidna-phase-03a-schema-registry-design.md
+++ b/docs/superpowers/specs/2026-04-12-echidna-phase-03a-schema-registry-design.md
@@ -1,0 +1,149 @@
+# Phase 0.3a — Echidna Schema + Registry Infrastructure
+
+Foundation layer for multi-asset Echidna. No UI changes — schema, registry, store renaming, and export branching only.
+
+## EchidnaFile v4 Schema
+
+### New type
+
+```ts
+export type EchidnaAssetKind = 'character' | 'map' | 'object';
+```
+
+### EchidnaFile changes (v3 → v4)
+
+- Add `kind: EchidnaAssetKind` field (required)
+- Add optional `tags?: string[]` (object-only, for future asset picker filtering)
+- `parts`, `poses`, `animations` stay optional (animations already is; make parts/poses optional too)
+- Bump `ECHIDNA_FILE_VERSION` to 4
+
+No `collision` field — collision grids are Bricklayer's responsibility (it assembles maps from multiple PLY assets).
+
+### Migration (v3 → v4)
+
+`migrateEchidnaFile` defaults `kind: 'character'` for all legacy files. All existing `.echidna` files are characters.
+
+### In-memory type rename
+
+`Character` → `Asset`:
+
+```ts
+export interface Asset {
+  id: string;
+  kind: EchidnaAssetKind;
+  characterName: string;   // semantically "asset name", field name kept for back-compat
+  gridWidth: number;
+  gridDepth: number;
+  voxels: Map<VoxelKey, Voxel>;
+  characterParts: BodyPart[];
+  characterPoses: Record<string, PoseData>;
+  animations: Record<string, AnimationClip>;
+  tags: string[];
+  currentFilename: string | null;
+}
+```
+
+`CharacterListEntry` → `AssetListEntry`:
+
+```ts
+export interface AssetListEntry {
+  id: string;
+  kind: EchidnaAssetKind;
+  name: string;
+  lastModified: number;
+}
+```
+
+## AssetRegistry + PROJECT_LAYOUT
+
+### AssetRegistry (additive, no version bump)
+
+- Add `objects: Record<string, FileEntry>` field
+- Add `registerObject(reg, id, filePath): AssetRegistry` function
+- `RefKind` gains `'object'`
+- `resolveRef` handles `'object'` kind
+
+### PROJECT_LAYOUT
+
+- Add `assets.objects = 'assets/objects'`
+- Add `'objects'` to `ASSET_KINDS` array
+- `AssetKind` type automatically includes it
+
+## Echidna Store Refactor
+
+### Renames
+
+| Old | New |
+|-----|-----|
+| `Character` interface | `Asset` |
+| `CharacterListEntry` | `AssetListEntry` |
+| `state.character` | `state.asset` |
+| `state.knownCharacters` | `state.knownAssets` |
+| `newCharacter(gridSize?, name?)` | `newAsset(kind, gridSize?, name?)` |
+| `openCharacter(id)` | `openAsset(id)` |
+| `listCharacters()` | `listAssets()` |
+| `deleteCharacter(id)` | `deleteAsset(id)` |
+| `renameCharacter(id, name)` | `renameAsset(id, name)` |
+| `duplicateCharacter(id, name)` | `duplicateAsset(id, name)` |
+| `requestOpenCharacter` | `requestOpenAsset` |
+| `ConfirmSwitch` (unchanged signature) | `ConfirmSwitch` (no rename needed) |
+| `CharactersPanel` | `AssetsPanel` |
+| `CharactersPanel.test.ts` | `AssetsPanel.test.ts` |
+
+### Export behavior per kind
+
+`save()` branches on `asset.kind` for the engine-file export step:
+
+| Kind | Engine output | Path |
+|------|--------------|------|
+| `character` | PLY + manifest JSON | `assets/characters/{id}/{id}.ply` + `{id}.manifest.json` |
+| `map` | PLY only | `assets/maps/{id}.ply` |
+| `object` | PLY only | `assets/objects/{id}.ply` |
+
+The `.echidna` source file save is identical for all kinds — always `tools_data/echidna_saves/{id}.echidna`.
+
+### projectFs.ts
+
+Function names stay generic (`listEchidnaProjects`, `loadEchidnaProject`, etc.). The `kind` field is now in the `.echidna` JSON, so `listAssets()` reads it from each file and populates `AssetListEntry.kind`.
+
+### newAsset(kind, gridSize?, name?)
+
+Creates a fresh asset of the given kind. For `map` and `object` kinds, `characterParts`, `characterPoses`, and `animations` default to empty (same as characters, but semantically unused).
+
+### DEFAULT_ASSET
+
+Replaces `DEFAULT_CHARACTER`. Adds `kind: 'character'`, `tags: []`.
+
+## Testing
+
+### Updated tests
+
+All existing tests in `characterStore.test.ts` and `CharactersPanel.test.ts` update field names (`character` → `asset`, `knownCharacters` → `knownAssets`, etc.).
+
+### New tests
+
+- `migrateEchidnaFile` v3 → v4: input without `kind` → outputs `kind: 'character'`
+- `newAsset('map', 32)`: creates asset with `kind: 'map'`, empty parts/poses/animations
+- `newAsset('object', 16, 'Crystal')`: creates asset with `kind: 'object'`, id `'crystal'`
+- `save()` for `map` kind: writes PLY to `assets/maps/{id}.ply`, no manifest, no `assets/characters/` dir
+- `save()` for `object` kind: writes PLY to `assets/objects/{id}.ply`, no manifest
+- `registerObject` + `resolveRef('object')` in registry tests
+
+## Scope Boundary
+
+### In scope (0.3a)
+
+- EchidnaFile v4 schema + migration
+- AssetRegistry `objects` kind + PROJECT_LAYOUT
+- Store rename Character → Asset, all actions
+- `newAsset(kind)` with kind parameter
+- Export branching by kind (PLY-only for map/object)
+- Register map/object in AssetRegistry on save
+- Tests
+
+### Out of scope (deferred to 0.3b+)
+
+- UI changes (Assets panel kind filter, kind-aware editor panels, "New" dropdown with kind picker)
+- Méliès asset picker refactor
+- Collision grid features
+- Bricklayer Map Painter changes

--- a/tools/apps/bricklayer/src/lib/__tests__/migrateBricklayerFile.test.ts
+++ b/tools/apps/bricklayer/src/lib/__tests__/migrateBricklayerFile.test.ts
@@ -79,6 +79,7 @@ describe('migrateBricklayerFile', () => {
         textures: {},
         audio: {},
         maps: {},
+        objects: {},
       },
       gridWidth: 32,
       gridDepth: 32,

--- a/tools/apps/echidna/src/App.tsx
+++ b/tools/apps/echidna/src/App.tsx
@@ -293,7 +293,7 @@ export function App() {
       <div style={styles.body}>
         {/* Left panel */}
         <div style={{ width: leftWidth, flexShrink: 0, display: 'flex', flexDirection: 'column' as const, overflow: 'hidden', background: '#1e1e3a', borderRight: '1px solid #333' }}>
-          <AssetsPanel onNewCharacter={handleNewAsset} />
+          <AssetsPanel onNewAsset={handleNewAsset} />
           <ModeTabs />
           <div style={{ flex: 1, overflow: 'auto' }}>
             {mode === 'build' ? <ToolBar /> : <AnimateLeftPanel />}

--- a/tools/apps/echidna/src/App.tsx
+++ b/tools/apps/echidna/src/App.tsx
@@ -7,7 +7,7 @@ import { AnimateLeftPanel } from './panels/AnimateLeftPanel.js';
 import { AnimateRightPanel } from './panels/AnimateRightPanel.js';
 import { Timeline } from './panels/Timeline.js';
 import { EmptyProjectState } from './panels/EmptyProjectState.js';
-import { CharactersPanel } from './panels/CharactersPanel.js';
+import { AssetsPanel } from './panels/AssetsPanel.js';
 import { NewProjectDialog } from './panels/NewProjectDialog.js';
 import { useCharacterStore } from './store/useCharacterStore.js';
 import type { ToolType } from './store/types.js';
@@ -127,9 +127,9 @@ export function App() {
   const [showNewDialog, setShowNewDialog] = useState(false);
 
   const projectRootHandle = useCharacterStore((s) => s.projectRootHandle);
-  const character = useCharacterStore((s) => s.character);
+  const asset = useCharacterStore((s) => s.asset);
 
-  const handleNewCharacter = useCallback(() => {
+  const handleNewAsset = useCallback(() => {
     const store = useCharacterStore.getState();
     if (store.dirty || store.undoStack.length > 0) {
       if (!confirm('Create new character? Unsaved changes will be lost.')) return;
@@ -143,7 +143,7 @@ export function App() {
       const handle: FileSystemDirectoryHandle = await window.showDirectoryPicker({ mode: 'readwrite' });
       await saveProjectRootHandle('echidna', handle);
       useCharacterStore.getState().setProjectRootHandle(handle);
-      await useCharacterStore.getState().listCharacters();
+      await useCharacterStore.getState().listAssets();
     } catch (e) {
       // User canceled or denied permission — silently ignore AbortError
       if ((e as Error).name !== 'AbortError') {
@@ -162,7 +162,7 @@ export function App() {
         if (handle && !useCharacterStore.getState().projectRootHandle) {
           useCharacterStore.getState().setProjectRootHandle(handle);
           console.info(`[echidna] Restored project root: ${handle.name}`);
-          await useCharacterStore.getState().listCharacters();
+          await useCharacterStore.getState().listAssets();
         }
       } catch (e) {
         // Silently ignore — user can pick the root again via File → Open Project Root…
@@ -204,7 +204,7 @@ export function App() {
       if (meta && e.key === 'n' && !e.shiftKey) {
         e.preventDefault();
         if (confirm('Create new character? Unsaved changes will be lost.')) {
-          store.newCharacter();
+          store.newAsset('character');
         }
         return;
       }
@@ -293,7 +293,7 @@ export function App() {
       <div style={styles.body}>
         {/* Left panel */}
         <div style={{ width: leftWidth, flexShrink: 0, display: 'flex', flexDirection: 'column' as const, overflow: 'hidden', background: '#1e1e3a', borderRight: '1px solid #333' }}>
-          <CharactersPanel onNewCharacter={handleNewCharacter} />
+          <AssetsPanel onNewCharacter={handleNewAsset} />
           <ModeTabs />
           <div style={{ flex: 1, overflow: 'auto' }}>
             {mode === 'build' ? <ToolBar /> : <AnimateLeftPanel />}
@@ -305,12 +305,12 @@ export function App() {
         <div style={{ flex: 1, position: 'relative' as const, overflow: 'hidden' }}>
           {projectRootHandle === null ? (
             <EmptyProjectState onOpenProjectRoot={handleOpenProjectRoot} />
-          ) : character === null ? (
+          ) : asset === null ? (
             <NoCharacterSelected />
           ) : (
             <CharacterViewport />
           )}
-          {character !== null && mode === 'animate' && (
+          {asset !== null && mode === 'animate' && (
             <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 }}>
               <Timeline />
             </div>

--- a/tools/apps/echidna/src/__tests__/AssetsPanel.test.ts
+++ b/tools/apps/echidna/src/__tests__/AssetsPanel.test.ts
@@ -4,15 +4,16 @@ import { testing } from '@gseurat/project-root';
 
 
 /**
- * CharactersPanel data contract tests.
+ * AssetsPanel data contract tests.
  *
- * These verify the store selectors and state shapes that CharactersPanel.tsx
+ * These verify the store selectors and state shapes that AssetsPanel.tsx
  * consumes. RTL render tests are deferred until @testing-library/react is
  * added to the workspace.
  */
 
-const makeCharacter = (id: string, name: string) => ({
+const makeAsset = (id: string, name: string) => ({
   id,
+  kind: 'character' as const,
   characterName: name,
   gridWidth: 32,
   gridDepth: 32,
@@ -20,27 +21,28 @@ const makeCharacter = (id: string, name: string) => ({
   characterParts: [],
   characterPoses: {},
   animations: {},
+  tags: [],
   currentFilename: null,
 });
 
-describe('CharactersPanel data contract', () => {
+describe('AssetsPanel data contract', () => {
   beforeEach(() => {
     useCharacterStore.setState({
-      character: null,
-      knownCharacters: [],
+      asset: null,
+      knownAssets: [],
       dirty: false,
       undoStack: [],
       redoStack: [],
     });
   });
 
-  it('knownCharacters is empty when no characters exist', () => {
+  it('knownAssets is empty when no assets exist', () => {
     const s = useCharacterStore.getState();
-    expect(s.knownCharacters).toEqual([]);
-    expect(s.character).toBeNull();
+    expect(s.knownAssets).toEqual([]);
+    expect(s.asset).toBeNull();
   });
 
-  it('knownCharacters reflects listed characters', async () => {
+  it('knownAssets reflects listed assets', async () => {
     const root = testing.makeRoot();
     const td = await root.getDirectoryHandle('tools_data', { create: true });
     const saves = await td.getDirectoryHandle('echidna_saves', { create: true });
@@ -57,23 +59,23 @@ describe('CharactersPanel data contract', () => {
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
     });
-    await useCharacterStore.getState().listCharacters();
+    await useCharacterStore.getState().listAssets();
 
-    const known = useCharacterStore.getState().knownCharacters;
+    const known = useCharacterStore.getState().knownAssets;
     expect(known).toHaveLength(2);
     const ids = known.map((c) => c.id).sort();
     expect(ids).toEqual(['knight', 'mage']);
   });
 
-  it('current character id matches character.id selector', () => {
-    useCharacterStore.setState({ character: makeCharacter('knight', 'Knight') });
+  it('current asset id matches asset.id selector', () => {
+    useCharacterStore.setState({ asset: makeAsset('knight', 'Knight') });
     const s = useCharacterStore.getState();
-    expect(s.character?.id).toBe('knight');
+    expect(s.asset?.id).toBe('knight');
   });
 
   it('dirty indicator is true only when dirty flag is set', () => {
     useCharacterStore.setState({
-      character: makeCharacter('knight', 'Knight'),
+      asset: makeAsset('knight', 'Knight'),
       dirty: false,
     });
     expect(useCharacterStore.getState().dirty).toBe(false);
@@ -84,7 +86,7 @@ describe('CharactersPanel data contract', () => {
 
   it('currentHasWork is true when undoStack or redoStack is non-empty', () => {
     useCharacterStore.setState({
-      character: makeCharacter('knight', 'Knight'),
+      asset: makeAsset('knight', 'Knight'),
       dirty: false,
       undoStack: [{} as any],
       redoStack: [],
@@ -94,12 +96,12 @@ describe('CharactersPanel data contract', () => {
     expect(currentHasWork).toBe(true);
   });
 
-  it('newCharacter adds optimistic entry to knownCharacters', () => {
-    useCharacterStore.getState().newCharacter(32, 'Archer');
+  it('newAsset adds optimistic entry to knownAssets', () => {
+    useCharacterStore.getState().newAsset('character', 32, 'Archer');
     const s = useCharacterStore.getState();
-    expect(s.knownCharacters).toHaveLength(1);
-    expect(s.knownCharacters[0].id).toBe('archer');
-    expect(s.knownCharacters[0].name).toBe('Archer');
-    expect(s.character?.id).toBe('archer');
+    expect(s.knownAssets).toHaveLength(1);
+    expect(s.knownAssets[0].id).toBe('archer');
+    expect(s.knownAssets[0].name).toBe('Archer');
+    expect(s.asset?.id).toBe('archer');
   });
 });

--- a/tools/apps/echidna/src/__tests__/characterStore.test.ts
+++ b/tools/apps/echidna/src/__tests__/characterStore.test.ts
@@ -1,7 +1,39 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useCharacterStore } from '../store/useCharacterStore';
 import { testing } from '@gseurat/project-root';
-import { CharacterListEntry } from '../store/types';
+import { CharacterListEntry, migrateEchidnaFile, ECHIDNA_FILE_VERSION } from '../store/types';
+
+describe('migrateEchidnaFile v3 → v4', () => {
+  it('defaults kind to character for legacy v3 files', () => {
+    const raw = {
+      version: 3, id: 'walker', characterName: 'Walker',
+      gridWidth: 32, gridDepth: 32, voxels: [], parts: [], poses: {},
+    };
+    const result = migrateEchidnaFile(raw);
+    expect(result.version).toBe(4);
+    expect(result.kind).toBe('character');
+  });
+
+  it('preserves kind when already present', () => {
+    const raw = {
+      version: 4, id: 'crystal', kind: 'object', characterName: 'Crystal',
+      gridWidth: 16, gridDepth: 16, voxels: [], parts: [], poses: {}, tags: ['prop'],
+    };
+    const result = migrateEchidnaFile(raw);
+    expect(result.kind).toBe('object');
+    expect(result.tags).toEqual(['prop']);
+  });
+
+  it('defaults tags to empty array', () => {
+    const raw = { version: 3, id: 'test', characterName: 'Test', voxels: [], parts: [], poses: {} };
+    const result = migrateEchidnaFile(raw);
+    expect(result.tags).toEqual([]);
+  });
+
+  it('ECHIDNA_FILE_VERSION is 4', () => {
+    expect(ECHIDNA_FILE_VERSION).toBe(4);
+  });
+});
 
 describe('useCharacterStore — dirty tracking', () => {
   beforeEach(() => {
@@ -9,6 +41,7 @@ describe('useCharacterStore — dirty tracking', () => {
     useCharacterStore.setState({
       character: {
         id: '',
+        kind: 'character' as const,
         characterName: 'Untitled',
         gridWidth: 32,
         gridDepth: 32,
@@ -16,6 +49,7 @@ describe('useCharacterStore — dirty tracking', () => {
         characterParts: [],
         characterPoses: {},
         animations: {},
+        tags: [],
         currentFilename: null,
       },
     });
@@ -96,7 +130,7 @@ describe('useCharacterStore.listCharacters', () => {
 
   it('preserves knownCharacters on transient failure', async () => {
     const stale: CharacterListEntry[] = [
-      { id: 'old', name: 'Old Character', lastModified: 1000 },
+      { id: 'old', kind: 'character', name: 'Old Character', lastModified: 1000 },
     ];
     useCharacterStore.setState({
       // Bogus handle that will make listEchidnaProjects throw when it tries
@@ -192,7 +226,7 @@ describe('useCharacterStore.openCharacter', () => {
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       knownCharacters: [
-        { id: 'ghost', name: 'Ghost', lastModified: 0 },
+        { id: 'ghost', kind: 'character', name: 'Ghost', lastModified: 0 },
       ],
     });
 
@@ -228,6 +262,7 @@ describe('useCharacterStore.save', () => {
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       character: {
         id: 'walker',
+        kind: 'character' as const,
         characterName: 'Walker Bot',
         gridWidth: 32,
         gridDepth: 32,
@@ -235,6 +270,7 @@ describe('useCharacterStore.save', () => {
         characterParts: [],
         characterPoses: {},
         animations: {},
+        tags: [],
         currentFilename: null,
       },
       dirty: true,
@@ -270,6 +306,7 @@ describe('useCharacterStore.save', () => {
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       character: {
         id: 'walker',
+        kind: 'character' as const,
         characterName: 'Walker',
         gridWidth: 32,
         gridDepth: 32,
@@ -277,6 +314,7 @@ describe('useCharacterStore.save', () => {
         characterParts: [],
         characterPoses: {},
         animations: {},
+        tags: [],
         currentFilename: null,
       },
       dirty: true,
@@ -300,6 +338,7 @@ describe('useCharacterStore.save', () => {
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       character: {
         id: 'walker',
+        kind: 'character' as const,
         characterName: 'Walker',
         gridWidth: 32,
         gridDepth: 32,
@@ -307,6 +346,7 @@ describe('useCharacterStore.save', () => {
         characterParts: [],
         characterPoses: {},
         animations: {},
+        tags: [],
         currentFilename: null,
       },
       dirty: true,
@@ -340,12 +380,14 @@ describe('useCharacterStore.save', () => {
       projectRootHandle: null,
       character: {
         id: 'walker',
+        kind: 'character' as const,
         characterName: 'Walker',
         gridWidth: 32, gridDepth: 32,
         voxels: new Map(),
         characterParts: [],
         characterPoses: {},
         animations: {},
+        tags: [],
         currentFilename: null,
       },
       dirty: true,
@@ -386,6 +428,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
       // open 'archer' are not caught by the re-entry guard (walker ≠ archer).
       character: {
         id: 'walker',
+        kind: 'character' as const,
         characterName: 'Walker',
         gridWidth: 32,
         gridDepth: 32,
@@ -393,12 +436,13 @@ describe('useCharacterStore.requestOpenCharacter', () => {
         characterParts: [],
         characterPoses: {},
         animations: {},
+        tags: [],
         currentFilename: null,
       },
       dirty: false,
       undoStack: [],
       knownCharacters: [
-        { id: 'archer', name: 'Archer', lastModified: 0 },
+        { id: 'archer', kind: 'character', name: 'Archer', lastModified: 0 },
       ],
     });
   });
@@ -447,6 +491,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
       dirty: true,
       character: {
         id: 'walker',
+        kind: 'character' as const,
         characterName: 'Walker',
         gridWidth: 32,
         gridDepth: 32,
@@ -454,6 +499,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
         characterParts: [],
         characterPoses: {},
         animations: {},
+        tags: [],
         currentFilename: null,
       },
     });
@@ -481,6 +527,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
       dirty: true,
       character: {
         id: 'walker',
+        kind: 'character' as const,
         characterName: 'Walker',
         gridWidth: 32,
         gridDepth: 32,
@@ -488,6 +535,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
         characterParts: [],
         characterPoses: {},
         animations: {},
+        tags: [],
         currentFilename: null,
       },
     });
@@ -518,6 +566,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
       dirty: true,  // even when dirty
       character: {
         id: 'walker',
+        kind: 'character' as const,
         characterName: 'Walker',
         gridWidth: 32,
         gridDepth: 32,
@@ -525,6 +574,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
         characterParts: [],
         characterPoses: {},
         animations: {},
+        tags: [],
         currentFilename: null,
       },
       undoStack: [{} as any],
@@ -560,11 +610,13 @@ describe('useCharacterStore.renameCharacter', () => {
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       character: {
         id: 'walker', characterName: 'Walker Bot',
+        kind: 'character' as const,
         gridWidth: 32, gridDepth: 32, voxels: new Map(),
         characterParts: [], characterPoses: {}, animations: {},
+        tags: [],
         currentFilename: null,
       },
-      knownCharacters: [{ id: 'walker', name: 'Walker Bot', lastModified: 0 }],
+      knownCharacters: [{ id: 'walker', kind: 'character', name: 'Walker Bot', lastModified: 0 }],
       dirty: false,
     });
 
@@ -592,11 +644,13 @@ describe('useCharacterStore.renameCharacter', () => {
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       character: {
         id: 'walker', characterName: 'Walker Bot',
+        kind: 'character' as const,
         gridWidth: 32, gridDepth: 32, voxels: new Map(),
         characterParts: [], characterPoses: {}, animations: {},
+        tags: [],
         currentFilename: null,
       },
-      knownCharacters: [{ id: 'walker', name: 'Walker Bot', lastModified: 0 }],
+      knownCharacters: [{ id: 'walker', kind: 'character', name: 'Walker Bot', lastModified: 0 }],
       dirty: false,
     });
 
@@ -629,13 +683,15 @@ describe('useCharacterStore.renameCharacter', () => {
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       character: {
         id: 'walker', characterName: 'Walker Bot',
+        kind: 'character' as const,
         gridWidth: 32, gridDepth: 32, voxels: new Map(),
         characterParts: [], characterPoses: {}, animations: {},
+        tags: [],
         currentFilename: null,
       },
       knownCharacters: [
-        { id: 'walker', name: 'Walker Bot', lastModified: 0 },
-        { id: 'archer', name: 'Archer', lastModified: 0 },
+        { id: 'walker', kind: 'character', name: 'Walker Bot', lastModified: 0 },
+        { id: 'archer', kind: 'character', name: 'Archer', lastModified: 0 },
       ],
       dirty: false,
     });
@@ -662,16 +718,18 @@ describe('useCharacterStore.deleteCharacter', () => {
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       knownCharacters: [
-        { id: 'walker', name: 'Walker', lastModified: 0 },
-        { id: 'archer', name: 'Archer', lastModified: 0 },
+        { id: 'walker', kind: 'character', name: 'Walker', lastModified: 0 },
+        { id: 'archer', kind: 'character', name: 'Archer', lastModified: 0 },
       ],
       // character is not walker, so deleting walker should not null it
       character: {
         id: 'archer',
+        kind: 'character' as const,
         characterName: 'Archer',
         gridWidth: 32, gridDepth: 32,
         voxels: new Map(),
         characterParts: [], characterPoses: {}, animations: {},
+        tags: [],
         currentFilename: null,
       },
     });
@@ -696,13 +754,15 @@ describe('useCharacterStore.deleteCharacter', () => {
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       character: {
         id: 'walker',
+        kind: 'character' as const,
         characterName: 'Walker',
         gridWidth: 32, gridDepth: 32,
         voxels: new Map(),
         characterParts: [], characterPoses: {}, animations: {},
+        tags: [],
         currentFilename: null,
       },
-      knownCharacters: [{ id: 'walker', name: 'Walker', lastModified: 0 }],
+      knownCharacters: [{ id: 'walker', kind: 'character', name: 'Walker', lastModified: 0 }],
       dirty: true,
       undoStack: [{} as any],
     });
@@ -735,8 +795,8 @@ describe('useCharacterStore.duplicateCharacter', () => {
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       knownCharacters: [
-        { id: 'walker', name: 'Walker', lastModified: 0 },
-        { id: 'walker_2', name: 'Walker', lastModified: 0 },
+        { id: 'walker', kind: 'character', name: 'Walker', lastModified: 0 },
+        { id: 'walker_2', kind: 'character', name: 'Walker', lastModified: 0 },
       ],
     });
 
@@ -759,7 +819,7 @@ describe('useCharacterStore.duplicateCharacter', () => {
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       character: null,
-      knownCharacters: [{ id: 'walker', name: 'Walker', lastModified: 0 }],
+      knownCharacters: [{ id: 'walker', kind: 'character', name: 'Walker', lastModified: 0 }],
     });
 
     await useCharacterStore.getState().duplicateCharacter('walker', 'Archer');
@@ -794,7 +854,7 @@ describe('useCharacterStore.newCharacter — name parameter', () => {
 
   it('deduplicates id when name collides with existing character', () => {
     useCharacterStore.setState({
-      knownCharacters: [{ id: 'knight', name: 'Knight', lastModified: 0 }],
+      knownCharacters: [{ id: 'knight', kind: 'character', name: 'Knight', lastModified: 0 }],
       character: null,
       dirty: false,
     });
@@ -824,8 +884,10 @@ describe('useCharacterStore.save — return value', () => {
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       character: {
         id: 'walker', characterName: 'Walker',
+        kind: 'character' as const,
         gridWidth: 32, gridDepth: 32, voxels: new Map(),
         characterParts: [], characterPoses: {}, animations: {},
+        tags: [],
         currentFilename: null,
       },
       dirty: true,
@@ -840,8 +902,10 @@ describe('useCharacterStore.save — return value', () => {
       projectRootHandle: null,
       character: {
         id: 'walker', characterName: 'Walker',
+        kind: 'character' as const,
         gridWidth: 32, gridDepth: 32, voxels: new Map(),
         characterParts: [], characterPoses: {}, animations: {},
+        tags: [],
         currentFilename: null,
       },
       dirty: true,
@@ -872,8 +936,10 @@ describe('useCharacterStore.save — return value', () => {
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       character: {
         id: 'walker', characterName: 'Walker',
+        kind: 'character' as const,
         gridWidth: 32, gridDepth: 32, voxels: new Map(),
         characterParts: [], characterPoses: {}, animations: {},
+        tags: [],
         currentFilename: null,
       },
       dirty: true,

--- a/tools/apps/echidna/src/__tests__/characterStore.test.ts
+++ b/tools/apps/echidna/src/__tests__/characterStore.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useCharacterStore } from '../store/useCharacterStore';
 import { testing } from '@gseurat/project-root';
-import { CharacterListEntry, migrateEchidnaFile, ECHIDNA_FILE_VERSION } from '../store/types';
+import { AssetListEntry, migrateEchidnaFile, ECHIDNA_FILE_VERSION } from '../store/types';
 
 describe('migrateEchidnaFile v3 → v4', () => {
   it('defaults kind to character for legacy v3 files', () => {
@@ -39,7 +39,7 @@ describe('useCharacterStore — dirty tracking', () => {
   beforeEach(() => {
     // Ensure a non-null character is present so mutating actions don't early-return
     useCharacterStore.setState({
-      character: {
+      asset: {
         id: '',
         kind: 'character' as const,
         characterName: 'Untitled',
@@ -82,25 +82,25 @@ describe('useCharacterStore — dirty tracking', () => {
   });
 
   it('addVoxel on null character is a no-op and does NOT dirty the state', () => {
-    useCharacterStore.setState({ character: null });
+    useCharacterStore.setState({ asset: null });
     useCharacterStore.getState().markClean();
     useCharacterStore.getState().addVoxel('0,0,0', { color: [255, 0, 0, 255] });
-    expect(useCharacterStore.getState().character).toBeNull();
+    expect(useCharacterStore.getState().asset).toBeNull();
     expect(useCharacterStore.getState().dirty).toBe(false);
   });
 });
 
-describe('useCharacterStore.listCharacters', () => {
+describe('useCharacterStore.listAssets', () => {
   it('is a no-op when projectRootHandle is null', async () => {
     useCharacterStore.setState({
       projectRootHandle: null,
-      knownCharacters: [],
+      knownAssets: [],
     });
-    await useCharacterStore.getState().listCharacters();
-    expect(useCharacterStore.getState().knownCharacters).toEqual([]);
+    await useCharacterStore.getState().listAssets();
+    expect(useCharacterStore.getState().knownAssets).toEqual([]);
   });
 
-  it('populates knownCharacters from the project root', async () => {
+  it('populates knownAssets from the project root', async () => {
     const root = testing.makeRoot();
     const toolsData = await root.getDirectoryHandle('tools_data', { create: true });
     const saves = await toolsData.getDirectoryHandle('echidna_saves', { create: true });
@@ -118,18 +118,18 @@ describe('useCharacterStore.listCharacters', () => {
 
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      knownCharacters: [],
+      knownAssets: [],
     });
 
-    await useCharacterStore.getState().listCharacters();
-    const known = useCharacterStore.getState().knownCharacters;
+    await useCharacterStore.getState().listAssets();
+    const known = useCharacterStore.getState().knownAssets;
     expect(known).toHaveLength(1);
     expect(known[0].id).toBe('walker');
     expect(known[0].name).toBe('Walker Bot');
   });
 
-  it('preserves knownCharacters on transient failure', async () => {
-    const stale: CharacterListEntry[] = [
+  it('preserves knownAssets on transient failure', async () => {
+    const stale: AssetListEntry[] = [
       { id: 'old', kind: 'character', name: 'Old Character', lastModified: 1000 },
     ];
     useCharacterStore.setState({
@@ -142,17 +142,17 @@ describe('useCharacterStore.listCharacters', () => {
           throw new Error('simulated transient failure');
         },
       } as unknown as FileSystemDirectoryHandle,
-      knownCharacters: stale,
+      knownAssets: stale,
     });
 
-    await useCharacterStore.getState().listCharacters();
+    await useCharacterStore.getState().listAssets();
 
     // The stale list should still be intact
-    expect(useCharacterStore.getState().knownCharacters).toEqual(stale);
+    expect(useCharacterStore.getState().knownAssets).toEqual(stale);
   });
 });
 
-describe('useCharacterStore.openCharacter', () => {
+describe('useCharacterStore.openAsset', () => {
   it('preserves global slice when switching characters', async () => {
     const root = testing.makeRoot();
     const toolsData = await root.getDirectoryHandle('tools_data', { create: true });
@@ -177,11 +177,11 @@ describe('useCharacterStore.openCharacter', () => {
       xrayMode: true,
     });
 
-    await useCharacterStore.getState().openCharacter('archer');
+    await useCharacterStore.getState().openAsset('archer');
 
     const s = useCharacterStore.getState();
-    expect(s.character?.id).toBe('archer');
-    expect(s.character?.characterName).toBe('Archer');
+    expect(s.asset?.id).toBe('archer');
+    expect(s.asset?.characterName).toBe('Archer');
     expect(s.mode).toBe('animate');         // global preserved
     expect(s.xrayMode).toBe(true);           // global preserved
   });
@@ -205,7 +205,7 @@ describe('useCharacterStore.openCharacter', () => {
       boxSelection: ['0,0,0', '1,1,1'] as any,
     });
 
-    await useCharacterStore.getState().openCharacter('mage');
+    await useCharacterStore.getState().openAsset('mage');
 
     const s = useCharacterStore.getState();
     expect(s.dirty).toBe(false);
@@ -214,7 +214,7 @@ describe('useCharacterStore.openCharacter', () => {
     expect(s.boxSelection).toBeNull();
   });
 
-  it('refreshes knownCharacters and leaves state.character unchanged when file is missing', async () => {
+  it('refreshes knownAssets and leaves state.character unchanged when file is missing', async () => {
     // Seed an empty project root — no .echidna files at all
     const root = testing.makeRoot();
     await root.getDirectoryHandle('tools_data', { create: true });
@@ -222,21 +222,21 @@ describe('useCharacterStore.openCharacter', () => {
 
     // Seed a stale known-characters list with a phantom entry, plus a
     // distinct existing character so we can detect unwanted reset.
-    const existingChar = useCharacterStore.getState().character;
+    const existingChar = useCharacterStore.getState().asset;
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      knownCharacters: [
+      knownAssets: [
         { id: 'ghost', kind: 'character', name: 'Ghost', lastModified: 0 },
       ],
     });
 
-    await useCharacterStore.getState().openCharacter('ghost');
+    await useCharacterStore.getState().openAsset('ghost');
 
     const s = useCharacterStore.getState();
-    // knownCharacters has been refreshed — the ghost entry dropped
-    expect(s.knownCharacters).toEqual([]);
+    // knownAssets has been refreshed — the ghost entry dropped
+    expect(s.knownAssets).toEqual([]);
     // state.character is unchanged (still whatever it was before the call)
-    expect(s.character).toEqual(existingChar);
+    expect(s.asset).toEqual(existingChar);
   });
 });
 
@@ -249,7 +249,7 @@ describe('useCharacterStore.save', () => {
   it('is a no-op when character is null', async () => {
     useCharacterStore.setState({
       projectRootHandle: testing.makeRoot() as unknown as FileSystemDirectoryHandle,
-      character: null,
+      asset: null,
     });
     // Should not throw
     await useCharacterStore.getState().save();
@@ -260,7 +260,7 @@ describe('useCharacterStore.save', () => {
     const root = testing.makeRoot();
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      character: {
+      asset: {
         id: 'walker',
         kind: 'character' as const,
         characterName: 'Walker Bot',
@@ -304,7 +304,7 @@ describe('useCharacterStore.save', () => {
     const root = testing.makeRoot();
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      character: {
+      asset: {
         id: 'walker',
         kind: 'character' as const,
         characterName: 'Walker',
@@ -336,7 +336,7 @@ describe('useCharacterStore.save', () => {
     const root = testing.makeRoot();
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      character: {
+      asset: {
         id: 'walker',
         kind: 'character' as const,
         characterName: 'Walker',
@@ -378,7 +378,7 @@ describe('useCharacterStore.save', () => {
   it('returns early with a warning when projectRootHandle is null', async () => {
     useCharacterStore.setState({
       projectRootHandle: null,
-      character: {
+      asset: {
         id: 'walker',
         kind: 'character' as const,
         characterName: 'Walker',
@@ -405,7 +405,7 @@ describe('useCharacterStore.save', () => {
   });
 });
 
-describe('useCharacterStore.requestOpenCharacter', () => {
+describe('useCharacterStore.requestOpenAsset', () => {
   beforeEach(async () => {
     // Seed a project root with one target character
     const root = testing.makeRoot();
@@ -426,7 +426,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
       // Use 'walker' as the "currently loaded" character so that tests which
       // open 'archer' are not caught by the re-entry guard (walker ≠ archer).
-      character: {
+      asset: {
         id: 'walker',
         kind: 'character' as const,
         characterName: 'Walker',
@@ -441,7 +441,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
       },
       dirty: false,
       undoStack: [],
-      knownCharacters: [
+      knownAssets: [
         { id: 'archer', kind: 'character', name: 'Archer', lastModified: 0 },
       ],
     });
@@ -449,29 +449,29 @@ describe('useCharacterStore.requestOpenCharacter', () => {
 
   it('opens directly when dirty is false AND undoStack is empty', async () => {
     let confirmCalled = false;
-    await useCharacterStore.getState().requestOpenCharacter('archer', async () => {
+    await useCharacterStore.getState().requestOpenAsset('archer', async () => {
       confirmCalled = true;
       return 'discard';
     });
     expect(confirmCalled).toBe(false);
-    expect(useCharacterStore.getState().character?.id).toBe('archer');
+    expect(useCharacterStore.getState().asset?.id).toBe('archer');
   });
 
   it('invokes the confirm callback when dirty is true', async () => {
     useCharacterStore.setState({ dirty: true });
     let confirmCalled = false;
-    await useCharacterStore.getState().requestOpenCharacter('archer', async () => {
+    await useCharacterStore.getState().requestOpenAsset('archer', async () => {
       confirmCalled = true;
       return 'discard';
     });
     expect(confirmCalled).toBe(true);
-    expect(useCharacterStore.getState().character?.id).toBe('archer');
+    expect(useCharacterStore.getState().asset?.id).toBe('archer');
   });
 
   it('invokes the confirm callback when undoStack has entries', async () => {
     useCharacterStore.setState({ undoStack: [{} as any] });
     let confirmCalled = false;
-    await useCharacterStore.getState().requestOpenCharacter('archer', async () => {
+    await useCharacterStore.getState().requestOpenAsset('archer', async () => {
       confirmCalled = true;
       return 'discard';
     });
@@ -480,16 +480,16 @@ describe('useCharacterStore.requestOpenCharacter', () => {
 
   it('does NOT switch when user cancels', async () => {
     useCharacterStore.setState({ dirty: true });
-    const initialCharId = useCharacterStore.getState().character?.id;
-    await useCharacterStore.getState().requestOpenCharacter('archer', async () => 'cancel');
-    expect(useCharacterStore.getState().character?.id).toBe(initialCharId);
+    const initialCharId = useCharacterStore.getState().asset?.id;
+    await useCharacterStore.getState().requestOpenAsset('archer', async () => 'cancel');
+    expect(useCharacterStore.getState().asset?.id).toBe(initialCharId);
   });
 
   it('save decision: saves successfully and then switches', async () => {
     // Seed current character as dirty
     useCharacterStore.setState({
       dirty: true,
-      character: {
+      asset: {
         id: 'walker',
         kind: 'character' as const,
         characterName: 'Walker',
@@ -505,7 +505,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
     });
 
     let confirmInfo: any = null;
-    await useCharacterStore.getState().requestOpenCharacter('archer', async (info) => {
+    await useCharacterStore.getState().requestOpenAsset('archer', async (info) => {
       confirmInfo = info;
       return 'save';
     });
@@ -518,14 +518,14 @@ describe('useCharacterStore.requestOpenCharacter', () => {
 
     // After save + switch: character is archer, dirty is false
     const s = useCharacterStore.getState();
-    expect(s.character?.id).toBe('archer');
+    expect(s.asset?.id).toBe('archer');
     expect(s.dirty).toBe(false);
   });
 
   it('save decision: aborts switch when save fails', async () => {
     useCharacterStore.setState({
       dirty: true,
-      character: {
+      asset: {
         id: 'walker',
         kind: 'character' as const,
         characterName: 'Walker',
@@ -548,7 +548,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     try {
-      await useCharacterStore.getState().requestOpenCharacter('archer', async () => 'save');
+      await useCharacterStore.getState().requestOpenAsset('archer', async () => 'save');
     } finally {
       spy.mockRestore();
       errSpy.mockRestore();
@@ -556,7 +556,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
 
     // After failed save: dirty still true, character is STILL walker (switch aborted)
     const s = useCharacterStore.getState();
-    expect(s.character?.id).toBe('walker');
+    expect(s.asset?.id).toBe('walker');
     expect(s.dirty).toBe(true);
   });
 
@@ -564,7 +564,7 @@ describe('useCharacterStore.requestOpenCharacter', () => {
     // Seed current character
     useCharacterStore.setState({
       dirty: true,  // even when dirty
-      character: {
+      asset: {
         id: 'walker',
         kind: 'character' as const,
         characterName: 'Walker',
@@ -581,19 +581,19 @@ describe('useCharacterStore.requestOpenCharacter', () => {
     });
 
     let confirmCalled = false;
-    await useCharacterStore.getState().requestOpenCharacter('walker', async () => {
+    await useCharacterStore.getState().requestOpenAsset('walker', async () => {
       confirmCalled = true;
       return 'discard';
     });
 
     // No confirm, no switch, no state change
     expect(confirmCalled).toBe(false);
-    expect(useCharacterStore.getState().character?.id).toBe('walker');
+    expect(useCharacterStore.getState().asset?.id).toBe('walker');
     expect(useCharacterStore.getState().dirty).toBe(true);  // still dirty — no-op means no clean
   });
 });
 
-describe('useCharacterStore.renameCharacter', () => {
+describe('useCharacterStore.renameAsset', () => {
   it('renames the current character in-memory and marks dirty', async () => {
     const root = testing.makeRoot();
     const td = await root.getDirectoryHandle('tools_data', { create: true });
@@ -608,7 +608,7 @@ describe('useCharacterStore.renameCharacter', () => {
 
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      character: {
+      asset: {
         id: 'walker', characterName: 'Walker Bot',
         kind: 'character' as const,
         gridWidth: 32, gridDepth: 32, voxels: new Map(),
@@ -616,15 +616,15 @@ describe('useCharacterStore.renameCharacter', () => {
         tags: [],
         currentFilename: null,
       },
-      knownCharacters: [{ id: 'walker', kind: 'character', name: 'Walker Bot', lastModified: 0 }],
+      knownAssets: [{ id: 'walker', kind: 'character', name: 'Walker Bot', lastModified: 0 }],
       dirty: false,
     });
 
-    await useCharacterStore.getState().renameCharacter('walker', 'Walker v2');
+    await useCharacterStore.getState().renameAsset('walker', 'Walker v2');
 
     const s = useCharacterStore.getState();
-    expect(s.character?.characterName).toBe('Walker v2');
-    expect(s.knownCharacters[0].name).toBe('Walker v2');
+    expect(s.asset?.characterName).toBe('Walker v2');
+    expect(s.knownAssets[0].name).toBe('Walker v2');
     expect(s.dirty).toBe(false);
   });
 
@@ -642,7 +642,7 @@ describe('useCharacterStore.renameCharacter', () => {
 
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      character: {
+      asset: {
         id: 'walker', characterName: 'Walker Bot',
         kind: 'character' as const,
         gridWidth: 32, gridDepth: 32, voxels: new Map(),
@@ -650,16 +650,16 @@ describe('useCharacterStore.renameCharacter', () => {
         tags: [],
         currentFilename: null,
       },
-      knownCharacters: [{ id: 'walker', kind: 'character', name: 'Walker Bot', lastModified: 0 }],
+      knownAssets: [{ id: 'walker', kind: 'character', name: 'Walker Bot', lastModified: 0 }],
       dirty: false,
     });
 
-    await useCharacterStore.getState().renameCharacter('walker', 'Walker v2');
+    await useCharacterStore.getState().renameAsset('walker', 'Walker v2');
 
     // In-memory state updated
     const s = useCharacterStore.getState();
-    expect(s.character?.characterName).toBe('Walker v2');
-    expect(s.knownCharacters[0].name).toBe('Walker v2');
+    expect(s.asset?.characterName).toBe('Walker v2');
+    expect(s.knownAssets[0].name).toBe('Walker v2');
 
     // Disk file also updated
     const fh2 = await saves.getFileHandle('walker.echidna');
@@ -681,7 +681,7 @@ describe('useCharacterStore.renameCharacter', () => {
 
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      character: {
+      asset: {
         id: 'walker', characterName: 'Walker Bot',
         kind: 'character' as const,
         gridWidth: 32, gridDepth: 32, voxels: new Map(),
@@ -689,24 +689,24 @@ describe('useCharacterStore.renameCharacter', () => {
         tags: [],
         currentFilename: null,
       },
-      knownCharacters: [
+      knownAssets: [
         { id: 'walker', kind: 'character', name: 'Walker Bot', lastModified: 0 },
         { id: 'archer', kind: 'character', name: 'Archer', lastModified: 0 },
       ],
       dirty: false,
     });
 
-    await useCharacterStore.getState().renameCharacter('archer', 'Ace Archer');
+    await useCharacterStore.getState().renameAsset('archer', 'Ace Archer');
 
     const s = useCharacterStore.getState();
-    expect(s.character?.characterName).toBe('Walker Bot');        // unchanged
-    expect(s.knownCharacters.find((c) => c.id === 'archer')?.name).toBe('Ace Archer');
+    expect(s.asset?.characterName).toBe('Walker Bot');        // unchanged
+    expect(s.knownAssets.find((c) => c.id === 'archer')?.name).toBe('Ace Archer');
     expect(s.dirty).toBe(false);                                    // still clean
   });
 });
 
-describe('useCharacterStore.deleteCharacter', () => {
-  it('removes the row from knownCharacters', async () => {
+describe('useCharacterStore.deleteAsset', () => {
+  it('removes the row from knownAssets', async () => {
     const root = testing.makeRoot();
     const td = await root.getDirectoryHandle('tools_data', { create: true });
     const saves = await td.getDirectoryHandle('echidna_saves', { create: true });
@@ -717,12 +717,12 @@ describe('useCharacterStore.deleteCharacter', () => {
 
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      knownCharacters: [
+      knownAssets: [
         { id: 'walker', kind: 'character', name: 'Walker', lastModified: 0 },
         { id: 'archer', kind: 'character', name: 'Archer', lastModified: 0 },
       ],
       // character is not walker, so deleting walker should not null it
-      character: {
+      asset: {
         id: 'archer',
         kind: 'character' as const,
         characterName: 'Archer',
@@ -734,11 +734,11 @@ describe('useCharacterStore.deleteCharacter', () => {
       },
     });
 
-    await useCharacterStore.getState().deleteCharacter('walker');
+    await useCharacterStore.getState().deleteAsset('walker');
 
-    expect(useCharacterStore.getState().knownCharacters.map((c) => c.id)).toEqual(['archer']);
+    expect(useCharacterStore.getState().knownAssets.map((c) => c.id)).toEqual(['archer']);
     // Non-current character deletion should not touch state.character
-    expect(useCharacterStore.getState().character?.id).toBe('archer');
+    expect(useCharacterStore.getState().asset?.id).toBe('archer');
   });
 
   it('clears state.character to null when deleting the current character', async () => {
@@ -752,7 +752,7 @@ describe('useCharacterStore.deleteCharacter', () => {
 
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      character: {
+      asset: {
         id: 'walker',
         kind: 'character' as const,
         characterName: 'Walker',
@@ -762,22 +762,22 @@ describe('useCharacterStore.deleteCharacter', () => {
         tags: [],
         currentFilename: null,
       },
-      knownCharacters: [{ id: 'walker', kind: 'character', name: 'Walker', lastModified: 0 }],
+      knownAssets: [{ id: 'walker', kind: 'character', name: 'Walker', lastModified: 0 }],
       dirty: true,
       undoStack: [{} as any],
     });
 
-    await useCharacterStore.getState().deleteCharacter('walker');
+    await useCharacterStore.getState().deleteAsset('walker');
 
     const s = useCharacterStore.getState();
-    expect(s.character).toBeNull();
+    expect(s.asset).toBeNull();
     expect(s.dirty).toBe(false);
-    expect(s.knownCharacters).toEqual([]);
+    expect(s.knownAssets).toEqual([]);
     expect(s.undoStack).toEqual([]);
   });
 });
 
-describe('useCharacterStore.duplicateCharacter', () => {
+describe('useCharacterStore.duplicateAsset', () => {
   it('appends a numeric suffix when newId collides', async () => {
     const root = testing.makeRoot();
     const td = await root.getDirectoryHandle('tools_data', { create: true });
@@ -794,16 +794,16 @@ describe('useCharacterStore.duplicateCharacter', () => {
 
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      knownCharacters: [
+      knownAssets: [
         { id: 'walker', kind: 'character', name: 'Walker', lastModified: 0 },
         { id: 'walker_2', kind: 'character', name: 'Walker', lastModified: 0 },
       ],
     });
 
-    await useCharacterStore.getState().duplicateCharacter('walker', 'Walker');
+    await useCharacterStore.getState().duplicateAsset('walker', 'Walker');
     // Expected: new id is walker_3 (since walker and walker_2 already exist)
 
-    const known = useCharacterStore.getState().knownCharacters;
+    const known = useCharacterStore.getState().knownAssets;
     expect(known.map((c) => c.id).sort()).toEqual(['walker', 'walker_2', 'walker_3']);
   });
 
@@ -818,55 +818,55 @@ describe('useCharacterStore.duplicateCharacter', () => {
 
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      character: null,
-      knownCharacters: [{ id: 'walker', kind: 'character', name: 'Walker', lastModified: 0 }],
+      asset: null,
+      knownAssets: [{ id: 'walker', kind: 'character', name: 'Walker', lastModified: 0 }],
     });
 
-    await useCharacterStore.getState().duplicateCharacter('walker', 'Archer');
-    expect(useCharacterStore.getState().character).toBeNull();  // still null
+    await useCharacterStore.getState().duplicateAsset('walker', 'Archer');
+    expect(useCharacterStore.getState().asset).toBeNull();  // still null
   });
 });
 
-describe('useCharacterStore.newCharacter — name parameter', () => {
+describe('useCharacterStore.newAsset — name parameter', () => {
   beforeEach(() => {
-    useCharacterStore.setState({ knownCharacters: [], character: null, dirty: false });
+    useCharacterStore.setState({ knownAssets: [], asset: null, dirty: false });
   });
 
   it('uses the provided name and derives id from it', () => {
-    useCharacterStore.getState().newCharacter(32, 'Knight');
+    useCharacterStore.getState().newAsset('character',32, 'Knight');
     const s = useCharacterStore.getState();
-    expect(s.character?.characterName).toBe('Knight');
-    expect(s.character?.id).toBe('knight');
+    expect(s.asset?.characterName).toBe('Knight');
+    expect(s.asset?.id).toBe('knight');
   });
 
   it('falls back to Untitled when name is undefined', () => {
-    useCharacterStore.getState().newCharacter(32);
+    useCharacterStore.getState().newAsset('character',32);
     const s = useCharacterStore.getState();
-    expect(s.character?.characterName).toBe('Untitled');
-    expect(s.character?.id).toBe('untitled');
+    expect(s.asset?.characterName).toBe('Untitled');
+    expect(s.asset?.id).toBe('untitled');
   });
 
   it('falls back to Untitled when name is empty string', () => {
-    useCharacterStore.getState().newCharacter(32, '');
+    useCharacterStore.getState().newAsset('character',32, '');
     const s = useCharacterStore.getState();
-    expect(s.character?.characterName).toBe('Untitled');
+    expect(s.asset?.characterName).toBe('Untitled');
   });
 
   it('deduplicates id when name collides with existing character', () => {
     useCharacterStore.setState({
-      knownCharacters: [{ id: 'knight', kind: 'character', name: 'Knight', lastModified: 0 }],
-      character: null,
+      knownAssets: [{ id: 'knight', kind: 'character', name: 'Knight', lastModified: 0 }],
+      asset: null,
       dirty: false,
     });
-    useCharacterStore.getState().newCharacter(32, 'Knight');
+    useCharacterStore.getState().newAsset('character',32, 'Knight');
     const s = useCharacterStore.getState();
-    expect(s.character?.id).toBe('knight_2');
+    expect(s.asset?.id).toBe('knight_2');
   });
 });
 
 describe('useCharacterStore.saveProject — null guard', () => {
   it('throws when character is null', () => {
-    useCharacterStore.setState({ character: null });
+    useCharacterStore.setState({ asset: null });
     expect(() => useCharacterStore.getState().saveProject()).toThrow(
       '[echidna] saveProject called with null character',
     );
@@ -882,7 +882,7 @@ describe('useCharacterStore.save — return value', () => {
     const root = testing.makeRoot();
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      character: {
+      asset: {
         id: 'walker', characterName: 'Walker',
         kind: 'character' as const,
         gridWidth: 32, gridDepth: 32, voxels: new Map(),
@@ -900,7 +900,7 @@ describe('useCharacterStore.save — return value', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     useCharacterStore.setState({
       projectRootHandle: null,
-      character: {
+      asset: {
         id: 'walker', characterName: 'Walker',
         kind: 'character' as const,
         gridWidth: 32, gridDepth: 32, voxels: new Map(),
@@ -918,7 +918,7 @@ describe('useCharacterStore.save — return value', () => {
   it('returns false when character is null', async () => {
     useCharacterStore.setState({
       projectRootHandle: testing.makeRoot() as unknown as FileSystemDirectoryHandle,
-      character: null,
+      asset: null,
     });
     const result = await useCharacterStore.getState().save();
     expect(result).toBe(false);
@@ -934,7 +934,7 @@ describe('useCharacterStore.save — return value', () => {
     const root = testing.makeRoot();
     useCharacterStore.setState({
       projectRootHandle: root as unknown as FileSystemDirectoryHandle,
-      character: {
+      asset: {
         id: 'walker', characterName: 'Walker',
         kind: 'character' as const,
         gridWidth: 32, gridDepth: 32, voxels: new Map(),
@@ -956,5 +956,77 @@ describe('useCharacterStore.save — return value', () => {
       spy.mockRestore();
       errSpy.mockRestore();
     }
+  });
+});
+
+describe('useCharacterStore.newAsset — kind parameter', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({ knownAssets: [], asset: null, dirty: false });
+  });
+
+  it('creates a map asset with no parts or poses', () => {
+    useCharacterStore.getState().newAsset('map', 64, 'Town');
+    const s = useCharacterStore.getState();
+    expect(s.asset?.kind).toBe('map');
+    expect(s.asset?.id).toBe('town');
+    expect(s.asset?.characterParts).toEqual([]);
+    expect(s.knownAssets[0].kind).toBe('map');
+  });
+
+  it('creates an object asset', () => {
+    useCharacterStore.getState().newAsset('object', 16, 'Crystal');
+    const s = useCharacterStore.getState();
+    expect(s.asset?.kind).toBe('object');
+    expect(s.asset?.id).toBe('crystal');
+    expect(s.knownAssets[0].kind).toBe('object');
+  });
+});
+
+describe('useCharacterStore.save — map kind', () => {
+  beforeEach(() => { useCharacterStore.setState({ _saving: false }); });
+
+  it('writes PLY to assets/maps/ without manifest', async () => {
+    const root = testing.makeRoot();
+    useCharacterStore.setState({
+      projectRootHandle: root as unknown as FileSystemDirectoryHandle,
+      asset: {
+        id: 'town', kind: 'map', characterName: 'Town',
+        gridWidth: 32, gridDepth: 32,
+        voxels: new Map([['0,0,0', { color: [100, 150, 100, 255] }]]),
+        characterParts: [], characterPoses: {}, animations: {},
+        tags: [], currentFilename: null,
+      },
+      dirty: true,
+    });
+    const ok = await useCharacterStore.getState().save();
+    expect(ok).toBe(true);
+    expect(useCharacterStore.getState().dirty).toBe(false);
+    const assets = await root.getDirectoryHandle('assets');
+    const maps = await assets.getDirectoryHandle('maps');
+    await maps.getFileHandle('town.ply');
+  });
+});
+
+describe('useCharacterStore.save — object kind', () => {
+  beforeEach(() => { useCharacterStore.setState({ _saving: false }); });
+
+  it('writes PLY to assets/objects/ without manifest', async () => {
+    const root = testing.makeRoot();
+    useCharacterStore.setState({
+      projectRootHandle: root as unknown as FileSystemDirectoryHandle,
+      asset: {
+        id: 'crystal', kind: 'object', characterName: 'Crystal',
+        gridWidth: 16, gridDepth: 16,
+        voxels: new Map([['0,0,0', { color: [200, 200, 255, 255] }]]),
+        characterParts: [], characterPoses: {}, animations: {},
+        tags: ['prop'], currentFilename: null,
+      },
+      dirty: true,
+    });
+    const ok = await useCharacterStore.getState().save();
+    expect(ok).toBe(true);
+    const assets = await root.getDirectoryHandle('assets');
+    const objects = await assets.getDirectoryHandle('objects');
+    await objects.getFileHandle('crystal.ply');
   });
 });

--- a/tools/apps/echidna/src/__tests__/echidnaFile.test.ts
+++ b/tools/apps/echidna/src/__tests__/echidnaFile.test.ts
@@ -33,7 +33,7 @@ describe('migrateEchidnaFile', () => {
     };
     const migrated = migrateEchidnaFile(old);
     expect(migrated.version).toBe(ECHIDNA_FILE_VERSION);
-    expect(migrated.version).toBe(3);
+    expect(migrated.version).toBe(4);
     expect(migrated.id).toBe('walker_bot');
   });
 

--- a/tools/apps/echidna/src/__tests__/echidnaFile.test.ts
+++ b/tools/apps/echidna/src/__tests__/echidnaFile.test.ts
@@ -1,22 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { migrateEchidnaFile, slugifyCharacterId, ECHIDNA_FILE_VERSION, type EchidnaFile } from '../store/types.js';
+import { migrateEchidnaFile, slugifyAssetId, ECHIDNA_FILE_VERSION, type EchidnaFile } from '../store/types.js';
 
-describe('slugifyCharacterId', () => {
+describe('slugifyAssetId', () => {
   it('lowercases and replaces whitespace with underscores', () => {
-    expect(slugifyCharacterId('Walker Bot')).toBe('walker_bot');
-    expect(slugifyCharacterId('  Hello   World  ')).toBe('hello_world');
+    expect(slugifyAssetId('Walker Bot')).toBe('walker_bot');
+    expect(slugifyAssetId('  Hello   World  ')).toBe('hello_world');
   });
   it('strips characters outside [a-z0-9_-]', () => {
-    expect(slugifyCharacterId('Cat/Dog#1')).toBe('catdog1');
-    expect(slugifyCharacterId('  Déjà Vu  ')).toBe('dj_vu');  // strips accented + ends up no-underscore run
+    expect(slugifyAssetId('Cat/Dog#1')).toBe('catdog1');
+    expect(slugifyAssetId('  Déjà Vu  ')).toBe('dj_vu');  // strips accented + ends up no-underscore run
   });
   it('preserves hyphens and underscores', () => {
-    expect(slugifyCharacterId('cool-guy_v2')).toBe('cool-guy_v2');
+    expect(slugifyAssetId('cool-guy_v2')).toBe('cool-guy_v2');
   });
   it('falls back to "character" when empty or all stripped', () => {
-    expect(slugifyCharacterId('')).toBe('character');
-    expect(slugifyCharacterId('   ')).toBe('character');
-    expect(slugifyCharacterId('###')).toBe('character');
+    expect(slugifyAssetId('')).toBe('character');
+    expect(slugifyAssetId('   ')).toBe('character');
+    expect(slugifyAssetId('###')).toBe('character');
   });
 });
 

--- a/tools/apps/echidna/src/__tests__/echidnaFile.test.ts
+++ b/tools/apps/echidna/src/__tests__/echidnaFile.test.ts
@@ -13,10 +13,10 @@ describe('slugifyAssetId', () => {
   it('preserves hyphens and underscores', () => {
     expect(slugifyAssetId('cool-guy_v2')).toBe('cool-guy_v2');
   });
-  it('falls back to "character" when empty or all stripped', () => {
-    expect(slugifyAssetId('')).toBe('character');
-    expect(slugifyAssetId('   ')).toBe('character');
-    expect(slugifyAssetId('###')).toBe('character');
+  it('falls back to "asset" when empty or all stripped', () => {
+    expect(slugifyAssetId('')).toBe('asset');
+    expect(slugifyAssetId('   ')).toBe('asset');
+    expect(slugifyAssetId('###')).toBe('asset');
   });
 });
 
@@ -53,10 +53,10 @@ describe('migrateEchidnaFile', () => {
     expect(migrated.characterName).toBe('Walker Bot');
   });
 
-  it('migrates even when characterName is missing, falling back to "character"', () => {
+  it('migrates even when characterName is missing, falling back to "asset"', () => {
     const old = { version: 2, gridWidth: 32, gridDepth: 32, voxels: [], parts: [], poses: {} };
     const migrated = migrateEchidnaFile(old);
-    expect(migrated.id).toBe('character');
+    expect(migrated.id).toBe('asset');
   });
 
   it('preserves animations field when present', () => {

--- a/tools/apps/echidna/src/__tests__/projectFs.test.ts
+++ b/tools/apps/echidna/src/__tests__/projectFs.test.ts
@@ -9,6 +9,8 @@ import {
   echidnaSavePath,
   characterPlyPath,
   characterManifestPath,
+  exportMapToProject,
+  exportObjectToProject,
 } from '../lib/projectFs';
 
 describe('Echidna project path helpers', () => {
@@ -173,6 +175,38 @@ describe('renameEchidnaProject', () => {
     const parsed = JSON.parse(await reFile.text());
     expect(parsed.id).toBe('walker');                          // same id
     expect(parsed.characterName).toBe('Walker v2');            // new display name
+  });
+});
+
+describe('exportMapToProject', () => {
+  it('writes PLY to assets/maps/{id}.ply', async () => {
+    const root = testing.makeRoot();
+    const ply = new Uint8Array([1, 2, 3]);
+    const result = await exportMapToProject(root as unknown as FileSystemDirectoryHandle, 'town', ply);
+    expect(result.plyPath).toBe('assets/maps/town.ply');
+
+    const assets = await root.getDirectoryHandle('assets');
+    const maps = await assets.getDirectoryHandle('maps');
+    const fh = await maps.getFileHandle('town.ply');
+    const file = await fh.getFile();
+    const buf = new Uint8Array(await file.arrayBuffer());
+    expect(buf).toEqual(ply);
+  });
+});
+
+describe('exportObjectToProject', () => {
+  it('writes PLY to assets/objects/{id}.ply', async () => {
+    const root = testing.makeRoot();
+    const ply = new Uint8Array([4, 5, 6]);
+    const result = await exportObjectToProject(root as unknown as FileSystemDirectoryHandle, 'crystal', ply);
+    expect(result.plyPath).toBe('assets/objects/crystal.ply');
+
+    const assets = await root.getDirectoryHandle('assets');
+    const objects = await assets.getDirectoryHandle('objects');
+    const fh = await objects.getFileHandle('crystal.ply');
+    const file = await fh.getFile();
+    const buf = new Uint8Array(await file.arrayBuffer());
+    expect(buf).toEqual(ply);
   });
 });
 

--- a/tools/apps/echidna/src/lib/projectFs.ts
+++ b/tools/apps/echidna/src/lib/projectFs.ts
@@ -51,6 +51,22 @@ export function characterManifestPath(id: string): string {
   return toAssetPath('characters', id, `${id}.manifest.json`);
 }
 
+/**
+ * Returns the project-relative path for a map PLY file.
+ * Example: `mapPlyPath('town')` → `'assets/maps/town.ply'`.
+ */
+export function mapPlyPath(id: string): string {
+  return toAssetPath('maps', `${id}.ply`);
+}
+
+/**
+ * Returns the project-relative path for an object PLY file.
+ * Example: `objectPlyPath('crystal')` → `'assets/objects/crystal.ply'`.
+ */
+export function objectPlyPath(id: string): string {
+  return toAssetPath('objects', `${id}.ply`);
+}
+
 /* ----- save / load / export ----- */
 
 /**
@@ -100,6 +116,36 @@ export async function exportCharacterToProject(
   await writeFileAtPath(root, manifestPath, manifestJson);
 
   return { plyPath, manifestPath };
+}
+
+/**
+ * Export a map PLY to `assets/maps/{id}.ply`.
+ * Creates the maps subdirectory if needed. Returns the written path.
+ */
+export async function exportMapToProject(
+  root: FileSystemDirectoryHandle,
+  id: string,
+  ply: Blob | Uint8Array,
+): Promise<{ plyPath: string }> {
+  await ensureSubdir(root, PROJECT_LAYOUT.assets.maps);
+  const plyPath = mapPlyPath(id);
+  await writeFileAtPath(root, plyPath, ply);
+  return { plyPath };
+}
+
+/**
+ * Export an object PLY to `assets/objects/{id}.ply`.
+ * Creates the objects subdirectory if needed. Returns the written path.
+ */
+export async function exportObjectToProject(
+  root: FileSystemDirectoryHandle,
+  id: string,
+  ply: Blob | Uint8Array,
+): Promise<{ plyPath: string }> {
+  await ensureSubdir(root, PROJECT_LAYOUT.assets.objects);
+  const plyPath = objectPlyPath(id);
+  await writeFileAtPath(root, plyPath, ply);
+  return { plyPath };
 }
 
 /**

--- a/tools/apps/echidna/src/lib/projectFs.ts
+++ b/tools/apps/echidna/src/lib/projectFs.ts
@@ -5,7 +5,7 @@ import {
   writeFileAtPath,
   readFileAtPath,
 } from '@gseurat/project-root';
-import { migrateEchidnaFile, type EchidnaFile, type CharacterListEntry } from '../store/types';
+import { migrateEchidnaFile, type EchidnaFile, type AssetListEntry } from '../store/types';
 
 /* ----- private helpers ----- */
 
@@ -158,7 +158,7 @@ export async function exportObjectToProject(
  */
 export async function listEchidnaProjects(
   handle: FileSystemDirectoryHandle,
-): Promise<CharacterListEntry[]> {
+): Promise<AssetListEntry[]> {
   let savesDir: FileSystemDirectoryHandle;
   try {
     savesDir = await getEchidnaSavesDir(handle);
@@ -184,7 +184,7 @@ export async function listEchidnaProjects(
     values(): AsyncIterable<DirChild>;
   }).values();
 
-  const entries: CharacterListEntry[] = [];
+  const entries: AssetListEntry[] = [];
   for await (const child of iter) {
     if (child.kind !== 'file') continue;
     if (!child.name.endsWith('.echidna')) continue;

--- a/tools/apps/echidna/src/lib/projectFs.ts
+++ b/tools/apps/echidna/src/lib/projectFs.ts
@@ -149,6 +149,7 @@ export async function listEchidnaProjects(
       const migrated = migrateEchidnaFile(raw);
       entries.push({
         id: migrated.id,
+        kind: migrated.kind,
         name: migrated.characterName,
         lastModified: file.lastModified ?? 0,
       });

--- a/tools/apps/echidna/src/lib/projectFs.ts
+++ b/tools/apps/echidna/src/lib/projectFs.ts
@@ -150,7 +150,7 @@ export async function exportObjectToProject(
 
 /**
  * Enumerate all .echidna files in tools_data/echidna_saves/ and return
- * their metadata for the CharactersPanel list. Skips malformed files with
+ * their metadata for the AssetsPanel list. Skips malformed files with
  * a console.warn rather than throwing — one bad file must not prevent the
  * panel from rendering the rest.
  *

--- a/tools/apps/echidna/src/panels/AnimateLeftPanel.tsx
+++ b/tools/apps/echidna/src/panels/AnimateLeftPanel.tsx
@@ -132,7 +132,7 @@ function BoneTree({ parts, parentId, depth, selected, onSelect, onReparent, drop
 
 export function AnimateLeftPanel() {
   useComponentRegistry('AnimateLeftPanel');
-  const parts = useCharacterStore((s) => s.character?.characterParts ?? []);
+  const parts = useCharacterStore((s) => s.asset?.characterParts ?? []);
   const selectedPart = useCharacterStore((s) => s.selectedPart);
   const setSelectedPart = useCharacterStore((s) => s.setSelectedPart);
   const addPart = useCharacterStore((s) => s.addPart);
@@ -145,7 +145,7 @@ export function AnimateLeftPanel() {
     setPartParent(childId, newParentId);
   };
 
-  const animations = useCharacterStore((s) => s.character?.animations ?? {});
+  const animations = useCharacterStore((s) => s.asset?.animations ?? {});
   const selectedAnimation = useCharacterStore((s) => s.selectedAnimation);
   const selectAnimation = useCharacterStore((s) => s.selectAnimation);
   const addAnimation = useCharacterStore((s) => s.addAnimation);

--- a/tools/apps/echidna/src/panels/AnimateRightPanel.tsx
+++ b/tools/apps/echidna/src/panels/AnimateRightPanel.tsx
@@ -44,7 +44,7 @@ const styles: Record<string, React.CSSProperties> = {
 };
 
 function BoneProperties() {
-  const parts = useCharacterStore((s) => s.character?.characterParts ?? []);
+  const parts = useCharacterStore((s) => s.asset?.characterParts ?? []);
   const selectedPart = useCharacterStore((s) => s.selectedPart);
   const updatePartJoint = useCharacterStore((s) => s.updatePartJoint);
   const autoCenterJoint = useCharacterStore((s) => s.autoCenterJoint);
@@ -107,11 +107,11 @@ function BoneProperties() {
 }
 
 function KeyframeEditor() {
-  const parts = useCharacterStore((s) => s.character?.characterParts ?? []);
+  const parts = useCharacterStore((s) => s.asset?.characterParts ?? []);
   const selectedAnimation = useCharacterStore((s) => s.selectedAnimation);
-  const animations = useCharacterStore((s) => s.character?.animations ?? {});
+  const animations = useCharacterStore((s) => s.asset?.animations ?? {});
   const playbackTime = useCharacterStore((s) => s.playbackTime);
-  const characterPoses = useCharacterStore((s) => s.character?.characterPoses ?? {});
+  const characterPoses = useCharacterStore((s) => s.asset?.characterPoses ?? {});
   const addKeyframe = useCharacterStore((s) => s.addKeyframe);
   const removeKeyframe = useCharacterStore((s) => s.removeKeyframe);
   const updateKeyframeEasing = useCharacterStore((s) => s.updateKeyframeEasing);

--- a/tools/apps/echidna/src/panels/AssetsPanel.tsx
+++ b/tools/apps/echidna/src/panels/AssetsPanel.tsx
@@ -1,4 +1,4 @@
-// tools/apps/echidna/src/panels/CharactersPanel.tsx
+// tools/apps/echidna/src/panels/AssetsPanel.tsx
 import React, { useState, useCallback, useRef } from 'react';
 import { useCharacterStore, type SwitchDecision } from '../store/useCharacterStore.js';
 import { SwitchCharacterDialog } from './SwitchCharacterDialog.js';
@@ -121,16 +121,16 @@ interface Props {
   onNewCharacter: () => void;
 }
 
-export function CharactersPanel({ onNewCharacter }: Props) {
-  const knownCharacters = useCharacterStore((s) => s.knownCharacters);
-  const currentId = useCharacterStore((s) => s.character?.id ?? null);
+export function AssetsPanel({ onNewCharacter }: Props) {
+  const knownAssets = useCharacterStore((s) => s.knownAssets);
+  const currentId = useCharacterStore((s) => s.asset?.id ?? null);
   const dirty = useCharacterStore((s) => s.dirty);
-  const currentCharacterName = useCharacterStore((s) => s.character?.characterName ?? '');
+  const currentAssetName = useCharacterStore((s) => s.asset?.characterName ?? '');
   const undoDepth = useCharacterStore((s) => s.undoStack.length);
-  const requestOpenCharacter = useCharacterStore((s) => s.requestOpenCharacter);
-  const renameCharacter = useCharacterStore((s) => s.renameCharacter);
-  const duplicateCharacter = useCharacterStore((s) => s.duplicateCharacter);
-  const deleteCharacter = useCharacterStore((s) => s.deleteCharacter);
+  const requestOpenAsset = useCharacterStore((s) => s.requestOpenAsset);
+  const renameAsset = useCharacterStore((s) => s.renameAsset);
+  const duplicateAsset = useCharacterStore((s) => s.duplicateAsset);
+  const deleteAsset = useCharacterStore((s) => s.deleteAsset);
 
   const [collapsed, setCollapsed] = useState(() =>
     localStorage.getItem(COLLAPSE_KEY) === '1',
@@ -152,7 +152,7 @@ export function CharactersPanel({ onNewCharacter }: Props) {
 
   const handleRowClick = (id: string) => {
     if (id === currentId) return;
-    void requestOpenCharacter(id, () =>
+    void requestOpenAsset(id, () =>
       new Promise<SwitchDecision>((resolve) => {
         pendingResolverRef.current = resolve;
         setActiveDialog({ kind: 'switch', targetId: id });
@@ -181,11 +181,11 @@ export function CharactersPanel({ onNewCharacter }: Props) {
       </div>
       {!collapsed && (
         <>
-          {knownCharacters.length === 0 ? (
+          {knownAssets.length === 0 ? (
             <div style={styles.empty}>No characters yet.</div>
           ) : (
             <div style={styles.list}>
-              {knownCharacters.map((c) => {
+              {knownAssets.map((c) => {
                 const isCurrent = c.id === currentId;
                 return (
                   <div
@@ -272,8 +272,8 @@ export function CharactersPanel({ onNewCharacter }: Props) {
       {/* Dialogs */}
       {activeDialog?.kind === 'switch' && (
         <SwitchCharacterDialog
-          currentName={currentCharacterName}
-          targetName={knownCharacters.find((c) => c.id === activeDialog.targetId)?.name ?? ''}
+          currentName={currentAssetName}
+          targetName={knownAssets.find((c) => c.id === activeDialog.targetId)?.name ?? ''}
           undoDepth={undoDepth}
           onDecide={handleSwitchDecision}
         />
@@ -282,7 +282,7 @@ export function CharactersPanel({ onNewCharacter }: Props) {
         <RenameCharacterDialog
           currentName={activeDialog.name}
           onSubmit={(newName) => {
-            void renameCharacter(activeDialog.id, newName);
+            void renameAsset(activeDialog.id, newName);
             setActiveDialog(null);
           }}
           onCancel={() => setActiveDialog(null)}
@@ -292,7 +292,7 @@ export function CharactersPanel({ onNewCharacter }: Props) {
         <DuplicateCharacterDialog
           sourceName={activeDialog.name}
           onSubmit={(newName) => {
-            void duplicateCharacter(activeDialog.id, newName);
+            void duplicateAsset(activeDialog.id, newName);
             setActiveDialog(null);
           }}
           onCancel={() => setActiveDialog(null)}
@@ -303,7 +303,7 @@ export function CharactersPanel({ onNewCharacter }: Props) {
           characterName={activeDialog.name}
           characterId={activeDialog.id}
           onConfirm={() => {
-            void deleteCharacter(activeDialog.id);
+            void deleteAsset(activeDialog.id);
             setActiveDialog(null);
           }}
           onCancel={() => setActiveDialog(null)}

--- a/tools/apps/echidna/src/panels/AssetsPanel.tsx
+++ b/tools/apps/echidna/src/panels/AssetsPanel.tsx
@@ -118,10 +118,10 @@ type ActiveDialog =
   | null;
 
 interface Props {
-  onNewCharacter: () => void;
+  onNewAsset: () => void;
 }
 
-export function AssetsPanel({ onNewCharacter }: Props) {
+export function AssetsPanel({ onNewAsset }: Props) {
   const knownAssets = useCharacterStore((s) => s.knownAssets);
   const currentId = useCharacterStore((s) => s.asset?.id ?? null);
   const dirty = useCharacterStore((s) => s.dirty);
@@ -217,7 +217,7 @@ export function AssetsPanel({ onNewCharacter }: Props) {
             </div>
           )}
           <div style={styles.footer}>
-            <button style={styles.newBtn} onClick={onNewCharacter}>
+            <button style={styles.newBtn} onClick={onNewAsset}>
               + New Character
             </button>
           </div>

--- a/tools/apps/echidna/src/panels/BuildPanel.tsx
+++ b/tools/apps/echidna/src/panels/BuildPanel.tsx
@@ -24,7 +24,7 @@ const styles: Record<string, React.CSSProperties> = {
 function YClipControl() {
   const yClip = useCharacterStore((s) => s.yClip);
   const setYClip = useCharacterStore((s) => s.setYClip);
-  const voxels = useCharacterStore((s) => s.character?.voxels ?? new Map());
+  const voxels = useCharacterStore((s) => s.asset?.voxels ?? new Map());
 
   let maxY = 0;
   for (const [key] of voxels) {

--- a/tools/apps/echidna/src/panels/ExportDialog.tsx
+++ b/tools/apps/echidna/src/panels/ExportDialog.tsx
@@ -59,8 +59,8 @@ export function ExportDialog({ onClose }: { onClose: () => void }) {
   const [includeBoneIndex, setIncludeBoneIndex] = useState(true);
   const [density, setDensity] = useState(1);
 
-  const characterName = useCharacterStore((s) => s.character?.characterName ?? 'Untitled');
-  const voxels = useCharacterStore((s) => s.character?.voxels ?? new Map());
+  const characterName = useCharacterStore((s) => s.asset?.characterName ?? 'Untitled');
+  const voxels = useCharacterStore((s) => s.asset?.voxels ?? new Map());
   const voxelCount = voxels.size;
   const estimatedGaussians = voxelCount * density * density * density;
   const baseName = characterName.replace(/\s+/g, '_').toLowerCase() || 'character';
@@ -68,7 +68,7 @@ export function ExportDialog({ onClose }: { onClose: () => void }) {
 
   const handleExport = () => {
     const s = useCharacterStore.getState();
-    const char = s.character;
+    const char = s.asset;
     const parts = includeBoneIndex ? char?.characterParts : undefined;
     const blob = exportPly(char?.voxels ?? new Map(), char?.gridWidth ?? 32, char?.gridDepth ?? 32, parts, density);
     download(blob, filename);

--- a/tools/apps/echidna/src/panels/MenuBar.tsx
+++ b/tools/apps/echidna/src/panels/MenuBar.tsx
@@ -7,7 +7,7 @@ import { parseVox } from '../lib/voxImport.js';
 import { parsePlyToVoxels } from '../lib/plyImport.js';
 import { parseObjToVoxels } from '../lib/objImport.js';
 import { sendBridgeCommand } from '@gseurat/engine-client';
-import type { EchidnaFile, Character } from '../store/types.js';
+import type { EchidnaFile, Asset } from '../store/types.js';
 import { NewProjectDialog } from './NewProjectDialog.js';
 import { ResizeGridDialog } from './ResizeGridDialog.js';
 import { ExportDialog } from './ExportDialog.js';
@@ -279,7 +279,7 @@ function DropdownMenu({ label, items, open, onOpen, onClose }: DropdownMenuProps
 type ToastState = { message: string; type: 'success' | 'error' | 'loading' } | null;
 
 function EchidnaTitle() {
-  const character = useCharacterStore((s) => s.character);
+  const character = useCharacterStore((s) => s.asset);
   const dirty = useCharacterStore((s) => s.dirty);
   const name = character?.characterName ?? '';
   return (
@@ -306,8 +306,8 @@ export function MenuBar() {
 
   const showGrid = useCharacterStore((s) => s.showGrid);
   const showGizmos = useCharacterStore((s) => s.showGizmos);
-  const voxels = useCharacterStore((s) => s.character?.voxels ?? new Map());
-  const characterParts = useCharacterStore((s) => s.character?.characterParts ?? []);
+  const voxels = useCharacterStore((s) => s.asset?.voxels ?? new Map());
+  const characterParts = useCharacterStore((s) => s.asset?.characterParts ?? []);
   const showToast = useCallback((message: string, type: 'success' | 'error' | 'loading', duration = 3000) => {
     if (toastTimer.current) clearTimeout(toastTimer.current);
     setToast({ message, type });
@@ -319,9 +319,9 @@ export function MenuBar() {
   // Shared Staging push logic. Uploads PLY + manifest via REST, sends
   // load_scene_json + load_character via WebSocket. Throws on failure.
   // Callers are responsible for toast/error-UI presentation.
-  const syncCharacterToStaging = useCallback(async (char: Character) => {
+  const syncCharacterToStaging = useCallback(async (char: Asset) => {
     const charId = char.id;
-    if (!charId) throw new Error('character has no id — call ensureCharacterId() first');
+    if (!charId) throw new Error('character has no id — call ensureAssetId() first');
 
     const plyBlob = exportPly(char.voxels, char.gridWidth, char.gridDepth, char.characterParts);
 
@@ -394,9 +394,9 @@ export function MenuBar() {
 
   const pushToStaging = useCallback(async () => {
     // Ensure stable id before using char.id as a filesystem path (Bug 1 fix)
-    useCharacterStore.getState().ensureCharacterId();
+    useCharacterStore.getState().ensureAssetId();
     const s = useCharacterStore.getState();
-    const char = s.character;
+    const char = s.asset;
     if (!char || char.voxels.size === 0) return;
 
     try {
@@ -501,7 +501,7 @@ export function MenuBar() {
 
   const handleExportPly = useCallback(() => {
     const s = useCharacterStore.getState();
-    const char = s.character;
+    const char = s.asset;
     if (!char) return;
     const blob = exportPly(char.voxels, char.gridWidth, char.gridDepth, char.characterParts);
     const name = char.characterName.replace(/\s+/g, '_').toLowerCase() || 'character';
@@ -510,7 +510,7 @@ export function MenuBar() {
 
   const handleExportManifest = useCallback(() => {
     const s = useCharacterStore.getState();
-    const char = s.character;
+    const char = s.asset;
     if (!char) return;
     const name = char.characterName.replace(/\s+/g, '_').toLowerCase() || 'character';
     const manifest = buildManifest(
@@ -527,9 +527,9 @@ export function MenuBar() {
 
   const handlePreviewInStaging = useCallback(async () => {
     // Ensure stable id before using char.id as a filesystem path (Bug 1 fix)
-    useCharacterStore.getState().ensureCharacterId();
+    useCharacterStore.getState().ensureAssetId();
     const s = useCharacterStore.getState();
-    const char = s.character;
+    const char = s.asset;
     if (!char || char.voxels.size === 0) {
       showToast('No voxels to preview', 'error');
       return;
@@ -580,7 +580,7 @@ export function MenuBar() {
       const handle: FileSystemDirectoryHandle = await window.showDirectoryPicker({ mode: 'readwrite' });
       await saveProjectRootHandle('echidna', handle);
       useCharacterStore.getState().setProjectRootHandle(handle);
-      await useCharacterStore.getState().listCharacters();
+      await useCharacterStore.getState().listAssets();
       showToast(`Project root set: ${handle.name}`, 'success');
     } catch (e) {
       // User canceled or denied permission

--- a/tools/apps/echidna/src/panels/NewProjectDialog.tsx
+++ b/tools/apps/echidna/src/panels/NewProjectDialog.tsx
@@ -55,7 +55,7 @@ export function NewProjectDialog({ onClose }: { onClose: () => void }) {
     : Number(sizeOption);
 
   const handleCreate = () => {
-    useCharacterStore.getState().newCharacter(resolvedSize, charName);
+    useCharacterStore.getState().newAsset('character', resolvedSize, charName);
     onClose();
   };
 

--- a/tools/apps/echidna/src/panels/PartsPanel.tsx
+++ b/tools/apps/echidna/src/panels/PartsPanel.tsx
@@ -69,9 +69,9 @@ function PartTree({ parts, parentId, depth, selected, onSelect }: {
 }
 
 export function PartsPanel() {
-  const characterName = useCharacterStore((s) => s.character?.characterName ?? 'Untitled');
+  const characterName = useCharacterStore((s) => s.asset?.characterName ?? 'Untitled');
   const setCharacterName = useCharacterStore((s) => s.setCharacterName);
-  const parts = useCharacterStore((s) => s.character?.characterParts ?? []);
+  const parts = useCharacterStore((s) => s.asset?.characterParts ?? []);
   const selectedPart = useCharacterStore((s) => s.selectedPart);
   const setSelectedPart = useCharacterStore((s) => s.setSelectedPart);
   const addPart = useCharacterStore((s) => s.addPart);

--- a/tools/apps/echidna/src/panels/PosePanel.tsx
+++ b/tools/apps/echidna/src/panels/PosePanel.tsx
@@ -30,8 +30,8 @@ const styles: Record<string, React.CSSProperties> = {
 };
 
 export function PosePanel() {
-  const parts = useCharacterStore((s) => s.character?.characterParts ?? []);
-  const poses = useCharacterStore((s) => s.character?.characterPoses ?? {});
+  const parts = useCharacterStore((s) => s.asset?.characterParts ?? []);
+  const poses = useCharacterStore((s) => s.asset?.characterPoses ?? {});
   const selectedPose = useCharacterStore((s) => s.selectedPose);
   const setSelectedPose = useCharacterStore((s) => s.setSelectedPose);
   const addPose = useCharacterStore((s) => s.addPose);

--- a/tools/apps/echidna/src/panels/ResizeGridDialog.tsx
+++ b/tools/apps/echidna/src/panels/ResizeGridDialog.tsx
@@ -49,8 +49,8 @@ const styles: Record<string, React.CSSProperties> = {
 };
 
 export function ResizeGridDialog({ onClose }: { onClose: () => void }) {
-  const currentSize = useCharacterStore((s) => s.character?.gridWidth ?? 32);
-  const voxels = useCharacterStore((s) => s.character?.voxels ?? new Map());
+  const currentSize = useCharacterStore((s) => s.asset?.gridWidth ?? 32);
+  const voxels = useCharacterStore((s) => s.asset?.voxels ?? new Map());
 
   const initialPreset = PRESETS.includes(currentSize) ? String(currentSize) : 'custom';
   const [preset, setPreset] = useState<string>(initialPreset);

--- a/tools/apps/echidna/src/panels/Timeline.tsx
+++ b/tools/apps/echidna/src/panels/Timeline.tsx
@@ -61,7 +61,7 @@ export function Timeline() {
   const trackRef = useRef<HTMLDivElement>(null);
 
   const selectedAnimation = useCharacterStore((s) => s.selectedAnimation);
-  const animations = useCharacterStore((s) => s.character?.animations ?? {});
+  const animations = useCharacterStore((s) => s.asset?.animations ?? {});
   const playbackTime = useCharacterStore((s) => s.playbackTime);
   const isPlaying = useCharacterStore((s) => s.isPlaying);
   const playbackSpeed = useCharacterStore((s) => s.playbackSpeed);

--- a/tools/apps/echidna/src/store/types.ts
+++ b/tools/apps/echidna/src/store/types.ts
@@ -106,8 +106,7 @@ export function slugifyAssetId(name: string): string {
   return cleaned.length > 0 ? cleaned : 'character';
 }
 
-/** @deprecated Use slugifyAssetId */
-export const slugifyCharacterId = slugifyAssetId;
+
 
 /**
  * Migrate a raw parsed JSON object to the current EchidnaFile shape.
@@ -179,9 +178,6 @@ export interface Asset {
   currentFilename: string | null;                    // legacy .echidna download target
 }
 
-/** @deprecated Use Asset */
-export type Character = Asset;
-
 export interface AssetListEntry {
   id: string;
   kind: EchidnaAssetKind;
@@ -189,5 +185,3 @@ export interface AssetListEntry {
   lastModified: number;
 }
 
-/** @deprecated Use AssetListEntry */
-export type CharacterListEntry = AssetListEntry;

--- a/tools/apps/echidna/src/store/types.ts
+++ b/tools/apps/echidna/src/store/types.ts
@@ -61,6 +61,10 @@ export interface AnimationClip {
 
 export type AppMode = 'build' | 'animate';
 
+// ── Asset kind ──
+
+export type EchidnaAssetKind = 'character' | 'map' | 'object';
+
 // ── Clipboard ──
 
 export interface ClipboardEntry {
@@ -70,13 +74,14 @@ export interface ClipboardEntry {
   color: [number, number, number, number];
 }
 
-// ── File format (v3) ──
+// ── File format (v4) ──
 
-export const ECHIDNA_FILE_VERSION = 3 as const;
+export const ECHIDNA_FILE_VERSION = 4 as const;
 
 export interface EchidnaFile {
   version: number;
   id: string;            // persistent slug, immutable after first save
+  kind: EchidnaAssetKind;
   characterName: string;
   gridWidth: number;
   gridDepth: number;
@@ -84,14 +89,15 @@ export interface EchidnaFile {
   parts: BodyPart[];
   poses: Record<string, PoseData>;
   animations?: Record<string, AnimationClip>;
+  tags: string[];
 }
 
 /**
- * Slugify a character name into a stable ID usable as a directory name.
+ * Slugify an asset name into a stable ID usable as a directory name.
  * Rules: lowercase, trim, collapse whitespace runs to single underscores,
  * strip characters outside [a-z0-9_-], fall back to "character" if empty.
  */
-export function slugifyCharacterId(name: string): string {
+export function slugifyAssetId(name: string): string {
   const cleaned = name
     .toLowerCase()
     .trim()
@@ -100,14 +106,19 @@ export function slugifyCharacterId(name: string): string {
   return cleaned.length > 0 ? cleaned : 'character';
 }
 
+/** @deprecated Use slugifyAssetId */
+export const slugifyCharacterId = slugifyAssetId;
+
 /**
  * Migrate a raw parsed JSON object to the current EchidnaFile shape.
  * - Adds a persistent `id` (slugified from characterName) if missing.
  * - Bumps version to ECHIDNA_FILE_VERSION.
+ * - Defaults `kind` to 'character' for legacy v3 files.
+ * - Defaults `tags` to [] if missing.
  * - Throws on non-object input.
  *
  * Does NOT attempt to validate voxel/part/pose structure — the store
- * loader handles those. This migration is specifically about schema v2 → v3.
+ * loader handles those. This migration covers schema v2 → v3 → v4.
  */
 export function migrateEchidnaFile(raw: any): EchidnaFile {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
@@ -115,11 +126,17 @@ export function migrateEchidnaFile(raw: any): EchidnaFile {
   }
   const id: string = typeof raw.id === 'string' && raw.id.length > 0
     ? raw.id
-    : slugifyCharacterId(typeof raw.characterName === 'string' ? raw.characterName : '');
+    : slugifyAssetId(typeof raw.characterName === 'string' ? raw.characterName : '');
+
+  const kind: EchidnaAssetKind =
+    raw.kind === 'character' || raw.kind === 'map' || raw.kind === 'object'
+      ? raw.kind
+      : 'character';
 
   return {
     version: ECHIDNA_FILE_VERSION,
     id,
+    kind,
     characterName: raw.characterName ?? '',
     gridWidth: raw.gridWidth ?? 32,
     gridDepth: raw.gridDepth ?? 32,
@@ -129,6 +146,7 @@ export function migrateEchidnaFile(raw: any): EchidnaFile {
     animations: raw.animations && typeof raw.animations === 'object' && !Array.isArray(raw.animations)
       ? raw.animations
       : undefined,
+    tags: Array.isArray(raw.tags) ? raw.tags : [],
   };
 }
 
@@ -139,16 +157,17 @@ export interface Snapshot {
   parts: BodyPart[];
 }
 
-// ── Per-character slice ──
+// ── Per-asset slice ──
 
 /**
- * Per-character slice of EchidnaStoreState. Nullable — null when no character
+ * Per-asset slice of EchidnaStoreState. Nullable — null when no asset
  * is loaded (empty project, or just after Delete). Swapped atomically on
  * openCharacter() and newCharacter(). Every mutating action that writes to
  * this slice must also call markDirty().
  */
-export interface Character {
-  id: string;                                        // slug, stable for the character's lifetime
+export interface Asset {
+  id: string;                                        // slug, stable for the asset's lifetime
+  kind: EchidnaAssetKind;
   characterName: string;                             // display name
   gridWidth: number;
   gridDepth: number;
@@ -156,11 +175,19 @@ export interface Character {
   characterParts: BodyPart[];
   characterPoses: Record<string, PoseData>;
   animations: Record<string, AnimationClip>;
+  tags: string[];
   currentFilename: string | null;                    // legacy .echidna download target
 }
 
-export interface CharacterListEntry {
+/** @deprecated Use Asset */
+export type Character = Asset;
+
+export interface AssetListEntry {
   id: string;
+  kind: EchidnaAssetKind;
   name: string;
   lastModified: number;
 }
+
+/** @deprecated Use AssetListEntry */
+export type CharacterListEntry = AssetListEntry;

--- a/tools/apps/echidna/src/store/types.ts
+++ b/tools/apps/echidna/src/store/types.ts
@@ -103,7 +103,7 @@ export function slugifyAssetId(name: string): string {
     .trim()
     .replace(/\s+/g, '_')
     .replace(/[^a-z0-9_-]/g, '');
-  return cleaned.length > 0 ? cleaned : 'character';
+  return cleaned.length > 0 ? cleaned : 'asset';
 }
 
 
@@ -161,7 +161,7 @@ export interface Snapshot {
 /**
  * Per-asset slice of EchidnaStoreState. Nullable — null when no asset
  * is loaded (empty project, or just after Delete). Swapped atomically on
- * openCharacter() and newCharacter(). Every mutating action that writes to
+ * openAsset() and newAsset(). Every mutating action that writes to
  * this slice must also call markDirty().
  */
 export interface Asset {

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -864,14 +864,14 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       const entries = await listEchidnaProjects(handle);
       set({ knownAssets: entries });
     } catch (e) {
-      console.error('[echidna] listCharacters failed:', e);
+      console.error('[echidna] listAssets failed:', e);
       // Do not clobber existing list on transient failure
     }
   },
   openAsset: async (id) => {
     const handle = get().projectRootHandle;
     if (!handle) {
-      console.warn('[echidna] openCharacter called with no projectRootHandle');
+      console.warn('[echidna] openAsset called with no projectRootHandle');
       return;
     }
     try {
@@ -925,11 +925,11 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       });
     } catch (e) {
       if ((e as Error).name === 'NotFoundError') {
-        console.warn(`[echidna] openCharacter: file missing for ${id}, refreshing list`);
+        console.warn(`[echidna] openAsset: file missing for ${id}, refreshing list`);
         await get().listAssets();
         return;
       }
-      console.error(`[echidna] openCharacter failed for ${id}:`, e);
+      console.error(`[echidna] openAsset failed for ${id}:`, e);
     }
   },
 
@@ -950,11 +950,11 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       if (decision === 'save') {
         const ok = await s.save();
         if (!ok) {
-          console.error('[echidna] requestOpenCharacter: save() failed, aborting switch');
+          console.error('[echidna] requestOpenAsset: save() failed, aborting switch');
           return;
         }
       }
-      // 'discard' falls through to openCharacter (losing the dirty work)
+      // 'discard' falls through to openAsset (losing the dirty work)
     }
     await get().openAsset(id);
   },
@@ -966,7 +966,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     try {
       await deleteEchidnaProject(handle, id);
     } catch (e) {
-      console.error(`[echidna] deleteCharacter failed for ${id}:`, e);
+      console.error(`[echidna] deleteAsset failed for ${id}:`, e);
       return;
     }
     set((state) => ({
@@ -994,7 +994,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     try {
       await renameEchidnaProject(handle, id, newName);
     } catch (e) {
-      console.error(`[echidna] renameCharacter failed for ${id}:`, e);
+      console.error(`[echidna] renameAsset failed for ${id}:`, e);
       return;
     }
 
@@ -1021,7 +1021,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     const MAX_DUPLICATE_SUFFIX = 1000;
     const baseId = slugifyAssetId(newName);
     if (baseId.length === 0) {
-      console.error(`[echidna] duplicateCharacter: slugifyAssetId returned empty for "${newName}"`);
+      console.error(`[echidna] duplicateAsset: slugifyAssetId returned empty for "${newName}"`);
       return;
     }
     const existingIds = new Set(s.knownAssets.map((c) => c.id));
@@ -1029,7 +1029,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     let counter = 2;
     while (existingIds.has(newId)) {
       if (counter > MAX_DUPLICATE_SUFFIX) {
-        console.error(`[echidna] duplicateCharacter: > ${MAX_DUPLICATE_SUFFIX} collisions for base id "${baseId}"`);
+        console.error(`[echidna] duplicateAsset: > ${MAX_DUPLICATE_SUFFIX} collisions for base id "${baseId}"`);
         return;
       }
       newId = `${baseId}_${counter}`;
@@ -1040,7 +1040,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       await duplicateEchidnaProject(handle, sourceId, newId, newName);
       await get().listAssets();
     } catch (e) {
-      console.error(`[echidna] duplicateCharacter failed:`, e);
+      console.error(`[echidna] duplicateAsset failed:`, e);
     }
   },
 
@@ -1119,10 +1119,10 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
       set((state) => ({
         dirty: false,
-        // Update the saved character's mtime in-place rather than calling
-        // listCharacters() which would re-read disk and wipe optimistic
-        // entries for characters that haven't been saved yet. The full
-        // listCharacters() refresh happens on project-root restore and
+        // Update the saved asset's mtime in-place rather than calling
+        // listAssets() which would re-read disk and wipe optimistic
+        // entries for assets that haven't been saved yet. The full
+        // listAssets() refresh happens on project-root restore and
         // after rename/duplicate/delete — save() just needs the mtime.
         knownAssets: state.knownAssets.map((c) =>
           c.id === id ? { ...c, lastModified: Date.now() } : c,
@@ -1152,7 +1152,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     // Mint a non-colliding id from the provided name. Without this,
     // creating two new characters in a row would give them both the same id
     // and the second save would silently overwrite the first. Matches the
-    // collision-suffix pattern used by duplicateCharacter.
+    // collision-suffix pattern used by duplicateAsset.
     const MAX_NEW_SUFFIX = 1000;
     const baseId = slugifyAssetId(charName);
     const existingIds = new Set(s.knownAssets.map((c) => c.id));
@@ -1160,7 +1160,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     let counter = 2;
     while (existingIds.has(newId)) {
       if (counter > MAX_NEW_SUFFIX) {
-        console.error(`[echidna] newCharacter: > ${MAX_NEW_SUFFIX} collisions for base id "${baseId}"`);
+        console.error(`[echidna] newAsset: > ${MAX_NEW_SUFFIX} collisions for base id "${baseId}"`);
         return;
       }
       newId = `${baseId}_${counter}`;

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -85,6 +85,7 @@ function voxelArrayToMap(
 
 const DEFAULT_CHARACTER: Character = {
   id: '',
+  kind: 'character',
   characterName: 'Untitled',
   gridWidth: 32,
   gridDepth: 32,
@@ -92,6 +93,7 @@ const DEFAULT_CHARACTER: Character = {
   characterParts: [],
   characterPoses: {},
   animations: {},
+  tags: [],
   currentFilename: null,
 };
 
@@ -894,6 +896,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       }
       const char: Character = {
         id: data.id,
+        kind: data.kind ?? 'character',
         characterName: data.characterName,
         gridWidth: data.gridWidth,
         gridDepth: data.gridDepth,
@@ -901,6 +904,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         characterParts: parts,
         characterPoses: data.poses,
         animations,
+        tags: data.tags ?? [],
         currentFilename: null,
       };
       set({
@@ -1147,6 +1151,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     set({
       character: {
         id: newId,
+        kind: 'character',
         voxels: new Map(),
         gridWidth: size,
         gridDepth: size,
@@ -1154,6 +1159,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         characterParts: [],
         characterPoses: {},
         animations: {},
+        tags: [],
         currentFilename: null,
       },
       // Optimistic panel entry: add to knownCharacters immediately so the new
@@ -1161,7 +1167,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       // listCharacters() which re-reads from disk and reconciles the entry.
       knownCharacters: [
         ...s.knownCharacters,
-        { id: newId, name: charName, lastModified: Date.now() },
+        { id: newId, kind: 'character', name: charName, lastModified: Date.now() },
       ],
       selectedPart: null,
       selectedPose: null,
@@ -1219,6 +1225,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     return {
       version: ECHIDNA_FILE_VERSION,
       id,
+      kind: char.kind ?? 'character',
       characterName: char.characterName,
       gridWidth: char.gridWidth,
       gridDepth: char.gridDepth,
@@ -1226,6 +1233,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       parts: char.characterParts,
       poses: char.characterPoses,
       animations: Object.keys(char.animations).length > 0 ? char.animations : undefined,
+      tags: char.tags ?? [],
     };
   },
 
@@ -1258,6 +1266,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     set({
       character: {
         id: data.id,
+        kind: data.kind ?? 'character',
         voxels,
         gridWidth: data.gridWidth,
         gridDepth: data.gridDepth,
@@ -1265,6 +1274,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         characterParts: parts,
         characterPoses: data.poses,
         animations,
+        tags: data.tags ?? [],
         currentFilename: get().character?.currentFilename ?? null,
       },
       selectedPart: null,

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -12,12 +12,13 @@ import type {
   AnimationKeyframe,
   ClipboardEntry,
   PlaybackMode,
-  Character,
-  CharacterListEntry,
+  Asset,
+  AssetListEntry,
+  EchidnaAssetKind,
 } from './types.js';
-import { migrateEchidnaFile, slugifyCharacterId, ECHIDNA_FILE_VERSION } from './types.js';
+import { migrateEchidnaFile, slugifyAssetId, ECHIDNA_FILE_VERSION } from './types.js';
 import { voxelKey, parseKey, floodFill3D, extrudeLayer } from '../lib/voxelUtils.js';
-import { listEchidnaProjects, loadEchidnaProject, saveEchidnaProject, exportCharacterToProject, deleteEchidnaProject, renameEchidnaProject, duplicateEchidnaProject } from '../lib/projectFs.js';
+import { listEchidnaProjects, loadEchidnaProject, saveEchidnaProject, exportCharacterToProject, exportMapToProject, exportObjectToProject, deleteEchidnaProject, renameEchidnaProject, duplicateEchidnaProject } from '../lib/projectFs.js';
 import { exportPly } from '../lib/plyExport.js';
 import { buildManifest } from '../lib/manifestExport.js';
 
@@ -83,7 +84,7 @@ function voxelArrayToMap(
   return map;
 }
 
-const DEFAULT_CHARACTER: Character = {
+const DEFAULT_ASSET: Asset = {
   id: '',
   kind: 'character',
   characterName: 'Untitled',
@@ -105,12 +106,12 @@ export type ConfirmSwitch = (info: {
 }) => Promise<SwitchDecision>;
 
 export interface CharacterStoreState {
-  // Per-character slice (currently non-null — Task 19 will make it nullable)
-  character: Character | null;
+  // Per-asset slice (nullable — null when no asset is loaded)
+  asset: Asset | null;
 
   // Global project state
   projectRootHandle: FileSystemDirectoryHandle | null;
-  knownCharacters: CharacterListEntry[];
+  knownAssets: AssetListEntry[];
   dirty: boolean;
 
   // App mode
@@ -234,21 +235,21 @@ export interface CharacterStoreState {
   setPlaybackSpeed: (speed: number) => void;
 
   // Actions – file
-  newCharacter: (gridSize?: number, name?: string) => void;
+  newAsset: (kind: EchidnaAssetKind, gridSize?: number, name?: string) => void;
   resizeGrid: (size: number) => void;
   saveProject: () => EchidnaFile;
   loadProject: (raw: any) => void;
   setCurrentFilename: (name: string | null) => void;
   setProjectRootHandle: (h: FileSystemDirectoryHandle | null) => void;
-  ensureCharacterId: () => string;
+  ensureAssetId: () => string;
   _saving: boolean;              // race guard — internal, not subscribed by consumers
   save: () => Promise<boolean>;
-  listCharacters: () => Promise<void>;
-  openCharacter: (id: string) => Promise<void>;
-  requestOpenCharacter: (id: string, confirm: ConfirmSwitch) => Promise<void>;
-  deleteCharacter: (id: string) => Promise<void>;
-  renameCharacter: (id: string, newName: string) => Promise<void>;
-  duplicateCharacter: (sourceId: string, newName: string) => Promise<void>;
+  listAssets: () => Promise<void>;
+  openAsset: (id: string) => Promise<void>;
+  requestOpenAsset: (id: string, confirm: ConfirmSwitch) => Promise<void>;
+  deleteAsset: (id: string) => Promise<void>;
+  renameAsset: (id: string, newName: string) => Promise<void>;
+  duplicateAsset: (sourceId: string, newName: string) => Promise<void>;
 
   // Actions – new tools and clipboard
   setXrayMode: (v: boolean) => void;
@@ -265,10 +266,10 @@ export interface CharacterStoreState {
 }
 
 export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
-  character: null,
+  asset: null,
 
   projectRootHandle: null,
-  knownCharacters: [],
+  knownAssets: [],
   dirty: false,
 
   mode: 'build',
@@ -319,21 +320,21 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
   // ── Undo ──
   pushUndo: () => {
     const s = get();
-    if (!s.character) return;
-    const snap = makeSnapshot(s.character.voxels, s.character.characterParts);
+    if (!s.asset) return;
+    const snap = makeSnapshot(s.asset.voxels, s.asset.characterParts);
     set({ undoStack: [...s.undoStack.slice(-49), snap], redoStack: [] });
   },
 
   undo: () => {
     const s = get();
-    if (!s.character) return;
+    if (!s.asset) return;
     if (s.undoStack.length === 0) return;
-    const current = makeSnapshot(s.character.voxels, s.character.characterParts);
+    const current = makeSnapshot(s.asset.voxels, s.asset.characterParts);
     const prev = s.undoStack[s.undoStack.length - 1];
     const restored = restoreSnapshot(prev);
     set({
-      character: {
-        ...s.character,
+      asset: {
+        ...s.asset,
         voxels: restored.voxels,
         characterParts: restored.characterParts,
       },
@@ -344,14 +345,14 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   redo: () => {
     const s = get();
-    if (!s.character) return;
+    if (!s.asset) return;
     if (s.redoStack.length === 0) return;
-    const current = makeSnapshot(s.character.voxels, s.character.characterParts);
+    const current = makeSnapshot(s.asset.voxels, s.asset.characterParts);
     const next = s.redoStack[s.redoStack.length - 1];
     const restored = restoreSnapshot(next);
     set({
-      character: {
-        ...s.character,
+      asset: {
+        ...s.asset,
         voxels: restored.voxels,
         characterParts: restored.characterParts,
       },
@@ -367,11 +368,11 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
    */
   addVoxel: (key, voxel) => {
     const s = get();
-    if (!s.character) return;
+    if (!s.asset) return;
     set({
-      character: {
-        ...s.character,
-        voxels: new Map(s.character.voxels).set(key, voxel),
+      asset: {
+        ...s.asset,
+        voxels: new Map(s.asset.voxels).set(key, voxel),
       },
       dirty: true,
     });
@@ -379,81 +380,81 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   placeVoxel: (x, y, z) => {
     const s = get();
-    if (!s.character) return;
-    const next = new Map(s.character.voxels);
+    if (!s.asset) return;
+    const next = new Map(s.asset.voxels);
     next.set(voxelKey(x, y, z), { color: [...s.activeColor] });
-    const m = mirrorPos(x, y, z, s.mirrorAxis, s.character.gridWidth);
+    const m = mirrorPos(x, y, z, s.mirrorAxis, s.asset.gridWidth);
     if (m) next.set(voxelKey(m[0], m[1], m[2]), { color: [...s.activeColor] });
-    set({ character: { ...s.character, voxels: next }, dirty: true });
+    set({ asset: { ...s.asset, voxels: next }, dirty: true });
   },
 
   placeVoxels: (positions) => {
     const s = get();
-    if (!s.character) return;
-    const next = new Map(s.character.voxels);
+    if (!s.asset) return;
+    const next = new Map(s.asset.voxels);
     for (const [x, y, z] of positions) {
       next.set(voxelKey(x, y, z), { color: [...s.activeColor] });
-      const m = mirrorPos(x, y, z, s.mirrorAxis, s.character.gridWidth);
+      const m = mirrorPos(x, y, z, s.mirrorAxis, s.asset.gridWidth);
       if (m) next.set(voxelKey(m[0], m[1], m[2]), { color: [...s.activeColor] });
     }
-    set({ character: { ...s.character, voxels: next }, dirty: true });
+    set({ asset: { ...s.asset, voxels: next }, dirty: true });
   },
 
   /** Batch-place voxels in a single state update. Programmatic API — does not apply mirror axis. */
   batchPlaceVoxels: (batch) => {
     const s = get();
-    if (!s.character) return;
-    const newVoxels = new Map(s.character.voxels);
+    if (!s.asset) return;
+    const newVoxels = new Map(s.asset.voxels);
     for (const { x, y, z, color } of batch) {
       const key = voxelKey(x, y, z);
       newVoxels.set(key, { color: color ? [...color] : [...s.activeColor] });
     }
-    set({ character: { ...s.character, voxels: newVoxels }, dirty: true });
+    set({ asset: { ...s.asset, voxels: newVoxels }, dirty: true });
   },
 
   paintVoxel: (x, y, z) => {
     const s = get();
-    if (!s.character) return;
+    if (!s.asset) return;
     const key = voxelKey(x, y, z);
-    if (!s.character.voxels.has(key)) return;
-    const next = new Map(s.character.voxels);
+    if (!s.asset.voxels.has(key)) return;
+    const next = new Map(s.asset.voxels);
     next.set(key, { color: [...s.activeColor] });
-    const m = mirrorPos(x, y, z, s.mirrorAxis, s.character.gridWidth);
+    const m = mirrorPos(x, y, z, s.mirrorAxis, s.asset.gridWidth);
     if (m) {
       const mk = voxelKey(m[0], m[1], m[2]);
       if (next.has(mk)) next.set(mk, { color: [...s.activeColor] });
     }
-    set({ character: { ...s.character, voxels: next }, dirty: true });
+    set({ asset: { ...s.asset, voxels: next }, dirty: true });
   },
 
   eraseVoxel: (x, y, z) => {
     const s = get();
-    if (!s.character) return;
+    if (!s.asset) return;
     const key = voxelKey(x, y, z);
-    if (!s.character.voxels.has(key)) return;
-    const next = new Map(s.character.voxels);
+    if (!s.asset.voxels.has(key)) return;
+    const next = new Map(s.asset.voxels);
     next.delete(key);
-    const m = mirrorPos(x, y, z, s.mirrorAxis, s.character.gridWidth);
+    const m = mirrorPos(x, y, z, s.mirrorAxis, s.asset.gridWidth);
     if (m) next.delete(voxelKey(m[0], m[1], m[2]));
-    set({ character: { ...s.character, voxels: next }, dirty: true });
+    set({ asset: { ...s.asset, voxels: next }, dirty: true });
   },
 
   eraseVoxels: (positions) => {
     const s = get();
-    if (!s.character) return;
-    const next = new Map(s.character.voxels);
+    if (!s.asset) return;
+    const next = new Map(s.asset.voxels);
     for (const [x, y, z] of positions) {
       next.delete(voxelKey(x, y, z));
-      const m = mirrorPos(x, y, z, s.mirrorAxis, s.character.gridWidth);
+      const m = mirrorPos(x, y, z, s.mirrorAxis, s.asset.gridWidth);
       if (m) next.delete(voxelKey(m[0], m[1], m[2]));
     }
-    set({ character: { ...s.character, voxels: next }, dirty: true });
+    set({ asset: { ...s.asset, voxels: next }, dirty: true });
   },
 
   eyedrop: (x, y, z) => {
     const s = get();
-    if (!s.character) return;
-    const v = s.character.voxels.get(voxelKey(x, y, z));
+    if (!s.asset) return;
+    const v = s.asset.voxels.get(voxelKey(x, y, z));
     if (v) set({ activeColor: [...v.color] });
   },
 
@@ -486,7 +487,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   // ── Part color coding ──
   setColorByPart: (v) => {
-    const parts = get().character?.characterParts ?? [];
+    const parts = get().asset?.characterParts ?? [];
     const colors = v ? generatePartColors(parts) : {};
     set({ colorByPart: v, partColors: colors });
   },
@@ -497,14 +498,14 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
   // ── Character actions ──
   setCharacterName: (name) => {
     const s = get();
-    if (!s.character) return;
-    set({ character: { ...s.character, characterName: name }, dirty: true });
+    if (!s.asset) return;
+    set({ asset: { ...s.asset, characterName: name }, dirty: true });
   },
 
   addPart: (name) => {
     const s = get();
-    if (!s.character) return;
-    const parts = s.character.characterParts;
+    if (!s.asset) return;
+    const parts = s.asset.characterParts;
     if (parts.some((p) => p.id === name)) return;
     const part: BodyPart = {
       id: name,
@@ -515,7 +516,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     };
     const newParts = [...parts, part];
     set({
-      character: { ...s.character, characterParts: newParts },
+      asset: { ...s.asset, characterParts: newParts },
       selectedPart: name,
       partColors: s.colorByPart ? generatePartColors(newParts) : s.partColors,
       dirty: true,
@@ -524,17 +525,17 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   removePart: (id) => {
     const s = get();
-    if (!s.character) return;
-    const parts = s.character.characterParts.filter((p) => p.id !== id);
+    if (!s.asset) return;
+    const parts = s.asset.characterParts.filter((p) => p.id !== id);
     const updated = parts.map((p) => (p.parent === id ? { ...p, parent: null } : p));
-    const poses = { ...s.character.characterPoses };
+    const poses = { ...s.asset.characterPoses };
     for (const name of Object.keys(poses)) {
       const rotations = { ...poses[name].rotations };
       delete rotations[id];
       poses[name] = { rotations };
     }
     set({
-      character: { ...s.character, characterParts: updated, characterPoses: poses },
+      asset: { ...s.asset, characterParts: updated, characterPoses: poses },
       selectedPart: s.selectedPart === id ? null : s.selectedPart,
       partColors: s.colorByPart ? generatePartColors(updated) : s.partColors,
       dirty: true,
@@ -543,11 +544,11 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   updatePartJoint: (id, joint) => {
     const s = get();
-    if (!s.character) return;
+    if (!s.asset) return;
     set({
-      character: {
-        ...s.character,
-        characterParts: s.character.characterParts.map((p) =>
+      asset: {
+        ...s.asset,
+        characterParts: s.asset.characterParts.map((p) =>
           p.id === id ? { ...p, joint } : p,
         ),
       },
@@ -557,11 +558,11 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   setPartParent: (id, parentId) => {
     const s = get();
-    if (!s.character) return;
+    if (!s.asset) return;
     set({
-      character: {
-        ...s.character,
-        characterParts: s.character.characterParts.map((p) =>
+      asset: {
+        ...s.asset,
+        characterParts: s.asset.characterParts.map((p) =>
           p.id === id ? { ...p, parent: parentId } : p,
         ),
       },
@@ -571,9 +572,9 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   assignVoxelsToPart: (keys, partId) => {
     const s = get();
-    if (!s.character) return;
+    if (!s.asset) return;
     const { mirrorAxis } = s;
-    const { voxels: voxelMap, gridWidth, characterParts } = s.character;
+    const { voxels: voxelMap, gridWidth, characterParts } = s.asset;
     const allKeys = [...keys];
     if (mirrorAxis) {
       for (const k of keys) {
@@ -587,8 +588,8 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     }
     const keySet = new Set(allKeys);
     set({
-      character: {
-        ...s.character,
+      asset: {
+        ...s.asset,
         characterParts: characterParts.map((p) => {
           if (p.id === partId) {
             const existing = new Set(p.voxelKeys);
@@ -607,21 +608,21 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   addPose: (name) => {
     const s = get();
-    if (!s.character) return;
-    const poses = { ...s.character.characterPoses };
+    if (!s.asset) return;
+    const poses = { ...s.asset.characterPoses };
     if (!poses[name]) {
       poses[name] = { rotations: {} };
     }
-    set({ character: { ...s.character, characterPoses: poses }, selectedPose: name, dirty: true });
+    set({ asset: { ...s.asset, characterPoses: poses }, selectedPose: name, dirty: true });
   },
 
   removePose: (name) => {
     const s = get();
-    if (!s.character) return;
-    const poses = { ...s.character.characterPoses };
+    if (!s.asset) return;
+    const poses = { ...s.asset.characterPoses };
     delete poses[name];
     set({
-      character: { ...s.character, characterPoses: poses },
+      asset: { ...s.asset, characterPoses: poses },
       selectedPose: s.selectedPose === name ? null : s.selectedPose,
       dirty: true,
     });
@@ -631,32 +632,32 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   updatePoseRotation: (poseName, partId, rotation) => {
     const s = get();
-    if (!s.character) return;
-    const poses = { ...s.character.characterPoses };
+    if (!s.asset) return;
+    const poses = { ...s.asset.characterPoses };
     const pose = poses[poseName] ?? { rotations: {} };
     poses[poseName] = { rotations: { ...pose.rotations, [partId]: rotation } };
-    set({ character: { ...s.character, characterPoses: poses }, dirty: true });
+    set({ asset: { ...s.asset, characterPoses: poses }, dirty: true });
   },
 
   updatePoseRootPosition: (poseName, position) => {
     const s = get();
-    if (!s.character) return;
-    const poses = { ...s.character.characterPoses };
+    if (!s.asset) return;
+    const poses = { ...s.asset.characterPoses };
     const pose = poses[poseName];
     if (pose) {
       poses[poseName] = { ...pose, rootPosition: position };
     }
-    set({ character: { ...s.character, characterPoses: poses }, dirty: true });
+    set({ asset: { ...s.asset, characterPoses: poses }, dirty: true });
   },
 
   setPreviewPose: (on) => set({ previewPose: on }),
 
   importVoxModels: (models) => {
     const s = get();
-    // When character is null, fall back to DEFAULT_CHARACTER as the base.
+    // When character is null, fall back to DEFAULT_ASSET as the base.
     // Importing creates a new in-memory character implicitly — the user hits
     // ⌘S to save it to the project. This matches pre-Phase-0.2 behavior (I1).
-    const base = s.character ?? DEFAULT_CHARACTER;
+    const base = s.asset ?? DEFAULT_ASSET;
     const voxels = new Map(base.voxels);
     const parts: BodyPart[] = [...base.characterParts];
 
@@ -675,17 +676,17 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       });
     }
 
-    set({ character: { ...base, voxels, characterParts: parts }, dirty: true });
+    set({ asset: { ...base, voxels, characterParts: parts }, dirty: true });
   },
 
   importFromPly: (voxels, parts, gridSize) => {
     const s = get();
-    // When character is null, fall back to DEFAULT_CHARACTER as the base.
+    // When character is null, fall back to DEFAULT_ASSET as the base.
     // Importing creates a new in-memory character implicitly — the user hits
     // ⌘S to save it to the project. This matches pre-Phase-0.2 behavior (I1).
     set({
-      character: {
-        ...(s.character ?? DEFAULT_CHARACTER),
+      asset: {
+        ...(s.asset ?? DEFAULT_ASSET),
         voxels,
         characterParts: parts,
         gridWidth: gridSize,
@@ -706,12 +707,12 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   importFromObj: (voxels, parts, gridSize) => {
     const s = get();
-    // When character is null, fall back to DEFAULT_CHARACTER as the base.
+    // When character is null, fall back to DEFAULT_ASSET as the base.
     // Importing creates a new in-memory character implicitly — the user hits
     // ⌘S to save it to the project. This matches pre-Phase-0.2 behavior (I1).
     set({
-      character: {
-        ...(s.character ?? DEFAULT_CHARACTER),
+      asset: {
+        ...(s.asset ?? DEFAULT_ASSET),
         voxels,
         characterParts: parts,
         gridWidth: gridSize,
@@ -733,21 +734,21 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
   // ── Animation actions ──
   addAnimation: (name) => {
     const s = get();
-    if (!s.character) return;
-    const anims = { ...s.character.animations };
+    if (!s.asset) return;
+    const anims = { ...s.asset.animations };
     if (!anims[name]) {
       anims[name] = { name, keyframes: [], duration: 1, playbackMode: 'loop' };
     }
-    set({ character: { ...s.character, animations: anims }, selectedAnimation: name, dirty: true });
+    set({ asset: { ...s.asset, animations: anims }, selectedAnimation: name, dirty: true });
   },
 
   removeAnimation: (name) => {
     const s = get();
-    if (!s.character) return;
-    const anims = { ...s.character.animations };
+    if (!s.asset) return;
+    const anims = { ...s.asset.animations };
     delete anims[name];
     set({
-      character: { ...s.character, animations: anims },
+      asset: { ...s.asset, animations: anims },
       selectedAnimation: s.selectedAnimation === name ? null : s.selectedAnimation,
       dirty: true,
     });
@@ -755,7 +756,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   selectAnimation: (name) => {
     const s = get();
-    const clip = name ? (s.character?.animations[name] ?? null) : null;
+    const clip = name ? (s.asset?.animations[name] ?? null) : null;
     set({
       selectedAnimation: name,
       playbackTime: 0,
@@ -766,72 +767,72 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   addKeyframe: (animName, keyframe) => {
     const s = get();
-    if (!s.character) return;
-    const anims = { ...s.character.animations };
+    if (!s.asset) return;
+    const anims = { ...s.asset.animations };
     const clip = anims[animName];
     if (!clip) return;
     const kf = { ...keyframe, easing: keyframe.easing ?? ('step' as const) };
     const keyframes = [...clip.keyframes, kf].sort((a, b) => a.time - b.time);
     anims[animName] = { ...clip, keyframes };
-    set({ character: { ...s.character, animations: anims }, dirty: true });
+    set({ asset: { ...s.asset, animations: anims }, dirty: true });
   },
 
   removeKeyframe: (animName, index) => {
     const s = get();
-    if (!s.character) return;
-    const anims = { ...s.character.animations };
+    if (!s.asset) return;
+    const anims = { ...s.asset.animations };
     const clip = anims[animName];
     if (!clip) return;
     const keyframes = clip.keyframes.filter((_, i) => i !== index);
     anims[animName] = { ...clip, keyframes };
-    set({ character: { ...s.character, animations: anims }, dirty: true });
+    set({ asset: { ...s.asset, animations: anims }, dirty: true });
   },
 
   updateKeyframeEasing: (animName, index, easing) => {
     const s = get();
-    if (!s.character) return;
-    const anims = { ...s.character.animations };
+    if (!s.asset) return;
+    const anims = { ...s.asset.animations };
     const clip = anims[animName];
     if (!clip) return;
     const keyframes = clip.keyframes.map((kf, i) => i === index ? { ...kf, easing } : kf);
     anims[animName] = { ...clip, keyframes };
-    set({ character: { ...s.character, animations: anims }, dirty: true });
+    set({ asset: { ...s.asset, animations: anims }, dirty: true });
   },
 
   updateAnimationDuration: (animName, duration) => {
     const s = get();
-    if (!s.character) return;
-    const anims = { ...s.character.animations };
+    if (!s.asset) return;
+    const anims = { ...s.asset.animations };
     const clip = anims[animName];
     if (!clip) return;
     anims[animName] = { ...clip, duration };
-    set({ character: { ...s.character, animations: anims }, dirty: true });
+    set({ asset: { ...s.asset, animations: anims }, dirty: true });
   },
 
   updateAnimationPlaybackMode: (animName, mode) => {
     const s = get();
-    if (!s.character) return;
-    const anims = { ...s.character.animations };
+    if (!s.asset) return;
+    const anims = { ...s.asset.animations };
     const clip = anims[animName];
     if (!clip) return;
     anims[animName] = { ...clip, playbackMode: mode };
-    set({ character: { ...s.character, animations: anims }, dirty: true });
+    set({ asset: { ...s.asset, animations: anims }, dirty: true });
   },
 
   updateAnimationRootMotion: (animName, enabled) => {
     const s = get();
-    if (!s.character) return;
-    const anims = { ...s.character.animations };
+    if (!s.asset) return;
+    const anims = { ...s.asset.animations };
     const clip = anims[animName];
     if (!clip) return;
     anims[animName] = { ...clip, rootMotion: enabled };
-    set({ character: { ...s.character, animations: anims }, dirty: true });
+    set({ asset: { ...s.asset, animations: anims }, dirty: true });
   },
 
   autoCenterJoint: (partId) => {
     const s = get();
-    if (!s.character) return;
-    const { characterParts, voxels } = s.character;
+    if (!s.asset) return;
+    const { characterParts, voxels } = s.asset;
     const part = characterParts.find((p) => p.id === partId);
     if (!part || part.voxelKeys.length === 0) return;
     let jx = 0, jy = 0, jz = 0;
@@ -842,7 +843,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     const n = part.voxelKeys.length;
     const joint: [number, number, number] = [Math.round(jx / n), Math.round(jy / n), Math.round(jz / n)];
     const parts = characterParts.map((p) => p.id === partId ? { ...p, joint } : p);
-    set({ character: { ...s.character, characterParts: parts }, dirty: true });
+    set({ asset: { ...s.asset, characterParts: parts }, dirty: true });
   },
 
   setPlaybackTime: (time) => set({ playbackTime: time }),
@@ -852,22 +853,22 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
   // ── File actions ──
   setCurrentFilename: (name) => {
     const s = get();
-    if (!s.character) return;
-    set({ character: { ...s.character, currentFilename: name }, dirty: true });
+    if (!s.asset) return;
+    set({ asset: { ...s.asset, currentFilename: name }, dirty: true });
   },
   setProjectRootHandle: (h) => set({ projectRootHandle: h }),
-  listCharacters: async () => {
+  listAssets: async () => {
     const handle = get().projectRootHandle;
     if (!handle) return;
     try {
       const entries = await listEchidnaProjects(handle);
-      set({ knownCharacters: entries });
+      set({ knownAssets: entries });
     } catch (e) {
       console.error('[echidna] listCharacters failed:', e);
       // Do not clobber existing list on transient failure
     }
   },
-  openCharacter: async (id) => {
+  openAsset: async (id) => {
     const handle = get().projectRootHandle;
     if (!handle) {
       console.warn('[echidna] openCharacter called with no projectRootHandle');
@@ -894,7 +895,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
           };
         }
       }
-      const char: Character = {
+      const char: Asset = {
         id: data.id,
         kind: data.kind ?? 'character',
         characterName: data.characterName,
@@ -908,7 +909,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         currentFilename: null,
       };
       set({
-        character: char,
+        asset: char,
         dirty: false,
         undoStack: [],
         redoStack: [],
@@ -925,23 +926,23 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     } catch (e) {
       if ((e as Error).name === 'NotFoundError') {
         console.warn(`[echidna] openCharacter: file missing for ${id}, refreshing list`);
-        await get().listCharacters();
+        await get().listAssets();
         return;
       }
       console.error(`[echidna] openCharacter failed for ${id}:`, e);
     }
   },
 
-  requestOpenCharacter: async (id, confirm) => {
+  requestOpenAsset: async (id, confirm) => {
     const s = get();
     // Clicking the already-current row is a no-op.
-    if (s.character?.id === id) return;
+    if (s.asset?.id === id) return;
 
     const currentHasWork = s.dirty || s.undoStack.length > 0 || s.redoStack.length > 0;
-    if (currentHasWork && s.character) {
-      const target = s.knownCharacters.find((c) => c.id === id);
+    if (currentHasWork && s.asset) {
+      const target = s.knownAssets.find((c) => c.id === id);
       const decision = await confirm({
-        currentName: s.character.characterName,
+        currentName: s.asset.characterName,
         targetName: target?.name ?? id,
         undoDepth: s.undoStack.length,
       });
@@ -955,10 +956,10 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       }
       // 'discard' falls through to openCharacter (losing the dirty work)
     }
-    await get().openCharacter(id);
+    await get().openAsset(id);
   },
 
-  deleteCharacter: async (id: string) => {
+  deleteAsset: async (id: string) => {
     const s = get();
     const handle = s.projectRootHandle;
     if (!handle) return;
@@ -969,10 +970,10 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       return;
     }
     set((state) => ({
-      knownCharacters: state.knownCharacters.filter((c) => c.id !== id),
-      ...(state.character?.id === id
+      knownAssets: state.knownAssets.filter((c) => c.id !== id),
+      ...(state.asset?.id === id
         ? {
-            character: null,
+            asset: null,
             dirty: false,
             undoStack: [],
             redoStack: [],
@@ -984,7 +985,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     }));
   },
 
-  renameCharacter: async (id, newName) => {
+  renameAsset: async (id, newName) => {
     const s = get();
     const handle = s.projectRootHandle;
     if (!handle) return;
@@ -997,33 +998,33 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       return;
     }
 
-    if (s.character?.id === id) {
+    if (s.asset?.id === id) {
       // Current character — also update in-memory state
       set((state) => ({
-        character: state.character ? { ...state.character, characterName: newName } : null,
-        knownCharacters: state.knownCharacters.map((c) =>
+        asset: state.asset ? { ...state.asset, characterName: newName } : null,
+        knownAssets: state.knownAssets.map((c) =>
           c.id === id ? { ...c, name: newName } : c,
         ),
       }));
     } else {
       // Non-current — refresh list from disk
-      await get().listCharacters();
+      await get().listAssets();
     }
   },
 
-  duplicateCharacter: async (sourceId, newName) => {
+  duplicateAsset: async (sourceId, newName) => {
     const s = get();
     const handle = s.projectRootHandle;
     if (!handle) return;
 
     // Mint a non-colliding id
     const MAX_DUPLICATE_SUFFIX = 1000;
-    const baseId = slugifyCharacterId(newName);
+    const baseId = slugifyAssetId(newName);
     if (baseId.length === 0) {
-      console.error(`[echidna] duplicateCharacter: slugifyCharacterId returned empty for "${newName}"`);
+      console.error(`[echidna] duplicateCharacter: slugifyAssetId returned empty for "${newName}"`);
       return;
     }
-    const existingIds = new Set(s.knownCharacters.map((c) => c.id));
+    const existingIds = new Set(s.knownAssets.map((c) => c.id));
     let newId = baseId;
     let counter = 2;
     while (existingIds.has(newId)) {
@@ -1037,7 +1038,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
     try {
       await duplicateEchidnaProject(handle, sourceId, newId, newName);
-      await get().listCharacters();
+      await get().listAssets();
     } catch (e) {
       console.error(`[echidna] duplicateCharacter failed:`, e);
     }
@@ -1057,13 +1058,13 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         console.warn('[echidna] save called with no projectRootHandle');
         return false;
       }
-      if (!handleCheck.character) return false;
+      if (!handleCheck.asset) return false;
 
-      // ensureCharacterId may replace state.character (via set()), so recapture
+      // ensureCharacterId may replace state.asset (via set()), so recapture
       // get() after it runs so downstream reads use a fresh snapshot.
-      const id = get().ensureCharacterId();
+      const id = get().ensureAssetId();
       const s = get();
-      if (!s.character) return false; // guard: ensureCharacterId should never null character, but be safe
+      if (!s.asset) return false; // guard: ensureCharacterId should never null character, but be safe
 
       // 1. Write the .echidna source via Phase 0.0 helper
       const file = s.saveProject();   // returns EchidnaFile DTO, does NOT write to disk
@@ -1074,23 +1075,41 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         return false;
       }
 
-      // 2. Build PLY + manifest and write engine-ready files
+      // 2. Build PLY + manifest and write engine-ready files (kind-branched)
       try {
-        const ply = exportPly(
-          s.character.voxels,
-          s.character.gridWidth,
-          s.character.gridDepth,
-          s.character.characterParts,
-        );
-        const manifest = buildManifest(
-          id,
-          `${id}.ply`,
-          1.0,
-          s.character.characterParts,
-          s.character.characterPoses,
-          s.character.animations,
-        );
-        await exportCharacterToProject(handle, id, ply, JSON.stringify(manifest, null, 2));
+        if (s.asset.kind === 'character') {
+          const ply = exportPly(
+            s.asset.voxels,
+            s.asset.gridWidth,
+            s.asset.gridDepth,
+            s.asset.characterParts,
+          );
+          const manifest = buildManifest(
+            id,
+            `${id}.ply`,
+            1.0,
+            s.asset.characterParts,
+            s.asset.characterPoses,
+            s.asset.animations,
+          );
+          await exportCharacterToProject(handle, id, ply, JSON.stringify(manifest, null, 2));
+        } else if (s.asset.kind === 'map') {
+          const ply = exportPly(
+            s.asset.voxels,
+            s.asset.gridWidth,
+            s.asset.gridDepth,
+            s.asset.characterParts,
+          );
+          await exportMapToProject(handle, id, ply);
+        } else if (s.asset.kind === 'object') {
+          const ply = exportPly(
+            s.asset.voxels,
+            s.asset.gridWidth,
+            s.asset.gridDepth,
+            s.asset.characterParts,
+          );
+          await exportObjectToProject(handle, id, ply);
+        }
       } catch (e) {
         console.error('[echidna] save: partial write — engine files may be stale:', e);
         // .echidna is on disk so dirty COULD clear, but partial-fail means
@@ -1105,7 +1124,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         // entries for characters that haven't been saved yet. The full
         // listCharacters() refresh happens on project-root restore and
         // after rename/duplicate/delete — save() just needs the mtime.
-        knownCharacters: state.knownCharacters.map((c) =>
+        knownAssets: state.knownAssets.map((c) =>
           c.id === id ? { ...c, lastModified: Date.now() } : c,
         ),
       }));
@@ -1115,17 +1134,17 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     }
   },
 
-  ensureCharacterId: () => {
+  ensureAssetId: () => {
     const s = get();
-    const char = s.character;
-    if (!char) return 'character';
+    const char = s.asset;
+    if (!char) return 'asset';
     if (char.id.length > 0) return char.id;
-    const id = slugifyCharacterId(char.characterName);
-    set({ character: { ...char, id }, dirty: true });
+    const id = slugifyAssetId(char.characterName);
+    set({ asset: { ...char, id }, dirty: true });
     return id;
   },
 
-  newCharacter: (gridSize?: number, name?: string) => {
+  newAsset: (kind: EchidnaAssetKind, gridSize?: number, name?: string) => {
     const size = gridSize ?? 32;
     const s = get();
     const charName = (name && name.trim().length > 0) ? name.trim() : 'Untitled';
@@ -1135,8 +1154,8 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     // and the second save would silently overwrite the first. Matches the
     // collision-suffix pattern used by duplicateCharacter.
     const MAX_NEW_SUFFIX = 1000;
-    const baseId = slugifyCharacterId(charName);
-    const existingIds = new Set(s.knownCharacters.map((c) => c.id));
+    const baseId = slugifyAssetId(charName);
+    const existingIds = new Set(s.knownAssets.map((c) => c.id));
     let newId = baseId;
     let counter = 2;
     while (existingIds.has(newId)) {
@@ -1149,9 +1168,9 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
     }
 
     set({
-      character: {
+      asset: {
         id: newId,
-        kind: 'character',
+        kind,
         voxels: new Map(),
         gridWidth: size,
         gridDepth: size,
@@ -1162,12 +1181,12 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         tags: [],
         currentFilename: null,
       },
-      // Optimistic panel entry: add to knownCharacters immediately so the new
-      // character is visible before first save. Phase 0.2 save() later calls
-      // listCharacters() which re-reads from disk and reconciles the entry.
-      knownCharacters: [
-        ...s.knownCharacters,
-        { id: newId, kind: 'character', name: charName, lastModified: Date.now() },
+      // Optimistic panel entry: add to knownAssets immediately so the new
+      // asset is visible before first save. Phase 0.2 save() later calls
+      // listAssets() which re-reads from disk and reconciles the entry.
+      knownAssets: [
+        ...s.knownAssets,
+        { id: newId, kind, name: charName, lastModified: Date.now() },
       ],
       selectedPart: null,
       selectedPose: null,
@@ -1180,9 +1199,9 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       boxSelection: null,
       colorByPart: false,
       partColors: {},
-      // A freshly-created character has unsaved state (the creation itself).
-      // Setting dirty=true ensures requestOpenCharacter's switch guard protects
-      // the new character from silent loss if the user clicks away before
+      // A freshly-created asset has unsaved state (the creation itself).
+      // Setting dirty=true ensures requestOpenAsset's switch guard protects
+      // the new asset from silent loss if the user clicks away before
       // editing or saving.
       dirty: true,
     });
@@ -1190,8 +1209,8 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   resizeGrid: (size: number) => {
     const s = get();
-    if (!s.character) return;
-    const { voxels, characterParts, gridWidth } = s.character;
+    if (!s.asset) return;
+    const { voxels, characterParts, gridWidth } = s.asset;
     if (size === gridWidth) return;
     const next = new Map<VoxelKey, Voxel>();
     for (const [key, vox] of voxels) {
@@ -1207,16 +1226,16 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         return x >= 0 && x < size && z >= 0 && z < size;
       }),
     }));
-    set({ character: { ...s.character, voxels: next, gridWidth: size, gridDepth: size, characterParts: nextParts }, dirty: true });
+    set({ asset: { ...s.asset, voxels: next, gridWidth: size, gridDepth: size, characterParts: nextParts }, dirty: true });
   },
 
   saveProject: () => {
-    const id = get().ensureCharacterId();
+    const id = get().ensureAssetId();
     const s = get();
-    if (!s.character) {
+    if (!s.asset) {
       throw new Error('[echidna] saveProject called with null character');
     }
-    const char = s.character;
+    const char = s.asset;
     const voxelArr: EchidnaFile['voxels'] = [];
     for (const [key, vox] of char.voxels) {
       const [x, y, z] = parseKey(key);
@@ -1264,7 +1283,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       }
     }
     set({
-      character: {
+      asset: {
         id: data.id,
         kind: data.kind ?? 'character',
         voxels,
@@ -1275,7 +1294,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         characterPoses: data.poses,
         animations,
         tags: data.tags ?? [],
-        currentFilename: get().character?.currentFilename ?? null,
+        currentFilename: get().asset?.currentFilename ?? null,
       },
       selectedPart: null,
       selectedPose: null,
@@ -1296,8 +1315,8 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   fillVoxels: (startKey) => {
     const s = get();
-    if (!s.character) return;
-    const { voxels, gridWidth } = s.character;
+    if (!s.asset) return;
+    const { voxels, gridWidth } = s.asset;
     const keys = floodFill3D(voxels, startKey);
     if (keys.length === 0) return;
     const next = new Map(voxels);
@@ -1310,13 +1329,13 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         if (next.has(mk)) next.set(mk, { color: [...s.activeColor] });
       }
     }
-    set({ character: { ...s.character, voxels: next }, dirty: true });
+    set({ asset: { ...s.asset, voxels: next }, dirty: true });
   },
 
   extrudeSelection: (dy) => {
     const s = get();
-    if (!s.character) return;
-    const { voxels, gridWidth } = s.character;
+    if (!s.asset) return;
+    const { voxels, gridWidth } = s.asset;
     const sel = s.boxSelection ?? s.lassoSelection;
     if (!sel || sel.length === 0) return;
     const results = extrudeLayer(voxels, sel, dy);
@@ -1327,13 +1346,13 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       const m = mirrorPos(x, y, z, s.mirrorAxis, gridWidth);
       if (m) next.set(voxelKey(m[0], m[1], m[2]), { color });
     }
-    set({ character: { ...s.character, voxels: next }, dirty: true });
+    set({ asset: { ...s.asset, voxels: next }, dirty: true });
   },
 
   copySelection: () => {
     const s = get();
-    if (!s.character) return;
-    const { voxels } = s.character;
+    if (!s.asset) return;
+    const { voxels } = s.asset;
     const sel = s.boxSelection ?? s.lassoSelection;
     if (!sel || sel.length === 0) return;
     let cx = 0, cy = 0, cz = 0;
@@ -1356,51 +1375,51 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
 
   pasteClipboard: (cx, cy, cz) => {
     const s = get();
-    if (!s.character) return;
+    if (!s.asset) return;
     const { clipboard } = s;
     if (!clipboard || clipboard.length === 0) return;
-    const next = new Map(s.character.voxels);
+    const next = new Map(s.asset.voxels);
     for (const { dx, dy, dz, color } of clipboard) {
       const x = cx + dx, y = cy + dy, z = cz + dz;
       next.set(voxelKey(x, y, z), { color: [...color] });
-      const m = mirrorPos(x, y, z, s.mirrorAxis, s.character.gridWidth);
+      const m = mirrorPos(x, y, z, s.mirrorAxis, s.asset.gridWidth);
       if (m) next.set(voxelKey(m[0], m[1], m[2]), { color: [...color] });
     }
-    set({ character: { ...s.character, voxels: next }, dirty: true });
+    set({ asset: { ...s.asset, voxels: next }, dirty: true });
   },
 
   deleteSelection: () => {
     const s = get();
-    if (!s.character) return;
+    if (!s.asset) return;
     const sel = s.boxSelection ?? s.lassoSelection;
     if (!sel || sel.length === 0) return;
-    const next = new Map(s.character.voxels);
+    const next = new Map(s.asset.voxels);
     for (const key of sel) {
       next.delete(key);
       const [x, y, z] = parseKey(key);
-      const m = mirrorPos(x, y, z, s.mirrorAxis, s.character.gridWidth);
+      const m = mirrorPos(x, y, z, s.mirrorAxis, s.asset.gridWidth);
       if (m) next.delete(voxelKey(m[0], m[1], m[2]));
     }
-    set({ character: { ...s.character, voxels: next }, boxSelection: null, lassoSelection: null, dirty: true });
+    set({ asset: { ...s.asset, voxels: next }, boxSelection: null, lassoSelection: null, dirty: true });
   },
 
   recolorSelection: () => {
     const s = get();
-    if (!s.character) return;
+    if (!s.asset) return;
     const sel = s.boxSelection ?? s.lassoSelection;
     if (!sel || sel.length === 0) return;
-    const next = new Map(s.character.voxels);
+    const next = new Map(s.asset.voxels);
     for (const key of sel) {
       if (!next.has(key)) continue;
       next.set(key, { color: [...s.activeColor] });
       const [x, y, z] = parseKey(key);
-      const m = mirrorPos(x, y, z, s.mirrorAxis, s.character.gridWidth);
+      const m = mirrorPos(x, y, z, s.mirrorAxis, s.asset.gridWidth);
       if (m) {
         const mk = voxelKey(m[0], m[1], m[2]);
         if (next.has(mk)) next.set(mk, { color: [...s.activeColor] });
       }
     }
-    set({ character: { ...s.character, voxels: next }, dirty: true });
+    set({ asset: { ...s.asset, voxels: next }, dirty: true });
   },
 
   setLassoSelection: (keys) => set({ lassoSelection: keys }),

--- a/tools/apps/echidna/src/viewport/CharacterViewport.tsx
+++ b/tools/apps/echidna/src/viewport/CharacterViewport.tsx
@@ -24,7 +24,7 @@ function InitialInvalidator() {
 
 /** Auto-fits the camera to the voxel bounding box when the voxel count changes significantly. */
 function CameraFitter() {
-  const voxels = useCharacterStore((s) => s.character?.voxels ?? new Map());
+  const voxels = useCharacterStore((s) => s.asset?.voxels ?? new Map());
   const { camera, controls } = useThree();
   const prevCount = useRef(0);
 
@@ -66,8 +66,8 @@ function CameraFitter() {
 
 export function CharacterViewport() {
   useComponentRegistry('CharacterViewport');
-  const gridWidth = useCharacterStore((s) => s.character?.gridWidth ?? 32);
-  const gridDepth = useCharacterStore((s) => s.character?.gridDepth ?? 32);
+  const gridWidth = useCharacterStore((s) => s.asset?.gridWidth ?? 32);
+  const gridDepth = useCharacterStore((s) => s.asset?.gridDepth ?? 32);
   const showGrid = useCharacterStore((s) => s.showGrid);
 
   return (

--- a/tools/apps/echidna/src/viewport/GroundPlane.tsx
+++ b/tools/apps/echidna/src/viewport/GroundPlane.tsx
@@ -4,8 +4,8 @@ import { useCharacterStore } from '../store/useCharacterStore.js';
 import { brushPositions } from '../lib/voxelUtils.js';
 
 export function GroundPlane() {
-  const gridWidth = useCharacterStore((s) => s.character?.gridWidth ?? 32);
-  const gridDepth = useCharacterStore((s) => s.character?.gridDepth ?? 32);
+  const gridWidth = useCharacterStore((s) => s.asset?.gridWidth ?? 32);
+  const gridDepth = useCharacterStore((s) => s.asset?.gridDepth ?? 32);
 
   const handleClick = useCallback((e: ThreeEvent<MouseEvent>) => {
     e.stopPropagation();
@@ -17,7 +17,7 @@ export function GroundPlane() {
     const y = 0;
     const z = Math.round(point.z);
 
-    if (x < 0 || x >= (store.character?.gridWidth ?? 32) || z < 0 || z >= (store.character?.gridDepth ?? 32)) return;
+    if (x < 0 || x >= (store.asset?.gridWidth ?? 32) || z < 0 || z >= (store.asset?.gridDepth ?? 32)) return;
 
     store.pushUndo();
     if (store.brushSize > 1) {

--- a/tools/apps/echidna/src/viewport/JointGizmos.tsx
+++ b/tools/apps/echidna/src/viewport/JointGizmos.tsx
@@ -155,13 +155,13 @@ function DraggableJoint({ part, isSelected, jointPos, parentPos, onSelect }: {
 }
 
 export function JointGizmos() {
-  const characterParts = useCharacterStore((s) => s.character?.characterParts ?? []);
+  const characterParts = useCharacterStore((s) => s.asset?.characterParts ?? []);
   const selectedPart = useCharacterStore((s) => s.selectedPart);
   const showGizmos = useCharacterStore((s) => s.showGizmos);
   const setSelectedPart = useCharacterStore((s) => s.setSelectedPart);
   const previewPose = useCharacterStore((s) => s.previewPose);
   const selectedPose = useCharacterStore((s) => s.selectedPose);
-  const characterPoses = useCharacterStore((s) => s.character?.characterPoses ?? {});
+  const characterPoses = useCharacterStore((s) => s.asset?.characterPoses ?? {});
 
   const posedJoints = useMemo(() => {
     if (!previewPose || !selectedPose) return null;

--- a/tools/apps/echidna/src/viewport/MirrorPlane.tsx
+++ b/tools/apps/echidna/src/viewport/MirrorPlane.tsx
@@ -3,8 +3,8 @@ import { useCharacterStore } from '../store/useCharacterStore.js';
 
 export function MirrorPlane() {
   const mirrorAxis = useCharacterStore((s) => s.mirrorAxis);
-  const gridWidth = useCharacterStore((s) => s.character?.gridWidth ?? 32);
-  const gridDepth = useCharacterStore((s) => s.character?.gridDepth ?? 32);
+  const gridWidth = useCharacterStore((s) => s.asset?.gridWidth ?? 32);
+  const gridDepth = useCharacterStore((s) => s.asset?.gridDepth ?? 32);
 
   if (!mirrorAxis) return null;
 

--- a/tools/apps/echidna/src/viewport/VoxelMesh.tsx
+++ b/tools/apps/echidna/src/viewport/VoxelMesh.tsx
@@ -205,19 +205,19 @@ function interpolateRootPosition(
 export function VoxelMesh() {
   const meshRef = useRef<THREE.InstancedMesh>(null!);
   const groupRef = useRef<THREE.Group>(null!);
-  const voxels = useCharacterStore((s) => s.character?.voxels ?? new Map());
-  const characterParts = useCharacterStore((s) => s.character?.characterParts ?? []);
+  const voxels = useCharacterStore((s) => s.asset?.voxels ?? new Map());
+  const characterParts = useCharacterStore((s) => s.asset?.characterParts ?? []);
   const selectedPart = useCharacterStore((s) => s.selectedPart);
   const previewPose = useCharacterStore((s) => s.previewPose);
   const selectedPose = useCharacterStore((s) => s.selectedPose);
-  const characterPoses = useCharacterStore((s) => s.character?.characterPoses ?? {});
+  const characterPoses = useCharacterStore((s) => s.asset?.characterPoses ?? {});
   const yClip = useCharacterStore((s) => s.yClip);
   const colorByPart = useCharacterStore((s) => s.colorByPart);
   const partColors = useCharacterStore((s) => s.partColors);
   const boxSelection = useCharacterStore((s) => s.boxSelection);
   const isPlaying = useCharacterStore((s) => s.isPlaying);
   const selectedAnimation = useCharacterStore((s) => s.selectedAnimation);
-  const animations = useCharacterStore((s) => s.character?.animations ?? {});
+  const animations = useCharacterStore((s) => s.asset?.animations ?? {});
   const playbackTime = useCharacterStore((s) => s.playbackTime);
   const mode = useCharacterStore((s) => s.mode);
   const xrayMode = useCharacterStore((s) => s.xrayMode);
@@ -285,7 +285,7 @@ export function VoxelMesh() {
 
     // Accumulated root motion
     if (clip.rootMotion && clip.keyframes.length > 0 && groupRef.current) {
-      const poses = store.character?.characterPoses ?? {};
+      const poses = store.asset?.characterPoses ?? {};
       const kfs = clip.keyframes;
       const curPos = interpolateRootPosition(kfs, poses, newTime);
 
@@ -514,7 +514,7 @@ export function VoxelMesh() {
       store.pushUndo();
       const positions = brushPositions(x, y, z, store.brushSize);
       const keys = positions
-        .filter(([px, py, pz]) => store.character?.voxels.has(voxelKey(px, py, pz)))
+        .filter(([px, py, pz]) => store.asset?.voxels.has(voxelKey(px, py, pz)))
         .map(([px, py, pz]) => voxelKey(px, py, pz));
       store.assignVoxelsToPart(keys, partId);
       return;
@@ -564,7 +564,7 @@ export function VoxelMesh() {
         store.pushUndo();
         const positions = brushPositions(x, y, z, store.brushSize);
         const keys = positions
-          .filter(([px, py, pz]) => store.character?.voxels.has(voxelKey(px, py, pz)))
+          .filter(([px, py, pz]) => store.asset?.voxels.has(voxelKey(px, py, pz)))
           .map(([px, py, pz]) => voxelKey(px, py, pz));
         store.assignVoxelsToPart(keys, partId);
         break;
@@ -597,7 +597,7 @@ export function VoxelMesh() {
           const minY = Math.min(sy, y), maxY = Math.max(sy, y);
           const minZ = Math.min(sz, z), maxZ = Math.max(sz, z);
           const selected: VoxelKey[] = [];
-          for (const [vk] of store.character?.voxels ?? []) {
+          for (const [vk] of store.asset?.voxels ?? []) {
             const [vx, vy, vz] = parseKey(vk);
             if (vx >= minX && vx <= maxX && vy >= minY && vy <= maxY && vz >= minZ && vz <= maxZ) {
               selected.push(vk);

--- a/tools/packages/project-root/src/layout.ts
+++ b/tools/packages/project-root/src/layout.ts
@@ -8,6 +8,7 @@ export const PROJECT_LAYOUT = {
     textures:   'assets/textures',
     audio:      'assets/audio',
     components: 'assets/components',
+    objects:    'assets/objects',
   },
   toolsData: {
     bricklayer:   'tools_data/bricklayer',
@@ -27,6 +28,7 @@ export const ASSET_KINDS = [
   'maps',
   'textures',
   'audio',
+  'objects',
 ] as const;
 
 export type AssetKind = typeof ASSET_KINDS[number];

--- a/tools/packages/project-root/src/registry.ts
+++ b/tools/packages/project-root/src/registry.ts
@@ -18,6 +18,7 @@ export interface AssetRegistry {
   textures:   Record<string, FileEntry>;
   audio:      Record<string, FileEntry>;
   maps:       Record<string, FileEntry>;
+  objects:    Record<string, FileEntry>;
 }
 
 export function createEmptyRegistry(): AssetRegistry {
@@ -28,6 +29,7 @@ export function createEmptyRegistry(): AssetRegistry {
     textures: {},
     audio: {},
     maps: {},
+    objects: {},
   };
 }
 
@@ -101,7 +103,13 @@ export function registerMap(
   };
 }
 
-export type RefKind = 'character' | 'vfx' | 'texture' | 'audio' | 'map';
+export function registerObject(
+  reg: AssetRegistry, id: string, entry: { file: string },
+): AssetRegistry {
+  return { ...reg, objects: { ...reg.objects, [id]: { id, file: entry.file } } };
+}
+
+export type RefKind = 'character' | 'vfx' | 'texture' | 'audio' | 'map' | 'object';
 
 /**
  * Resolve an asset ref to its canonical project-relative file path.
@@ -140,6 +148,11 @@ export function resolveRef(ref: string, kind: RefKind, reg: AssetRegistry): stri
     case 'map': {
       const e = reg.maps[parsed.id];
       if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in the map registry`);
+      return e.file;
+    }
+    case 'object': {
+      const e = reg.objects[parsed.id];
+      if (!e) throw new Error(`resolveRef: unknown id "${parsed.id}" in the object registry`);
       return e.file;
     }
     default: {

--- a/tools/packages/project-root/test/layout.test.ts
+++ b/tools/packages/project-root/test/layout.test.ts
@@ -25,6 +25,14 @@ describe('PROJECT_LAYOUT', () => {
     expect(ASSET_KINDS).toContain('vfx');
     expect(ASSET_KINDS).toContain('maps');
   });
+
+  it('ASSET_KINDS includes objects', () => {
+    expect(ASSET_KINDS).toContain('objects');
+  });
+
+  it('PROJECT_LAYOUT.assets.objects is assets/objects', () => {
+    expect(PROJECT_LAYOUT.assets.objects).toBe('assets/objects');
+  });
 });
 
 describe('classifiers', () => {

--- a/tools/packages/project-root/test/registry.test.ts
+++ b/tools/packages/project-root/test/registry.test.ts
@@ -6,6 +6,7 @@ import {
   registerTexture,
   registerAudio,
   registerMap,
+  registerObject,
   resolveRef,
   type AssetRegistry,
 } from '../src/registry';
@@ -33,6 +34,17 @@ describe('AssetRegistry', () => {
       manifest: 'assets/characters/walker/walker.manifest.json',
     });
     expect(r0.characters.walker).toBeUndefined();  // original unchanged
+  });
+
+  it('starts empty with objects field', () => {
+    const r = createEmptyRegistry();
+    expect(Object.keys(r.objects)).toEqual([]);
+  });
+
+  it('registers an object', () => {
+    let r = createEmptyRegistry();
+    r = registerObject(r, 'crystal', { file: 'assets/objects/crystal.ply' });
+    expect(r.objects.crystal).toEqual({ id: 'crystal', file: 'assets/objects/crystal.ply' });
   });
 
   it('registers vfx, textures, audio, and maps', () => {
@@ -135,6 +147,17 @@ describe('resolveRef', () => {
   it('throws on unknown id (vfx)', () => {
     const r = createEmptyRegistry();
     expect(() => resolveRef('#missing', 'vfx', r)).toThrow(/unknown id.*vfx.*registry/i);
+  });
+
+  it('returns object path by id', () => {
+    const r0 = createEmptyRegistry();
+    const r = registerObject(r0, 'crystal', { file: 'assets/objects/crystal.ply' });
+    expect(resolveRef('#crystal', 'object', r)).toBe('assets/objects/crystal.ply');
+  });
+
+  it('throws on unknown object id', () => {
+    const r = createEmptyRegistry();
+    expect(() => resolveRef('#missing', 'object', r)).toThrow(/unknown id.*object.*registry/i);
   });
 
   it('rejects bare filenames (delegates to parseAssetRef)', () => {


### PR DESCRIPTION
## Summary

Foundation layer for multi-asset Echidna. No UI changes — schema, registry, store renaming, and export branching only.

- **PROJECT_LAYOUT + AssetRegistry**: added `objects` kind (`assets/objects/`), `registerObject`, `resolveRef` support
- **EchidnaFile v4**: `kind: 'character' | 'map' | 'object'` discriminator, `tags: string[]`, migration defaults legacy files to `kind: 'character'`
- **Character → Asset rename**: 22+ files updated — `state.character` → `state.asset`, `knownCharacters` → `knownAssets`, all actions renamed (newAsset, openAsset, listAssets, etc.)
- **Kind-based save branching**: characters write PLY + manifest to `assets/characters/`, maps write PLY to `assets/maps/`, objects write PLY to `assets/objects/`
- **New exports**: `exportMapToProject`, `exportObjectToProject` in projectFs

## Test plan

- [x] 130/130 echidna tests pass (10 new test cases for migration, map/object save)
- [x] 87/87 project-root tests pass (4 new for registerObject + resolveRef)
- [x] `pnpm build` succeeds for echidna and project-root
- [ ] Manual: create character, save, verify PLY in assets/characters/
- [ ] Manual: (Phase 0.3b will add UI for creating map/object assets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)