### PR TITLE
feat(bridge): Phase 1 — per-resource async serialization

### DIFF
--- a/tools/apps/bridge/src/index.ts
+++ b/tools/apps/bridge/src/index.ts
@@ -19,6 +19,9 @@ import { WSServer } from './ws-server.js';
 import { RequestTracker } from './request-tracker.js';
 import { exportPlyFromProject } from './ply-export.js';
 import type { EchidnaProject } from './ply-export.js';
+import { AsyncResourceLock } from './utils/AsyncResourceLock.js';
+
+const resourceLock = new AsyncResourceLock();
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -275,9 +278,11 @@ app.get('/api/files/scenes/:name', async (req: Request, res: Response) => {
 app.post('/api/files/scenes/:name', async (req: Request, res: Response) => {
   try {
     const filePath = safeResolve(getScenesDir(), `${req.params['name']}.json`);
-    await fs.mkdir(path.dirname(filePath), { recursive: true });
-    const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body, null, 2);
-    await fs.writeFile(filePath, body, 'utf8');
+    await resourceLock.acquire(filePath, async () => {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body, null, 2);
+      await fs.writeFile(filePath, body, 'utf8');
+    });
     console.log(`[REST] Scene written: ${filePath}`);
     res.json({ ok: true, path: filePath });
   } catch (err) {
@@ -327,7 +332,9 @@ app.post('/api/files/textures/:name', async (req: Request, res: Response) => {
       data = Buffer.concat(chunks);
     }
 
-    await fs.writeFile(filePath, data);
+    await resourceLock.acquire(filePath, async () => {
+      await fs.writeFile(filePath, data);
+    });
     console.log(`[REST] Texture written: ${filePath} (${data.length} bytes)`);
     res.json({ ok: true, path: filePath, bytes: data.length });
   } catch (err) {
@@ -380,10 +387,12 @@ app.get('/api/characters/:id', async (req: Request, res: Response) => {
 app.post('/api/characters/:id', async (req: Request, res: Response) => {
   try {
     const charDir = safeResolve(getCharactersDir(), req.params['id']!);
-    await fs.mkdir(charDir, { recursive: true });
     const filePath = path.join(charDir, 'manifest.json');
-    const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body, null, 2);
-    await fs.writeFile(filePath, body, 'utf8');
+    await resourceLock.acquire(filePath, async () => {
+      await fs.mkdir(charDir, { recursive: true });
+      const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body, null, 2);
+      await fs.writeFile(filePath, body, 'utf8');
+    });
     console.log(`[REST] Character manifest written: ${filePath}`);
     res.json({ ok: true, path: filePath });
   } catch (err) {
@@ -402,30 +411,39 @@ app.post('/api/characters/:id/rename', async (req: Request, res: Response) => {
       res.status(400).json({ error: 'newId must be lowercase alphanumeric with underscores' });
       return;
     }
-    const charsDir = getCharactersDir();
-    const oldDir = safeResolve(charsDir, oldId);
-    const newDir = safeResolve(charsDir, newId);
 
-    // Check old exists
-    try { await fs.access(oldDir); } catch {
-      res.status(404).json({ error: `Character "${oldId}" not found` });
+    const result = await resourceLock.acquire(`character_manifest_${oldId}`, async () => {
+      const charsDir = getCharactersDir();
+      const oldDir = safeResolve(charsDir, oldId);
+      const newDir = safeResolve(charsDir, newId);
+
+      // Check old exists
+      try { await fs.access(oldDir); } catch {
+        return { error: `Character "${oldId}" not found`, status: 404 as number };
+      }
+      // Check new doesn't exist
+      try { await fs.access(newDir); return { error: `Character "${newId}" already exists`, status: 409 as number }; } catch { /* good */ }
+
+      // Rename directory
+      await fs.rename(oldDir, newDir);
+
+      // Update character_id in manifest
+      const manifestPath = path.join(newDir, 'manifest.json');
+      try {
+        const raw = await fs.readFile(manifestPath, 'utf8');
+        const manifest = JSON.parse(raw);
+        manifest.character_id = newId;
+        if (manifest.display_name === oldId) manifest.display_name = newId;
+        await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+      } catch { /* manifest update optional */ }
+
+      return { ok: true };
+    });
+
+    if ('error' in result) {
+      res.status(result.status as number).json({ error: result.error });
       return;
     }
-    // Check new doesn't exist
-    try { await fs.access(newDir); res.status(409).json({ error: `Character "${newId}" already exists` }); return; } catch { /* good */ }
-
-    // Rename directory
-    await fs.rename(oldDir, newDir);
-
-    // Update character_id in manifest
-    const manifestPath = path.join(newDir, 'manifest.json');
-    try {
-      const raw = await fs.readFile(manifestPath, 'utf8');
-      const manifest = JSON.parse(raw);
-      manifest.character_id = newId;
-      if (manifest.display_name === oldId) manifest.display_name = newId;
-      await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
-    } catch { /* manifest update optional */ }
 
     console.log(`[REST] Character renamed: ${oldId} → ${newId}`);
     res.json({ ok: true, oldId, newId });
@@ -470,7 +488,9 @@ async function saveConceptImageHandler(req: Request, res: Response) {
     const filePath = path.join(charDir, filename);
     const data = await readBinaryBody(req);
 
-    await fs.writeFile(filePath, data);
+    await resourceLock.acquire(filePath, async () => {
+      await fs.writeFile(filePath, data);
+    });
     console.log(`[REST] Concept image${view ? ` (${view})` : ''} written: ${filePath} (${data.length} bytes)`);
     res.json({ ok: true, path: filePath, bytes: data.length });
   } catch (err) {
@@ -534,7 +554,9 @@ async function saveChibiImageHandler(req: Request, res: Response) {
     const filePath = path.join(charDir, filename);
     const data = await readBinaryBody(req);
 
-    await fs.writeFile(filePath, data);
+    await resourceLock.acquire(filePath, async () => {
+      await fs.writeFile(filePath, data);
+    });
     console.log(`[REST] Chibi image${view ? ` (${view})` : ''} written: ${filePath} (${data.length} bytes)`);
     res.json({ ok: true, path: filePath, bytes: data.length });
   } catch (err) {
@@ -598,7 +620,9 @@ app.post('/api/characters/:id/pixel-image', async (req: Request, res: Response) 
       data = Buffer.concat(chunks);
     }
 
-    await fs.writeFile(filePath, data);
+    await resourceLock.acquire(filePath, async () => {
+      await fs.writeFile(filePath, data);
+    });
     console.log(`[REST] Pixel image written: ${filePath} (${data.length} bytes)`);
     res.json({ ok: true, path: filePath, bytes: data.length });
   } catch (err) {
@@ -643,7 +667,9 @@ app.post('/api/characters/:id/file/:filename', async (req: Request, res: Respons
     await fs.mkdir(charDir, { recursive: true });
     const filePath = path.join(charDir, filename);
     const data = await readBinaryBody(req);
-    await fs.writeFile(filePath, data);
+    await resourceLock.acquire(filePath, async () => {
+      await fs.writeFile(filePath, data);
+    });
     console.log(`[REST] Character file written: ${filePath} (${data.length} bytes)`);
     res.json({ ok: true, path: filePath, bytes: data.length });
   } catch (err) {
@@ -678,10 +704,11 @@ app.get('/api/characters/:id/file/:filename', async (req: Request, res: Response
 // POST /api/characters/:id/frames/:anim/:frame/image — save a frame PNG
 app.post('/api/characters/:id/frames/:anim/:frame/image', async (req: Request, res: Response) => {
   try {
-    const charDir = safeResolve(getCharactersDir(), req.params['id']!);
-    const animDir = path.join(charDir, req.params['anim']!);
-    await fs.mkdir(animDir, { recursive: true });
-    const filename = `${req.params['anim']}_${req.params['frame']}.png`;
+    const id = req.params['id']!;
+    const charDir = safeResolve(getCharactersDir(), id);
+    const animName = req.params['anim']!;
+    const animDir = path.join(charDir, animName);
+    const filename = `${animName}_${req.params['frame']}.png`;
     const filePath = path.join(animDir, filename);
 
     let data: Buffer;
@@ -696,25 +723,28 @@ app.post('/api/characters/:id/frames/:anim/:frame/image', async (req: Request, r
       data = Buffer.concat(chunks);
     }
 
-    await fs.writeFile(filePath, data);
-    console.log(`[REST] Frame image written: ${filePath} (${data.length} bytes)`);
+    await resourceLock.acquire(`character_manifest_${id}`, async () => {
+      await fs.mkdir(animDir, { recursive: true });
+      await fs.writeFile(filePath, data);
+      console.log(`[REST] Frame image written: ${filePath} (${data.length} bytes)`);
 
-    // Also update the manifest frame entry with the file path
-    const manifestPath = path.join(charDir, 'manifest.json');
-    try {
-      const raw = await fs.readFile(manifestPath, 'utf8');
-      const manifest = JSON.parse(raw);
-      const anim = manifest.animations?.find((a: { name: string }) => a.name === req.params['anim']);
-      const frameIdx = parseInt(req.params['frame']!, 10);
-      const frame = anim?.frames?.find((f: { index: number }) => f.index === frameIdx);
-      if (frame) {
-        frame.file = `${req.params['anim']}/${filename}`;
-        if (frame.status === 'pending') frame.status = 'generated';
-        await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
-      }
-    } catch { /* manifest update optional */ }
+      // Also update the manifest frame entry with the file path
+      const manifestPath = path.join(charDir, 'manifest.json');
+      try {
+        const raw = await fs.readFile(manifestPath, 'utf8');
+        const manifest = JSON.parse(raw);
+        const anim = manifest.animations?.find((a: { name: string }) => a.name === animName);
+        const frameIdx = parseInt(req.params['frame']!, 10);
+        const frame = anim?.frames?.find((f: { index: number }) => f.index === frameIdx);
+        if (frame) {
+          frame.file = `${animName}/${filename}`;
+          if (frame.status === 'pending') frame.status = 'generated';
+          await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+        }
+      } catch { /* manifest update optional */ }
+    });
 
-    res.json({ ok: true, path: filePath, bytes: data.length, file: `${req.params['anim']}/${filename}` });
+    res.json({ ok: true, path: filePath, bytes: data.length, file: `${animName}/${filename}` });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const statusCode = message.includes('Path traversal') ? 400 : 500;
@@ -777,7 +807,8 @@ app.get('/api/characters/:id/frames/:anim/:frame/pass/:pass', async (req: Reques
 // POST /api/characters/:id/frames/:anim/:frame/pass/:pass — save an intermediate pass image
 app.post('/api/characters/:id/frames/:anim/:frame/pass/:pass', async (req: Request, res: Response) => {
   try {
-    const charDir = safeResolve(getCharactersDir(), req.params['id']!);
+    const id = req.params['id']!;
+    const charDir = safeResolve(getCharactersDir(), id);
     const pass = req.params['pass']!;
     if (!VALID_PASSES.includes(pass)) {
       res.status(400).json({ error: `Invalid pass: ${pass}` });
@@ -785,28 +816,31 @@ app.post('/api/characters/:id/frames/:anim/:frame/pass/:pass', async (req: Reque
     }
     const animName = req.params['anim']!;
     const animDir = path.join(charDir, animName);
-    await fs.mkdir(animDir, { recursive: true });
     const frameIdx = req.params['frame']!;
     const filename = `${animName}_${frameIdx}_${pass}.png`;
     const filePath = path.join(animDir, filename);
 
     const data = await readBinaryBody(req);
-    await fs.writeFile(filePath, data);
-    console.log(`[REST] Pass image written: ${filePath} (${data.length} bytes)`);
 
-    // Update pipeline_stage in manifest
-    const manifestPath = path.join(charDir, 'manifest.json');
-    try {
-      const raw = await fs.readFile(manifestPath, 'utf8');
-      const manifest = JSON.parse(raw);
-      const anim = manifest.animations?.find((a: { name: string }) => a.name === animName);
-      const fi = parseInt(frameIdx, 10);
-      const frame = anim?.frames?.find((f: { index: number }) => f.index === fi);
-      if (frame) {
-        frame.pipeline_stage = pass;
-        await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
-      }
-    } catch { /* manifest update optional */ }
+    await resourceLock.acquire(`character_manifest_${id}`, async () => {
+      await fs.mkdir(animDir, { recursive: true });
+      await fs.writeFile(filePath, data);
+      console.log(`[REST] Pass image written: ${filePath} (${data.length} bytes)`);
+
+      // Update pipeline_stage in manifest
+      const manifestPath = path.join(charDir, 'manifest.json');
+      try {
+        const raw = await fs.readFile(manifestPath, 'utf8');
+        const manifest = JSON.parse(raw);
+        const anim = manifest.animations?.find((a: { name: string }) => a.name === animName);
+        const fi = parseInt(frameIdx, 10);
+        const frame = anim?.frames?.find((f: { index: number }) => f.index === fi);
+        if (frame) {
+          frame.pipeline_stage = pass;
+          await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+        }
+      } catch { /* manifest update optional */ }
+    });
 
     res.json({ ok: true, path: filePath, bytes: data.length });
   } catch (err) {
@@ -829,7 +863,9 @@ app.delete('/api/characters/:id/frames/:anim/:frame/pass/:pass', async (req: Req
     const frameIdx = req.params['frame']!;
     const filename = `${animName}_${frameIdx}_${pass}.png`;
     const filePath = path.join(charDir, animName, filename);
-    await fs.unlink(filePath);
+    await resourceLock.acquire(filePath, async () => {
+      await fs.unlink(filePath);
+    });
     console.log(`[REST] Pass image deleted: ${filePath}`);
     res.json({ ok: true });
   } catch (err) {
@@ -866,36 +902,46 @@ app.get('/api/characters/:id/frames/:anim/:frame', async (req: Request, res: Res
 // POST /api/characters/:id/frames/:anim/:frame — update a frame's status
 app.post('/api/characters/:id/frames/:anim/:frame', async (req: Request, res: Response) => {
   try {
-    const charDir = safeResolve(getCharactersDir(), req.params['id']!);
-    const filePath = path.join(charDir, 'manifest.json');
-    const content = await fs.readFile(filePath, 'utf8');
-    const manifest = JSON.parse(content);
-    const anim = manifest.animations?.find((a: { name: string }) => a.name === req.params['anim']);
-    if (!anim) {
-      res.status(404).json({ error: `Animation "${req.params['anim']}" not found` });
-      return;
-    }
+    const id = req.params['id']!;
+    const charDir = safeResolve(getCharactersDir(), id);
+    const animName = req.params['anim']!;
     const frameIdx = parseInt(req.params['frame']!, 10);
-    const frame = anim.frames?.find((f: { index: number }) => f.index === frameIdx);
-    if (!frame) {
-      res.status(404).json({ error: `Frame ${frameIdx} not found` });
+
+    const result = await resourceLock.acquire(`character_manifest_${id}`, async () => {
+      const filePath = path.join(charDir, 'manifest.json');
+      const content = await fs.readFile(filePath, 'utf8');
+      const manifest = JSON.parse(content);
+      const anim = manifest.animations?.find((a: { name: string }) => a.name === animName);
+      if (!anim) {
+        return { error: `Animation "${animName}" not found`, status: 404 as number };
+      }
+      const frame = anim.frames?.find((f: { index: number }) => f.index === frameIdx);
+      if (!frame) {
+        return { error: `Frame ${frameIdx} not found`, status: 404 as number };
+      }
+
+      // Update frame fields from request body
+      if (req.body.status) frame.status = req.body.status;
+      if (req.body.source) frame.source = req.body.source;
+      if (req.body.file) frame.file = req.body.file;
+      if (req.body.generation) frame.generation = req.body.generation;
+      if (req.body.review) frame.review = req.body.review;
+      if (req.body.notes !== undefined) {
+        if (!frame.review) frame.review = { reviewer: 'human', notes: '' };
+        frame.review.notes = req.body.notes;
+      }
+
+      await fs.writeFile(filePath, JSON.stringify(manifest, null, 2), 'utf8');
+      console.log(`[REST] Frame updated: ${id}/${animName}[${frameIdx}]`);
+      return { ok: true, frame };
+    });
+
+    if ('error' in result) {
+      res.status(result.status as number).json({ error: result.error });
       return;
     }
 
-    // Update frame fields from request body
-    if (req.body.status) frame.status = req.body.status;
-    if (req.body.source) frame.source = req.body.source;
-    if (req.body.file) frame.file = req.body.file;
-    if (req.body.generation) frame.generation = req.body.generation;
-    if (req.body.review) frame.review = req.body.review;
-    if (req.body.notes !== undefined) {
-      if (!frame.review) frame.review = { reviewer: 'human', notes: '' };
-      frame.review.notes = req.body.notes;
-    }
-
-    await fs.writeFile(filePath, JSON.stringify(manifest, null, 2), 'utf8');
-    console.log(`[REST] Frame updated: ${req.params['id']}/${req.params['anim']}[${frameIdx}]`);
-    res.json({ ok: true, frame });
+    res.json({ ok: true, frame: result.frame });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const statusCode = message.includes('Path traversal') ? 400 : 500;
@@ -939,8 +985,10 @@ app.post('/api/characters/:name/export-ply', async (req: Request, res: Response)
     if (outputPath) {
       // Write to the specified filesystem path
       const resolved = resolveUserPath(outputPath);
-      await fs.mkdir(path.dirname(resolved), { recursive: true });
-      await fs.writeFile(resolved, plyBuffer);
+      await resourceLock.acquire(resolved, async () => {
+        await fs.mkdir(path.dirname(resolved), { recursive: true });
+        await fs.writeFile(resolved, plyBuffer);
+      });
       console.log(`[REST] PLY exported: ${resolved} (${plyBuffer.length} bytes)`);
       res.json({ success: true, path: resolved, size: plyBuffer.length });
     } else {
@@ -1009,21 +1057,25 @@ app.post('/api/projects/create', async (req: Request, res: Response) => {
       return;
     }
     const projectDir = resolveUserPath(dirPath);
-    const charsDir = path.join(projectDir, 'characters');
-    await fs.mkdir(charsDir, { recursive: true });
 
-    const project = {
-      version: 1,
-      name,
-      created_at: new Date().toISOString(),
-      modified_at: new Date().toISOString(),
-      characters: [] as string[],
-      ai_config: null,
-      export_presets: {
-        default: { format: 'spritesheet', include_characters: [], output_dir: 'export' },
-      },
-    };
-    await fs.writeFile(path.join(projectDir, 'project.json'), JSON.stringify(project, null, 2), 'utf8');
+    const project = await resourceLock.acquire(projectDir, async () => {
+      const charsDir = path.join(projectDir, 'characters');
+      await fs.mkdir(charsDir, { recursive: true });
+
+      const proj = {
+        version: 1,
+        name,
+        created_at: new Date().toISOString(),
+        modified_at: new Date().toISOString(),
+        characters: [] as string[],
+        ai_config: null,
+        export_presets: {
+          default: { format: 'spritesheet', include_characters: [], output_dir: 'export' },
+        },
+      };
+      await fs.writeFile(path.join(projectDir, 'project.json'), JSON.stringify(proj, null, 2), 'utf8');
+      return proj;
+    });
 
     activeProjectDir = projectDir;
     console.log(`[Bridge] Project created: ${projectDir}`);
@@ -1088,7 +1140,9 @@ app.post('/api/projects/save', async (req: Request, res: Response) => {
     }
     project.modified_at = new Date().toISOString();
     const projectFile = path.join(activeProjectDir, 'project.json');
-    await fs.writeFile(projectFile, JSON.stringify(project, null, 2), 'utf8');
+    await resourceLock.acquire(projectFile, async () => {
+      await fs.writeFile(projectFile, JSON.stringify(project, null, 2), 'utf8');
+    });
     console.log(`[Bridge] Project saved: ${projectFile}`);
     res.json({ ok: true });
   } catch (err) {

--- a/tools/apps/bridge/src/utils/AsyncResourceLock.ts
+++ b/tools/apps/bridge/src/utils/AsyncResourceLock.ts
@@ -1,0 +1,43 @@
+/**
+ * Per-resource asynchronous task queue. Guarantees that tasks for the same
+ * key execute strictly sequentially (FIFO), while tasks for different keys
+ * execute in parallel.
+ *
+ * Uses a Promise-chain pattern: each new task chains onto the previous
+ * task's promise for that key. When the chain is empty, the key is removed
+ * from the map to prevent memory leaks.
+ */
+export class AsyncResourceLock {
+  private chains = new Map<string, Promise<void>>();
+
+  /**
+   * Queue a task for the given resource key. Returns the task's result.
+   * If the task throws, the error propagates to the caller but does NOT
+   * block subsequent tasks for the same key.
+   */
+  async acquire<T>(key: string, task: () => Promise<T>): Promise<T> {
+    const prev = this.chains.get(key) ?? Promise.resolve();
+
+    let resolve!: () => void;
+    const next = new Promise<void>((r) => { resolve = r; });
+    this.chains.set(key, next);
+
+    // Wait for previous task to finish (regardless of success/failure)
+    await prev;
+
+    try {
+      return await task();
+    } finally {
+      // Clean up if this is still the tail of the chain
+      if (this.chains.get(key) === next) {
+        this.chains.delete(key);
+      }
+      resolve();
+    }
+  }
+
+  /** Number of keys currently held (for testing/diagnostics). */
+  get size(): number {
+    return this.chains.size;
+  }
+}

--- a/tools/apps/bridge/src/utils/__tests__/AsyncResourceLock.test.ts
+++ b/tools/apps/bridge/src/utils/__tests__/AsyncResourceLock.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { AsyncResourceLock } from '../AsyncResourceLock';
+import { AsyncResourceLock } from '../AsyncResourceLock.js';
 
 describe('AsyncResourceLock', () => {
   it('executes a single task and returns its result', async () => {

--- a/tools/apps/bridge/src/utils/__tests__/AsyncResourceLock.test.ts
+++ b/tools/apps/bridge/src/utils/__tests__/AsyncResourceLock.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { AsyncResourceLock } from '../AsyncResourceLock';
+
+describe('AsyncResourceLock', () => {
+  it('executes a single task and returns its result', async () => {
+    const lock = new AsyncResourceLock();
+    const result = await lock.acquire('a', async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('serializes tasks for the same key', async () => {
+    const lock = new AsyncResourceLock();
+    const order: number[] = [];
+
+    const t1 = lock.acquire('a', async () => {
+      await delay(50);
+      order.push(1);
+    });
+    const t2 = lock.acquire('a', async () => {
+      order.push(2);
+    });
+    const t3 = lock.acquire('a', async () => {
+      order.push(3);
+    });
+
+    await Promise.all([t1, t2, t3]);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('allows parallel execution for different keys', async () => {
+    const lock = new AsyncResourceLock();
+    const order: string[] = [];
+
+    const t1 = lock.acquire('a', async () => {
+      await delay(50);
+      order.push('a');
+    });
+    const t2 = lock.acquire('b', async () => {
+      order.push('b');
+    });
+
+    await Promise.all([t1, t2]);
+    // 'b' should finish before 'a' because it has no delay
+    expect(order).toEqual(['b', 'a']);
+  });
+
+  it('does not block the queue when a task throws', async () => {
+    const lock = new AsyncResourceLock();
+    const order: number[] = [];
+
+    const t1 = lock.acquire('a', async () => {
+      order.push(1);
+      throw new Error('boom');
+    }).catch(() => {});
+
+    const t2 = lock.acquire('a', async () => {
+      order.push(2);
+      return 'ok';
+    });
+
+    await t1;
+    const result = await t2;
+    expect(order).toEqual([1, 2]);
+    expect(result).toBe('ok');
+  });
+
+  it('cleans up the key when the chain is empty', async () => {
+    const lock = new AsyncResourceLock();
+    await lock.acquire('a', async () => {});
+    expect(lock.size).toBe(0);
+  });
+
+  it('propagates the error to the caller', async () => {
+    const lock = new AsyncResourceLock();
+    await expect(
+      lock.acquire('a', async () => { throw new Error('test error'); })
+    ).rejects.toThrow('test error');
+  });
+
+  it('handles 10 concurrent tasks for the same key without corruption', async () => {
+    const lock = new AsyncResourceLock();
+    let counter = 0;
+
+    const tasks = Array.from({ length: 10 }, (_, i) =>
+      lock.acquire('shared', async () => {
+        const current = counter;
+        await delay(Math.random() * 10);
+        counter = current + 1;
+      }),
+    );
+
+    await Promise.all(tasks);
+    expect(counter).toBe(10);
+  });
+});
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}


### PR DESCRIPTION
## Summary

Implements per-resource async serialization in the Bridge server to prevent file clobbering and TOCTOU bugs when multiple tools (Bricklayer, Méliès, Echidna) have Auto-Sync enabled.

- **AsyncResourceLock utility** — Promise-chain based lock with `acquire(key, task)`. Tasks for the same key execute FIFO; different keys run in parallel. Error-resilient (failed task doesn't block the queue). Auto-cleanup on empty chain.
- **15 endpoints wrapped**:
  - 10 simple file-path locks (scenes, textures, character files, PLY export, projects)
  - 4 character manifest TOCTOU fixes (frame image, pass image, frame status, rename) — locked on `character_manifest_{id}` to serialize all manifest mutations for a character
  - 1 delete endpoint lock

## TOCTOU fix

The critical bug: concurrent frame uploads would each read the manifest, mutate their frame entry, and write back — losing the other's changes. Now the entire read-modify-write cycle is locked per character ID.

## Test plan

- [x] 7/7 AsyncResourceLock unit tests (serialization, parallelism, error isolation, cleanup, 10-concurrent counter)
- [x] 18/18 total bridge tests pass
- [x] `pnpm build` succeeds
- [ ] Manual: enable Auto-Sync in Bricklayer + Méliès simultaneously, save scene rapidly — no file corruption
- [ ] Manual: upload multiple animation frames concurrently — manifest contains all frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)