### PR TITLE
fix(gs): barrier UB in render and post-process shaders

### DIFF
--- a/shaders/gs_post_process.comp
+++ b/shaders/gs_post_process.comp
@@ -33,19 +33,22 @@ void main() {
     uint width = uint(dimensions.y);
     uint height = uint(dimensions.z);
 
-    if (pixel.x >= width || pixel.y >= height) return;
+    bool valid_pixel = (pixel.x < width && pixel.y < height);
 
-    // Load raw HDR color and depth
-    vec4 raw = imageLoad(input_image, ivec2(pixel));
-    float depth = imageLoad(depth_image, ivec2(pixel)).r;
+    // Load raw HDR color and depth (only for valid pixels)
+    vec4 raw = valid_pixel ? imageLoad(input_image, ivec2(pixel)) : vec4(0.0);
+    float depth = valid_pixel ? imageLoad(depth_image, ivec2(pixel)).r : 0.0;
     float alpha = raw.a;
 
     // ── 0. Hybrid background (ground plane + sky gradient) ──
     bool bg_enabled = sky_enable.w > 0.5;
-    if (alpha < 0.001 && !bg_enabled) {
+    if (valid_pixel && alpha < 0.001 && !bg_enabled) {
         // No background configured — pass through transparent
         imageStore(output_image, ivec2(pixel), raw);
-        return;
+        // Still must participate in barrier below, so don't return.
+        // Mark as handled by zeroing alpha so later effects are skipped.
+        raw = vec4(0.0);
+        alpha = 0.0;
     }
 
     vec3 color = raw.rgb;
@@ -53,7 +56,7 @@ void main() {
     // Store into shared memory for tile-based effects
     tile_color[local_id.y][local_id.x] = vec4(color, alpha);
     tile_depth_s[local_id.y][local_id.x] = depth;
-    barrier();
+    barrier();  // ALL invocations in workgroup must reach this
 
     // Unpack parameters
     float fog_density       = fog_params.x;
@@ -235,5 +238,7 @@ void main() {
         alpha = 1.0;  // output is fully opaque
     }
 
-    imageStore(output_image, ivec2(pixel), vec4(color, alpha));
+    if (valid_pixel) {
+        imageStore(output_image, ivec2(pixel), vec4(color, alpha));
+    }
 }

--- a/shaders/gs_render.comp
+++ b/shaders/gs_render.comp
@@ -88,7 +88,7 @@ void main() {
     uint height = params.y;
     uint count = static_count + dynamic_count;  // compute directly, bypass merge shader's thread 0 write
 
-    if (pixel.x >= width || pixel.y >= height) return;
+    bool valid_pixel = (pixel.x < width && pixel.y < height);
 
     vec2 pix_center = vec2(pixel) + 0.5;
 
@@ -103,8 +103,8 @@ void main() {
     float first_hit_depth = 0.0;
     bool has_first_hit = false;
 
-    // Iterate through sorted Gaussians
-    for (uint s = 0; s < count; ++s) {
+    // Iterate through sorted Gaussians (only for valid pixels)
+    for (uint s = 0; s < (valid_pixel ? count : 0u); ++s) {
         uint idx = merged_entries[s].index;
 
         // Culled Gaussians (key == 0xFFFF) are sorted to the end — stop immediately
@@ -168,15 +168,15 @@ void main() {
     }
 
     // Store depth in shared memory for tile-based effects
-    tile_depth[local_id.y][local_id.x] = has_first_hit ? first_hit_depth : 0.0;
-    barrier();
+    tile_depth[local_id.y][local_id.x] = (valid_pixel && has_first_hit) ? first_hit_depth : 0.0;
+    barrier();  // ALL invocations in workgroup must reach this
 
     // Apply post-processing effects if any are active
     float toon_bands = effect_flags.x;
     float light_mode = effect_flags.y;
 
     float non_emissive_alpha = alpha_accum - emission_alpha;
-    if (non_emissive_alpha > 0.001 && (light_mode > 0.5 || toon_bands > 0.5)) {
+    if (valid_pixel && non_emissive_alpha > 0.001 && (light_mode > 0.5 || toon_bands > 0.5)) {
         // Un-premultiply non-emissive color only for lighting
         vec3 base_color = color / max(non_emissive_alpha, 0.001);
 
@@ -344,7 +344,7 @@ void main() {
     }
 
     // --- X-Ray color treatment ---
-    if (xray_depth > 0.0 && alpha_accum > 0.001) {
+    if (valid_pixel && xray_depth > 0.0 && alpha_accum > 0.001) {
         vec3 base = color / max(alpha_accum, 0.001);
         float lum = dot(base, vec3(0.299, 0.587, 0.114));
         // Blue-green medical-scan tint
@@ -359,6 +359,8 @@ void main() {
     color += emission;
 
     // Write output (premultiplied alpha) + depth for post-processing
-    imageStore(output_image, ivec2(pixel), vec4(color, alpha_accum));
-    imageStore(depth_image, ivec2(pixel), vec4(first_hit_depth, 0.0, 0.0, 0.0));
+    if (valid_pixel) {
+        imageStore(output_image, ivec2(pixel), vec4(color, alpha_accum));
+        imageStore(depth_image, ivec2(pixel), vec4(first_hit_depth, 0.0, 0.0, 0.0));
+    }
 }


### PR DESCRIPTION
## Summary
- Fix undefined behavior in `gs_render.comp` and `gs_post_process.comp` where boundary-tile threads returned early before `barrier()`, violating GLSL requirement that all workgroup invocations reach the barrier
- Replace early `return` with a `valid_pixel` flag — invalid threads skip work but still participate in barriers and shared memory operations
- On AMD Windows drivers this produced a row of garbage pixels at the bottom of the GS output; macOS/MoltenVK silently tolerated the UB

## Test plan
- [x] Shaders compile on macOS
- [x] Shaders compile on Windows
- [x] Garbage pixel row at bottom of screen eliminated on Windows release build (AMD RX 6600M)
- [x] macOS rendering unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)