### PR TITLE
feat: Phase 2 — Streaming Architecture (Slab Allocator + Transfer Queue + Instances)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ add_library(gseurat_core OBJECT
     src/engine/gs_scene_loader.cpp
     src/engine/collision_gen.cpp
     src/engine/save_system.cpp
+    src/engine/slab_allocator.cpp
     src/engine/async_loader.cpp
     src/engine/staging_uploader.cpp
     src/engine/gs_chunk_streamer.cpp
@@ -345,3 +346,4 @@ add_gseurat_test(test_camera_review_state src/staging/camera_review_state.cpp
 target_link_libraries(test_camera_review_state PRIVATE glfw imgui_lib)
 add_gseurat_test(test_visual_state  src/staging/visual_state.cpp)
 add_gseurat_test(test_project_root  src/engine/project_root.cpp)
+add_gseurat_test(test_slab_allocator src/engine/slab_allocator.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ add_library(gseurat_core OBJECT
     src/engine/input_manager.cpp
     src/engine/scene.cpp
     src/engine/tilemap.cpp
+    src/engine/transfer_queue.cpp
     src/engine/pathfinder.cpp
     src/engine/parallax_layer.cpp
     src/engine/animation.cpp

--- a/docs/superpowers/specs/2026-04-13-phase-2-streaming-architecture-design.md
+++ b/docs/superpowers/specs/2026-04-13-phase-2-streaming-architecture-design.md
@@ -1,0 +1,311 @@
+# Phase 2: Room-based Loading & Vulkan Streaming Architecture
+
+## Goal
+
+Replace GsRenderer's destroy-and-recreate memory model with a streaming-ready architecture: pre-allocated VRAM managed by a slab allocator with GPU page table indirection, async background uploads via a dedicated transfer queue (with fallback), and Bricklayer Instance/Portal support to drive room-based loading.
+
+## Requirements
+
+### R1: Fixed-Size Slab Allocator with GPU Page Table
+### R2: Async Background Transfer Queue
+### R3: Instances (Rooms) & Portal Extension in Bricklayer
+
+---
+
+## R1: Fixed-Size Slab Allocator with GPU Page Table
+
+### Overview
+
+At startup, `GsRenderer` allocates one massive static SSBO sized to a configurable budget (default 10M splats × 64 bytes = 640 MB). This SSBO is logically divided into fixed-size slabs of 100K splats each. A `SlabAllocator` free-list manager tracks which slabs are in use.
+
+Slabs are **non-contiguous** — a checkout may return scattered slab indices (e.g., `{2, 7, 15}`). A GPU-side page table SSBO maps logical splat indices to physical slab locations, eliminating external fragmentation entirely.
+
+### New Files
+
+- `include/gseurat/engine/slab_allocator.hpp` — Free-list manager (header-only or with .cpp)
+- `src/engine/slab_allocator.cpp` — Implementation + unit tests
+
+### SlabAllocator Interface
+
+```cpp
+class SlabAllocator {
+public:
+    SlabAllocator(uint32_t total_slabs, uint32_t splats_per_slab);
+
+    struct SlabHandle {
+        uint32_t chunk_id;
+        std::vector<uint32_t> slab_indices;  // non-contiguous physical slab IDs
+    };
+
+    // Checkout N slabs from the free list. Returns scattered indices.
+    // Throws if not enough slabs available.
+    SlabHandle checkout(uint32_t slab_count);
+
+    // Return slabs to the free list.
+    void release(const SlabHandle& handle);
+
+    // Number of free slabs remaining.
+    uint32_t available() const;
+
+    uint32_t splats_per_slab() const;
+    uint32_t total_slabs() const;
+};
+```
+
+### GPU Resources
+
+- **`page_table_ssbo_`** — `uint32_t[]` array, one entry per logical slab index across all active chunks. Maps `logical_slab_index → physical_slab_index`. Updated only on load/unload (not per-frame).
+
+- **`chunk_table_ssbo_`** — Small buffer describing active chunks: `{ slab_offset_in_page_table, slab_count, splats_in_last_slab }` per chunk. Lets the preprocess shader know which page table range belongs to which chunk.
+
+### Preprocess Shader Change (`gs_preprocess.comp`)
+
+```glsl
+// Indirection through page table (replaces direct indexing)
+uint logical_idx = gl_GlobalInvocationID.x;
+uint slab_logical = logical_idx / SPLATS_PER_SLAB;
+uint offset_in_slab = logical_idx % SPLATS_PER_SLAB;
+uint physical_slab = page_table[slab_logical];
+uint physical_idx = physical_slab * SPLATS_PER_SLAB + offset_in_slab;
+Gaussian g = gaussians[physical_idx];
+```
+
+Cost: one integer divide, one modulo, one table lookup, one multiply-add per invocation — negligible.
+
+### Changes to GsRenderer
+
+- **`init_streaming(config)`** (new) — Called once at startup. Allocates the main SSBO, page table SSBO, chunk table SSBO, sort buffers, projected SSBO, and merge SSBO all to budget size. Creates the `SlabAllocator`.
+
+- **`load_cloud()`** — No longer destroys/recreates buffers. Calls `slab_allocator_.checkout(N)` to get scattered slabs, writes Gaussian data into each slab's physical offset in the mapped SSBO, updates page table entries for this chunk.
+
+- **`unload_cloud(handle)`** (new) — Calls `slab_allocator_.release(handle)`, invalidates page table entries, decrements active splat count.
+
+- Sort buffers, projected SSBO, merge SSBO are pre-allocated to the max budget size at init. They do not grow or shrink.
+
+### Configuration
+
+Read from `engine_config.json` at project root:
+
+```json
+{
+  "streaming": {
+    "gpu_budget_splats": 10000000,
+    "slab_size_splats": 100000
+  }
+}
+```
+
+Default: 10M splats (100 slabs × 100K splats/slab = 640 MB at 64 bytes/splat).
+
+---
+
+## R2: Async Background Transfer Queue
+
+### Overview
+
+PLY parsing happens on a background `std::thread`. Parsed data is staged into a host-visible ring buffer, then copied to physical slab offsets in the main SSBO. Two paths: dedicated transfer queue (true async) or time-sliced copies on the graphics queue (fallback for MoltenVK/single-queue GPUs).
+
+### New Files
+
+- `include/gseurat/engine/transfer_queue.hpp` — Interface + both path implementations
+- `src/engine/transfer_queue.cpp` — Implementation
+
+### Queue Discovery (VkContext changes)
+
+At device creation:
+
+1. Enumerate queue families.
+2. Look for a family with `VK_QUEUE_TRANSFER_BIT` but **not** `VK_QUEUE_GRAPHICS_BIT`.
+3. If found → request a queue from that family → `DedicatedTransferPath`.
+4. If not found → `FallbackTransferPath` (time-sliced on graphics queue).
+5. Store: `transfer_queue_`, `transfer_queue_family_`, `has_dedicated_transfer_`.
+
+### TransferQueue Interface
+
+```cpp
+class TransferQueue {
+public:
+    void submit(StagingRegion region, uint64_t dest_offset, uint64_t size,
+                std::function<void()> on_complete);
+    void poll_completions();  // called once per frame from main loop
+    bool is_dedicated() const;
+};
+```
+
+### Path A — Dedicated Transfer Queue (Fence-Based, Non-Blocking)
+
+- Own `VkCommandPool` + `VkCommandBuffer` on the transfer family.
+- `submit()`: record `vkCmdCopyBuffer(staging → main SSBO)`, submit to transfer queue with a **`VkFence`** (no semaphore).
+- **Graphics queue never waits** — continues rendering existing active chunks at full frame rate with zero awareness of in-flight transfers.
+- `poll_completions()` (called each frame on main thread): calls `vkGetFenceStatus(fence)` — non-blocking check:
+  - `VK_NOT_READY` → transfer still in flight, do nothing.
+  - `VK_SUCCESS` → transfer complete:
+    1. Update `page_table_ssbo_` with the new chunk's slab mappings.
+    2. Update `chunk_table_ssbo_` to register the chunk as active.
+    3. Increment active splat count so preprocess dispatches the new range.
+    4. Reset fence for reuse.
+    5. Fire `on_complete` callback.
+- New chunk appears on the **very next frame** after fence signals — seamless pop-in.
+
+### Path C — Fallback (Time-Sliced on Graphics Queue)
+
+- Maintains a pending queue: `std::deque<TransferChunk>`.
+- Each `TransferChunk` = `{staging_offset, dest_offset, size}`.
+- `poll_completions()` pops up to `transfer_budget_mb_per_frame` (default 4 MB) of chunks, records `vkCmdCopyBuffer` calls into the frame's command buffer before the preprocess dispatch.
+- Uses a `VkFence` per batch to know when staging memory can be reused.
+- Page table updated only after all slabs for a chunk have completed.
+
+### Staging Buffer
+
+- Single host-visible ring buffer (`VMA_MEMORY_USAGE_CPU_TO_GPU`), sized to 2× slab size (double-buffered — write next chunk while previous is in flight).
+- Background thread writes parsed Gaussian data into the ring.
+- Main thread consumes from the ring via copy commands.
+
+### Background Thread Flow
+
+```
+1. std::thread spawned per load request
+2. Parse PLY → vector<GpuGaussian>
+3. For each slab in the SlabHandle:
+   a. Wait for staging ring space
+   b. memcpy slab's worth of GpuGaussians into staging buffer
+   c. Enqueue TransferChunk {staging_offset, physical_slab_offset, slab_bytes}
+4. After all slabs queued → enqueue completion marker
+5. Thread exits
+```
+
+### Synchronization
+
+- `std::mutex` on the transfer chunk deque (producer = background thread, consumer = main thread).
+- Dedicated path: `VkFence` per submission, polled non-blocking via `vkGetFenceStatus`.
+- Fallback path: fence per frame-batch; page table updated only after all slabs for a chunk complete.
+
+### Chunk Lifecycle States
+
+```
+LOADING   → slabs checked out, transfer in flight, not in page table yet
+ACTIVE    → fence signaled, page table updated, rendering
+UNLOADING → removed from page table, slabs released back to free list
+```
+
+### Configuration
+
+```json
+{
+  "streaming": {
+    "transfer_budget_mb_per_frame": 4
+  }
+}
+```
+
+---
+
+## R3: Instances (Rooms) & Portal Extension
+
+### Overview
+
+Add `InstanceData` to Bricklayer as a named scene reference (metadata, no spatial representation). Extend `PortalData` with `target_instance_id`. Update the properties panel for instance management and portal assignment.
+
+### Type Changes (`tools/apps/bricklayer/src/store/types.ts`)
+
+New type:
+
+```typescript
+export interface InstanceData {
+  id: string;           // unique key, e.g. "tavern_interior"
+  display_name: string; // human label, e.g. "Tavern Interior"
+  scene_file: string;   // relative path, e.g. "assets/scenes/tavern.scene.json"
+}
+```
+
+Portal extension:
+
+```typescript
+export interface PortalData {
+  // ... existing fields (id, position, size, spawn_position, spawn_facing)
+  target_scene: string;          // kept for back-compat with legacy scenes
+  target_instance_id?: string;   // NEW — references InstanceData.id
+}
+```
+
+BricklayerFile scene block gains:
+
+```typescript
+instances?: InstanceData[];
+```
+
+### Store Changes (`useSceneStore.ts`)
+
+- State: `instances: InstanceData[]`
+- Actions: `addInstance()`, `updateInstance(id, patch)`, `removeInstance(id)`
+- Portal actions unchanged — `updatePortal` already accepts partial patches.
+
+### UI Changes
+
+1. **EntitiesTab** — New "Instances" section below Portals. Lists instances with name + scene file. "+" button to add, click to select for editing.
+
+2. **InstanceProperties** (new component in `ScenePropertiesPanel.tsx`) — Fields: display name (text input), scene file (text input), delete button. Rendered when `selectedEntity.type === 'instance'`.
+
+3. **PortalProperties** — Add a `target_instance_id` dropdown above the existing `target_scene` field. Dropdown lists all defined instances by `display_name`. Selecting one sets `target_instance_id` and clears `target_scene`. A "None (legacy)" option keeps the old `target_scene` behavior.
+
+### Path Validation
+
+`validateScenePaths()` in `tools/apps/bricklayer/src/lib/sceneExport.ts` must also validate every `instance.scene_file` entry. Each instance's `scene_file` is checked as an asset reference (relative path, no absolute paths, resolves against project root). Broken or absolute paths produce a `ScenePathError` entry.
+
+### Migration
+
+Existing scenes with `target_scene` on portals continue to work. The engine checks `target_instance_id` first; if absent, falls back to `target_scene`. No forced migration needed. `instances` field is optional in `BricklayerFile` — absent means empty array.
+
+### No Viewport Changes
+
+Instances are metadata. Portal markers already render in the viewport and don't change.
+
+---
+
+## Acceptance Criteria
+
+1. **Memory Stability:** Running the Staging engine and dynamically loading/unloading 5 different PLY files results in exactly zero new VMA buffer allocations/destructions after the initial `init_streaming()` call.
+
+2. **Frame Rate Stability:** Triggering a new PLY load over the Bridge does not freeze the Staging engine's render loop. Background thread parses PLY, transfer queue uploads to VRAM, page table update makes chunk appear seamlessly.
+
+3. **Editor Support:** In Bricklayer, users can define Instances (named scene references) and assign a `target_instance_id` to any Portal via the properties panel dropdown.
+
+4. **Path Validation:** `validateScenePaths()` catches broken or absolute `instance.scene_file` paths before export.
+
+5. **Backward Compatibility:** Scenes without `instances` or with `target_scene`-only portals continue to load and work without modification.
+
+---
+
+## File Summary
+
+### New Files (C++)
+| File | Purpose |
+|------|---------|
+| `include/gseurat/engine/slab_allocator.hpp` | Free-list slab manager with non-contiguous allocation |
+| `src/engine/slab_allocator.cpp` | Implementation |
+| `include/gseurat/engine/transfer_queue.hpp` | Async transfer interface (dedicated + fallback paths) |
+| `src/engine/transfer_queue.cpp` | Implementation |
+
+### Modified Files (C++)
+| File | Change |
+|------|--------|
+| `src/engine/vk_context.cpp` | Request dedicated transfer queue family if available |
+| `include/gseurat/engine/vk_context.hpp` | Add transfer queue members |
+| `src/engine/gs_renderer.cpp` | Replace destroy/recreate with `init_streaming` + slab checkout/release |
+| `include/gseurat/engine/gs_renderer.hpp` | Add slab allocator, transfer queue, chunk state members |
+| `src/engine/buffer.cpp` | No changes expected (existing `create_storage` reused) |
+| `shaders/gs_preprocess.comp` | Add page table indirection lookup |
+
+### Modified Files (TypeScript)
+| File | Change |
+|------|--------|
+| `tools/apps/bricklayer/src/store/types.ts` | Add `InstanceData`, extend `PortalData` |
+| `tools/apps/bricklayer/src/store/useSceneStore.ts` | Add `instances` state + actions |
+| `tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx` | Add `InstanceProperties`, update `PortalProperties` dropdown |
+| `tools/apps/bricklayer/src/panels/EntitiesTab.tsx` | Add Instances section |
+| `tools/apps/bricklayer/src/lib/sceneExport.ts` | Validate `instance.scene_file` paths |
+
+### Config
+| File | Purpose |
+|------|--------|
+| `engine_config.json` (project root) | `streaming.gpu_budget_splats`, `streaming.slab_size_splats`, `streaming.transfer_budget_mb_per_frame` |

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -5,13 +5,16 @@
 #include "gseurat/engine/pbd_types.hpp"
 #include "gseurat/engine/slab_allocator.hpp"
 #include "gseurat/engine/streaming_config.hpp"
+#include "gseurat/engine/transfer_queue.hpp"
 #include "gseurat/engine/types.hpp"
 
 #include <vk_mem_alloc.h>
 #include <vulkan/vulkan.h>
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
+#include <atomic>
 #include <memory>
+#include <thread>
 #include <vector>
 
 namespace gseurat {
@@ -69,6 +72,10 @@ public:
     void load_cloud(const GaussianCloud& cloud);
     void init_streaming(const StreamingConfig& config);
     void unload_cloud(uint32_t chunk_id);
+    void load_cloud_async(const std::string& ply_path);
+    void poll_transfers(VkCommandBuffer frame_cmd);
+    void create_transfer_queue(VkQueue transfer_q, uint32_t transfer_family,
+                               bool dedicated, VkQueue graphics_q);
     void update_active_gaussians(const Gaussian* data, uint32_t count);
     void update_gaussian_data(const Gaussian* data, uint32_t count);
 
@@ -272,6 +279,11 @@ private:
     std::vector<ChunkState> active_chunks_;
     uint32_t total_active_splats_{0};
     bool streaming_initialized_{false};
+
+    // Async transfer + background loading
+    std::unique_ptr<TransferQueue> transfer_queue_;
+    std::vector<std::thread> load_threads_;
+    std::atomic<uint32_t> pending_loads_{0};
 
     uint32_t gaussian_count_ = 0;
     uint32_t max_gaussian_count_ = 0;

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -3,12 +3,15 @@
 #include "gseurat/engine/buffer.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/pbd_types.hpp"
+#include "gseurat/engine/slab_allocator.hpp"
+#include "gseurat/engine/streaming_config.hpp"
 #include "gseurat/engine/types.hpp"
 
 #include <vk_mem_alloc.h>
 #include <vulkan/vulkan.h>
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
+#include <memory>
 #include <vector>
 
 namespace gseurat {
@@ -64,6 +67,8 @@ class GsRenderer {
 public:
     void init(VkDevice device, VmaAllocator allocator, VkDescriptorPool pool);
     void load_cloud(const GaussianCloud& cloud);
+    void init_streaming(const StreamingConfig& config);
+    void unload_cloud(uint32_t chunk_id);
     void update_active_gaussians(const Gaussian* data, uint32_t count);
     void update_gaussian_data(const Gaussian* data, uint32_t count);
 
@@ -186,6 +191,7 @@ private:
     void dispatch_radix_sort(VkCommandBuffer cmd, uint32_t sort_size, uint32_t num_workgroups,
         VkDescriptorSet hist_a, VkDescriptorSet hist_b, VkDescriptorSet scan,
         VkDescriptorSet scatter_ab, VkDescriptorSet scatter_ba);
+    void load_cloud_legacy(const GaussianCloud& cloud);
 
     VkDevice device_ = VK_NULL_HANDLE;
     VmaAllocator allocator_ = VK_NULL_HANDLE;
@@ -249,6 +255,23 @@ private:
     uint32_t static_sort_workgroups_ = 0;
     uint32_t dynamic_sort_workgroups_ = 0;
     bool static_dirty_ = true;
+
+    // --- Streaming architecture (Phase 2) ---
+    StreamingConfig streaming_config_;
+    std::unique_ptr<SlabAllocator> slab_allocator_;
+    Buffer page_table_ssbo_;
+    Buffer chunk_table_ssbo_;
+
+    struct ChunkState {
+        enum class Status { LOADING, ACTIVE, UNLOADING };
+        Status status;
+        SlabAllocator::SlabHandle handle;
+        uint32_t page_table_offset;
+        uint32_t splat_count;
+    };
+    std::vector<ChunkState> active_chunks_;
+    uint32_t total_active_splats_{0};
+    bool streaming_initialized_{false};
 
     uint32_t gaussian_count_ = 0;
     uint32_t max_gaussian_count_ = 0;

--- a/include/gseurat/engine/slab_allocator.hpp
+++ b/include/gseurat/engine/slab_allocator.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace gseurat {
+
+class SlabAllocator {
+public:
+    struct SlabHandle {
+        uint32_t chunk_id;
+        std::vector<uint32_t> slab_indices;
+    };
+
+    SlabAllocator(uint32_t total_slabs, uint32_t splats_per_slab);
+
+    SlabHandle checkout(uint32_t slab_count);
+    void release(const SlabHandle& handle);
+
+    uint32_t available() const;
+    uint32_t total_slabs() const { return total_slabs_; }
+    uint32_t splats_per_slab() const { return splats_per_slab_; }
+
+private:
+    uint32_t total_slabs_;
+    uint32_t splats_per_slab_;
+    uint32_t next_chunk_id_{0};
+    std::vector<uint32_t> free_list_;
+};
+
+}  // namespace gseurat

--- a/include/gseurat/engine/slab_allocator.hpp
+++ b/include/gseurat/engine/slab_allocator.hpp
@@ -27,6 +27,7 @@ private:
     uint32_t splats_per_slab_;
     uint32_t next_chunk_id_{0};
     std::vector<uint32_t> free_list_;
+    std::vector<bool> in_use_;
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/streaming_config.hpp
+++ b/include/gseurat/engine/streaming_config.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+namespace gseurat {
+
+struct StreamingConfig {
+    uint32_t gpu_budget_splats = 10'000'000;
+    uint32_t slab_size_splats = 100'000;
+    uint32_t transfer_budget_mb_per_frame = 4;
+
+    uint32_t total_slabs() const { return gpu_budget_splats / slab_size_splats; }
+    uint64_t total_bytes() const { return static_cast<uint64_t>(gpu_budget_splats) * 64; }
+    uint64_t slab_bytes() const { return static_cast<uint64_t>(slab_size_splats) * 64; }
+
+    static StreamingConfig load(const std::string& project_root) {
+        StreamingConfig cfg;
+        const auto path = project_root + "/engine_config.json";
+        std::ifstream f(path);
+        if (!f.is_open()) return cfg;
+        try {
+            nlohmann::json j;
+            f >> j;
+            if (j.contains("streaming")) {
+                auto& s = j["streaming"];
+                if (s.contains("gpu_budget_splats"))
+                    cfg.gpu_budget_splats = s["gpu_budget_splats"].get<uint32_t>();
+                if (s.contains("slab_size_splats"))
+                    cfg.slab_size_splats = s["slab_size_splats"].get<uint32_t>();
+                if (s.contains("transfer_budget_mb_per_frame"))
+                    cfg.transfer_budget_mb_per_frame = s["transfer_budget_mb_per_frame"].get<uint32_t>();
+            }
+        } catch (...) {
+            // Malformed config — use defaults
+        }
+        return cfg;
+    }
+};
+
+}  // namespace gseurat

--- a/include/gseurat/engine/transfer_queue.hpp
+++ b/include/gseurat/engine/transfer_queue.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <vector>
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+#include "gseurat/engine/buffer.hpp"
+
+namespace gseurat {
+
+struct TransferChunk {
+    uint64_t staging_offset;
+    uint64_t dest_offset;
+    uint64_t size;
+    std::function<void()> on_complete;
+    bool is_completion_marker{false};
+};
+
+class TransferQueue {
+public:
+    TransferQueue(VkDevice device, VmaAllocator allocator,
+                  VkQueue transfer_queue, uint32_t transfer_family,
+                  bool dedicated, uint64_t staging_size,
+                  uint32_t transfer_budget_mb,
+                  VkBuffer dest_buffer);
+
+    ~TransferQueue();
+
+    // Not copyable or movable — owns Vulkan handles
+    TransferQueue(const TransferQueue&) = delete;
+    TransferQueue& operator=(const TransferQueue&) = delete;
+    TransferQueue(TransferQueue&&) = delete;
+    TransferQueue& operator=(TransferQueue&&) = delete;
+
+    // Enqueue a copy from staging_offset -> dest_offset of the given size.
+    // on_complete is called once the GPU copy has finished.
+    void enqueue(uint64_t staging_offset, uint64_t dest_offset,
+                 uint64_t size, std::function<void()> on_complete = nullptr);
+
+    // Enqueue a callback with no associated copy (fires after all preceding copies finish).
+    void enqueue_completion(std::function<void()> on_complete);
+
+    // Called once per frame. Checks for completed transfers and fires callbacks.
+    // frame_cmd is used on the fallback (graphics-queue) path only.
+    void poll_completions(VkCommandBuffer frame_cmd);
+
+    void* staging_mapped() const { return staging_buffer_.mapped(); }
+    uint64_t staging_size() const { return staging_size_; }
+    bool is_dedicated() const { return dedicated_; }
+
+    void shutdown();
+
+private:
+    VkDevice device_;
+    VmaAllocator allocator_;
+    VkQueue transfer_queue_;
+    uint32_t transfer_family_;
+    bool dedicated_;
+    uint64_t staging_size_;
+    uint64_t transfer_budget_bytes_;
+    VkBuffer dest_buffer_;  // not owned — reference to main Gaussian SSBO
+
+    Buffer staging_buffer_;
+
+    // Dedicated transfer path
+    VkCommandPool transfer_cmd_pool_{VK_NULL_HANDLE};
+    VkCommandBuffer transfer_cmd_{VK_NULL_HANDLE};
+    VkFence transfer_fence_{VK_NULL_HANDLE};
+    bool transfer_in_flight_{false};
+
+    // Pending transfer queue (thread-safe)
+    std::mutex queue_mutex_;
+    std::deque<TransferChunk> pending_chunks_;
+
+    struct InFlightBatch {
+        VkFence fence;
+        std::vector<std::function<void()>> callbacks;
+    };
+    std::deque<InFlightBatch> in_flight_;
+};
+
+}  // namespace gseurat

--- a/include/gseurat/engine/vk_context.hpp
+++ b/include/gseurat/engine/vk_context.hpp
@@ -18,6 +18,9 @@ public:
     VkPhysicalDevice physical_device() const { return physical_device_; }
     VkQueue graphics_queue() const { return graphics_queue_; }
     uint32_t graphics_queue_family() const { return graphics_queue_family_; }
+    VkQueue transfer_queue() const { return transfer_queue_; }
+    uint32_t transfer_queue_family() const { return transfer_queue_family_; }
+    bool has_dedicated_transfer() const { return has_dedicated_transfer_; }
     VkSurfaceKHR surface() const { return surface_; }
     VmaAllocator allocator() const { return allocator_; }
 
@@ -39,6 +42,9 @@ private:
     VkDevice device_ = VK_NULL_HANDLE;
     VkQueue graphics_queue_ = VK_NULL_HANDLE;
     uint32_t graphics_queue_family_ = 0;
+    VkQueue transfer_queue_{VK_NULL_HANDLE};
+    uint32_t transfer_queue_family_{0};
+    bool has_dedicated_transfer_{false};
     VmaAllocator allocator_ = VK_NULL_HANDLE;
 };
 

--- a/shaders/gs_preprocess.comp
+++ b/shaders/gs_preprocess.comp
@@ -78,11 +78,26 @@ layout(set = 0, binding = 6) readonly buffer PbdBuffer {
     PbdState pbd_states[];
 };
 
+layout(set = 0, binding = 8) readonly buffer PageTableBuffer {
+    uint page_table[];
+};
+
 layout(push_constant) uniform PushConstants {
     uint projected_offset;  // 0 for static, max_static_count for dynamic
     uint gaussian_count;    // number of Gaussians in this layer
     uint counts_index;      // 0 for static, 1 for dynamic
 };
+
+layout(constant_id = 0) const uint SPLATS_PER_SLAB = 100000;
+layout(constant_id = 1) const uint USE_PAGE_TABLE = 0;
+
+uint resolve_physical_index(uint logical_idx) {
+    if (USE_PAGE_TABLE == 0u) return logical_idx;
+    uint slab_logical = logical_idx / SPLATS_PER_SLAB;
+    uint offset_in_slab = logical_idx % SPLATS_PER_SLAB;
+    uint physical_slab = page_table[slab_logical];
+    return physical_slab * SPLATS_PER_SLAB + offset_in_slab;
+}
 
 // Simple hash for per-Gaussian variation
 float hash_uint(uint n) {
@@ -139,7 +154,8 @@ void main() {
     uint idx = gl_GlobalInvocationID.x;
     if (idx >= gaussian_count) return;
 
-    GpuGaussian g = gaussians[idx];
+    uint physical_idx = resolve_physical_index(idx);
+    GpuGaussian g = gaussians[physical_idx];
     vec3 pos = g.pos_opacity.xyz;
     float opacity = g.pos_opacity.w;
     vec3 col = g.color_pad.rgb;

--- a/shaders/gs_render.comp
+++ b/shaders/gs_render.comp
@@ -88,7 +88,7 @@ void main() {
     uint height = params.y;
     uint count = static_count + dynamic_count;  // compute directly, bypass merge shader's thread 0 write
 
-    if (pixel.x >= width || pixel.y >= height) return;
+    bool valid_pixel = (pixel.x < width && pixel.y < height);
 
     vec2 pix_center = vec2(pixel) + 0.5;
 
@@ -103,8 +103,8 @@ void main() {
     float first_hit_depth = 0.0;
     bool has_first_hit = false;
 
-    // Iterate through sorted Gaussians
-    for (uint s = 0; s < count; ++s) {
+    // Iterate through sorted Gaussians (only for valid pixels)
+    for (uint s = 0; s < (valid_pixel ? count : 0u); ++s) {
         uint idx = merged_entries[s].index;
 
         // Culled Gaussians (key == 0xFFFF) are sorted to the end — stop immediately
@@ -168,15 +168,15 @@ void main() {
     }
 
     // Store depth in shared memory for tile-based effects
-    tile_depth[local_id.y][local_id.x] = has_first_hit ? first_hit_depth : 0.0;
-    barrier();
+    tile_depth[local_id.y][local_id.x] = (valid_pixel && has_first_hit) ? first_hit_depth : 0.0;
+    barrier();  // ALL invocations in workgroup must reach this
 
     // Apply post-processing effects if any are active
     float toon_bands = effect_flags.x;
     float light_mode = effect_flags.y;
 
     float non_emissive_alpha = alpha_accum - emission_alpha;
-    if (non_emissive_alpha > 0.001 && (light_mode > 0.5 || toon_bands > 0.5)) {
+    if (valid_pixel && non_emissive_alpha > 0.001 && (light_mode > 0.5 || toon_bands > 0.5)) {
         // Un-premultiply non-emissive color only for lighting
         vec3 base_color = color / max(non_emissive_alpha, 0.001);
 
@@ -344,7 +344,7 @@ void main() {
     }
 
     // --- X-Ray color treatment ---
-    if (xray_depth > 0.0 && alpha_accum > 0.001) {
+    if (valid_pixel && xray_depth > 0.0 && alpha_accum > 0.001) {
         vec3 base = color / max(alpha_accum, 0.001);
         float lum = dot(base, vec3(0.299, 0.587, 0.114));
         // Blue-green medical-scan tint
@@ -359,6 +359,8 @@ void main() {
     color += emission;
 
     // Write output (premultiplied alpha) + depth for post-processing
-    imageStore(output_image, ivec2(pixel), vec4(color, alpha_accum));
-    imageStore(depth_image, ivec2(pixel), vec4(first_hit_depth, 0.0, 0.0, 0.0));
+    if (valid_pixel) {
+        imageStore(output_image, ivec2(pixel), vec4(color, alpha_accum));
+        imageStore(depth_image, ivec2(pixel), vec4(first_hit_depth, 0.0, 0.0, 0.0));
+    }
 }

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -480,7 +480,293 @@ void GsRenderer::create_compute_pipelines() {
                     radix_scatter_pipeline_layout_, radix_scatter_pipeline_);
 }
 
+void GsRenderer::init_streaming(const StreamingConfig& config) {
+    streaming_config_ = config;
+    slab_allocator_ = std::make_unique<SlabAllocator>(config.total_slabs(), config.slab_size_splats);
+
+    // Wait for GPU before destroying existing buffers
+    if (initialized_) {
+        vkDeviceWaitIdle(device_);
+    }
+
+    sort_done_once_ = false;
+    static_dirty_ = true;
+
+    // Pre-allocate ALL buffers to full budget size
+    max_static_count_ = config.gpu_budget_splats;
+    max_dynamic_count_ = kDynamicHeadroom;
+    static_count_ = 0;
+    dynamic_count_ = 0;
+    gaussian_count_ = 0;
+    max_gaussian_count_ = max_static_count_ + max_dynamic_count_;
+
+    // Compute sort params
+    auto compute_sort_params = [](uint32_t max_count, uint32_t& sort_size, uint32_t& num_wg) {
+        sort_size = ((max_count + 1023) / 1024) * 1024;
+        if (sort_size < max_count) sort_size = max_count;
+        num_wg = sort_size / 1024;
+        if (num_wg == 0) num_wg = 1;
+        sort_size = num_wg * 1024;
+    };
+
+    compute_sort_params(max_static_count_, static_sort_size_, static_sort_workgroups_);
+    compute_sort_params(max_dynamic_count_, dynamic_sort_size_, dynamic_sort_workgroups_);
+    sort_size_ = static_sort_size_;
+    num_sort_workgroups_ = static_sort_workgroups_;
+
+    // Buffer sizes
+    VkDeviceSize static_gauss_size = static_cast<VkDeviceSize>(max_static_count_) * sizeof(GpuGaussian);
+    VkDeviceSize dynamic_gauss_size = static_cast<VkDeviceSize>(max_dynamic_count_) * sizeof(GpuGaussian);
+    VkDeviceSize projected_buf_size = static_cast<VkDeviceSize>(max_static_count_ + max_dynamic_count_) * sizeof(ProjectedSplat);
+    VkDeviceSize static_sort_buf_size = static_cast<VkDeviceSize>(static_sort_size_) * sizeof(SortEntry);
+    VkDeviceSize dynamic_sort_buf_size = static_cast<VkDeviceSize>(dynamic_sort_size_) * sizeof(SortEntry);
+    VkDeviceSize merged_sort_buf_size = static_cast<VkDeviceSize>(max_static_count_ + max_dynamic_count_) * sizeof(SortEntry);
+    VkDeviceSize static_hist_size = static_cast<VkDeviceSize>(256) * static_sort_workgroups_ * sizeof(uint32_t);
+    VkDeviceSize dynamic_hist_size = static_cast<VkDeviceSize>(256) * dynamic_sort_workgroups_ * sizeof(uint32_t);
+
+    // Destroy ALL old buffers (legacy + split)
+    gaussian_ssbo_.destroy(allocator_);
+    projected_ssbo_.destroy(allocator_);
+    sort_keys_ssbo_.destroy(allocator_);
+    sort_b_ssbo_.destroy(allocator_);
+    histogram_ssbo_.destroy(allocator_);
+    uniform_buffer_.destroy(allocator_);
+    visible_count_ssbo_.destroy(allocator_);
+    bone_ssbo_.destroy(allocator_);
+    pbd_state_ssbo_.destroy(allocator_);
+    pbd_params_ssbo_.destroy(allocator_);
+    pbd_constraint_ssbo_.destroy(allocator_);
+    pbd_uniform_buffer_.destroy(allocator_);
+    static_gaussian_ssbo_.destroy(allocator_);
+    dynamic_gaussian_ssbo_.destroy(allocator_);
+    static_sort_a_.destroy(allocator_);
+    static_sort_b_.destroy(allocator_);
+    dynamic_sort_a_.destroy(allocator_);
+    dynamic_sort_b_.destroy(allocator_);
+    static_histogram_ssbo_.destroy(allocator_);
+    dynamic_histogram_ssbo_.destroy(allocator_);
+    merged_sort_ssbo_.destroy(allocator_);
+    counts_ssbo_.destroy(allocator_);
+    page_table_ssbo_.destroy(allocator_);
+    chunk_table_ssbo_.destroy(allocator_);
+    pp_ubo_buffer_.destroy(allocator_);
+
+    // Create split buffers at full budget size
+    static_gaussian_ssbo_ = Buffer::create_storage(allocator_, static_gauss_size);
+    dynamic_gaussian_ssbo_ = Buffer::create_storage(allocator_, dynamic_gauss_size);
+    projected_ssbo_ = Buffer::create_storage(allocator_, projected_buf_size);
+    static_sort_a_ = Buffer::create_storage(allocator_, static_sort_buf_size);
+    static_sort_b_ = Buffer::create_storage(allocator_, static_sort_buf_size);
+    dynamic_sort_a_ = Buffer::create_storage(allocator_, dynamic_sort_buf_size);
+    dynamic_sort_b_ = Buffer::create_storage(allocator_, dynamic_sort_buf_size);
+    static_histogram_ssbo_ = Buffer::create_storage(allocator_, static_hist_size);
+    dynamic_histogram_ssbo_ = Buffer::create_storage(allocator_, dynamic_hist_size);
+    merged_sort_ssbo_ = Buffer::create_storage(allocator_, merged_sort_buf_size);
+    counts_ssbo_ = Buffer::create_storage_readback(allocator_, 3 * sizeof(uint32_t));
+    uniform_buffer_ = Buffer::create_uniform(allocator_, sizeof(GsUniforms));
+    visible_count_ssbo_ = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
+
+    // Legacy buffers (same sizes as static counterparts for backward compat)
+    gaussian_ssbo_ = Buffer::create_storage(allocator_,
+        static_cast<VkDeviceSize>(max_gaussian_count_) * sizeof(GpuGaussian));
+    sort_keys_ssbo_ = Buffer::create_storage(allocator_, static_sort_buf_size);
+    sort_b_ssbo_ = Buffer::create_storage(allocator_, static_sort_buf_size);
+    histogram_ssbo_ = Buffer::create_storage(allocator_, static_hist_size);
+
+    // Bone transform SSBO
+    bone_ssbo_ = Buffer::create_storage(allocator_, kMaxBones * sizeof(glm::mat4));
+    bone_count_ = 0;
+    {
+        auto* bones = static_cast<glm::mat4*>(bone_ssbo_.mapped());
+        for (uint32_t i = 0; i < kMaxBones; ++i) bones[i] = glm::mat4(1.0f);
+    }
+
+    // PBD buffers
+    pbd_state_ssbo_ = Buffer::create_storage(allocator_,
+        kMaxPbdElements * sizeof(PbdPhysicsState));
+    pbd_params_ssbo_ = Buffer::create_storage(allocator_,
+        kMaxPbdElements * sizeof(PbdElementParams));
+    pbd_constraint_ssbo_ = Buffer::create_storage(allocator_,
+        kMaxPbdConstraints * sizeof(PbdConstraint));
+    pbd_count_ = 0;
+    pbd_constraint_count_ = 0;
+    {
+        auto* states = static_cast<PbdPhysicsState*>(pbd_state_ssbo_.mapped());
+        for (uint32_t i = 0; i < kMaxPbdElements; ++i) {
+            states[i].position = glm::vec4(0.0f, 0.0f, 0.0f, 0.0f);
+            states[i].prev_position = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
+            states[i].velocity = glm::vec4(0.0f);
+            states[i].params = glm::vec4(0.0f);
+        }
+        std::memset(pbd_params_ssbo_.mapped(), 0,
+                    kMaxPbdElements * sizeof(PbdElementParams));
+        std::memset(pbd_constraint_ssbo_.mapped(), 0,
+                    kMaxPbdConstraints * sizeof(PbdConstraint));
+    }
+    pbd_uniform_buffer_ = Buffer::create_uniform(allocator_, 32);
+    pp_ubo_buffer_ = Buffer::create_uniform(allocator_, sizeof(GsPostProcessUbo));
+
+    // Page table: one uint32 per slab, initialized to 0xFFFFFFFF (invalid)
+    page_table_ssbo_ = Buffer::create_storage(allocator_,
+        static_cast<VkDeviceSize>(config.total_slabs()) * sizeof(uint32_t));
+    std::memset(page_table_ssbo_.mapped(), 0xFF,
+                config.total_slabs() * sizeof(uint32_t));
+
+    // Chunk table: 256 entries x 16 bytes each, zeroed
+    chunk_table_ssbo_ = Buffer::create_storage(allocator_, 256 * 16);
+    std::memset(chunk_table_ssbo_.mapped(), 0, 256 * 16);
+
+    // Zero the counts buffer
+    {
+        auto* counts = static_cast<uint32_t*>(counts_ssbo_.mapped());
+        counts[0] = 0;
+        counts[1] = 0;
+        counts[2] = 0;
+    }
+
+    active_chunks_.clear();
+    total_active_splats_ = 0;
+    streaming_initialized_ = true;
+    initialized_ = true;
+
+    update_descriptors();
+
+    std::fprintf(stderr, "GS: Streaming initialized — budget=%u splats, %u slabs of %u\n",
+                 config.gpu_budget_splats, config.total_slabs(), config.slab_size_splats);
+}
+
 void GsRenderer::load_cloud(const GaussianCloud& cloud) {
+    if (!streaming_initialized_) {
+        load_cloud_legacy(cloud);
+        return;
+    }
+
+    if (cloud.empty()) return;
+
+    // Wait for GPU before writing to buffers
+    if (initialized_) {
+        vkDeviceWaitIdle(device_);
+    }
+
+    sort_done_once_ = false;
+    static_dirty_ = true;
+
+    uint32_t sps = streaming_config_.slab_size_splats;
+    uint32_t slabs_needed = (cloud.count() + sps - 1) / sps;
+    auto handle = slab_allocator_->checkout(slabs_needed);
+
+    // Calculate page table offset from existing chunks
+    uint32_t page_table_offset = 0;
+    for (const auto& chunk : active_chunks_) {
+        page_table_offset += static_cast<uint32_t>(chunk.handle.slab_indices.size());
+    }
+
+    // Write page table entries
+    auto* pt = static_cast<uint32_t*>(page_table_ssbo_.mapped());
+    for (uint32_t i = 0; i < slabs_needed; ++i) {
+        pt[page_table_offset + i] = handle.slab_indices[i];
+    }
+
+    // Write Gaussian data into physical slab locations
+    {
+        auto* gpu = static_cast<GpuGaussian*>(static_gaussian_ssbo_.mapped());
+        for (uint32_t slab_idx = 0; slab_idx < slabs_needed; ++slab_idx) {
+            uint32_t phys_slab = handle.slab_indices[slab_idx];
+            uint32_t base_src = slab_idx * sps;
+            uint32_t base_dst = phys_slab * sps;
+            uint32_t count_in_slab = std::min(sps, cloud.count() - base_src);
+
+            std::vector<GpuGaussian> staging(count_in_slab);
+            for (uint32_t i = 0; i < count_in_slab; ++i) {
+                const auto& g = cloud.gaussians()[base_src + i];
+                float bone_as_float;
+                uint32_t bone_idx = g.bone_index;
+                std::memcpy(&bone_as_float, &bone_idx, sizeof(float));
+                staging[i].pos_opacity = glm::vec4(g.position, g.opacity);
+                staging[i].scale_pad = glm::vec4(g.scale, bone_as_float);
+                staging[i].rot = glm::vec4(g.rotation.x, g.rotation.y, g.rotation.z, g.rotation.w);
+                staging[i].color_pad = glm::vec4(g.color, g.emission);
+            }
+            std::memcpy(gpu + base_dst, staging.data(), count_in_slab * sizeof(GpuGaussian));
+        }
+    }
+
+    // Write chunk table entry
+    {
+        auto* ct = static_cast<uint8_t*>(chunk_table_ssbo_.mapped());
+        uint32_t chunk_idx = static_cast<uint32_t>(active_chunks_.size());
+        uint32_t last_slab_splats = cloud.count() - (slabs_needed - 1) * sps;
+        uint32_t entry[4] = {page_table_offset, slabs_needed, last_slab_splats, cloud.count()};
+        std::memcpy(ct + chunk_idx * 16, entry, 16);
+    }
+
+    // Record chunk state
+    ChunkState cs;
+    cs.status = ChunkState::Status::ACTIVE;
+    cs.handle = std::move(handle);
+    cs.page_table_offset = page_table_offset;
+    cs.splat_count = cloud.count();
+    active_chunks_.push_back(std::move(cs));
+
+    // Recalculate total static count
+    static_count_ = 0;
+    for (const auto& chunk : active_chunks_) {
+        static_count_ += chunk.splat_count;
+    }
+    total_active_splats_ = static_count_;
+    gaussian_count_ = static_count_;
+
+    // Initialize sort buffers with sentinel keys
+    auto init_sort_buf = [](Buffer& buf, uint32_t sort_size, uint32_t valid_count) {
+        std::vector<SortEntry> staging(sort_size);
+        for (uint32_t i = 0; i < sort_size; ++i) {
+            staging[i].key = 0xFFFFFFFF;
+            staging[i].index = i < valid_count ? i : 0;
+        }
+        std::memcpy(buf.mapped(), staging.data(), sort_size * sizeof(SortEntry));
+    };
+    init_sort_buf(static_sort_a_, static_sort_size_, static_count_);
+    init_sort_buf(static_sort_b_, static_sort_size_, static_count_);
+
+    static_dirty_ = true;
+
+    std::fprintf(stderr, "GS: Loaded chunk %u — %u splats in %u slabs (total active: %u)\n",
+                 active_chunks_.back().handle.chunk_id, cloud.count(), slabs_needed, static_count_);
+}
+
+void GsRenderer::unload_cloud(uint32_t chunk_id) {
+    if (!streaming_initialized_) return;
+    auto it = std::find_if(active_chunks_.begin(), active_chunks_.end(),
+        [chunk_id](const ChunkState& c) { return c.handle.chunk_id == chunk_id; });
+    if (it == active_chunks_.end()) return;
+
+    // Invalidate page table entries
+    auto* pt = static_cast<uint32_t*>(page_table_ssbo_.mapped());
+    for (uint32_t i = 0; i < it->handle.slab_indices.size(); ++i) {
+        pt[it->page_table_offset + i] = 0xFFFFFFFF;
+    }
+    slab_allocator_->release(it->handle);
+    active_chunks_.erase(it);
+
+    // Rebuild chunk table and recalculate counts
+    auto* ct = static_cast<uint8_t*>(chunk_table_ssbo_.mapped());
+    uint32_t sps = streaming_config_.slab_size_splats;
+    static_count_ = 0;
+    for (size_t i = 0; i < active_chunks_.size(); ++i) {
+        auto& c = active_chunks_[i];
+        uint32_t nslabs = static_cast<uint32_t>(c.handle.slab_indices.size());
+        uint32_t last_slab_splats = c.splat_count - (nslabs - 1) * sps;
+        uint32_t entry[4] = {c.page_table_offset, nslabs, last_slab_splats, c.splat_count};
+        std::memcpy(ct + i * 16, entry, 16);
+        static_count_ += c.splat_count;
+    }
+    std::memset(ct + active_chunks_.size() * 16, 0, (256 - active_chunks_.size()) * 16);
+    total_active_splats_ = static_count_;
+    gaussian_count_ = static_count_;
+    static_dirty_ = true;
+}
+
+void GsRenderer::load_cloud_legacy(const GaussianCloud& cloud) {
     if (cloud.empty()) return;
 
     // Wait for GPU before destroying existing buffers
@@ -1649,6 +1935,13 @@ void GsRenderer::set_point_lights(const std::vector<PointLight>& lights) {
 
 void GsRenderer::shutdown(VmaAllocator allocator) {
     if (!initialized_) return;
+
+    // Streaming resources
+    page_table_ssbo_.destroy(allocator);
+    chunk_table_ssbo_.destroy(allocator);
+    slab_allocator_.reset();
+    active_chunks_.clear();
+    streaming_initialized_ = false;
 
     // Legacy buffers
     gaussian_ssbo_.destroy(allocator);

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -228,10 +228,11 @@ void GsRenderer::create_descriptor_resources() {
             {4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
             {5, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
             {6, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},  // PBD
+            {8, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},  // Page table
         };
         VkDescriptorSetLayoutCreateInfo ci{};
         ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        ci.bindingCount = 7;
+        ci.bindingCount = 8;
         ci.pBindings = bindings;
         vkCreateDescriptorSetLayout(device_, &ci, nullptr, &preprocess_layout_);
     }
@@ -1045,6 +1046,14 @@ void GsRenderer::load_cloud_legacy(const GaussianCloud& cloud) {
         counts[2] = 0;
     }
 
+    // Allocate a dummy page table buffer for binding 8 (legacy path, USE_PAGE_TABLE=0)
+    page_table_ssbo_.destroy(allocator_);
+    page_table_ssbo_ = Buffer::create_storage(allocator_, sizeof(uint32_t));
+    {
+        auto* pt = static_cast<uint32_t*>(page_table_ssbo_.mapped());
+        pt[0] = 0xFFFFFFFF;
+    }
+
     update_descriptors();
 }
 
@@ -1255,7 +1264,7 @@ void GsRenderer::clear_bone_transforms() {
 }
 
 void GsRenderer::update_descriptors() {
-    // Preprocess set: gaussians(0), projected(1), sort_keys_A(2), uniforms(3), visible_count(4), bones(5), pbd(6)
+    // Preprocess set: gaussians(0), projected(1), sort_keys_A(2), uniforms(3), visible_count(4), bones(5), pbd(6), page_table(8)
     {
         VkDescriptorBufferInfo gaussian_info{gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
@@ -1264,6 +1273,7 @@ void GsRenderer::update_descriptors() {
         VkDescriptorBufferInfo visible_count_info{visible_count_ssbo_.buffer(), 0, sizeof(uint32_t)};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo pbd_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo page_table_info{page_table_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
         VkWriteDescriptorSet writes[] = {
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 0, 0, 1,
@@ -1280,8 +1290,10 @@ void GsRenderer::update_descriptors() {
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &bone_info, nullptr},
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 6, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 8, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &page_table_info, nullptr},
         };
-        vkUpdateDescriptorSets(device_, 7, writes, 0, nullptr);
+        vkUpdateDescriptorSets(device_, 8, writes, 0, nullptr);
     }
 
     // Legacy sort set
@@ -1415,7 +1427,7 @@ void GsRenderer::update_descriptors() {
     // Only write these if the split buffers have been allocated
     if (!static_gaussian_ssbo_.buffer() || !counts_ssbo_.buffer()) return;
 
-    // Static preprocess set: static_gaussian(0), projected(1), static_sort_a(2), uniforms(3), counts[0](4), bones(5), pbd(6)
+    // Static preprocess set: static_gaussian(0), projected(1), static_sort_a(2), uniforms(3), counts[0](4), bones(5), pbd(6), page_table(8)
     {
         VkDescriptorBufferInfo gaussian_info{static_gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
@@ -1424,6 +1436,7 @@ void GsRenderer::update_descriptors() {
         VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo pbd_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo page_table_info{page_table_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
         VkWriteDescriptorSet writes[] = {
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 0, 0, 1,
@@ -1440,11 +1453,13 @@ void GsRenderer::update_descriptors() {
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &bone_info, nullptr},
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 6, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 8, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &page_table_info, nullptr},
         };
-        vkUpdateDescriptorSets(device_, 7, writes, 0, nullptr);
+        vkUpdateDescriptorSets(device_, 8, writes, 0, nullptr);
     }
 
-    // Dynamic preprocess set: dynamic_gaussian(0), projected(1), dynamic_sort_a(2), uniforms(3), counts[1](4), bones(5), pbd(6)
+    // Dynamic preprocess set: dynamic_gaussian(0), projected(1), dynamic_sort_a(2), uniforms(3), counts[1](4), bones(5), pbd(6), page_table(8)
     {
         VkDescriptorBufferInfo gaussian_info{dynamic_gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
@@ -1453,6 +1468,7 @@ void GsRenderer::update_descriptors() {
         VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo pbd_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo page_table_info{page_table_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
         VkWriteDescriptorSet writes[] = {
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 0, 0, 1,
@@ -1469,8 +1485,10 @@ void GsRenderer::update_descriptors() {
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &bone_info, nullptr},
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 6, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 8, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &page_table_info, nullptr},
         };
-        vkUpdateDescriptorSets(device_, 7, writes, 0, nullptr);
+        vkUpdateDescriptorSets(device_, 8, writes, 0, nullptr);
     }
 
     // PBD solver descriptor set: pbd_states(0), pbd_params(1), pbd_constraints(2), pbd_uniforms(3)

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -766,6 +766,111 @@ void GsRenderer::unload_cloud(uint32_t chunk_id) {
     static_dirty_ = true;
 }
 
+void GsRenderer::create_transfer_queue(VkQueue transfer_q, uint32_t transfer_family,
+                                        bool dedicated, VkQueue graphics_q) {
+    if (!streaming_initialized_) return;
+    const uint64_t staging_size = streaming_config_.slab_bytes() * 2;  // double-buffered
+    transfer_queue_ = std::make_unique<TransferQueue>(
+        device_, allocator_,
+        transfer_q, transfer_family,
+        dedicated, staging_size,
+        streaming_config_.transfer_budget_mb_per_frame,
+        static_gaussian_ssbo_.buffer());
+}
+
+void GsRenderer::load_cloud_async(const std::string& ply_path) {
+    if (!streaming_initialized_ || !transfer_queue_) {
+        // Fall back to synchronous load
+        GaussianCloud cloud;
+        cloud.load_ply(ply_path);
+        load_cloud(cloud);
+        return;
+    }
+
+    pending_loads_++;
+
+    load_threads_.emplace_back([this, ply_path]() {
+        GaussianCloud cloud;
+        cloud.load_ply(ply_path);
+
+        const uint32_t splat_count = cloud.count();
+        const uint32_t sps = streaming_config_.slab_size_splats;
+        const uint32_t slabs_needed = (splat_count + sps - 1) / sps;
+
+        auto handle = slab_allocator_->checkout(slabs_needed);
+
+        const auto& gaussians = cloud.gaussians();
+        auto* staging = static_cast<uint8_t*>(transfer_queue_->staging_mapped());
+        const uint64_t slab_bytes = static_cast<uint64_t>(sps) * sizeof(GpuGaussian);
+
+        for (uint32_t s = 0; s < slabs_needed; ++s) {
+            const uint32_t physical_slab = handle.slab_indices[s];
+            const uint32_t src_start = s * sps;
+            const uint32_t src_end = std::min(src_start + sps, splat_count);
+            const uint32_t count = src_end - src_start;
+
+            // Write into staging buffer (ring: alternate halves)
+            const uint64_t staging_offset = (s % 2) * slab_bytes;
+            auto* dst = reinterpret_cast<GpuGaussian*>(staging + staging_offset);
+            for (uint32_t i = 0; i < count; ++i) {
+                const auto& g = gaussians[src_start + i];
+                float bone_as_float;
+                uint32_t bone_idx = g.bone_index;
+                std::memcpy(&bone_as_float, &bone_idx, sizeof(float));
+                dst[i].pos_opacity = glm::vec4(g.position, g.opacity);
+                dst[i].scale_pad = glm::vec4(g.scale, bone_as_float);
+                dst[i].rot = glm::vec4(g.rotation.x, g.rotation.y, g.rotation.z, g.rotation.w);
+                dst[i].color_pad = glm::vec4(g.color, g.emission);
+            }
+
+            const uint64_t dest_offset = static_cast<uint64_t>(physical_slab) * sps * sizeof(GpuGaussian);
+            const uint64_t copy_size = static_cast<uint64_t>(count) * sizeof(GpuGaussian);
+            transfer_queue_->enqueue(staging_offset, dest_offset, copy_size);
+        }
+
+        // Completion callback — runs on main thread via poll_completions
+        transfer_queue_->enqueue_completion(
+            [this, handle = std::move(handle), splat_count, slabs_needed, sps]() mutable {
+                uint32_t page_table_offset = 0;
+                for (const auto& chunk : active_chunks_) {
+                    page_table_offset += static_cast<uint32_t>(chunk.handle.slab_indices.size());
+                }
+
+                auto* pt = static_cast<uint32_t*>(page_table_ssbo_.mapped());
+                for (uint32_t i = 0; i < slabs_needed; ++i) {
+                    pt[page_table_offset + i] = handle.slab_indices[i];
+                }
+
+                // Update chunk table
+                auto* ct = static_cast<uint8_t*>(chunk_table_ssbo_.mapped());
+                uint32_t chunk_idx = static_cast<uint32_t>(active_chunks_.size());
+                uint32_t last_slab_splats = splat_count - (slabs_needed - 1) * sps;
+                uint32_t entry[4] = {page_table_offset, slabs_needed, last_slab_splats, splat_count};
+                std::memcpy(ct + chunk_idx * 16, entry, 16);
+
+                ChunkState cs;
+                cs.status = ChunkState::Status::ACTIVE;
+                cs.handle = std::move(handle);
+                cs.page_table_offset = page_table_offset;
+                cs.splat_count = splat_count;
+                active_chunks_.push_back(std::move(cs));
+
+                static_count_ = 0;
+                for (const auto& c : active_chunks_) static_count_ += c.splat_count;
+                total_active_splats_ = static_count_;
+                gaussian_count_ = static_count_;
+                static_dirty_ = true;
+
+                pending_loads_--;
+                std::printf("[gs_renderer] Async load complete: %u splats\n", splat_count);
+            });
+    });
+}
+
+void GsRenderer::poll_transfers(VkCommandBuffer frame_cmd) {
+    if (transfer_queue_) transfer_queue_->poll_completions(frame_cmd);
+}
+
 void GsRenderer::load_cloud_legacy(const GaussianCloud& cloud) {
     if (cloud.empty()) return;
 
@@ -1935,6 +2040,16 @@ void GsRenderer::set_point_lights(const std::vector<PointLight>& lights) {
 
 void GsRenderer::shutdown(VmaAllocator allocator) {
     if (!initialized_) return;
+
+    // Join background load threads before destroying resources
+    for (auto& t : load_threads_) {
+        if (t.joinable()) t.join();
+    }
+    load_threads_.clear();
+    if (transfer_queue_) {
+        transfer_queue_->shutdown();
+        transfer_queue_.reset();
+    }
 
     // Streaming resources
     page_table_ssbo_.destroy(allocator);

--- a/src/engine/slab_allocator.cpp
+++ b/src/engine/slab_allocator.cpp
@@ -1,4 +1,5 @@
 #include "gseurat/engine/slab_allocator.hpp"
+#include <string>
 
 namespace gseurat {
 

--- a/src/engine/slab_allocator.cpp
+++ b/src/engine/slab_allocator.cpp
@@ -1,0 +1,39 @@
+#include "gseurat/engine/slab_allocator.hpp"
+
+namespace gseurat {
+
+SlabAllocator::SlabAllocator(uint32_t total_slabs, uint32_t splats_per_slab)
+    : total_slabs_(total_slabs), splats_per_slab_(splats_per_slab) {
+    free_list_.reserve(total_slabs);
+    for (uint32_t i = total_slabs; i > 0; --i) {
+        free_list_.push_back(i - 1);
+    }
+}
+
+SlabAllocator::SlabHandle SlabAllocator::checkout(uint32_t slab_count) {
+    if (slab_count > free_list_.size()) {
+        throw std::runtime_error("SlabAllocator: not enough free slabs ("
+            + std::to_string(free_list_.size()) + " available, "
+            + std::to_string(slab_count) + " requested)");
+    }
+    SlabHandle handle;
+    handle.chunk_id = next_chunk_id_++;
+    handle.slab_indices.reserve(slab_count);
+    for (uint32_t i = 0; i < slab_count; ++i) {
+        handle.slab_indices.push_back(free_list_.back());
+        free_list_.pop_back();
+    }
+    return handle;
+}
+
+void SlabAllocator::release(const SlabHandle& handle) {
+    for (auto idx : handle.slab_indices) {
+        free_list_.push_back(idx);
+    }
+}
+
+uint32_t SlabAllocator::available() const {
+    return static_cast<uint32_t>(free_list_.size());
+}
+
+}  // namespace gseurat

--- a/src/engine/slab_allocator.cpp
+++ b/src/engine/slab_allocator.cpp
@@ -3,7 +3,8 @@
 namespace gseurat {
 
 SlabAllocator::SlabAllocator(uint32_t total_slabs, uint32_t splats_per_slab)
-    : total_slabs_(total_slabs), splats_per_slab_(splats_per_slab) {
+    : total_slabs_(total_slabs), splats_per_slab_(splats_per_slab),
+      in_use_(total_slabs, false) {
     free_list_.reserve(total_slabs);
     for (uint32_t i = total_slabs; i > 0; --i) {
         free_list_.push_back(i - 1);
@@ -20,15 +21,20 @@ SlabAllocator::SlabHandle SlabAllocator::checkout(uint32_t slab_count) {
     handle.chunk_id = next_chunk_id_++;
     handle.slab_indices.reserve(slab_count);
     for (uint32_t i = 0; i < slab_count; ++i) {
-        handle.slab_indices.push_back(free_list_.back());
+        uint32_t idx = free_list_.back();
         free_list_.pop_back();
+        in_use_[idx] = true;
+        handle.slab_indices.push_back(idx);
     }
     return handle;
 }
 
 void SlabAllocator::release(const SlabHandle& handle) {
     for (auto idx : handle.slab_indices) {
-        free_list_.push_back(idx);
+        if (idx < total_slabs_ && in_use_[idx]) {
+            in_use_[idx] = false;
+            free_list_.push_back(idx);
+        }
     }
 }
 

--- a/src/engine/transfer_queue.cpp
+++ b/src/engine/transfer_queue.cpp
@@ -1,0 +1,232 @@
+#include "gseurat/engine/transfer_queue.hpp"
+
+#include <stdexcept>
+
+namespace gseurat {
+
+TransferQueue::TransferQueue(VkDevice device, VmaAllocator allocator,
+                             VkQueue transfer_queue, uint32_t transfer_family,
+                             bool dedicated, uint64_t staging_size,
+                             uint32_t transfer_budget_mb,
+                             VkBuffer dest_buffer)
+    : device_(device),
+      allocator_(allocator),
+      transfer_queue_(transfer_queue),
+      transfer_family_(transfer_family),
+      dedicated_(dedicated),
+      staging_size_(staging_size),
+      transfer_budget_bytes_(static_cast<uint64_t>(transfer_budget_mb) * 1024u * 1024u),
+      dest_buffer_(dest_buffer) {
+    staging_buffer_ = Buffer::create_staging(allocator_, staging_size_);
+
+    if (dedicated_) {
+        VkCommandPoolCreateInfo pool_info{};
+        pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        pool_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+        pool_info.queueFamilyIndex = transfer_family_;
+        if (vkCreateCommandPool(device_, &pool_info, nullptr, &transfer_cmd_pool_) != VK_SUCCESS) {
+            throw std::runtime_error("TransferQueue: failed to create transfer command pool");
+        }
+
+        VkCommandBufferAllocateInfo alloc_info{};
+        alloc_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        alloc_info.commandPool = transfer_cmd_pool_;
+        alloc_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        alloc_info.commandBufferCount = 1;
+        if (vkAllocateCommandBuffers(device_, &alloc_info, &transfer_cmd_) != VK_SUCCESS) {
+            throw std::runtime_error("TransferQueue: failed to allocate transfer command buffer");
+        }
+
+        VkFenceCreateInfo fence_info{};
+        fence_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+        // Do not pre-signal — we check transfer_in_flight_ before polling
+        if (vkCreateFence(device_, &fence_info, nullptr, &transfer_fence_) != VK_SUCCESS) {
+            throw std::runtime_error("TransferQueue: failed to create transfer fence");
+        }
+    }
+}
+
+TransferQueue::~TransferQueue() {
+    shutdown();
+}
+
+void TransferQueue::enqueue(uint64_t staging_offset, uint64_t dest_offset,
+                            uint64_t size, std::function<void()> on_complete) {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    pending_chunks_.push_back({staging_offset, dest_offset, size, std::move(on_complete), false});
+}
+
+void TransferQueue::enqueue_completion(std::function<void()> on_complete) {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    TransferChunk marker{};
+    marker.on_complete = std::move(on_complete);
+    marker.is_completion_marker = true;
+    pending_chunks_.push_back(std::move(marker));
+}
+
+void TransferQueue::poll_completions(VkCommandBuffer frame_cmd) {
+    if (dedicated_) {
+        // --- Dedicated transfer queue path ---
+
+        // 1. Check if current in-flight batch has finished
+        if (transfer_in_flight_) {
+            VkResult status = vkGetFenceStatus(device_, transfer_fence_);
+            if (status == VK_SUCCESS) {
+                vkResetFences(device_, 1, &transfer_fence_);
+                // Fire all callbacks from the completed batch
+                if (!in_flight_.empty()) {
+                    for (auto& cb : in_flight_.front().callbacks) {
+                        if (cb) cb();
+                    }
+                    in_flight_.pop_front();
+                }
+                transfer_in_flight_ = false;
+            }
+            // If still pending, do not submit a new batch this frame
+            if (transfer_in_flight_) return;
+        }
+
+        // 2. Drain pending_chunks_ and record a new batch
+        std::deque<TransferChunk> local_chunks;
+        {
+            std::lock_guard<std::mutex> lock(queue_mutex_);
+            local_chunks.swap(pending_chunks_);
+        }
+        if (local_chunks.empty()) return;
+
+        InFlightBatch batch;
+        batch.fence = transfer_fence_;
+
+        vkResetCommandBuffer(transfer_cmd_, 0);
+        VkCommandBufferBeginInfo begin_info{};
+        begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        vkBeginCommandBuffer(transfer_cmd_, &begin_info);
+
+        for (auto& chunk : local_chunks) {
+            if (chunk.is_completion_marker) {
+                if (chunk.on_complete) batch.callbacks.push_back(chunk.on_complete);
+                continue;
+            }
+            VkBufferCopy region{};
+            region.srcOffset = chunk.staging_offset;
+            region.dstOffset = chunk.dest_offset;
+            region.size = chunk.size;
+            vkCmdCopyBuffer(transfer_cmd_, staging_buffer_.buffer(), dest_buffer_, 1, &region);
+            if (chunk.on_complete) batch.callbacks.push_back(chunk.on_complete);
+        }
+
+        vkEndCommandBuffer(transfer_cmd_);
+
+        VkSubmitInfo submit_info{};
+        submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submit_info.commandBufferCount = 1;
+        submit_info.pCommandBuffers = &transfer_cmd_;
+        vkQueueSubmit(transfer_queue_, 1, &submit_info, transfer_fence_);
+
+        in_flight_.push_back(std::move(batch));
+        transfer_in_flight_ = true;
+
+    } else {
+        // --- Fallback graphics-queue path ---
+
+        // 1. Fire any completed in-flight fences (FIFO)
+        while (!in_flight_.empty()) {
+            auto& front = in_flight_.front();
+            if (vkGetFenceStatus(device_, front.fence) == VK_SUCCESS) {
+                vkDestroyFence(device_, front.fence, nullptr);
+                for (auto& cb : front.callbacks) {
+                    if (cb) cb();
+                }
+                in_flight_.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        // 2. Drain up to transfer_budget_bytes_ into frame_cmd
+        std::deque<TransferChunk> local_chunks;
+        {
+            std::lock_guard<std::mutex> lock(queue_mutex_);
+            local_chunks.swap(pending_chunks_);
+        }
+        if (local_chunks.empty()) return;
+
+        uint64_t bytes_this_frame = 0;
+        std::deque<TransferChunk> deferred;
+
+        for (auto& chunk : local_chunks) {
+            if (chunk.is_completion_marker) {
+                // Fire completion markers inline after copies already recorded
+                if (chunk.on_complete) chunk.on_complete();
+                continue;
+            }
+            if (bytes_this_frame + chunk.size > transfer_budget_bytes_) {
+                deferred.push_back(std::move(chunk));
+                continue;
+            }
+            VkBufferCopy region{};
+            region.srcOffset = chunk.staging_offset;
+            region.dstOffset = chunk.dest_offset;
+            region.size = chunk.size;
+            vkCmdCopyBuffer(frame_cmd, staging_buffer_.buffer(), dest_buffer_, 1, &region);
+            bytes_this_frame += chunk.size;
+            // Callbacks fire immediately for the graphics-queue path — the copy
+            // executes before the queue submission that contains frame_cmd.
+            if (chunk.on_complete) chunk.on_complete();
+        }
+
+        // Re-queue anything that didn't fit this frame
+        if (!deferred.empty()) {
+            std::lock_guard<std::mutex> lock(queue_mutex_);
+            for (auto& chunk : deferred) {
+                pending_chunks_.push_front(std::move(chunk));
+            }
+        }
+    }
+}
+
+void TransferQueue::shutdown() {
+    if (device_ == VK_NULL_HANDLE) return;
+
+    vkDeviceWaitIdle(device_);
+
+    // Fire any remaining callbacks before destroying resources
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        for (auto& chunk : pending_chunks_) {
+            if (chunk.on_complete) chunk.on_complete();
+        }
+        pending_chunks_.clear();
+    }
+    for (auto& batch : in_flight_) {
+        for (auto& cb : batch.callbacks) {
+            if (cb) cb();
+        }
+        // Destroy per-batch fences from the fallback path
+        if (!dedicated_ && batch.fence != VK_NULL_HANDLE) {
+            vkDestroyFence(device_, batch.fence, nullptr);
+        }
+    }
+    in_flight_.clear();
+
+    if (staging_buffer_.buffer() != VK_NULL_HANDLE) {
+        staging_buffer_.destroy(allocator_);
+    }
+
+    if (transfer_cmd_pool_ != VK_NULL_HANDLE) {
+        vkDestroyCommandPool(device_, transfer_cmd_pool_, nullptr);
+        transfer_cmd_pool_ = VK_NULL_HANDLE;
+        transfer_cmd_ = VK_NULL_HANDLE;
+    }
+
+    if (transfer_fence_ != VK_NULL_HANDLE) {
+        vkDestroyFence(device_, transfer_fence_, nullptr);
+        transfer_fence_ = VK_NULL_HANDLE;
+    }
+
+    transfer_in_flight_ = false;
+    device_ = VK_NULL_HANDLE;
+}
+
+}  // namespace gseurat

--- a/src/engine/vk_context.cpp
+++ b/src/engine/vk_context.cpp
@@ -1,6 +1,7 @@
 #define VMA_IMPLEMENTATION
 #include "gseurat/engine/vk_context.hpp"
 
+#include <cstdio>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
@@ -189,12 +190,43 @@ void VkContext::pick_physical_device() {
 void VkContext::create_logical_device() {
     graphics_queue_family_ = static_cast<uint32_t>(find_queue_family());
 
+    // Look for dedicated transfer queue (TRANSFER but NOT GRAPHICS)
+    int32_t transfer_family = -1;
+    uint32_t family_count = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(physical_device_, &family_count, nullptr);
+    std::vector<VkQueueFamilyProperties> families(family_count);
+    vkGetPhysicalDeviceQueueFamilyProperties(physical_device_, &family_count, families.data());
+    for (uint32_t i = 0; i < families.size(); ++i) {
+        if ((families[i].queueFlags & VK_QUEUE_TRANSFER_BIT) &&
+            !(families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)) {
+            transfer_family = static_cast<int32_t>(i);
+            break;
+        }
+    }
+
+    std::vector<VkDeviceQueueCreateInfo> queue_infos;
     float priority = 1.0f;
-    VkDeviceQueueCreateInfo queue_info{};
-    queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-    queue_info.queueFamilyIndex = graphics_queue_family_;
-    queue_info.queueCount = 1;
-    queue_info.pQueuePriorities = &priority;
+
+    VkDeviceQueueCreateInfo gfx_info{};
+    gfx_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    gfx_info.queueFamilyIndex = graphics_queue_family_;
+    gfx_info.queueCount = 1;
+    gfx_info.pQueuePriorities = &priority;
+    queue_infos.push_back(gfx_info);
+
+    if (transfer_family >= 0 && static_cast<uint32_t>(transfer_family) != graphics_queue_family_) {
+        VkDeviceQueueCreateInfo xfer_info{};
+        xfer_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        xfer_info.queueFamilyIndex = static_cast<uint32_t>(transfer_family);
+        xfer_info.queueCount = 1;
+        xfer_info.pQueuePriorities = &priority;
+        queue_infos.push_back(xfer_info);
+        transfer_queue_family_ = static_cast<uint32_t>(transfer_family);
+        has_dedicated_transfer_ = true;
+    } else {
+        transfer_queue_family_ = graphics_queue_family_;
+        has_dedicated_transfer_ = false;
+    }
 
     VkPhysicalDeviceFeatures features{};
 
@@ -202,8 +234,8 @@ void VkContext::create_logical_device() {
 
     VkDeviceCreateInfo create_info{};
     create_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-    create_info.queueCreateInfoCount = 1;
-    create_info.pQueueCreateInfos = &queue_info;
+    create_info.queueCreateInfoCount = static_cast<uint32_t>(queue_infos.size());
+    create_info.pQueueCreateInfos = queue_infos.data();
     create_info.pEnabledFeatures = &features;
     create_info.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
     create_info.ppEnabledExtensionNames = extensions.data();
@@ -213,6 +245,14 @@ void VkContext::create_logical_device() {
     }
 
     vkGetDeviceQueue(device_, graphics_queue_family_, 0, &graphics_queue_);
+
+    if (has_dedicated_transfer_) {
+        vkGetDeviceQueue(device_, transfer_queue_family_, 0, &transfer_queue_);
+        std::printf("[vk_context] Dedicated transfer queue: family %u\n", transfer_queue_family_);
+    } else {
+        transfer_queue_ = graphics_queue_;
+        std::printf("[vk_context] No dedicated transfer queue; using graphics queue fallback\n");
+    }
 }
 
 void VkContext::create_allocator() {

--- a/tests/test_slab_allocator.cpp
+++ b/tests/test_slab_allocator.cpp
@@ -1,6 +1,8 @@
 #include "gseurat/engine/slab_allocator.hpp"
+#include "gseurat/engine/streaming_config.hpp"
 #include <cassert>
 #include <cstdio>
+#include <fstream>
 #include <set>
 
 using namespace gseurat;
@@ -127,6 +129,49 @@ int main() {
             if (i >= 100) { in_bounds = false; break; }
         }
         check(in_bounds, "all indices < total_slabs");
+    }
+
+    // Test 11: Double-release is harmless (no corruption)
+    {
+        std::printf("Test 11: Double-release protection\n");
+        SlabAllocator alloc(10, 100000);
+        auto h = alloc.checkout(5);
+        alloc.release(h);
+        check(alloc.available() == 10, "10 after first release");
+        alloc.release(h);  // double release
+        check(alloc.available() == 10, "still 10 after double release");
+        // Verify no corruption: can still checkout all 10
+        auto h2 = alloc.checkout(10);
+        std::set<uint32_t> unique;
+        for (auto i : h2.slab_indices) unique.insert(i);
+        check(unique.size() == 10, "10 unique indices after double-release");
+    }
+
+    // Test 12: Release zero-slab handle
+    {
+        std::printf("Test 12: Release zero-slab handle\n");
+        SlabAllocator alloc(5, 100000);
+        auto h = alloc.checkout(0);
+        alloc.release(h);
+        check(alloc.available() == 5, "no change after releasing empty handle");
+    }
+
+    // Test 13: StreamingConfig defaults
+    {
+        std::printf("Test 13: StreamingConfig defaults\n");
+        gseurat::StreamingConfig cfg;
+        check(cfg.gpu_budget_splats == 10'000'000, "default budget 10M");
+        check(cfg.slab_size_splats == 100'000, "default slab size 100K");
+        check(cfg.total_slabs() == 100, "100 slabs");
+        check(cfg.total_bytes() == 640'000'000ULL, "640MB total");
+        check(cfg.slab_bytes() == 6'400'000ULL, "6.4MB per slab");
+    }
+
+    // Test 14: StreamingConfig load from nonexistent file uses defaults
+    {
+        std::printf("Test 14: StreamingConfig nonexistent file\n");
+        auto cfg = gseurat::StreamingConfig::load("/nonexistent/path");
+        check(cfg.gpu_budget_splats == 10'000'000, "fallback to default budget");
     }
 
     std::printf("\n=== Results: %d passed, %d failed ===\n", passed, failed);

--- a/tests/test_slab_allocator.cpp
+++ b/tests/test_slab_allocator.cpp
@@ -1,0 +1,134 @@
+#include "gseurat/engine/slab_allocator.hpp"
+#include <cassert>
+#include <cstdio>
+#include <set>
+
+using namespace gseurat;
+
+static int passed = 0;
+static int failed = 0;
+
+static void check(bool cond, const char* msg) {
+    if (cond) { std::printf("  PASS: %s\n", msg); passed++; }
+    else      { std::printf("  FAIL: %s\n", msg); failed++; }
+}
+
+int main() {
+    std::printf("=== SlabAllocator Tests ===\n\n");
+
+    // Test 1: Construction
+    {
+        std::printf("Test 1: Construction\n");
+        SlabAllocator alloc(10, 100000);
+        check(alloc.total_slabs() == 10, "total_slabs == 10");
+        check(alloc.splats_per_slab() == 100000, "splats_per_slab == 100000");
+        check(alloc.available() == 10, "all 10 slabs available");
+    }
+
+    // Test 2: Checkout reduces available count
+    {
+        std::printf("Test 2: Checkout reduces available\n");
+        SlabAllocator alloc(10, 100000);
+        auto h = alloc.checkout(3);
+        check(h.slab_indices.size() == 3, "got 3 slab indices");
+        check(alloc.available() == 7, "7 slabs remaining");
+    }
+
+    // Test 3: Slab indices are unique
+    {
+        std::printf("Test 3: Unique slab indices\n");
+        SlabAllocator alloc(10, 100000);
+        auto h1 = alloc.checkout(3);
+        auto h2 = alloc.checkout(4);
+        std::set<uint32_t> all;
+        for (auto i : h1.slab_indices) all.insert(i);
+        for (auto i : h2.slab_indices) all.insert(i);
+        check(all.size() == 7, "all 7 indices unique across two checkouts");
+    }
+
+    // Test 4: Chunk IDs are sequential
+    {
+        std::printf("Test 4: Sequential chunk IDs\n");
+        SlabAllocator alloc(10, 100000);
+        auto h1 = alloc.checkout(1);
+        auto h2 = alloc.checkout(1);
+        auto h3 = alloc.checkout(1);
+        check(h1.chunk_id == 0, "first chunk_id == 0");
+        check(h2.chunk_id == 1, "second chunk_id == 1");
+        check(h3.chunk_id == 2, "third chunk_id == 2");
+    }
+
+    // Test 5: Release returns slabs to pool
+    {
+        std::printf("Test 5: Release returns slabs\n");
+        SlabAllocator alloc(10, 100000);
+        auto h = alloc.checkout(5);
+        check(alloc.available() == 5, "5 remaining after checkout");
+        alloc.release(h);
+        check(alloc.available() == 10, "10 available after release");
+    }
+
+    // Test 6: Released slabs can be reused
+    {
+        std::printf("Test 6: Released slabs reused\n");
+        SlabAllocator alloc(4, 100000);
+        auto h1 = alloc.checkout(4);
+        alloc.release(h1);
+        auto h2 = alloc.checkout(4);
+        check(h2.slab_indices.size() == 4, "can checkout 4 after releasing 4");
+        check(alloc.available() == 0, "0 remaining");
+    }
+
+    // Test 7: Checkout more than available throws
+    {
+        std::printf("Test 7: Over-checkout throws\n");
+        SlabAllocator alloc(3, 100000);
+        alloc.checkout(2);
+        bool threw = false;
+        try { alloc.checkout(5); }
+        catch (const std::runtime_error&) { threw = true; }
+        check(threw, "throws runtime_error when requesting 5 with 1 available");
+    }
+
+    // Test 8: Checkout zero slabs
+    {
+        std::printf("Test 8: Checkout zero\n");
+        SlabAllocator alloc(5, 100000);
+        auto h = alloc.checkout(0);
+        check(h.slab_indices.empty(), "empty handle for 0 checkout");
+        check(alloc.available() == 5, "no slabs consumed");
+    }
+
+    // Test 9: Non-contiguous reuse after fragmentation
+    {
+        std::printf("Test 9: Non-contiguous reuse (fragmentation-proof)\n");
+        SlabAllocator alloc(10, 100000);
+        auto a = alloc.checkout(3);
+        auto b = alloc.checkout(2);
+        auto c = alloc.checkout(3);
+        alloc.release(b);
+        check(alloc.available() == 4, "4 available (2 freed + 2 never used)");
+        auto d = alloc.checkout(3);
+        check(d.slab_indices.size() == 3, "got 3 scattered slabs after fragmentation");
+        check(alloc.available() == 1, "1 remaining");
+        alloc.release(a);
+        alloc.release(c);
+        alloc.release(d);
+        check(alloc.available() == 10, "all 10 returned");
+    }
+
+    // Test 10: Slab indices are within bounds
+    {
+        std::printf("Test 10: Indices within bounds\n");
+        SlabAllocator alloc(100, 50000);
+        auto h = alloc.checkout(100);
+        bool in_bounds = true;
+        for (auto i : h.slab_indices) {
+            if (i >= 100) { in_bounds = false; break; }
+        }
+        check(in_bounds, "all indices < total_slabs");
+    }
+
+    std::printf("\n=== Results: %d passed, %d failed ===\n", passed, failed);
+    return failed > 0 ? 1 : 0;
+}

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -140,6 +140,22 @@ export function validateScenePaths(scene: any, reg: AssetRegistry): ScenePathErr
     }
   }
 
+  if (Array.isArray(scene?.instances)) {
+    for (let i = 0; i < scene.instances.length; i++) {
+      const inst = scene.instances[i];
+      const path = inst?.scene_file;
+      if (typeof path === 'string' && path.length > 0) {
+        if (path.startsWith('/') || path.startsWith('\\') || /^[A-Za-z]:/.test(path)) {
+          errs.push({
+            field: `instances[${i}].scene_file`,
+            value: path,
+            message: 'Absolute path not allowed — use relative path from project root',
+          });
+        }
+      }
+    }
+  }
+
   return errs;
 }
 
@@ -198,8 +214,17 @@ export function exportSceneJson(
       position: p.position,
       size: p.size,
       target_scene: p.target_scene,
+      ...(p.target_instance_id ? { target_instance_id: p.target_instance_id } : {}),
       spawn_position: p.spawn_position,
       spawn_facing: p.spawn_facing,
+    }));
+  }
+
+  if (state.instances.length > 0) {
+    scene.instances = state.instances.map((i) => ({
+      id: i.id,
+      display_name: i.display_name,
+      scene_file: i.scene_file,
     }));
   }
 

--- a/tools/apps/bricklayer/src/panels/EntitiesTab.tsx
+++ b/tools/apps/bricklayer/src/panels/EntitiesTab.tsx
@@ -58,16 +58,6 @@ function PortalEditor({ portal }: { portal: PortalData }) {
           style={{ ...styles.input, maxWidth: 60 }}
         />
       </div>
-      <div style={styles.row}>
-        <span style={{ fontSize: 12, minWidth: 40 }}>Target</span>
-        <input
-          type="text"
-          value={portal.target_scene}
-          onChange={(e) => updatePortal(portal.id, { target_scene: e.target.value })}
-          style={styles.input}
-          placeholder="scene name"
-        />
-      </div>
       <Vec3Input
         value={portal.spawn_position}
         onChange={(v) => updatePortal(portal.id, { spawn_position: v })}

--- a/tools/apps/bricklayer/src/panels/EntitiesTab.tsx
+++ b/tools/apps/bricklayer/src/panels/EntitiesTab.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NumberInput } from '../components/NumberInput.js';
 import { Vec3Input } from '../components/Vec3Input.js';
 import { useSceneStore } from '../store/useSceneStore.js';
-import type { PortalData } from '../store/types.js';
+import type { PortalData, InstanceData } from '../store/types.js';
 import { panelStyles } from '../styles/panel.js';
 
 const styles = { ...panelStyles };
@@ -76,11 +76,28 @@ function PortalEditor({ portal }: { portal: PortalData }) {
   );
 }
 
+function InstanceItem({ inst }: { inst: InstanceData }) {
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
+  const isSelected = selectedEntity?.type === 'instance' && selectedEntity.id === inst.id;
+
+  return (
+    <div
+      style={{ ...styles.item, ...(isSelected ? styles.itemSelected : {}) }}
+      onClick={() => setSelectedEntity({ type: 'instance', id: inst.id })}
+    >
+      <span style={{ fontSize: 13 }}>{inst.display_name || '(unnamed)'}</span>
+    </div>
+  );
+}
+
 export function EntitiesTab() {
   const player = useSceneStore((s) => s.player);
   const updatePlayer = useSceneStore((s) => s.updatePlayer);
   const portals = useSceneStore((s) => s.portals);
   const addPortal = useSceneStore((s) => s.addPortal);
+  const instances = useSceneStore((s) => s.instances);
+  const addInstance = useSceneStore((s) => s.addInstance);
 
   return (
     <div>
@@ -117,6 +134,14 @@ export function EntitiesTab() {
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
         {portals.map((p) => <PortalEditor key={p.id} portal={p} />)}
+      </div>
+
+      <div style={{ ...styles.row, marginBottom: 8, marginTop: 16 }}>
+        <span style={{ ...styles.label, flex: 1 }}>Instances ({instances.length})</span>
+        <button style={styles.btn} onClick={() => addInstance()}>+ Add</button>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {instances.map((inst) => <InstanceItem key={inst.id} inst={inst} />)}
       </div>
     </div>
   );

--- a/tools/apps/bricklayer/src/panels/ProjectTree.tsx
+++ b/tools/apps/bricklayer/src/panels/ProjectTree.tsx
@@ -170,6 +170,9 @@ export function ProjectTree() {
   const removeGameObject = useSceneStore((st) => st.removeGameObject);
   const staticLights = useSceneStore((st) => st.staticLights);
   const portals = useSceneStore((st) => st.portals);
+  const instances = useSceneStore((st) => st.instances);
+  const addInstance = useSceneStore((st) => st.addInstance);
+  const removeInstance = useSceneStore((st) => st.removeInstance);
   const addLight = useSceneStore((st) => st.addLight);
   const addPortal = useSceneStore((st) => st.addPortal);
   const gsParticleEmitters = useSceneStore((st) => st.gsParticleEmitters);
@@ -202,6 +205,7 @@ export function ProjectTree() {
   const [gameObjOpen, setGameObjOpen] = useState(true);
   const [lightOpen, setLightOpen] = useState(true);
   const [portalOpen, setPortalOpen] = useState(true);
+  const [instanceOpen, setInstanceOpen] = useState(true);
   const [emitterOpen, setEmitterOpen] = useState(true);
   const [animOpen, setAnimOpen] = useState(true);
   const [vfxOpen, setVfxOpen] = useState(true);
@@ -349,6 +353,27 @@ export function ProjectTree() {
                 isActive={isActive({ kind: 'scene_item', entityType: 'portal', entityId: p.id })}
                 onClick={() => click({ kind: 'scene_item', entityType: 'portal', entityId: p.id })}
                 actions={removeBtn(() => removePortal(p.id))}
+              />
+            ))}
+          </TreeNode>
+
+          {/* Instances (Room references) */}
+          <TreeNode
+            icon="⬚" label="Instances" count={instances.length}
+            arrow={instanceOpen ? '\u25BE' : '\u25B8'}
+            isActive={isActive({ kind: 'scene_category', category: 'instances' as any })}
+            onClick={() => { setInstanceOpen(!instanceOpen); click({ kind: 'scene_category', category: 'instances' as any }); }}
+            actions={addBtn(() => addInstance())}
+            isOpen={instanceOpen}
+          >
+            {instances.map((inst) => (
+              <TreeNode
+                key={inst.id}
+                icon="⬚"
+                label={inst.display_name || '(unnamed)'}
+                isActive={isActive({ kind: 'scene_item', entityType: 'instance', entityId: inst.id })}
+                onClick={() => click({ kind: 'scene_item', entityType: 'instance', entityId: inst.id })}
+                actions={removeBtn(() => removeInstance(inst.id))}
               />
             ))}
           </TreeNode>

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -6,6 +6,7 @@ import { useSceneStore } from '../store/useSceneStore.js';
 import type {
   StaticLight,
   PortalData,
+  InstanceData,
   PlayerData,
   GameObjectData,
   PbdConfig,
@@ -637,6 +638,7 @@ function LightProperties({ light }: { light: StaticLight }) {
 function PortalProperties({ portal }: { portal: PortalData }) {
   const update = useSceneStore((s) => s.updatePortal);
   const remove = useSceneStore((s) => s.removePortal);
+  const instances = useSceneStore((s) => s.instances);
 
   return (
     <div>
@@ -672,6 +674,27 @@ function PortalProperties({ portal }: { portal: PortalData }) {
       </div>
 
       <div style={styles.section}>
+        <span style={styles.label}>Target Instance</span>
+        <select
+          style={styles.select}
+          value={portal.target_instance_id ?? ''}
+          onChange={(e) => {
+            const val = e.target.value;
+            if (val) {
+              update(portal.id, { target_instance_id: val, target_scene: '' });
+            } else {
+              update(portal.id, { target_instance_id: undefined });
+            }
+          }}
+        >
+          <option value="">None (use Target Scene)</option>
+          {instances.map((inst) => (
+            <option key={inst.id} value={inst.id}>{inst.display_name}</option>
+          ))}
+        </select>
+      </div>
+
+      <div style={styles.section}>
         <span style={styles.label}>Target Scene</span>
         <input
           type="text"
@@ -699,6 +722,42 @@ function PortalProperties({ portal }: { portal: PortalData }) {
         >
           {facings.map((f) => <option key={f} value={f}>{f}</option>)}
         </select>
+      </div>
+    </div>
+  );
+}
+
+function InstanceProperties({ instance }: { instance: InstanceData }) {
+  const update = useSceneStore((s) => s.updateInstance);
+  const remove = useSceneStore((s) => s.removeInstance);
+
+  return (
+    <div>
+      <div style={{ ...styles.row, marginBottom: 12 }}>
+        <span style={{ ...styles.label, flex: 1 }}>Instance</span>
+        <button style={styles.btnDanger} onClick={() => remove(instance.id)}>Remove</button>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Display Name</span>
+        <input
+          type="text"
+          value={instance.display_name}
+          onChange={(e) => update(instance.id, { display_name: e.target.value })}
+          style={styles.input}
+          placeholder="Instance name"
+        />
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Scene File</span>
+        <input
+          type="text"
+          value={instance.scene_file}
+          onChange={(e) => update(instance.id, { scene_file: e.target.value })}
+          style={styles.input}
+          placeholder="relative/path/to/scene.json"
+        />
       </div>
     </div>
   );
@@ -1496,6 +1555,7 @@ export function ScenePropertiesPanel() {
   const gsAnimations = useSceneStore((s) => s.gsAnimations);
   const vfxInstances = useSceneStore((s) => s.vfxInstances);
   const player = useSceneStore((s) => s.player);
+  const instances = useSceneStore((s) => s.instances);
   const cameraVolumes = useSceneStore((s) => s.cameraVolumes);
   const cameraTriggers = useSceneStore((s) => s.cameraTriggers);
   const cameraRails = useSceneStore((s) => s.cameraRails);
@@ -1520,6 +1580,12 @@ export function ScenePropertiesPanel() {
     const portal = portals.find((p) => p.id === selectedEntity.id);
     if (!portal) return <div style={styles.empty}>Portal not found</div>;
     return <PortalProperties portal={portal} />;
+  }
+
+  if (selectedEntity.type === 'instance') {
+    const instance = instances.find((i) => i.id === selectedEntity.id);
+    if (!instance) return <div style={styles.empty}>Instance not found</div>;
+    return <InstanceProperties instance={instance} />;
   }
 
   if (selectedEntity.type === 'gs_emitter') {

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -681,28 +681,17 @@ function PortalProperties({ portal }: { portal: PortalData }) {
           onChange={(e) => {
             const val = e.target.value;
             if (val) {
-              update(portal.id, { target_instance_id: val, target_scene: '' });
+              update(portal.id, { target_instance_id: val });
             } else {
               update(portal.id, { target_instance_id: undefined });
             }
           }}
         >
-          <option value="">None (use Target Scene)</option>
+          <option value="">None</option>
           {instances.map((inst) => (
             <option key={inst.id} value={inst.id}>{inst.display_name}</option>
           ))}
         </select>
-      </div>
-
-      <div style={styles.section}>
-        <span style={styles.label}>Target Scene</span>
-        <input
-          type="text"
-          value={portal.target_scene}
-          onChange={(e) => update(portal.id, { target_scene: e.target.value })}
-          style={styles.input}
-          placeholder="scene name"
-        />
       </div>
 
       <div style={styles.section}>

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -77,8 +77,15 @@ export interface PortalData {
   position: [number, number, number];
   size: [number, number];
   target_scene: string;
+  target_instance_id?: string;
   spawn_position: [number, number, number];
   spawn_facing: string;
+}
+
+export interface InstanceData {
+  id: string;
+  display_name: string;
+  scene_file: string;
 }
 
 export interface EmitterConfig {
@@ -470,5 +477,6 @@ export interface BricklayerFile {
     cameraRails?: CameraZoneRail[];
     cameraDefaultParams?: Partial<CameraZoneParams>;
     cameraShowDebugVolumes?: boolean;
+    instances?: InstanceData[];
   };
 }

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -7,6 +7,7 @@ import type {
   VoxelKey,
   StaticLight,
   PortalData,
+  InstanceData,
   GameObjectData,
   ComponentSchema,
   GsParticleEmitterData,
@@ -236,6 +237,7 @@ export interface SceneStoreState {
   gameObjects: GameObjectData[];
   componentSchemas: ComponentSchema[];
   portals: PortalData[];
+  instances: InstanceData[];
   gsParticleEmitters: GsParticleEmitterData[];
   gsAnimations: GsAnimationGroupData[];
   vfxInstances: VfxInstanceData[];
@@ -310,6 +312,9 @@ export interface SceneStoreState {
   addPortal: (position?: [number, number, number]) => void;
   updatePortal: (id: string, patch: Partial<PortalData>) => void;
   removePortal: (id: string) => void;
+  addInstance: () => void;
+  updateInstance: (id: string, patch: Partial<InstanceData>) => void;
+  removeInstance: (id: string) => void;
   storeAssetBlob: (path: string, blob: Blob) => void;
   addGsEmitter: (position?: [number, number, number]) => void;
   updateGsEmitter: (id: string, patch: Partial<GsParticleEmitterData>) => void;
@@ -510,6 +515,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   gameObjects: [] as GameObjectData[],
   componentSchemas: [] as ComponentSchema[],
   portals: [],
+  instances: [],
   gsParticleEmitters: [],
   gsAnimations: [],
   vfxInstances: [] as VfxInstanceData[],
@@ -742,6 +748,23 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   }),
   removePortal: (id) => set({
     portals: get().portals.filter((p) => p.id !== id), isDirty: true,
+  }),
+
+  addInstance: () => {
+    const inst: InstanceData = {
+      id: genId('instance'),
+      display_name: 'New Instance',
+      scene_file: '',
+    };
+    set({ instances: [...get().instances, inst], isDirty: true });
+  },
+  updateInstance: (id, patch) => set({
+    instances: get().instances.map((i) => (i.id === id ? { ...i, ...patch } : i)),
+    isDirty: true,
+  }),
+  removeInstance: (id) => set({
+    instances: get().instances.filter((i) => i.id !== id),
+    isDirty: true,
   }),
 
   storeAssetBlob: (path, blob) => {
@@ -1335,6 +1358,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
         staticLights: s.staticLights,
         gameObjects: s.gameObjects.length > 0 ? s.gameObjects : undefined,
         portals: s.portals,
+        instances: s.instances.length > 0 ? s.instances : undefined,
         player: s.player,
         backgroundLayers: s.backgroundLayers,
         torchEmitter: s.torchEmitter,
@@ -1434,6 +1458,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
         return gameObjects;
       })(),
       portals: migratedPortals,
+      instances: data.scene.instances ?? [],
       gsParticleEmitters: data.scene.gsParticleEmitters ?? [],
       gsAnimations: data.scene.gsAnimations ?? [],
       vfxInstances: data.scene.vfxInstances ?? [],


### PR DESCRIPTION
## Summary

- **R1: Fixed-Size Slab Allocator with GPU Page Table** — Pre-allocate VRAM budget at startup (configurable, default 10M splats / 640 MB). Non-contiguous slab allocation eliminates external fragmentation. GPU page table SSBO maps logical → physical indices in `gs_preprocess.comp`.
- **R2: Async Background Transfer Queue** — Dedicated transfer queue discovery (fallback to graphics queue on MoltenVK). Background threads parse PLY files, stage data to ring buffer, upload via VkFence-based polling. Graphics queue never stalls.
- **R3: Bricklayer Instances & Portal Extension** — `InstanceData` type (named scene reference), store CRUD, EntitiesTab UI, InstanceProperties editor, Portal `target_instance_id` dropdown, path validation, scene JSON export.

### Key Files

| Component | Files |
|-----------|-------|
| Slab Allocator | `slab_allocator.hpp/cpp`, `streaming_config.hpp`, 14 unit tests |
| Page Table Shader | `gs_preprocess.comp` (specialization constants, `resolve_physical_index`) |
| Renderer Streaming | `gs_renderer.hpp/cpp` (`init_streaming`, `load_cloud` refactor, `unload_cloud`, `load_cloud_async`, `poll_transfers`) |
| Transfer Queue | `transfer_queue.hpp/cpp`, `vk_context.hpp/cpp` (dedicated queue discovery) |
| Bricklayer Instances | `types.ts`, `useSceneStore.ts`, `EntitiesTab.tsx`, `ScenePropertiesPanel.tsx`, `sceneExport.ts` |

## Test plan

- [ ] `test_slab_allocator` — 14 tests pass (construction, checkout, release, fragmentation, double-free, StreamingConfig)
- [ ] C++ build succeeds (`cmake --build --preset macos-debug`)
- [ ] Bricklayer build succeeds (`pnpm build` in tools/)
- [ ] Manual: Create Instance in Bricklayer EntitiesTab, assign to Portal via dropdown
- [ ] Manual: Verify `validateScenePaths` rejects absolute instance.scene_file paths
- [ ] Manual: Load scene in Staging — verify zero VMA allocations after init_streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)