### PR TITLE
feat: Portal regions (box/sphere) + Staging gizmos

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,23 +154,31 @@ Header-only (`include/gseurat/engine/ecs/`): archetype-based storage with typed 
 
 ### Async Asset Streaming
 
-Background asset loading for open-world support:
+Two-tier streaming architecture for open-world support:
+
+**Tier 1 — Slab Allocator + GPU Page Table:**
+All GPU memory for Gaussians is allocated once at startup as a configurable budget (default 10M splats / 640 MB). Fixed-size slabs (100K splats each) are managed by a free-list allocator with non-contiguous allocation — zero external fragmentation by construction. A GPU-side page table SSBO maps logical splat indices to physical slab offsets; the preprocess shader resolves indices via `resolve_physical_index()`.
+
+**Tier 2 — Transfer Queue:**
+Dedicated Vulkan transfer queue (falls back to time-sliced graphics queue on MoltenVK). Background threads parse PLY files and stage data to a double-buffered ring buffer. `VkFence`-based polling drives completion on the main thread — the graphics queue never stalls.
 
 ```
 Main Thread                     Worker Thread (std::thread)
 ─────────────                   ────────────────────────────
-submit request ──► request_queue_ ──► disk I/O + CPU parsing
-poll_results() ◄── completed_    ◄── push result
-flush() ──► GPU upload (budget-limited, 4MB/frame)
+load_cloud_async() ──────────►  Parse PLY → GpuGaussian
+poll_transfers()                Stage to ring buffer
+  vkGetFenceStatus ◄── fence ── vkCmdCopyBuffer to slab
+  page table update             enqueue completion marker
+  chunk appears next frame
 ```
 
 | Component | Description |
 |---|---|
-| `AsyncLoader` | Thread-safe work queue with single worker thread |
-| `StagingUploader` | Double-buffered, budget-limited per-frame GPU texture uploads |
-| `GsChunkStreamer` | Distance-based GS chunk streaming with hysteresis and memory budget |
+| `SlabAllocator` | Non-contiguous slab checkout/release with double-free protection |
+| `TransferQueue` | Dedicated/fallback transfer paths with staging ring buffer |
+| `GsChunkStreamer` | Distance-based chunk streaming with hysteresis and memory budget |
 
-All disk I/O and CPU parsing runs on the worker thread. All Vulkan API calls stay on the main thread.
+All disk I/O and CPU parsing runs on worker threads. All Vulkan API calls and page table updates stay on the main thread. Configuration via `engine_config.json`.
 
 ### 3D Gaussian Splatting
 
@@ -298,6 +306,15 @@ Auto-generated from Gaussian data via `generate_collision_from_gaussians()`, or 
         "Patrol": { "speed": 2.0, "waypoints": [[20, 0, 25], [30, 0, 25]] }
       }}
   ],
