### PR TITLE
feat(echidna): Phase 0.3b assets panel UI

### DIFF
--- a/docs/superpowers/plans/2026-04-12-echidna-phase-03b-assets-panel-ui.md
+++ b/docs/superpowers/plans/2026-04-12-echidna-phase-03b-assets-panel-ui.md
@@ -1,0 +1,439 @@
+# Phase 0.3b — Assets Panel UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add kind filtering, kind badges, kind picker in NewProjectDialog, and hide animate mode for non-character assets.
+
+**Architecture:** Pure UI changes in 3 files: AssetsPanel.tsx (filter + badges), NewProjectDialog.tsx (kind picker), App.tsx (conditional panels/tabs). One small store change in openAsset for mode reset.
+
+**Tech Stack:** React, Zustand, TypeScript
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `tools/apps/echidna/src/panels/AssetsPanel.tsx` | Modify | Kind filter dropdown + kind badges on rows |
+| `tools/apps/echidna/src/panels/NewProjectDialog.tsx` | Modify | Kind picker dropdown, dynamic title/label |
+| `tools/apps/echidna/src/App.tsx` | Modify | Conditional mode tabs, conditional panels, mode reset |
+| `tools/apps/echidna/src/store/useCharacterStore.ts` | Modify | Mode reset in openAsset for non-character assets |
+| `tools/apps/echidna/src/__tests__/characterStore.test.ts` | Modify | Test mode reset on openAsset |
+
+---
+
+### Task 1: AssetsPanel — kind filter dropdown + kind badges
+
+**Files:**
+- Modify: `tools/apps/echidna/src/panels/AssetsPanel.tsx`
+
+- [ ] **Step 1: Add kind filter state and badge styles**
+
+In `tools/apps/echidna/src/panels/AssetsPanel.tsx`, add to the styles object:
+
+```typescript
+  filterRow: {
+    display: 'flex',
+    padding: '4px 10px',
+    borderBottom: '1px solid #2a2a3a',
+  },
+  filterSelect: {
+    flex: 1,
+    background: '#2a2a4a',
+    color: '#aaa',
+    border: '1px solid #444',
+    borderRadius: 3,
+    padding: '2px 6px',
+    fontSize: 10,
+  },
+  kindBadge: {
+    fontSize: 9,
+    fontWeight: 700,
+    padding: '1px 4px',
+    borderRadius: 2,
+    marginRight: 6,
+    letterSpacing: 0.5,
+  },
+```
+
+Add a badge color helper outside the component:
+
+```typescript
+const KIND_BADGE: Record<string, { label: string; bg: string; color: string }> = {
+  character: { label: 'CHR', bg: '#1a3a2a', color: '#6c8' },
+  map:       { label: 'MAP', bg: '#1a2a3a', color: '#68c' },
+  object:    { label: 'OBJ', bg: '#3a2a1a', color: '#c86' },
+};
+```
+
+- [ ] **Step 2: Add filter state and filter dropdown to the component**
+
+Inside the `AssetsPanel` component, add filter state:
+
+```typescript
+  const [kindFilter, setKindFilter] = useState<string>('all');
+```
+
+Add import for `EchidnaAssetKind` type:
+```typescript
+import type { EchidnaAssetKind } from '../store/types.js';
+```
+
+Compute filtered assets:
+```typescript
+  const filteredAssets = kindFilter === 'all'
+    ? knownAssets
+    : knownAssets.filter((c) => c.kind === kindFilter);
+```
+
+Add the filter dropdown after the header, before the list:
+
+```tsx
+          <div style={styles.filterRow}>
+            <select
+              style={styles.filterSelect}
+              value={kindFilter}
+              onChange={(e) => setKindFilter(e.target.value)}
+            >
+              <option value="all">All</option>
+              <option value="character">Characters</option>
+              <option value="map">Maps</option>
+              <option value="object">Objects</option>
+            </select>
+          </div>
+```
+
+- [ ] **Step 3: Update the list to use filteredAssets and add badges**
+
+Change `knownAssets.length === 0` check to `filteredAssets.length === 0`:
+```tsx
+          {filteredAssets.length === 0 ? (
+            <div style={styles.empty}>No assets yet.</div>
+          ) : (
+```
+
+Change `knownAssets.map((c) =>` to `filteredAssets.map((c) =>`.
+
+Add the kind badge inside each row, before the name span:
+```tsx
+                    <span style={{
+                      ...styles.kindBadge,
+                      background: KIND_BADGE[c.kind]?.bg ?? '#333',
+                      color: KIND_BADGE[c.kind]?.color ?? '#888',
+                    }}>
+                      {KIND_BADGE[c.kind]?.label ?? c.kind.toUpperCase().slice(0, 3)}
+                    </span>
+```
+
+- [ ] **Step 4: Update header and button text**
+
+Change the header label from `"Characters"` to `"Assets"`:
+```tsx
+        <span style={styles.headerLabel}>Assets</span>
+```
+
+Change the new button text from `"+ New Character"` to `"+ New Asset"`:
+```tsx
+            <button style={styles.newBtn} onClick={onNewAsset}>
+              + New Asset
+            </button>
+```
+
+- [ ] **Step 5: Run build**
+
+Run: `cd /Users/eccyan/dev/GSeurat/tools && pnpm build 2>&1 | tail -10`
+Expected: Build succeeds
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/apps/echidna/src/panels/AssetsPanel.tsx
+git commit -m "feat(echidna): add kind filter and badges to AssetsPanel"
+```
+
+---
+
+### Task 2: NewProjectDialog — kind picker
+
+**Files:**
+- Modify: `tools/apps/echidna/src/panels/NewProjectDialog.tsx`
+
+- [ ] **Step 1: Add kind state and dropdown**
+
+In `tools/apps/echidna/src/panels/NewProjectDialog.tsx`:
+
+Add import:
+```typescript
+import type { EchidnaAssetKind } from '../store/types.js';
+```
+
+Add kind state as the first state variable:
+```typescript
+  const [kind, setKind] = useState<EchidnaAssetKind>('character');
+```
+
+Add a label helper:
+```typescript
+const KIND_LABELS: Record<EchidnaAssetKind, string> = {
+  character: 'Character',
+  map: 'Map',
+  object: 'Object',
+};
+```
+
+Update `handleCreate` to pass `kind`:
+```typescript
+  const handleCreate = () => {
+    useCharacterStore.getState().newAsset(kind, resolvedSize, charName);
+    onClose();
+  };
+```
+
+- [ ] **Step 2: Update dialog title and labels**
+
+Change the title from hardcoded to dynamic:
+```tsx
+        <div style={styles.title}>New {KIND_LABELS[kind]}</div>
+```
+
+Add the Kind dropdown as the first section (before Character Name):
+```tsx
+        <div style={styles.section}>
+          <span style={styles.label}>Kind</span>
+          <select
+            style={styles.select}
+            value={kind}
+            onChange={(e) => setKind(e.target.value as EchidnaAssetKind)}
+          >
+            <option value="character">Character</option>
+            <option value="map">Map</option>
+            <option value="object">Object</option>
+          </select>
+        </div>
+```
+
+Change the name label to be dynamic:
+```tsx
+          <span style={styles.label}>{KIND_LABELS[kind]} Name</span>
+```
+
+- [ ] **Step 3: Run build**
+
+Run: `cd /Users/eccyan/dev/GSeurat/tools && pnpm build 2>&1 | tail -10`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/echidna/src/panels/NewProjectDialog.tsx
+git commit -m "feat(echidna): add kind picker to NewProjectDialog"
+```
+
+---
+
+### Task 3: Kind-aware editor — conditional panels and mode tabs
+
+**Files:**
+- Modify: `tools/apps/echidna/src/App.tsx`
+- Modify: `tools/apps/echidna/src/store/useCharacterStore.ts`
+- Test: `tools/apps/echidna/src/__tests__/characterStore.test.ts`
+
+- [ ] **Step 1: Write test for mode reset in openAsset**
+
+In `tools/apps/echidna/src/__tests__/characterStore.test.ts`, add to the `useCharacterStore.openAsset` describe block:
+
+```typescript
+  it('resets mode to build when opening a non-character asset', async () => {
+    const root = testing.makeRoot();
+    const toolsData = await root.getDirectoryHandle('tools_data', { create: true });
+    const saves = await toolsData.getDirectoryHandle('echidna_saves', { create: true });
+    const fh = await saves.getFileHandle('town.echidna', { create: true });
+    const w = await fh.createWritable();
+    await w.write(JSON.stringify({
+      version: 4, id: 'town', kind: 'map', characterName: 'Town',
+      gridWidth: 64, gridDepth: 64, voxels: [], parts: [], poses: {}, tags: [],
+    }));
+    await w.close();
+
+    useCharacterStore.setState({
+      projectRootHandle: root as unknown as FileSystemDirectoryHandle,
+      mode: 'animate',
+    });
+
+    await useCharacterStore.getState().openAsset('town');
+
+    const s = useCharacterStore.getState();
+    expect(s.asset?.kind).toBe('map');
+    expect(s.mode).toBe('build');
+  });
+
+  it('preserves mode when opening a character asset', async () => {
+    const root = testing.makeRoot();
+    const toolsData = await root.getDirectoryHandle('tools_data', { create: true });
+    const saves = await toolsData.getDirectoryHandle('echidna_saves', { create: true });
+    const fh = await saves.getFileHandle('archer.echidna', { create: true });
+    const w = await fh.createWritable();
+    await w.write(JSON.stringify({
+      version: 4, id: 'archer', kind: 'character', characterName: 'Archer',
+      gridWidth: 32, gridDepth: 32, voxels: [], parts: [], poses: {}, tags: [],
+    }));
+    await w.close();
+
+    useCharacterStore.setState({
+      projectRootHandle: root as unknown as FileSystemDirectoryHandle,
+      mode: 'animate',
+    });
+
+    await useCharacterStore.getState().openAsset('archer');
+
+    const s = useCharacterStore.getState();
+    expect(s.asset?.kind).toBe('character');
+    expect(s.mode).toBe('animate');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/eccyan/dev/GSeurat/tools && pnpm --filter echidna test -- --run --reporter verbose 2>&1 | tail -20`
+Expected: FAIL — openAsset doesn't reset mode
+
+- [ ] **Step 3: Add mode reset in openAsset**
+
+In `tools/apps/echidna/src/store/useCharacterStore.ts`, in the `openAsset` action, add a mode reset to the `set()` call (around line 911). Add `mode` conditionally:
+
+Change the `set()` call from:
+```typescript
+      set({
+        asset: char,
+        dirty: false,
+        undoStack: [],
+        ...
+      });
+```
+
+To:
+```typescript
+      set({
+        asset: char,
+        dirty: false,
+        undoStack: [],
+        redoStack: [],
+        boxSelection: null,
+        lassoSelection: null,
+        clipboard: null,
+        selectedPart: null,
+        selectedPose: null,
+        selectedAnimation: null,
+        previewPose: false,
+        playbackTime: 0,
+        isPlaying: false,
+        ...(char.kind !== 'character' ? { mode: 'build' as const } : {}),
+      });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/eccyan/dev/GSeurat/tools && pnpm --filter echidna test -- --run --reporter verbose 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Update App.tsx — conditional mode tabs**
+
+In `tools/apps/echidna/src/App.tsx`, add an `assetKind` selector:
+
+```typescript
+  const assetKind = useCharacterStore((s) => s.asset?.kind ?? null);
+```
+
+Update the `ModeTabs` component to accept a `showAnimate` prop:
+
+```typescript
+function ModeTabs({ showAnimate }: { showAnimate: boolean }) {
+  const mode = useCharacterStore((s) => s.mode);
+  const setMode = useCharacterStore((s) => s.setMode);
+
+  if (!showAnimate) {
+    return (
+      <div style={modeTabStyles.container}>
+        <div style={{ ...modeTabStyles.tab, ...modeTabStyles.tabActive }}>BUILD</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={modeTabStyles.container}>
+      <button
+        style={{ ...modeTabStyles.tab, ...(mode === 'build' ? modeTabStyles.tabActive : {}) }}
+        onClick={() => setMode('build')}
+      >
+        BUILD
+      </button>
+      <button
+        style={{ ...modeTabStyles.tab, ...(mode === 'animate' ? modeTabStyles.tabActive : {}) }}
+        onClick={() => setMode('animate')}
+      >
+        ANIMATE
+      </button>
+    </div>
+  );
+}
+```
+
+Update the `<ModeTabs />` usage in App to pass the prop:
+```tsx
+          <ModeTabs showAnimate={assetKind === 'character'} />
+```
+
+- [ ] **Step 6: Update App.tsx — conditional left/right panels**
+
+For the left panel, only show AnimateLeftPanel for characters:
+```tsx
+          <div style={{ flex: 1, overflow: 'auto' }}>
+            {mode === 'build' || assetKind !== 'character' ? <ToolBar /> : <AnimateLeftPanel />}
+          </div>
+```
+
+For the right panel:
+```tsx
+        <div style={{ ...styles.inspector, width: rightWidth }}>
+          {mode === 'build' || assetKind !== 'character' ? <BuildPanel /> : <AnimateRightPanel />}
+        </div>
+```
+
+For the Timeline overlay, only show for characters:
+```tsx
+          {asset !== null && mode === 'animate' && assetKind === 'character' && (
+            <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 }}>
+              <Timeline />
+            </div>
+          )}
+```
+
+- [ ] **Step 7: Update NoCharacterSelected text**
+
+Change the placeholder text:
+```typescript
+function NoCharacterSelected() {
+  return (
+    <div style={{
+      width: '100%', height: '100%',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: '#16162a', color: '#888', fontSize: 14,
+    }}>
+      Select an asset from the panel or create a new one.
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8: Run full test suite and build**
+
+Run: `cd /Users/eccyan/dev/GSeurat/tools && pnpm --filter echidna test -- --run --reporter verbose 2>&1 | tail -20`
+Run: `cd /Users/eccyan/dev/GSeurat/tools && pnpm build 2>&1 | tail -10`
+Expected: all PASS, build succeeds
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tools/apps/echidna/src/App.tsx tools/apps/echidna/src/store/useCharacterStore.ts tools/apps/echidna/src/__tests__/characterStore.test.ts
+git commit -m "feat(echidna): kind-aware editor — hide animate mode for non-character assets"
+```

--- a/docs/superpowers/specs/2026-04-12-echidna-phase-03b-assets-panel-ui-design.md
+++ b/docs/superpowers/specs/2026-04-12-echidna-phase-03b-assets-panel-ui-design.md
@@ -1,0 +1,80 @@
+# Phase 0.3b — Echidna Assets Panel UI
+
+UI layer for multi-asset Echidna. Builds on Phase 0.3a's schema + store infrastructure.
+
+## 1. AssetsPanel Kind Filter
+
+Add a kind filter dropdown and kind badges to the existing AssetsPanel.
+
+### Filter dropdown
+
+- Position: top of the list area, below the "Characters" header (rename header to "Assets")
+- Options: `All` (default), `Characters`, `Maps`, `Objects`
+- State: local component state (`useState`), not persisted to localStorage
+- When a filter is active, only assets matching that kind appear in the list
+- The `knownAssets` array is filtered client-side — no store changes needed
+
+### Kind badge
+
+- Each row shows a small text badge before the asset name: `CHR`, `MAP`, or `OBJ`
+- Badge color: muted, kind-specific (e.g., green for CHR, blue for MAP, orange for OBJ)
+- Badge is always visible regardless of filter selection
+
+### No other changes
+
+The "+ New Asset" button, context menu (rename/duplicate/delete), dialogs (switch/rename/duplicate/delete), collapse state, and dirty indicator all stay the same.
+
+## 2. NewProjectDialog Kind Picker
+
+Add a "Kind" dropdown as the **first field** in NewProjectDialog, before "Character Name".
+
+- Options: `Character`, `Map`, `Object` — default: `Character`
+- The "Character Name" label changes based on kind: "Character Name" / "Map Name" / "Object Name"
+- Dialog title changes: "New Character" / "New Map" / "New Object"
+- On Create: calls `newAsset(selectedKind, resolvedSize, charName)`
+- Grid size defaults stay the same for all kinds
+
+## 3. Kind-Aware Editor Panels
+
+Restrict the editor based on `asset.kind`:
+
+### Characters (kind = 'character')
+
+Full editor — no changes from current behavior:
+- Mode tabs: Build / Animate
+- Build mode: left = BuildPanel, right = PartsPanel
+- Animate mode: left = AnimateLeftPanel, right = AnimateRightPanel
+- Timeline overlay visible in animate mode
+
+### Maps and Objects (kind = 'map' | 'object')
+
+Build-only editor:
+- Mode tabs: hidden (or show only "Build" as a static label)
+- Build mode: left = BuildPanel, right = empty or minimal info panel
+- No PartsPanel, PosePanel, Timeline, or animation panels
+- If `mode` is `'animate'` when switching to a non-character asset, reset to `'build'`
+
+### Implementation
+
+- `App.tsx` checks `store.asset?.kind` to decide:
+  - Whether to show mode tabs (only for characters)
+  - Which panels to render in left/right columns
+  - Whether to show the Timeline overlay
+- The mode reset happens in `openAsset()` — if the loaded asset is not a character, set `mode: 'build'`
+- No new components needed — just conditional rendering in `App.tsx`
+
+## 4. Scope Boundary
+
+### In scope
+
+- AssetsPanel kind filter dropdown + kind badges
+- NewProjectDialog kind picker
+- Hide animate mode + character-specific panels for map/object assets
+- Mode reset on opening non-character asset
+
+### Out of scope (deferred)
+
+- Kind-specific toolsets (different brush sets for maps)
+- Tags editing UI for objects
+- Méliès asset picker integration (Phase 0.3c)
+- Any new panels for map/object-specific features

--- a/tools/apps/echidna/src/App.tsx
+++ b/tools/apps/echidna/src/App.tsx
@@ -108,7 +108,7 @@ function NoCharacterSelected() {
       display: 'flex', alignItems: 'center', justifyContent: 'center',
       background: '#16162a', color: '#888', fontSize: 14,
     }}>
-      Select a character from the panel or create a new one.
+      Select an asset from the panel or create a new one.
     </div>
   );
 }
@@ -128,6 +128,7 @@ export function App() {
 
   const projectRootHandle = useCharacterStore((s) => s.projectRootHandle);
   const asset = useCharacterStore((s) => s.asset);
+  const assetKind = useCharacterStore((s) => s.asset?.kind ?? null);
 
   const handleNewAsset = useCallback(() => {
     const store = useCharacterStore.getState();
@@ -294,9 +295,9 @@ export function App() {
         {/* Left panel */}
         <div style={{ width: leftWidth, flexShrink: 0, display: 'flex', flexDirection: 'column' as const, overflow: 'hidden', background: '#1e1e3a', borderRight: '1px solid #333' }}>
           <AssetsPanel onNewAsset={handleNewAsset} />
-          <ModeTabs />
+          <ModeTabs showAnimate={assetKind === 'character'} />
           <div style={{ flex: 1, overflow: 'auto' }}>
-            {mode === 'build' ? <ToolBar /> : <AnimateLeftPanel />}
+            {mode === 'build' || assetKind !== 'character' ? <ToolBar /> : <AnimateLeftPanel />}
           </div>
         </div>
         <ResizeHandle onDrag={handleLeftDrag} />
@@ -310,7 +311,7 @@ export function App() {
           ) : (
             <CharacterViewport />
           )}
-          {asset !== null && mode === 'animate' && (
+          {asset !== null && mode === 'animate' && assetKind === 'character' && (
             <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 }}>
               <Timeline />
             </div>
@@ -320,7 +321,7 @@ export function App() {
 
         {/* Right panel */}
         <div style={{ ...styles.inspector, width: rightWidth }}>
-          {mode === 'build' ? <BuildPanel /> : <AnimateRightPanel />}
+          {mode === 'build' || assetKind !== 'character' ? <BuildPanel /> : <AnimateRightPanel />}
         </div>
       </div>
       {showNewDialog && <NewProjectDialog onClose={() => setShowNewDialog(false)} />}
@@ -356,9 +357,17 @@ const modeTabStyles: Record<string, React.CSSProperties> = {
   },
 };
 
-function ModeTabs() {
+function ModeTabs({ showAnimate }: { showAnimate: boolean }) {
   const mode = useCharacterStore((s) => s.mode);
   const setMode = useCharacterStore((s) => s.setMode);
+
+  if (!showAnimate) {
+    return (
+      <div style={modeTabStyles.container}>
+        <div style={{ ...modeTabStyles.tab, ...modeTabStyles.tabActive }}>BUILD</div>
+      </div>
+    );
+  }
 
   return (
     <div style={modeTabStyles.container}>

--- a/tools/apps/echidna/src/__tests__/characterStore.test.ts
+++ b/tools/apps/echidna/src/__tests__/characterStore.test.ts
@@ -238,6 +238,54 @@ describe('useCharacterStore.openAsset', () => {
     // state.character is unchanged (still whatever it was before the call)
     expect(s.asset).toEqual(existingChar);
   });
+
+  it('resets mode to build when opening a non-character asset', async () => {
+    const root = testing.makeRoot();
+    const toolsData = await root.getDirectoryHandle('tools_data', { create: true });
+    const saves = await toolsData.getDirectoryHandle('echidna_saves', { create: true });
+    const fh = await saves.getFileHandle('town.echidna', { create: true });
+    const w = await fh.createWritable();
+    await w.write(JSON.stringify({
+      version: 4, id: 'town', kind: 'map', characterName: 'Town',
+      gridWidth: 64, gridDepth: 64, voxels: [], parts: [], poses: {}, tags: [],
+    }));
+    await w.close();
+
+    useCharacterStore.setState({
+      projectRootHandle: root as unknown as FileSystemDirectoryHandle,
+      mode: 'animate',
+    });
+
+    await useCharacterStore.getState().openAsset('town');
+
+    const s = useCharacterStore.getState();
+    expect(s.asset?.kind).toBe('map');
+    expect(s.mode).toBe('build');
+  });
+
+  it('preserves mode when opening a character asset', async () => {
+    const root = testing.makeRoot();
+    const toolsData = await root.getDirectoryHandle('tools_data', { create: true });
+    const saves = await toolsData.getDirectoryHandle('echidna_saves', { create: true });
+    const fh = await saves.getFileHandle('archer.echidna', { create: true });
+    const w = await fh.createWritable();
+    await w.write(JSON.stringify({
+      version: 4, id: 'archer', kind: 'character', characterName: 'Archer',
+      gridWidth: 32, gridDepth: 32, voxels: [], parts: [], poses: {}, tags: [],
+    }));
+    await w.close();
+
+    useCharacterStore.setState({
+      projectRootHandle: root as unknown as FileSystemDirectoryHandle,
+      mode: 'animate',
+    });
+
+    await useCharacterStore.getState().openAsset('archer');
+
+    const s = useCharacterStore.getState();
+    expect(s.asset?.kind).toBe('character');
+    expect(s.mode).toBe('animate');
+  });
 });
 
 describe('useCharacterStore.save', () => {

--- a/tools/apps/echidna/src/panels/AssetsPanel.tsx
+++ b/tools/apps/echidna/src/panels/AssetsPanel.tsx
@@ -8,6 +8,12 @@ import { DeleteCharacterDialog } from './DeleteCharacterDialog.js';
 
 const COLLAPSE_KEY = 'echidna:characters-panel-collapsed';
 
+const KIND_BADGE: Record<string, { label: string; bg: string; color: string }> = {
+  character: { label: 'CHR', bg: '#1a3a2a', color: '#6c8' },
+  map:       { label: 'MAP', bg: '#1a2a3a', color: '#68c' },
+  object:    { label: 'OBJ', bg: '#3a2a1a', color: '#c86' },
+};
+
 const styles: Record<string, React.CSSProperties> = {
   root: {
     display: 'flex',
@@ -86,6 +92,28 @@ const styles: Record<string, React.CSSProperties> = {
     color: '#666',
     fontStyle: 'italic',
   },
+  filterRow: {
+    display: 'flex',
+    padding: '4px 10px',
+    borderBottom: '1px solid #2a2a3a',
+  },
+  filterSelect: {
+    flex: 1,
+    background: '#2a2a4a',
+    color: '#aaa',
+    border: '1px solid #444',
+    borderRadius: 3,
+    padding: '2px 6px',
+    fontSize: 10,
+  },
+  kindBadge: {
+    fontSize: 9,
+    fontWeight: 700,
+    padding: '1px 4px',
+    borderRadius: 2,
+    marginRight: 6,
+    letterSpacing: 0.5,
+  },
   contextMenu: {
     position: 'fixed',
     background: '#1e1e3a',
@@ -135,6 +163,7 @@ export function AssetsPanel({ onNewAsset }: Props) {
   const [collapsed, setCollapsed] = useState(() =>
     localStorage.getItem(COLLAPSE_KEY) === '1',
   );
+  const [kindFilter, setKindFilter] = useState<string>('all');
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
   const [activeDialog, setActiveDialog] = useState<ActiveDialog>(null);
 
@@ -173,19 +202,31 @@ export function AssetsPanel({ onNewAsset }: Props) {
 
   const closeContextMenu = () => setContextMenu(null);
 
+  const filteredAssets = kindFilter === 'all'
+    ? knownAssets
+    : knownAssets.filter((c) => c.kind === kindFilter);
+
   return (
     <div style={styles.root}>
       <div style={styles.header} onClick={toggleCollapsed}>
-        <span style={styles.headerLabel}>Characters</span>
+        <span style={styles.headerLabel}>Assets</span>
         <button style={styles.collapseBtn}>{collapsed ? '+' : '−'}</button>
       </div>
       {!collapsed && (
         <>
-          {knownAssets.length === 0 ? (
-            <div style={styles.empty}>No characters yet.</div>
+          <div style={styles.filterRow}>
+            <select style={styles.filterSelect} value={kindFilter} onChange={(e) => setKindFilter(e.target.value)}>
+              <option value="all">All</option>
+              <option value="character">Characters</option>
+              <option value="map">Maps</option>
+              <option value="object">Objects</option>
+            </select>
+          </div>
+          {filteredAssets.length === 0 ? (
+            <div style={styles.empty}>No assets yet.</div>
           ) : (
             <div style={styles.list}>
-              {knownAssets.map((c) => {
+              {filteredAssets.map((c) => {
                 const isCurrent = c.id === currentId;
                 return (
                   <div
@@ -199,6 +240,13 @@ export function AssetsPanel({ onNewAsset }: Props) {
                   >
                     <span style={{ ...styles.dot, ...(isCurrent ? styles.dotCurrent : styles.dotOther) }}>
                       {isCurrent ? '●' : '○'}
+                    </span>
+                    <span style={{
+                      ...styles.kindBadge,
+                      background: KIND_BADGE[c.kind]?.bg ?? '#333',
+                      color: KIND_BADGE[c.kind]?.color ?? '#888',
+                    }}>
+                      {KIND_BADGE[c.kind]?.label ?? c.kind.toUpperCase().slice(0, 3)}
                     </span>
                     <span style={styles.name}>{c.name}</span>
                     {isCurrent && dirty && <span style={styles.dirtyMarker}>●</span>}
@@ -218,7 +266,7 @@ export function AssetsPanel({ onNewAsset }: Props) {
           )}
           <div style={styles.footer}>
             <button style={styles.newBtn} onClick={onNewAsset}>
-              + New Character
+              + New Asset
             </button>
           </div>
         </>

--- a/tools/apps/echidna/src/panels/NewProjectDialog.tsx
+++ b/tools/apps/echidna/src/panels/NewProjectDialog.tsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react';
 import { useCharacterStore } from '../store/useCharacterStore.js';
+import type { EchidnaAssetKind } from '../store/types.js';
 
 const PRESET_SIZES = [32, 64, 128, 256];
+
+const KIND_LABELS: Record<EchidnaAssetKind, string> = {
+  character: 'Character',
+  map: 'Map',
+  object: 'Object',
+};
 
 const styles: Record<string, React.CSSProperties> = {
   overlay: {
@@ -45,6 +52,7 @@ const styles: Record<string, React.CSSProperties> = {
 };
 
 export function NewProjectDialog({ onClose }: { onClose: () => void }) {
+  const [kind, setKind] = useState<EchidnaAssetKind>('character');
   const [charName, setCharName] = useState('');
   const [sizeOption, setSizeOption] = useState<string>('64');
   const [customSize, setCustomSize] = useState<number>(64);
@@ -55,17 +63,30 @@ export function NewProjectDialog({ onClose }: { onClose: () => void }) {
     : Number(sizeOption);
 
   const handleCreate = () => {
-    useCharacterStore.getState().newAsset('character', resolvedSize, charName);
+    useCharacterStore.getState().newAsset(kind, resolvedSize, charName);
     onClose();
   };
 
   return (
     <div style={styles.overlay} onClick={onClose}>
       <div style={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div style={styles.title}>New Character</div>
+        <div style={styles.title}>New {KIND_LABELS[kind]}</div>
 
         <div style={styles.section}>
-          <span style={styles.label}>Character Name</span>
+          <span style={styles.label}>Kind</span>
+          <select
+            style={styles.select}
+            value={kind}
+            onChange={(e) => setKind(e.target.value as EchidnaAssetKind)}
+          >
+            <option value="character">Character</option>
+            <option value="map">Map</option>
+            <option value="object">Object</option>
+          </select>
+        </div>
+
+        <div style={styles.section}>
+          <span style={styles.label}>{KIND_LABELS[kind]} Name</span>
           <input
             type="text"
             style={styles.input}

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -922,6 +922,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         previewPose: false,
         playbackTime: 0,
         isPlaying: false,
+        ...(char.kind !== 'character' ? { mode: 'build' as const } : {}),
       });
     } catch (e) {
       if ((e as Error).name === 'NotFoundError') {


### PR DESCRIPTION
## Summary

UI layer for multi-asset Echidna, building on Phase 0.3a's schema infrastructure.

- **AssetsPanel kind filter**: dropdown to filter by All/Characters/Maps/Objects, colored kind badges (CHR/MAP/OBJ) on each row, updated header/button text
- **NewProjectDialog kind picker**: Kind dropdown as first field, dynamic title ("New Character"/"New Map"/"New Object") and name label
- **Kind-aware editor**: animate mode tab hidden for map/object assets (build-only), mode auto-resets to 'build' when opening non-character asset, Timeline/animation panels gated on character kind

## Test plan

- [x] 132/132 echidna tests pass (2 new: mode reset on openAsset)
- [x] `pnpm build` succeeds
- [ ] Manual: create a Map asset, verify no Animate tab shows
- [ ] Manual: create an Object asset, verify kind badge + filter work
- [ ] Manual: switch from character (in animate mode) to map, verify mode resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)