### PR TITLE
 Windows build fixes and documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,11 @@ add_custom_target(sync_assets ALL
     COMMAND ${CMAKE_COMMAND} -E copy_directory
         ${PROJECT_SOURCE_DIR}/assets
         ${CMAKE_CURRENT_BINARY_DIR}/assets
-    COMMENT "Syncing assets to build directory"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_CURRENT_BINARY_DIR}/shaders
+        ${PROJECT_SOURCE_DIR}/shaders
+    COMMENT "Syncing assets and shaders to build directory"
+    DEPENDS shaders
 )
 
 # --- Tests ------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -51,15 +51,55 @@ Install the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home).
 
 ## Building
 
+### Linux & macOS
+
 ```bash
 # Configure
-cmake --preset <platform>-debug    # linux-debug, macos-debug, windows-debug
-cmake --preset <platform>-release  # linux-release, macos-release, windows-release
+cmake --preset <platform>-debug    # linux-debug, macos-debug
+cmake --preset <platform>-release  # linux-release, macos-release
 
 # Build
 cmake --build --preset <platform>-debug
 cmake --build --preset <platform>-release
 ```
+
+### Windows
+
+**Prerequisites:**
+- Visual Studio 2022 Community or equivalent (C++ workload)
+- CMake 3.25+ (installed or in PATH)
+- Ninja (installed or available)
+- Vulkan SDK 1.4+ (install from [vulkan.lunarg.com](https://vulkan.lunarg.com/sdk/home))
+
+**Build Steps:**
+
+Open the **x64 Native Tools Command Prompt for VS 2022** (search in Windows Start Menu):
+
+```cmd
+# Navigate to project
+cd C:\path\to\GSeurat
+
+# Configure (generates build\windows-debug or build\windows-release)
+cmake --preset windows-debug -DCMAKE_GENERATOR_PLATFORM= -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe
+
+# Build
+cmake --build --preset windows-debug --target gseurat_demo
+
+# Run
+build\windows-debug\gseurat_demo.exe
+```
+
+**Notes:**
+- The `-DCMAKE_GENERATOR_PLATFORM=` flag ensures x64 architecture (required for Vulkan SDK on Windows)
+- Use `windows-release` preset for optimized builds
+- Shader files are automatically compiled and deployed to the source `shaders/` directory during build
+- First build may take 2-3 minutes; subsequent builds are faster
+
+**Troubleshooting:**
+- If you see "The program can't start because vk*.dll is missing", ensure Vulkan SDK is installed and its `bin/` is in PATH
+- If CMake fails to find tools, run vcvars explicitly: `"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"`
+
+---
 
 One demo executable is produced:
 


### PR DESCRIPTION
# Windows Build Improvements

## Summary
This PR improves Windows build support with shader deployment fixes and comprehensive documentation.

## Changes

### 1. Build System Fix (CMakeLists.txt)
- Added shader copy command to sync_assets target
- Compiled shaders (.spv files) now automatically deployed from build directory to source directory
- Ensures shaders are available for runtime access
- Fixes missing shader file errors on demo startup

### 2. Documentation (README.md)
- Added dedicated Windows build section with step-by-step instructions
- Included x64 Native Tools Command Prompt setup
- Documented required compiler flags for architecture compatibility
- Added troubleshooting section for common Windows issues (PATH, vcvars, DLL errors)

## Testing
- Build completes successfully on Windows 10/11 x64
- Shaders properly deployed to source directory
- Demo executable runs and loads island scene with 2.2M Gaussians

## Related
Fixes Windows x86/x64 architecture mismatch and shader file deployment issues