+  "portals": [
+    { "position": [10, 0, 5], "region_shape": "box", "region_radius": 2,
+      "region_half_extents": [1, 2, 1], "target_instance_id": "tavern",
+      "spawn_position": [5, 0, 5], "spawn_facing": "down" }
+  ],
+  "instances": [
+    { "id": "tavern", "display_name": "Tavern Interior",
+      "scene_file": "assets/scenes/tavern.scene.json" }
+  ],
   "collision": {
     "width": 64, "height": 64, "cell_size": 1.0,
     "solid": ["..."], "elevation": ["..."], "nav_zone": ["..."]
@@ -372,7 +389,7 @@ Engine (Vulkan) ←→ Unix Socket ←→ Bridge Proxy (ws://localhost:9100) ←
 | Tool | Port | Description |
 |------|------|-------------|
 | **Bridge Proxy** | 9100/9101 | Node.js relay between Unix socket and WebSocket clients |
-| **Bricklayer** | 5180 | 3DGS map editor: voxel terrain, Game Objects with component composition, PBD physics configuration, emitters, animations, VFX, lights |
+| **Bricklayer** | 5180 | 3DGS map editor: voxel terrain, Game Objects with component composition, PBD physics, emitters, animations, VFX, lights, portals with region triggers (box/sphere), instances (named scene references) |
 | **Méliès** | 5181 | VFX editor: particle emitters, GS animations, spline paths, object layers, light layers |
 | **Echidna** | 5179 | Voxel character editor: .vox import, body parts, bone posing, PLY export |
 | **Staging** | C++ app | ImGui rendering review: live scene preview, gizmos for lights/emitters/VFX/game objects, bridge auto-sync |

--- a/include/gseurat/engine/scene_loader.hpp
+++ b/include/gseurat/engine/scene_loader.hpp
@@ -120,8 +120,11 @@ struct GsAnimationData {
 
 struct PortalData {
     coord::GridPos position;
-    glm::vec2 size{1.0f};
+    std::string region_shape{"box"};  // "box" or "sphere"
+    float region_radius{2.0f};
+    glm::vec3 region_half_extents{1.0f, 1.0f, 1.0f};
     std::string target_scene;
+    std::string target_instance_id;
     coord::GridPos spawn_position;
     Direction spawn_facing = Direction::Down;
 };

--- a/include/gseurat/staging/staging_state.hpp
+++ b/include/gseurat/staging/staging_state.hpp
@@ -98,6 +98,7 @@ private:
     bool show_gizmo_vfx_ = true;
     bool show_gizmo_game_objects_ = true;
     bool show_gizmo_camera_zones_ = true;
+    bool show_gizmo_portals_ = true;
 
     // Hide all UI (Tab key toggle)
     bool hide_ui_ = false;

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -359,8 +359,9 @@ void CommandDispatcher::register_default_commands() {
                 ctx_.renderer.add_vfx_instance(std::move(inst));
             }
 
-            // Update stored game object data with world positions for gizmo rendering
+            // Update stored game object and portal data for gizmo rendering
             ctx_.scene_objects.game_objects = scene_data.game_objects;
+            ctx_.scene_objects.portals = scene_data.portals;
 
             std::vector<coord::WorldPos> world_positions;
             world_positions.reserve(scene_data.game_objects.size());

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -483,11 +483,20 @@ SceneData SceneLoader::from_json(const nlohmann::json& j) {
         for (const auto& portal_j : j["portals"]) {
             PortalData portal;
             portal.position = coord::GridPos(parse_vec3(portal_j["position"]));
-            if (portal_j.contains("size")) portal.size = parse_vec2(portal_j["size"]);
-            portal.target_scene = portal_j["target_scene"].get<std::string>();
+            if (portal_j.contains("region_shape")) portal.region_shape = portal_j["region_shape"].get<std::string>();
+            if (portal_j.contains("region_radius")) portal.region_radius = portal_j["region_radius"].get<float>();
+            if (portal_j.contains("region_half_extents")) portal.region_half_extents = parse_vec3(portal_j["region_half_extents"]);
+            if (portal_j.contains("target_scene")) portal.target_scene = portal_j["target_scene"].get<std::string>();
+            if (portal_j.contains("target_instance_id")) portal.target_instance_id = portal_j["target_instance_id"].get<std::string>();
             portal.spawn_position = coord::GridPos(parse_vec3(portal_j["spawn_position"]));
             if (portal_j.contains("spawn_facing"))
                 portal.spawn_facing = parse_direction(portal_j["spawn_facing"]);
+            // Back-compat: convert legacy size to region_half_extents
+            if (portal_j.contains("size") && !portal_j.contains("region_shape")) {
+                auto s = parse_vec2(portal_j["size"]);
+                portal.region_half_extents = glm::vec3(s.x * 0.5f, 1.0f, s.y * 0.5f);
+                portal.region_shape = "box";
+            }
             data.portals.push_back(std::move(portal));
         }
     }
@@ -1185,8 +1194,11 @@ nlohmann::json SceneLoader::to_json(const SceneData& data) {
         for (const auto& portal : data.portals) {
             portals.push_back({
                 {"position", vec3_json(portal.position.vec())},
-                {"size", vec2_json(portal.size)},
+                {"region_shape", portal.region_shape},
+                {"region_radius", portal.region_radius},
+                {"region_half_extents", vec3_json(portal.region_half_extents)},
                 {"target_scene", portal.target_scene},
+                {"target_instance_id", portal.target_instance_id},
                 {"spawn_position", vec3_json(portal.spawn_position.vec())},
                 {"spawn_facing", direction_to_string(portal.spawn_facing)}
             });

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -315,6 +315,8 @@ void StagingApp::shutdown_imgui() {
 void StagingApp::init_scene(const std::string& scene_path) {
     scene_objects_.current_scene_path = scene_path;
     auto scene_data = SceneLoader::load(scene_path);
+    scene_objects_.game_objects = scene_data.game_objects;
+    scene_objects_.portals = scene_data.portals;
     load_gs_scene(scene_data);
     std::fprintf(stderr, "[Staging] Loaded scene: %s\n", scene_path.c_str());
 }

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -198,6 +198,8 @@ void StagingState::on_enter(AppBase& app) {
             vs.gizmos.push_back({"camera_zones", show_gizmo_camera_zones_,
                 sd && sd->camera_zones
                     ? static_cast<int>(sd->camera_zones->volumes.size()) : 0});
+            vs.gizmos.push_back({"portals", show_gizmo_portals_,
+                sd ? static_cast<int>(sd->portals.size()) : 0});
 
             // Scene
             auto& gsr = app.renderer().gs_renderer();
@@ -556,6 +558,7 @@ void StagingState::draw_imgui(AppBase& app) {
             ImGui::MenuItem("Gizmo: VFX", nullptr, &show_gizmo_vfx_);
             ImGui::MenuItem("Gizmo: Game Objects", nullptr, &show_gizmo_game_objects_);
             ImGui::MenuItem("Gizmo: Camera Zones", nullptr, &show_gizmo_camera_zones_);
+            ImGui::MenuItem("Gizmo: Portals", nullptr, &show_gizmo_portals_);
             ImGui::Separator();
             if (ImGui::MenuItem("Deselect All")) {
                 show_viewport_info_ = false;
@@ -571,6 +574,7 @@ void StagingState::draw_imgui(AppBase& app) {
                 show_gizmo_vfx_ = false;
                 show_gizmo_game_objects_ = false;
                 show_gizmo_camera_zones_ = false;
+                show_gizmo_portals_ = false;
             }
             ImGui::EndMenu();
         }
@@ -1238,6 +1242,36 @@ void StagingState::draw_gizmos(AppBase& app) {
             char label[64];
             std::snprintf(label, sizeof(label), "%s", go.name.c_str());
             dl->AddText(ImVec2(sx + 6, sy - 10), col, label);
+        }
+    }
+
+    // ── Portal gizmos ──
+    if (show_gizmo_portals_) {
+        ImU32 portal_col = IM_COL32(0, 220, 220, 200);  // cyan
+        const auto& portals = app.scene_objects().portals;
+        for (size_t i = 0; i < portals.size(); i++) {
+            const auto& p = portals[i];
+            glm::vec3 pos(p.position.x(), p.position.y(), p.position.z());
+            float sx, sy;
+            if (!project_to_screen(pos, vp, sw, sh, sx, sy)) continue;
+
+            if (p.region_shape == "sphere") {
+                draw_sphere_gizmo(dl, pos, p.region_radius,
+                                  vp, sw, sh, portal_col, project_wrapper, this);
+            } else {
+                draw_box_gizmo(dl, pos, p.region_half_extents,
+                               vp, sw, sh, portal_col, project_wrapper, this);
+            }
+
+            // Diamond marker at center
+            float d = 5.0f;
+            dl->AddQuadFilled(
+                ImVec2(sx, sy - d), ImVec2(sx + d, sy),
+                ImVec2(sx, sy + d), ImVec2(sx - d, sy), portal_col);
+
+            char label[64];
+            std::snprintf(label, sizeof(label), "Portal%zu", i);
+            dl->AddText(ImVec2(sx + 8, sy - 10), portal_col, label);
         }
     }
 

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -1249,9 +1249,11 @@ void StagingState::draw_gizmos(AppBase& app) {
     if (show_gizmo_portals_) {
         ImU32 portal_col = IM_COL32(0, 220, 220, 200);  // cyan
         const auto& portals = app.scene_objects().portals;
+        auto terrain_aabb = app.gs_terrain().terrain_aabb;
         for (size_t i = 0; i < portals.size(); i++) {
             const auto& p = portals[i];
-            glm::vec3 pos(p.position.x(), p.position.y(), p.position.z());
+            auto world_pos = coord::to_world(p.position, terrain_aabb);
+            glm::vec3 pos = world_pos.vec();
             float sx, sy;
             if (!project_to_screen(pos, vp, sw, sh, sx, sy)) continue;
 

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -212,8 +212,9 @@ export function exportSceneJson(
   if (state.portals.length > 0) {
     scene.portals = state.portals.map((p) => ({
       position: p.position,
-      size: p.size,
-      target_scene: p.target_scene,
+      region_shape: p.region_shape,
+      region_radius: p.region_radius,
+      region_half_extents: p.region_half_extents,
       ...(p.target_instance_id ? { target_instance_id: p.target_instance_id } : {}),
       spawn_position: p.spawn_position,
       spawn_facing: p.spawn_facing,

--- a/tools/apps/bricklayer/src/panels/EntitiesTab.tsx
+++ b/tools/apps/bricklayer/src/panels/EntitiesTab.tsx
@@ -46,17 +46,12 @@ function PortalEditor({ portal }: { portal: PortalData }) {
         />
       </div>
       <div style={styles.row}>
-        <span style={{ fontSize: 12, minWidth: 40 }}>Size</span>
-        <NumberInput
-          value={portal.size[0]}
-          onChange={(v) => updatePortal(portal.id, { size: [v, portal.size[1]] })}
-          style={{ ...styles.input, maxWidth: 60 }}
-        />
-        <NumberInput
-          value={portal.size[1]}
-          onChange={(v) => updatePortal(portal.id, { size: [portal.size[0], v] })}
-          style={{ ...styles.input, maxWidth: 60 }}
-        />
+        <span style={{ fontSize: 12, minWidth: 40 }}>Region</span>
+        <span style={{ fontSize: 11, color: '#aaa' }}>
+          {portal.region_shape === 'sphere'
+            ? `sphere r=${portal.region_radius}`
+            : `box ${portal.region_half_extents.join('x')}`}
+        </span>
       </div>
       <Vec3Input
         value={portal.spawn_position}

--- a/tools/apps/bricklayer/src/panels/ProjectTree.tsx
+++ b/tools/apps/bricklayer/src/panels/ProjectTree.tsx
@@ -349,7 +349,7 @@ export function ProjectTree() {
               <TreeNode
                 key={p.id}
                 icon={icons.portals}
-                label={p.target_scene || `Portal ${i + 1}`}
+                label={p.target_instance_id || `Portal ${i + 1}`}
                 isActive={isActive({ kind: 'scene_item', entityType: 'portal', entityId: p.id })}
                 onClick={() => click({ kind: 'scene_item', entityType: 'portal', entityId: p.id })}
                 actions={removeBtn(() => removePortal(p.id))}

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -656,22 +656,35 @@ function PortalProperties({ portal }: { portal: PortalData }) {
       </div>
 
       <div style={styles.section}>
-        <span style={styles.label}>Size</span>
-        <div style={styles.row}>
+        <span style={styles.label}>Region Shape</span>
+        <select
+          style={styles.select}
+          value={portal.region_shape}
+          onChange={(e) => update(portal.id, { region_shape: e.target.value as 'box' | 'sphere' })}
+        >
+          <option value="box">Box</option>
+          <option value="sphere">Sphere</option>
+        </select>
+      </div>
+
+      {portal.region_shape === 'sphere' ? (
+        <div style={styles.section}>
+          <span style={styles.label}>Radius</span>
           <NumberInput
-            label="W"
-            value={portal.size[0]}
-            onChange={(v) => update(portal.id, { size: [v, portal.size[1]] })}
-            style={styles.input}
-          />
-          <NumberInput
-            label="H"
-            value={portal.size[1]}
-            onChange={(v) => update(portal.id, { size: [portal.size[0], v] })}
+            value={portal.region_radius}
+            onChange={(v) => update(portal.id, { region_radius: v })}
             style={styles.input}
           />
         </div>
-      </div>
+      ) : (
+        <div style={styles.section}>
+          <span style={styles.label}>Half Extents</span>
+          <Vec3Input
+            value={portal.region_half_extents}
+            onChange={(v) => update(portal.id, { region_half_extents: v })}
+          />
+        </div>
+      )}
 
       <div style={styles.section}>
         <span style={styles.label}>Target Instance</span>

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -75,8 +75,9 @@ export interface GameObjectData {
 export interface PortalData {
   id: string;
   position: [number, number, number];
-  size: [number, number];
-  target_scene: string;
+  region_shape: 'box' | 'sphere';
+  region_radius: number;
+  region_half_extents: [number, number, number];
   target_instance_id?: string;
   spawn_position: [number, number, number];
   spawn_facing: string;

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -736,8 +736,9 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     const portal: PortalData = {
       id: genId('portal'),
       position: pos ?? [0, 0, 0],
-      size: [2, 2],
-      target_scene: '',
+      region_shape: 'box',
+      region_radius: 2,
+      region_half_extents: [1, 1, 1],
       spawn_position: [0, 0, 0],
       spawn_facing: 'down',
     };
@@ -1400,12 +1401,24 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       const { height: _, ...rest } = raw;
       return rest as StaticLight;
     });
-    const migratedPortals: PortalData[] = data.scene.portals.map((p) => {
+    const migratedPortals: PortalData[] = data.scene.portals.map((p: any) => {
       const pos = p.position as unknown as number[];
-      if (pos.length === 2) {
-        return { ...p, position: [pos[0], 0, pos[1]] as [number, number, number] };
+      const migrated = pos.length === 2
+        ? { ...p, position: [pos[0], 0, pos[1]] as [number, number, number] }
+        : { ...p };
+      // Back-compat: convert legacy size to region fields
+      if (migrated.size && !migrated.region_shape) {
+        migrated.region_shape = 'box' as const;
+        migrated.region_radius = 2;
+        migrated.region_half_extents = [migrated.size[0] * 0.5, 1, migrated.size[1] * 0.5] as [number, number, number];
+        delete migrated.size;
+        delete migrated.target_scene;
       }
-      return p;
+      // Ensure new fields have defaults
+      if (!migrated.region_shape) migrated.region_shape = 'box';
+      if (migrated.region_radius == null) migrated.region_radius = 2;
+      if (!migrated.region_half_extents) migrated.region_half_extents = [1, 1, 1];
+      return migrated as PortalData;
     });
     set({
       voxels,

--- a/tools/apps/bricklayer/src/viewport/PortalMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/PortalMarkers.tsx
@@ -1,30 +1,65 @@
 import React from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 
-function PortalMarker({ position, size, isSelected, onSelect }: {
+function PortalMarker({ position, regionShape, regionRadius, regionHalfExtents, isSelected, onSelect }: {
   position: [number, number, number];
-  size: [number, number];
+  regionShape: 'box' | 'sphere';
+  regionRadius: number;
+  regionHalfExtents: [number, number, number];
   isSelected: boolean;
   onSelect: () => void;
 }) {
+  const color = isSelected ? '#ffffff' : '#ab47bc';
+  const opacity = isSelected ? 0.8 : 0.6;
+
+  if (regionShape === 'sphere') {
+    return (
+      <>
+        {/* Invisible hit sphere */}
+        <mesh
+          position={[position[0], position[1] + regionRadius, position[2]]}
+          onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}
+        >
+          <sphereGeometry args={[regionRadius + 0.4, 16, 12]} />
+          <meshBasicMaterial visible={false} />
+        </mesh>
+        {/* Visible wireframe sphere */}
+        <mesh position={[position[0], position[1] + regionRadius, position[2]]}>
+          <sphereGeometry args={[regionRadius, 16, 12]} />
+          <meshBasicMaterial
+            color={color}
+            wireframe
+            transparent
+            opacity={opacity}
+          />
+        </mesh>
+      </>
+    );
+  }
+
+  // Box region
+  const w = regionHalfExtents[0] * 2;
+  const h = regionHalfExtents[1] * 2;
+  const d = regionHalfExtents[2] * 2;
+
   return (
     <>
       {/* Invisible hit box */}
       <mesh
-        position={[position[0] + size[0] / 2, position[1] + 1, position[2] + size[1] / 2]}
+        position={[position[0], position[1] + regionHalfExtents[1], position[2]]}
         onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}
       >
-        <boxGeometry args={[size[0] + 0.8, 3.0, size[1] + 0.8]} />
+        <boxGeometry args={[w + 0.8, h + 0.8, d + 0.8]} />
         <meshBasicMaterial visible={false} />
       </mesh>
-      {/* Visible wireframe */}
-      <mesh position={[position[0] + size[0] / 2, position[1] + 1, position[2] + size[1] / 2]}>
-        <boxGeometry args={[size[0] + 0.2, 2.4, size[1] + 0.2]} />
+      {/* Visible wireframe box */}
+      <mesh position={[position[0], position[1] + regionHalfExtents[1], position[2]]}>
+        <boxGeometry args={[w, h, d]} />
         <meshBasicMaterial
-          color={isSelected ? '#ffffff' : '#ab47bc'}
+          color={color}
           wireframe
           transparent
-          opacity={isSelected ? 0.8 : 0.6}
+          opacity={opacity}
         />
       </mesh>
     </>
@@ -45,7 +80,9 @@ export function PortalMarkers() {
         <PortalMarker
           key={portal.id}
           position={portal.position}
-          size={portal.size}
+          regionShape={portal.region_shape}
+          regionRadius={portal.region_radius}
+          regionHalfExtents={portal.region_half_extents}
           isSelected={selectedEntity?.type === 'portal' && selectedEntity.id === portal.id}
           onSelect={() => setSelectedEntity({ type: 'portal', id: portal.id })}
         />


### PR DESCRIPTION
## Summary

- **Portal regions**: Replace simple `position + size[w,h]` with region system (box/sphere) matching emitters/animations. PortalData gains `region_shape`, `region_radius`, `region_half_extents`. Legacy `size` field auto-migrated.
- **Staging portal gizmos**: Render portal wireframes (cyan) in the Staging ImGui viewport. Box portals draw wireframe boxes, sphere portals draw wireframe spheres. Toggle via View menu "Gizmo: Portals".

### Changes

| Area | Files |
|------|-------|
| C++ engine | `scene_loader.hpp/cpp` — PortalData with region fields + target_instance_id, back-compat migration |
| C++ staging | `staging_state.hpp/cpp` — portal gizmo rendering with show/hide toggle |
| Bricklayer types | `types.ts` — PortalData interface updated |
| Bricklayer store | `useSceneStore.ts` — new defaults, load migration |
| Bricklayer UI | `ScenePropertiesPanel.tsx` — shape dropdown, conditional radius/half_extents |
| Bricklayer viewport | `PortalMarkers.tsx` — box/sphere wireframe rendering |
| Bricklayer export | `sceneExport.ts` — serialize region fields |

## Test plan

- [ ] C++ build succeeds (`cmake --build --preset macos-debug`)
- [ ] Bricklayer build succeeds (`pnpm build` in tools/)
- [ ] Create portal in Bricklayer — default is box with half_extents [1,1,1]
- [ ] Switch portal shape to sphere — radius input appears, half_extents hidden
- [ ] Viewport shows correct wireframe for both shapes
- [ ] Load scene in Staging — portal gizmos visible (cyan wireframes)
- [ ] Toggle "Gizmo: Portals" in Staging View menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)