### PR TITLE
chore(echidna): rename Character dialogs and viewport to Asset

### DIFF
--- a/tools/apps/echidna/src/App.tsx
+++ b/tools/apps/echidna/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
-import { CharacterViewport } from './viewport/CharacterViewport.js';
+import { AssetViewport } from './viewport/AssetViewport.js';
 import { MenuBar } from './panels/MenuBar.js';
 import { ToolBar } from './panels/ToolBar.js';
 import { BuildPanel } from './panels/BuildPanel.js';
@@ -285,7 +285,7 @@ export function App() {
     return () => window.removeEventListener('keydown', handler);
   }, []);
 
-  // URL param loading and postMessage API are handled inside CharacterViewport's
+  // URL param loading and postMessage API are handled inside AssetViewport's
   // ExternalLoadBridge component (within R3F Canvas) to ensure proper re-rendering.
 
   return (
@@ -309,7 +309,7 @@ export function App() {
           ) : asset === null ? (
             <NoCharacterSelected />
           ) : (
-            <CharacterViewport />
+            <AssetViewport />
           )}
           {asset !== null && mode === 'animate' && assetKind === 'character' && (
             <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 }}>

--- a/tools/apps/echidna/src/expected-components.json
+++ b/tools/apps/echidna/src/expected-components.json
@@ -1,5 +1,5 @@
 {
-  "always": ["MenuBar", "CharacterViewport"],
+  "always": ["MenuBar", "AssetViewport"],
   "modes": {
     "build": ["ToolBar", "BuildPanel"],
     "animate": ["AnimateLeftPanel", "AnimateRightPanel", "Timeline"]

--- a/tools/apps/echidna/src/panels/AssetsPanel.tsx
+++ b/tools/apps/echidna/src/panels/AssetsPanel.tsx
@@ -1,10 +1,10 @@
 // tools/apps/echidna/src/panels/AssetsPanel.tsx
 import React, { useState, useCallback, useRef } from 'react';
 import { useCharacterStore, type SwitchDecision } from '../store/useCharacterStore.js';
-import { SwitchCharacterDialog } from './SwitchCharacterDialog.js';
-import { RenameCharacterDialog } from './RenameCharacterDialog.js';
-import { DuplicateCharacterDialog } from './DuplicateCharacterDialog.js';
-import { DeleteCharacterDialog } from './DeleteCharacterDialog.js';
+import { SwitchAssetDialog } from './SwitchAssetDialog.js';
+import { RenameAssetDialog } from './RenameAssetDialog.js';
+import { DuplicateAssetDialog } from './DuplicateAssetDialog.js';
+import { DeleteAssetDialog } from './DeleteAssetDialog.js';
 
 const COLLAPSE_KEY = 'echidna:characters-panel-collapsed';
 
@@ -319,7 +319,7 @@ export function AssetsPanel({ onNewAsset }: Props) {
 
       {/* Dialogs */}
       {activeDialog?.kind === 'switch' && (
-        <SwitchCharacterDialog
+        <SwitchAssetDialog
           currentName={currentAssetName}
           targetName={knownAssets.find((c) => c.id === activeDialog.targetId)?.name ?? ''}
           undoDepth={undoDepth}
@@ -327,7 +327,7 @@ export function AssetsPanel({ onNewAsset }: Props) {
         />
       )}
       {activeDialog?.kind === 'rename' && (
-        <RenameCharacterDialog
+        <RenameAssetDialog
           currentName={activeDialog.name}
           onSubmit={(newName) => {
             void renameAsset(activeDialog.id, newName);
@@ -337,7 +337,7 @@ export function AssetsPanel({ onNewAsset }: Props) {
         />
       )}
       {activeDialog?.kind === 'duplicate' && (
-        <DuplicateCharacterDialog
+        <DuplicateAssetDialog
           sourceName={activeDialog.name}
           onSubmit={(newName) => {
             void duplicateAsset(activeDialog.id, newName);
@@ -347,9 +347,9 @@ export function AssetsPanel({ onNewAsset }: Props) {
         />
       )}
       {activeDialog?.kind === 'delete' && (
-        <DeleteCharacterDialog
-          characterName={activeDialog.name}
-          characterId={activeDialog.id}
+        <DeleteAssetDialog
+          assetName={activeDialog.name}
+          assetId={activeDialog.id}
           onConfirm={() => {
             void deleteAsset(activeDialog.id);
             setActiveDialog(null);

--- a/tools/apps/echidna/src/panels/DeleteAssetDialog.tsx
+++ b/tools/apps/echidna/src/panels/DeleteAssetDialog.tsx
@@ -1,9 +1,9 @@
-// tools/apps/echidna/src/panels/DeleteCharacterDialog.tsx
+// tools/apps/echidna/src/panels/DeleteAssetDialog.tsx
 import React from 'react';
 
 interface Props {
-  characterName: string;
-  characterId: string;
+  assetName: string;
+  assetId: string;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -25,15 +25,15 @@ const styles: Record<string, React.CSSProperties> = {
   buttonNeutral: { background: '#2a2a4a', color: '#ccc' },
 };
 
-export function DeleteCharacterDialog({ characterName, characterId, onConfirm, onCancel }: Props) {
+export function DeleteAssetDialog({ assetName, assetId, onConfirm, onCancel }: Props) {
   return (
     <div style={styles.overlay} onClick={onCancel}>
       <div style={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div style={styles.title}>Delete character</div>
+        <div style={styles.title}>Delete asset</div>
         <div style={styles.body}>
-          Delete <strong>{characterName}</strong>? The <code>.echidna</code> source file will be permanently removed from <code>tools_data/echidna_saves/</code>.
+          Delete <strong>{assetName}</strong>? The <code>.echidna</code> source file will be permanently removed from <code>tools_data/echidna_saves/</code>.
           <div style={styles.warn}>
-            ⚠ Exported files in <code>assets/characters/{characterId}/</code> will NOT be removed. Delete them manually if desired.
+            ⚠ Exported files in <code>assets/characters/{assetId}/</code> will NOT be removed. Delete them manually if desired.
           </div>
           <div style={{ marginTop: 12 }}>This cannot be undone.</div>
         </div>

--- a/tools/apps/echidna/src/panels/DuplicateAssetDialog.tsx
+++ b/tools/apps/echidna/src/panels/DuplicateAssetDialog.tsx
@@ -1,8 +1,8 @@
-// tools/apps/echidna/src/panels/RenameCharacterDialog.tsx
+// tools/apps/echidna/src/panels/DuplicateAssetDialog.tsx
 import React, { useState, useRef, useEffect } from 'react';
 
 interface Props {
-  currentName: string;
+  sourceName: string;
   onSubmit: (newName: string) => void;
   onCancel: () => void;
 }
@@ -16,49 +16,33 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex', alignItems: 'center', justifyContent: 'center',
     zIndex: 1000,
   },
-  dialog: {
-    background: '#1e1e3a', border: '1px solid #444', borderRadius: 6,
-    padding: 24, width: 420,
-  },
+  dialog: { background: '#1e1e3a', border: '1px solid #444', borderRadius: 6, padding: 24, width: 420 },
   title: { fontSize: 15, color: '#ddd', marginBottom: 12 },
   input: {
-    width: '100%',
-    padding: '8px 10px',
-    fontSize: 13,
-    background: '#16162a',
-    border: '1px solid #444',
-    borderRadius: 4,
-    color: '#ddd',
-    marginBottom: 16,
+    width: '100%', padding: '8px 10px', fontSize: 13,
+    background: '#16162a', border: '1px solid #444', borderRadius: 4,
+    color: '#ddd', marginBottom: 16,
   },
   buttons: { display: 'flex', gap: 8, justifyContent: 'flex-end' },
-  button: {
-    padding: '8px 16px', fontSize: 13,
-    border: '1px solid #444', borderRadius: 4, cursor: 'pointer',
-  },
+  button: { padding: '8px 16px', fontSize: 13, border: '1px solid #444', borderRadius: 4, cursor: 'pointer' },
   buttonPrimary: { background: '#3a6a8a', color: '#fff', borderColor: '#4a7a9a' },
   buttonNeutral: { background: '#2a2a4a', color: '#ccc' },
   buttonDisabled: { opacity: 0.4, cursor: 'not-allowed' },
 };
 
-export function RenameCharacterDialog({ currentName, onSubmit, onCancel }: Props) {
-  const [value, setValue] = useState(currentName);
+export function DuplicateAssetDialog({ sourceName, onSubmit, onCancel }: Props) {
+  const [value, setValue] = useState(`Copy of ${sourceName}`);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    inputRef.current?.focus();
-    inputRef.current?.select();
-  }, []);
+  useEffect(() => { inputRef.current?.focus(); inputRef.current?.select(); }, []);
 
   const trimmed = value.trim();
   const valid = trimmed.length > 0 && trimmed.length <= 64 && NAME_RE.test(trimmed);
-
   const submit = () => { if (valid) onSubmit(trimmed); };
 
   return (
     <div style={styles.overlay} onClick={onCancel}>
       <div style={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div style={styles.title}>Rename character</div>
+        <div style={styles.title}>Duplicate "{sourceName}"</div>
         <input
           ref={inputRef}
           style={styles.input}
@@ -71,9 +55,7 @@ export function RenameCharacterDialog({ currentName, onSubmit, onCancel }: Props
           maxLength={64}
         />
         <div style={styles.buttons}>
-          <button style={{ ...styles.button, ...styles.buttonNeutral }} onClick={onCancel}>
-            Cancel
-          </button>
+          <button style={{ ...styles.button, ...styles.buttonNeutral }} onClick={onCancel}>Cancel</button>
           <button
             style={{
               ...styles.button,
@@ -83,7 +65,7 @@ export function RenameCharacterDialog({ currentName, onSubmit, onCancel }: Props
             disabled={!valid}
             onClick={submit}
           >
-            Rename
+            Duplicate
           </button>
         </div>
       </div>

--- a/tools/apps/echidna/src/panels/MenuBar.tsx
+++ b/tools/apps/echidna/src/panels/MenuBar.tsx
@@ -319,7 +319,7 @@ export function MenuBar() {
   // Shared Staging push logic. Uploads PLY + manifest via REST, sends
   // load_scene_json + load_character via WebSocket. Throws on failure.
   // Callers are responsible for toast/error-UI presentation.
-  const syncCharacterToStaging = useCallback(async (char: Asset) => {
+  const syncAssetToStaging = useCallback(async (char: Asset) => {
     const charId = char.id;
     if (!charId) throw new Error('character has no id — call ensureAssetId() first');
 
@@ -400,12 +400,12 @@ export function MenuBar() {
     if (!char || char.voxels.size === 0) return;
 
     try {
-      await syncCharacterToStaging(char);
+      await syncAssetToStaging(char);
     } catch (err) {
       // Auto-sync is silent — don't toast, just log
       console.warn('[echidna] auto-sync push to Staging failed:', err);
     }
-  }, [syncCharacterToStaging]);
+  }, [syncAssetToStaging]);
 
   // Auto-sync: debounced push to staging when voxels or parts change
   useEffect(() => {
@@ -537,13 +537,13 @@ export function MenuBar() {
 
     showToast('Sending to Staging...', 'loading');
     try {
-      await syncCharacterToStaging(char);
+      await syncAssetToStaging(char);
       showToast('Character sent to Staging', 'success');
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       showToast(`Preview failed: ${msg}`, 'error', 5000);
     }
-  }, [showToast, syncCharacterToStaging]);
+  }, [showToast, syncAssetToStaging]);
 
   const handleConnectBridgeToProject = useCallback(async () => {
     const projectPath = window.prompt(

--- a/tools/apps/echidna/src/panels/RenameAssetDialog.tsx
+++ b/tools/apps/echidna/src/panels/RenameAssetDialog.tsx
@@ -1,8 +1,8 @@
-// tools/apps/echidna/src/panels/DuplicateCharacterDialog.tsx
+// tools/apps/echidna/src/panels/RenameAssetDialog.tsx
 import React, { useState, useRef, useEffect } from 'react';
 
 interface Props {
-  sourceName: string;
+  currentName: string;
   onSubmit: (newName: string) => void;
   onCancel: () => void;
 }
@@ -16,33 +16,49 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex', alignItems: 'center', justifyContent: 'center',
     zIndex: 1000,
   },
-  dialog: { background: '#1e1e3a', border: '1px solid #444', borderRadius: 6, padding: 24, width: 420 },
+  dialog: {
+    background: '#1e1e3a', border: '1px solid #444', borderRadius: 6,
+    padding: 24, width: 420,
+  },
   title: { fontSize: 15, color: '#ddd', marginBottom: 12 },
   input: {
-    width: '100%', padding: '8px 10px', fontSize: 13,
-    background: '#16162a', border: '1px solid #444', borderRadius: 4,
-    color: '#ddd', marginBottom: 16,
+    width: '100%',
+    padding: '8px 10px',
+    fontSize: 13,
+    background: '#16162a',
+    border: '1px solid #444',
+    borderRadius: 4,
+    color: '#ddd',
+    marginBottom: 16,
   },
   buttons: { display: 'flex', gap: 8, justifyContent: 'flex-end' },
-  button: { padding: '8px 16px', fontSize: 13, border: '1px solid #444', borderRadius: 4, cursor: 'pointer' },
+  button: {
+    padding: '8px 16px', fontSize: 13,
+    border: '1px solid #444', borderRadius: 4, cursor: 'pointer',
+  },
   buttonPrimary: { background: '#3a6a8a', color: '#fff', borderColor: '#4a7a9a' },
   buttonNeutral: { background: '#2a2a4a', color: '#ccc' },
   buttonDisabled: { opacity: 0.4, cursor: 'not-allowed' },
 };
 
-export function DuplicateCharacterDialog({ sourceName, onSubmit, onCancel }: Props) {
-  const [value, setValue] = useState(`Copy of ${sourceName}`);
+export function RenameAssetDialog({ currentName, onSubmit, onCancel }: Props) {
+  const [value, setValue] = useState(currentName);
   const inputRef = useRef<HTMLInputElement>(null);
-  useEffect(() => { inputRef.current?.focus(); inputRef.current?.select(); }, []);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
 
   const trimmed = value.trim();
   const valid = trimmed.length > 0 && trimmed.length <= 64 && NAME_RE.test(trimmed);
+
   const submit = () => { if (valid) onSubmit(trimmed); };
 
   return (
     <div style={styles.overlay} onClick={onCancel}>
       <div style={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div style={styles.title}>Duplicate "{sourceName}"</div>
+        <div style={styles.title}>Rename asset</div>
         <input
           ref={inputRef}
           style={styles.input}
@@ -55,7 +71,9 @@ export function DuplicateCharacterDialog({ sourceName, onSubmit, onCancel }: Pro
           maxLength={64}
         />
         <div style={styles.buttons}>
-          <button style={{ ...styles.button, ...styles.buttonNeutral }} onClick={onCancel}>Cancel</button>
+          <button style={{ ...styles.button, ...styles.buttonNeutral }} onClick={onCancel}>
+            Cancel
+          </button>
           <button
             style={{
               ...styles.button,
@@ -65,7 +83,7 @@ export function DuplicateCharacterDialog({ sourceName, onSubmit, onCancel }: Pro
             disabled={!valid}
             onClick={submit}
           >
-            Duplicate
+            Rename
           </button>
         </div>
       </div>

--- a/tools/apps/echidna/src/panels/SwitchAssetDialog.tsx
+++ b/tools/apps/echidna/src/panels/SwitchAssetDialog.tsx
@@ -1,4 +1,4 @@
-// tools/apps/echidna/src/panels/SwitchCharacterDialog.tsx
+// tools/apps/echidna/src/panels/SwitchAssetDialog.tsx
 import React from 'react';
 import type { SwitchDecision } from '../store/useCharacterStore.js';
 
@@ -42,7 +42,7 @@ const styles: Record<string, React.CSSProperties> = {
   buttonNeutral: { background: '#2a2a4a', color: '#ccc' },
 };
 
-export function SwitchCharacterDialog({ currentName, targetName, undoDepth, onDecide }: Props) {
+export function SwitchAssetDialog({ currentName, targetName, undoDepth, onDecide }: Props) {
   return (
     <div style={styles.overlay} onClick={() => onDecide('cancel')}>
       <div style={styles.dialog} onClick={(e) => e.stopPropagation()}>

--- a/tools/apps/echidna/src/viewport/AssetViewport.tsx
+++ b/tools/apps/echidna/src/viewport/AssetViewport.tsx
@@ -64,8 +64,8 @@ function CameraFitter() {
   return null;
 }
 
-export function CharacterViewport() {
-  useComponentRegistry('CharacterViewport');
+export function AssetViewport() {
+  useComponentRegistry('AssetViewport');
   const gridWidth = useCharacterStore((s) => s.asset?.gridWidth ?? 32);
   const gridDepth = useCharacterStore((s) => s.asset?.gridDepth ?? 32);
   const showGrid = useCharacterStore((s) => s.showGrid);


### PR DESCRIPTION
## Summary

Mechanical rename of remaining "Character" references to "Asset" after Phase 0.3a's Character→Asset migration.

- Renamed 5 files: SwitchCharacterDialog → SwitchAssetDialog, RenameCharacterDialog → RenameAssetDialog, DuplicateCharacterDialog → DuplicateAssetDialog, DeleteCharacterDialog → DeleteAssetDialog, CharacterViewport → AssetViewport
- Updated all importers (AssetsPanel, App, MenuBar)
- Renamed `syncCharacterToStaging` → `syncAssetToStaging` in MenuBar
- Updated expected-components.json

## Test plan

- [x] 132/132 echidna tests pass
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)