### PR TITLE
feat(demo): data-driven bone-animated NPCs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,7 +346,10 @@ add_gseurat_test(test_gs_post_process)
 add_gseurat_test(test_pbd_solver)
 add_gseurat_test(test_component_registry src/engine/component_registry.cpp)
 add_gseurat_test(test_system_scheduler  src/engine/system_scheduler.cpp)
-add_gseurat_test(test_island_systems    src/demo/island_systems.cpp)
+add_gseurat_test(test_island_systems    src/demo/island_systems.cpp
+    src/character/character_manifest.cpp
+    src/character/bone_animation_player.cpp
+    src/character/bone_animation_state_machine.cpp)
 add_gseurat_test(test_character_manifest src/character/character_manifest.cpp)
 add_gseurat_test(test_bone_animation_player src/character/character_manifest.cpp src/character/bone_animation_player.cpp)
 add_gseurat_test(test_bone_animation_state_machine src/character/character_manifest.cpp src/character/bone_animation_player.cpp src/character/bone_animation_state_machine.cpp)

--- a/assets/scenes/seurat_island.json
+++ b/assets/scenes/seurat_island.json
@@ -75260,6 +75260,25 @@
       }
     },
     {
+      "id": "knight_01",
+      "name": "Knight",
+      "position": [202.0, 0.0, 187.0],
+      "rotation": [0, 0, 0],
+      "scale": 0.45,
+      "ply_file": "assets/characters/knight/knight.ply",
+      "components": {
+        "BoneAnimated": {
+          "manifest": "assets/characters/knight/knight.manifest.json",
+          "default_clip": "idle"
+        },
+        "NpcWalker": {
+          "patrol_radius": 12.0,
+          "speed": 8.0,
+          "pause_duration": 1.5
+        }
+      }
+    },
+    {
       "id": "slime_npc_1",
       "name": "Slime (patrol)",
       "position": [
@@ -75273,7 +75292,12 @@
         0
       ],
       "scale": 0.5,
+      "ply_file": "assets/characters/slime/slime.ply",
       "components": {
+        "BoneAnimated": {
+          "manifest": "assets/characters/slime/slime.manifest.json",
+          "default_clip": "idle"
+        },
         "NpcWalker": {
           "patrol_radius": 20.0,
           "speed": 8.0,
@@ -75304,7 +75328,12 @@
         0
       ],
       "scale": 0.5,
+      "ply_file": "assets/characters/slime/slime.ply",
       "components": {
+        "BoneAnimated": {
+          "manifest": "assets/characters/slime/slime.manifest.json",
+          "default_clip": "idle"
+        },
         "NpcWalker": {
           "patrol_radius": 16.0,
           "speed": 10.0,
@@ -75335,7 +75364,12 @@
         0
       ],
       "scale": 0.5,
+      "ply_file": "assets/characters/slime/slime.ply",
       "components": {
+        "BoneAnimated": {
+          "manifest": "assets/characters/slime/slime.manifest.json",
+          "default_clip": "idle"
+        },
         "NpcWalker": {
           "patrol_radius": 25.0,
           "speed": 12.0,

--- a/docs/superpowers/plans/2026-04-13-data-driven-npc-animation.md
+++ b/docs/superpowers/plans/2026-04-13-data-driven-npc-animation.md
@@ -1,0 +1,740 @@
+# Data-Driven Bone-Animated NPCs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move knight and slime NPC spawning from hardcoded C++ into scene JSON, so portal transitions handle NPCs automatically via `init_scene`.
+
+**Architecture:** Add a `BoneAnimatedTag` marker component (trivially copyable) to ECS, with full animation state in a side map (`BoneAnimationRegistry`). The scene loader assigns bone indices during PLY merge. A new `bone_animation_system` drives playback and uploads transforms each frame.
+
+**Tech Stack:** C++23, ECS (header-only archetype), GLM, nlohmann/json, existing `BoneAnimationPlayer`/`BoneAnimationStateMachine`/`CharacterData`.
+
+---
+
+### Task 1: Add BoneAnimatedTag component and BoneAnimationRegistry
+
+**Files:**
+- Modify: `include/gseurat/demo/island_components.hpp`
+- Create: `include/gseurat/demo/bone_animation_registry.hpp`
+- Modify: `src/engine/app_base.cpp` (component registration)
+
+- [ ] **Step 1: Add BoneAnimatedTag to island_components.hpp**
+
+Add after the `CollisionGridRef` struct (around line 94):
+
+```cpp
+/// Marker component for bone-animated entities (actual state in BoneAnimationRegistry).
+struct BoneAnimatedTag {
+    uint32_t registry_id = 0;  // key into BoneAnimationRegistry
+};
+```
+
+- [ ] **Step 2: Create bone_animation_registry.hpp**
+
+```cpp
+#pragma once
+
+#include "gseurat/character/bone_animation_player.hpp"
+#include "gseurat/character/bone_animation_state_machine.hpp"
+#include "gseurat/character/character_manifest.hpp"
+#include "gseurat/engine/ecs/types.hpp"
+
+#include <glm/glm.hpp>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace gseurat {
+
+struct BoneAnimationEntry {
+    std::string manifest_path;
+    std::string default_clip;
+    std::string requested_clip;       // set by behavior systems
+    uint32_t first_bone_index = 0;
+    uint32_t bone_count = 0;
+    float char_scale = 1.0f;         // from game object scale
+    float gs_scale_multiplier = 1.0f; // scene scale_multiplier
+    glm::vec3 spawn_pos{0.0f};       // initial world position (for bone transform anchoring)
+    glm::vec3 current_pos{0.0f};     // updated by walker system
+    float facing_angle = 0.0f;       // updated by walker system
+
+    // Lazy-initialized
+    std::unique_ptr<CharacterData> character_data;
+    std::unique_ptr<BoneAnimationPlayer> anim_player;
+    std::unique_ptr<BoneAnimationStateMachine> anim_sm;
+    bool initialized = false;
+};
+
+class BoneAnimationRegistry {
+public:
+    uint32_t add(ecs::Entity entity, BoneAnimationEntry entry) {
+        uint32_t id = next_id_++;
+        entries_[id] = std::move(entry);
+        entity_to_id_[entity] = id;
+        return id;
+    }
+
+    BoneAnimationEntry* get(uint32_t id) {
+        auto it = entries_.find(id);
+        return it != entries_.end() ? &it->second : nullptr;
+    }
+
+    BoneAnimationEntry* get_by_entity(ecs::Entity entity) {
+        auto it = entity_to_id_.find(entity);
+        if (it == entity_to_id_.end()) return nullptr;
+        return get(it->second);
+    }
+
+    void clear() {
+        entries_.clear();
+        entity_to_id_.clear();
+        next_id_ = 1;
+    }
+
+    const std::unordered_map<uint32_t, BoneAnimationEntry>& entries() const {
+        return entries_;
+    }
+
+private:
+    std::unordered_map<uint32_t, BoneAnimationEntry> entries_;
+    std::unordered_map<ecs::Entity, uint32_t> entity_to_id_;
+    uint32_t next_id_ = 1;
+};
+
+}  // namespace gseurat
+```
+
+- [ ] **Step 3: Register BoneAnimatedTag component in app_base.cpp**
+
+Add after the `NpcWalker` registration (around line 342):
+
+```cpp
+component_registry_.register_component<BoneAnimatedTag>("BoneAnimated",
+    [](const nlohmann::json& j) -> BoneAnimatedTag {
+        BoneAnimatedTag c;
+        // registry_id is assigned by scene loader, not from JSON
+        (void)j;
+        return c;
+    },
+    [](const BoneAnimatedTag& c) -> nlohmann::json {
+        return {{"registry_id", c.registry_id}};
+    });
+```
+
+- [ ] **Step 4: Add include for island_components.hpp in app_base.cpp**
+
+Ensure `#include "gseurat/demo/island_components.hpp"` is present (it should already be, since NpcWalker is registered there).
+
+- [ ] **Step 5: Build to verify compilation**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add include/gseurat/demo/island_components.hpp \
+        include/gseurat/demo/bone_animation_registry.hpp \
+        src/engine/app_base.cpp
+git commit -m "feat: add BoneAnimatedTag component and BoneAnimationRegistry"
+```
+
+---
+
+### Task 2: Extend scene loader with bone-aware PLY merging
+
+**Files:**
+- Modify: `include/gseurat/engine/gs_terrain_state.hpp`
+- Modify: `src/engine/gs_scene_loader.cpp`
+
+- [ ] **Step 1: Add bone allocation storage to GsTerrainState**
+
+In `include/gseurat/engine/gs_terrain_state.hpp`, add after `pbd_configs` (line 18):
+
+```cpp
+// Bone-animated game object allocations (populated by scene loader)
+struct BoneAllocation {
+    std::string manifest_path;
+    std::string default_clip;
+    uint32_t first_bone_index = 0;
+    uint32_t bone_count = 0;
+    float char_scale = 1.0f;
+    float gs_scale_multiplier = 1.0f;
+    glm::vec3 world_pos{0.0f};
+    size_t game_object_index = 0;  // index into snapped_objects for entity lookup
+};
+std::vector<BoneAllocation> bone_allocations;
+uint32_t bone_slot_counter = 8;  // first 8 reserved for player
+```
+
+Add `#include <string>` to the header if not already present.
+
+- [ ] **Step 2: Add bone index assignment in the PLY merge loop**
+
+In `src/engine/gs_scene_loader.cpp`, before the game object PLY merge loop (around line 99), add bone allocation scanning:
+
+```cpp
+// Pre-scan: allocate bone slots for BoneAnimated game objects
+ctx.terrain.bone_allocations.clear();
+ctx.terrain.bone_slot_counter = 8;  // reserve 0-7 for player
+for (size_t i = 0; i < snapped_objects.size(); ++i) {
+    const auto& go = snapped_objects[i];
+    if (go.components.is_null() || !go.components.contains("BoneAnimated")) continue;
+    const auto& ba_json = go.components["BoneAnimated"];
+    std::string manifest_path = ba_json.value("manifest", std::string{});
+    if (manifest_path.empty()) continue;
+
+    auto manifest = load_character_manifest(manifest_path);
+    if (!manifest) {
+        std::fprintf(stderr, "[GS] BoneAnimated: failed to load manifest '%s'\n",
+                     manifest_path.c_str());
+        continue;
+    }
+    uint32_t bone_count = static_cast<uint32_t>(manifest->bones.size());
+    if (ctx.terrain.bone_slot_counter + bone_count > 32) {
+        std::fprintf(stderr, "[GS] BoneAnimated: bone budget exceeded for '%s' (need %u, have %u)\n",
+                     go.id.c_str(), bone_count, 32 - ctx.terrain.bone_slot_counter);
+        continue;
+    }
+
+    GsTerrainState::BoneAllocation alloc;
+    alloc.manifest_path = manifest_path;
+    alloc.default_clip = ba_json.value("default_clip", std::string{"idle"});
+    alloc.first_bone_index = ctx.terrain.bone_slot_counter;
+    alloc.bone_count = bone_count;
+    alloc.char_scale = go.scale;
+    alloc.gs_scale_multiplier = gs_scale_multiplier;
+    alloc.world_pos = world_positions[i].vec();
+    alloc.game_object_index = i;
+    ctx.terrain.bone_allocations.push_back(alloc);
+    ctx.terrain.bone_slot_counter += bone_count;
+
+    std::fprintf(stderr, "[GS] BoneAnimated '%s': bones %u-%u (count=%u)\n",
+                 go.id.c_str(), alloc.first_bone_index,
+                 alloc.first_bone_index + bone_count - 1, bone_count);
+}
+```
+
+Add `#include "gseurat/character/character_manifest.hpp"` at the top of gs_scene_loader.cpp.
+
+- [ ] **Step 3: Apply bone indices during PLY merge**
+
+Inside the existing PLY merge loop (around line 141, where each Gaussian is transformed), add bone index remapping. Find the block that transforms placed Gaussians and add a check:
+
+After the transform application and before `merged.push_back(g)`, check if this game object has a bone allocation:
+
+```cpp
+// Check if this game object has bone animation
+uint32_t ba_first_bone = 0;
+bool has_bone_anim = false;
+for (const auto& alloc : ctx.terrain.bone_allocations) {
+    if (alloc.game_object_index == i) {
+        ba_first_bone = alloc.first_bone_index;
+        has_bone_anim = true;
+        break;
+    }
+}
+```
+
+Then in the per-Gaussian loop, if `has_bone_anim`:
+```cpp
+if (has_bone_anim) {
+    g.bone_index = ba_first_bone + g.bone_index;
+}
+```
+
+This replaces the PBD bone_index assignment for these objects (PBD and bone animation are mutually exclusive per game object — PBD is for trees, bone animation is for characters).
+
+- [ ] **Step 4: Build to verify compilation**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add include/gseurat/engine/gs_terrain_state.hpp \
+        src/engine/gs_scene_loader.cpp
+git commit -m "feat: bone-aware PLY merging in scene loader"
+```
+
+---
+
+### Task 3: Add bone_animation_system
+
+**Files:**
+- Modify: `include/gseurat/demo/island_systems.hpp`
+- Modify: `src/demo/island_systems.cpp`
+
+- [ ] **Step 1: Declare bone_animation_system in island_systems.hpp**
+
+Add after the `npc_walker_system` declaration:
+
+```cpp
+void bone_animation_system(ecs::World& world, float dt);
+```
+
+- [ ] **Step 2: Add global BoneAnimationRegistry accessor**
+
+The system needs access to the registry. Add a simple global accessor in `island_systems.hpp`:
+
+```cpp
+class BoneAnimationRegistry;
+void set_bone_animation_registry(BoneAnimationRegistry* reg);
+BoneAnimationRegistry* get_bone_animation_registry();
+```
+
+- [ ] **Step 3: Implement bone_animation_system in island_systems.cpp**
+
+Add at the end of the file:
+
+```cpp
+#include "gseurat/demo/bone_animation_registry.hpp"
+#include "gseurat/character/character_manifest.hpp"
+
+namespace {
+BoneAnimationRegistry* g_bone_anim_registry = nullptr;
+}
+
+void set_bone_animation_registry(BoneAnimationRegistry* reg) {
+    g_bone_anim_registry = reg;
+}
+
+BoneAnimationRegistry* get_bone_animation_registry() {
+    return g_bone_anim_registry;
+}
+
+void bone_animation_system(ecs::World& world, float dt) {
+    if (!g_bone_anim_registry) return;
+
+    world.view<BoneAnimatedTag, ecs::Transform>().each(
+        [&](ecs::Entity entity, BoneAnimatedTag& tag, ecs::Transform& t) {
+            auto* entry = g_bone_anim_registry->get(tag.registry_id);
+            if (!entry) return;
+
+            // Lazy initialization
+            if (!entry->initialized) {
+                auto manifest = load_character_manifest(entry->manifest_path);
+                if (!manifest) return;
+                entry->character_data = std::make_unique<CharacterData>(std::move(*manifest));
+                entry->anim_player = std::make_unique<BoneAnimationPlayer>(*entry->character_data);
+                entry->anim_sm = std::make_unique<BoneAnimationStateMachine>(*entry->anim_player);
+
+                // Register clips as states
+                for (const auto& clip : entry->character_data->clips) {
+                    entry->anim_sm->add_state(clip.name, clip.name);
+                }
+                entry->anim_sm->set_state(entry->default_clip);
+
+                entry->spawn_pos = t.position.vec();
+                entry->current_pos = t.position.vec();
+                entry->initialized = true;
+                std::fprintf(stderr, "[BoneAnimSystem] Initialized '%s': %u bones, clip='%s'\n",
+                             entry->manifest_path.c_str(), entry->bone_count, entry->default_clip.c_str());
+            }
+
+            // Update position from Transform (NpcWalker moves this)
+            entry->current_pos = t.position.vec();
+
+            // Check for clip change from behavior systems
+            if (!entry->requested_clip.empty() &&
+                entry->requested_clip != entry->anim_sm->current_state()) {
+                entry->anim_sm->set_state(entry->requested_clip);
+            }
+
+            // Advance animation
+            entry->anim_player->update(dt);
+        });
+}
+```
+
+- [ ] **Step 4: Add include for BoneAnimatedTag**
+
+Ensure `#include "gseurat/demo/island_components.hpp"` is included in `island_systems.cpp` (should already be present).
+
+- [ ] **Step 5: Build to verify compilation**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add include/gseurat/demo/island_systems.hpp \
+        src/demo/island_systems.cpp
+git commit -m "feat: add bone_animation_system with lazy initialization"
+```
+
+---
+
+### Task 4: Wire bone_animation_system into island_demo_state and upload transforms
+
+**Files:**
+- Modify: `include/gseurat/demo/island_demo_state.hpp`
+- Modify: `src/demo/island_demo_state.cpp`
+
+- [ ] **Step 1: Add BoneAnimationRegistry member to IslandDemoState**
+
+In `include/gseurat/demo/island_demo_state.hpp`, add include:
+
+```cpp
+#include "gseurat/demo/bone_animation_registry.hpp"
+```
+
+Add member after `world_streamer_` (around line 124):
+
+```cpp
+// Bone animation registry (data-driven NPC animation)
+BoneAnimationRegistry bone_anim_registry_;
+```
+
+- [ ] **Step 2: Register the system and set up registry in on_enter()**
+
+In `src/demo/island_demo_state.cpp`, in `on_enter()`, after the existing `add_system` calls (around line 258):
+
+```cpp
+app.system_scheduler().add_system({"bone_animation", bone_animation_system, {}, {}});
+set_bone_animation_registry(&bone_anim_registry_);
+```
+
+- [ ] **Step 3: Populate registry from scene loader bone allocations**
+
+After `init_scene` and the player entity creation (around line 253), add:
+
+```cpp
+// Populate bone animation registry from scene loader allocations
+bone_anim_registry_.clear();
+for (const auto& alloc : app.gs_terrain().bone_allocations) {
+    // Find the ECS entity for this game object
+    // The entity was created by gs_scene_loader at the same index
+    // We need to match by transform position
+    app.world().view<BoneAnimatedTag, ecs::Transform>().each(
+        [&](ecs::Entity entity, BoneAnimatedTag& tag, ecs::Transform& t) {
+            if (tag.registry_id != 0) return;  // already assigned
+            glm::vec3 diff = t.position.vec() - alloc.world_pos;
+            if (glm::length(diff) < 1.0f) {
+                BoneAnimationEntry entry;
+                entry.manifest_path = alloc.manifest_path;
+                entry.default_clip = alloc.default_clip;
+                entry.first_bone_index = alloc.first_bone_index;
+                entry.bone_count = alloc.bone_count;
+                entry.char_scale = alloc.char_scale;
+                entry.gs_scale_multiplier = alloc.gs_scale_multiplier;
+                entry.spawn_pos = alloc.world_pos;
+                entry.current_pos = alloc.world_pos;
+                tag.registry_id = bone_anim_registry_.add(entity, std::move(entry));
+            }
+        });
+}
+```
+
+- [ ] **Step 4: Add bone transform upload in update_walk_animation**
+
+In `update_walk_animation()`, after the player bone transforms are written to `bones[]` (around line 1416) but before the existing knight/slime code, add NPC bone gathering:
+
+```cpp
+// Gather bone transforms from BoneAnimationRegistry (data-driven NPCs)
+for (const auto& [id, entry] : bone_anim_registry_.entries()) {
+    if (!entry.initialized || !entry.anim_player) continue;
+
+    const float scale_val = entry.char_scale;
+    const glm::vec3 y_off(0.0f, 2.0f, 0.0f);
+    const glm::vec3 char_scale(scale_val, scale_val * entry.gs_scale_multiplier, scale_val);
+    const glm::vec3 inv_scale(1.0f / char_scale.x, 1.0f / char_scale.y, 1.0f / char_scale.z);
+
+    glm::mat4 from_world =
+        glm::rotate(glm::mat4(1.0f), -glm::pi<float>(), {0, 1, 0}) *
+        glm::scale(glm::mat4(1.0f), inv_scale) *
+        glm::translate(glm::mat4(1.0f), -(entry.spawn_pos + y_off));
+
+    glm::quat rot = glm::angleAxis(entry.facing_angle, glm::vec3(0, 1, 0));
+    glm::mat4 to_world =
+        glm::translate(glm::mat4(1.0f), entry.current_pos + y_off) *
+        glm::mat4_cast(rot) *
+        glm::scale(glm::mat4(1.0f), char_scale) *
+        glm::rotate(glm::mat4(1.0f), glm::pi<float>(), {0, 1, 0});
+
+    const auto& npc_bones = entry.anim_player->bone_transforms();
+    for (uint32_t i = 0; i < entry.bone_count && (entry.first_bone_index + i) < 32; ++i) {
+        bones[entry.first_bone_index + i] = to_world * npc_bones[i] * from_world;
+    }
+}
+
+// Update total bone count to include registry NPCs
+if (app.gs_terrain().bone_slot_counter > static_cast<uint32_t>(total_bones)) {
+    total_bones = static_cast<int>(app.gs_terrain().bone_slot_counter);
+}
+```
+
+- [ ] **Step 5: Build to verify compilation**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add include/gseurat/demo/island_demo_state.hpp \
+        src/demo/island_demo_state.cpp
+git commit -m "feat: wire bone_animation_system into demo state with transform upload"
+```
+
+---
+
+### Task 5: Update NpcWalker to set requested_clip on BoneAnimated entities
+
+**Files:**
+- Modify: `src/demo/island_systems.cpp`
+
+- [ ] **Step 1: Update npc_walker_system to set requested_clip**
+
+In `npc_walker_system` in `island_systems.cpp`, after the NpcWalker movement logic updates the transform, add clip request. At the end of the `each` lambda (before the closing brace), add:
+
+```cpp
+// Set animation clip based on movement state
+if (g_bone_anim_registry) {
+    auto* ba_entry = g_bone_anim_registry->get_by_entity(entity);
+    if (ba_entry) {
+        ba_entry->requested_clip = npc.paused ? "idle" : "walk";
+        // Update facing angle from movement direction
+        if (!npc.paused) {
+            float dx = npc.target_x - t.position.x();
+            float dz = npc.target_z - t.position.z();
+            if (dx * dx + dz * dz > 0.01f) {
+                ba_entry->facing_angle = std::atan2(dx, dz);
+            }
+        }
+    }
+}
+```
+
+Add `#include <cmath>` if not already present.
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/demo/island_systems.cpp
+git commit -m "feat: NpcWalker sets requested_clip on BoneAnimated entries"
+```
+
+---
+
+### Task 6: Add knight and slime NPCs to seurat_island.json
+
+**Files:**
+- Modify: `assets/scenes/seurat_island.json`
+
+- [ ] **Step 1: Add knight game object with BoneAnimated component**
+
+In the `game_objects` array of `assets/scenes/seurat_island.json`, add:
+
+```json
+{
+  "id": "knight_01",
+  "name": "Knight",
+  "position": [202.0, 0.0, 187.0],
+  "rotation": [0, 0, 0],
+  "scale": 0.45,
+  "ply_file": "assets/characters/knight/knight.ply",
+  "components": {
+    "BoneAnimated": {
+      "manifest": "assets/characters/knight/knight.manifest.json",
+      "default_clip": "idle"
+    },
+    "NpcWalker": {
+      "patrol_radius": 12.0,
+      "speed": 8.0,
+      "pause_duration": 1.5
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Add slime NPC game objects with BoneAnimated component**
+
+For each existing slime NPC in the `game_objects` array (those with `"name": "Slime ..."` and `NpcWalker` component), add `ply_file` and `BoneAnimated`:
+
+```json
+{
+  "id": "slime_npc_1",
+  "name": "Slime (scout)",
+  "position": [190.0, 3.0, 210.0],
+  "rotation": [0, 0, 0],
+  "scale": 0.5,
+  "ply_file": "assets/characters/slime/slime.ply",
+  "components": {
+    "BoneAnimated": {
+      "manifest": "assets/characters/slime/slime.manifest.json",
+      "default_clip": "idle"
+    },
+    "NpcWalker": {
+      "patrol_radius": 20.0,
+      "speed": 8.0,
+      "pause_duration": 0.8
+    },
+    "ProximityTrigger": { "radius": 6 },
+    "AnimationTrigger": {
+      "effect_name": "pulse",
+      "anim_radius": 4.0,
+      "lifetime": 2.0,
+      "loop": true
+    }
+  }
+}
+```
+
+Repeat for all slime NPCs (slime_npc_1, slime_npc_2, slime_npc_3). Keep their existing positions and component data, just add `ply_file` and `BoneAnimated`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add assets/scenes/seurat_island.json
+git commit -m "feat: add BoneAnimated component to knight and slime NPCs in scene JSON"
+```
+
+---
+
+### Task 7: Remove hardcoded NPC code from island_demo_state
+
+**Files:**
+- Modify: `include/gseurat/demo/island_demo_state.hpp`
+- Modify: `src/demo/island_demo_state.cpp`
+
+- [ ] **Step 1: Remove NPC members from header**
+
+In `include/gseurat/demo/island_demo_state.hpp`, remove:
+
+- `NpcInfo` struct (lines 71-80)
+- `std::vector<NpcInfo> npc_infos_` (line 81)
+- `uint32_t next_bone_index_` (line 82)
+- `kSlimeJumpDuration` and `kSlimeJumpHeight` constants (lines 83-84)
+- `KnightInfo` struct (lines 87-95)
+- `kKnightSpeed` and `kKnightPatrolRadius` constants (lines 96-97)
+- `std::optional<KnightInfo> knight_info_` (line 98)
+- `std::unique_ptr<gseurat::CharacterData> knight_data_` (line 99)
+- `std::unique_ptr<gseurat::BoneAnimationPlayer> knight_anim_player_` (line 100)
+- `std::unique_ptr<gseurat::BoneAnimationStateMachine> knight_anim_sm_` (line 101)
+
+- [ ] **Step 2: Remove knight spawning code from on_enter()**
+
+In `src/demo/island_demo_state.cpp`, remove the entire knight loading and PLY merge block (lines 331-389 approximately — from `// Load knight character manifest and PLY` through the end of the knight spawn).
+
+- [ ] **Step 3: Remove slime Gaussian merging from on_enter()**
+
+Remove the slime PLY loading and per-NPC merge block (lines 391-434 approximately — from `auto slime_cloud = GaussianCloud::load_ply("assets/characters/slime/slime.ply")` through the end of the NPC loop).
+
+- [ ] **Step 4: Remove knight/slime bone transforms from update_walk_animation()**
+
+Remove:
+- The slime squish/jump transform block (the `for (auto& npc : npc_infos_)` loop, approximately lines 1420-1477)
+- The knight bone transform block (the `if (knight_info_ && ...)` block, approximately lines 1479-1560)
+- The `next_bone_index_` references in the total_bones calculation
+
+Keep the player bone transform code and the new registry-based bone gathering from Task 4.
+
+- [ ] **Step 5: Remove NPC re-spawn code from portal transition**
+
+Remove the entire knight and slime re-spawn blocks from the portal `is_overworld` path (approximately lines 810-885 — the `if (knight_data_)` block and the slime re-spawn block added in PR #233).
+
+Also remove from the `world.clear()` block:
+- `npc_infos_.clear()`
+- `knight_info_.reset()`
+
+- [ ] **Step 6: Update portal transition to repopulate bone registry**
+
+After the `init_scene` call in the portal transition, add registry repopulation (same pattern as Task 4 Step 3):
+
+```cpp
+// Repopulate bone animation registry for the new scene
+bone_anim_registry_.clear();
+for (const auto& alloc : app.gs_terrain().bone_allocations) {
+    app.world().view<BoneAnimatedTag, ecs::Transform>().each(
+        [&](ecs::Entity entity, BoneAnimatedTag& tag, ecs::Transform& t) {
+            if (tag.registry_id != 0) return;
+            glm::vec3 diff = t.position.vec() - alloc.world_pos;
+            if (glm::length(diff) < 1.0f) {
+                BoneAnimationEntry entry;
+                entry.manifest_path = alloc.manifest_path;
+                entry.default_clip = alloc.default_clip;
+                entry.first_bone_index = alloc.first_bone_index;
+                entry.bone_count = alloc.bone_count;
+                entry.char_scale = alloc.char_scale;
+                entry.gs_scale_multiplier = alloc.gs_scale_multiplier;
+                entry.spawn_pos = alloc.world_pos;
+                entry.current_pos = alloc.world_pos;
+                tag.registry_id = bone_anim_registry_.add(entity, std::move(entry));
+            }
+        });
+}
+```
+
+- [ ] **Step 7: Clean up on_exit()**
+
+Remove knight_data_ cleanup from `on_exit()` if present. Add:
+
+```cpp
+bone_anim_registry_.clear();
+set_bone_animation_registry(nullptr);
+```
+
+- [ ] **Step 8: Build to verify compilation**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add include/gseurat/demo/island_demo_state.hpp \
+        src/demo/island_demo_state.cpp
+git commit -m "refactor: remove hardcoded NPC spawning, use data-driven bone animation"
+```
+
+---
+
+### Task 8: Add bone_animation_registry.hpp to CMakeLists.txt and final build
+
+**Files:**
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Add new header to CMakeLists.txt**
+
+If the project uses explicit source lists (it does — no globbing), add `include/gseurat/demo/bone_animation_registry.hpp` to the appropriate header list in CMakeLists.txt. Since it's a header-only file, it may only need to be in an IDE sources list if one exists.
+
+Check if other headers from `include/gseurat/demo/` are listed. If not, no change needed (header-only, found via include path).
+
+- [ ] **Step 2: Full release build**
+
+Run: `cmake --build --preset macos-release --target gseurat_demo 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 3: Verify the demo launches**
+
+Run (from build dir): `./gseurat_demo`
+
+Expected log output:
+```
+[GS] BoneAnimated 'knight_01': bones 8-13 (count=6)
+[GS] BoneAnimated 'slime_npc_1': bones 14-14 (count=1)
+[GS] BoneAnimated 'slime_npc_2': bones 15-15 (count=1)
+[GS] BoneAnimated 'slime_npc_3': bones 16-16 (count=1)
+[BoneAnimSystem] Initialized '...knight.manifest.json': 6 bones, clip='idle'
+[BoneAnimSystem] Initialized '...slime.manifest.json': 1 bones, clip='idle'
+```
+
+- [ ] **Step 4: Test portal round-trip**
+
+Walk to dungeon portal → enter → walk to exit portal → return to overworld.
+
+Expected: Knight and slimes are present after return. No re-spawn log messages needed — `init_scene` handles everything.
+
+- [ ] **Step 5: Commit if any final fixes were needed**
+
+```bash
+git add -A
+git commit -m "fix: final adjustments for data-driven NPC animation"
+```

--- a/docs/superpowers/specs/2026-04-13-data-driven-npc-animation-design.md
+++ b/docs/superpowers/specs/2026-04-13-data-driven-npc-animation-design.md
@@ -1,0 +1,190 @@
+# Data-Driven Bone-Animated NPCs
+
+**Date:** 2026-04-13
+**Status:** Draft
+
+## Problem
+
+Knight and slime NPCs are hardcoded in `island_demo_state.cpp` (~200 lines of manual PLY merging, bone slot assignment, and re-spawn logic). Portal transitions require manually re-creating NPCs, which caused the "NPCs gone after dungeon" bug (PR #233). Adding or changing NPCs requires C++ code changes.
+
+## Goal
+
+Define bone-animated NPCs entirely in scene JSON. Portal transitions automatically handle NPC creation/destruction via the standard `init_scene` flow.
+
+## Design Decisions
+
+- **Demo-level, not engine-level** — New component and system live in the demo layer (`island_components.hpp`, `island_systems.hpp`), consistent with existing demo components. Can be promoted to engine later.
+- **Sequential bone slot allocation** — Scene loader assigns bone indices automatically at load time. No manual bookkeeping.
+- **Scene loader handles PLY merge** — `GsSceneLoader` assigns bone indices during Gaussian merging, so portal transitions work automatically.
+- **Generic animation system** — One `bone_animation_system` updates all `BoneAnimated` entities. Behavior components (NpcWalker, PlayerController) choose which clip to play.
+
+## New Component: `BoneAnimated`
+
+### Scene JSON
+
+```json
+{
+  "id": "knight_01",
+  "name": "Knight",
+  "position": [202, 0, 187],
+  "ply_file": "assets/characters/knight/knight.ply",
+  "scale": 0.45,
+  "components": {
+    "BoneAnimated": {
+      "manifest": "assets/characters/knight/knight.manifest.json",
+      "default_clip": "idle"
+    },
+    "NpcWalker": { "patrol_radius": 12.0, "speed": 8.0 }
+  }
+}
+```
+
+### C++ Struct (`island_components.hpp`)
+
+```cpp
+struct BoneAnimated {
+    std::string manifest_path;       // path to character manifest JSON
+    std::string default_clip;        // initial animation clip name
+    uint32_t first_bone_index = 0;   // assigned by scene loader
+    uint32_t bone_count = 0;         // from manifest, set at load time
+    std::string requested_clip;      // set by behavior systems (NpcWalker, etc.)
+};
+```
+
+Note: ECS archetypes use memcpy, so `BoneAnimated` cannot be stored directly in the archetype. It must use an indirection pattern — either a side map keyed by entity, or a pointer/index into a separate storage. The recommended approach is a `std::unordered_map<ecs::Entity, BoneAnimated>` managed by the animation system.
+
+### Registration
+
+```cpp
+// In app_base.cpp init_game_object_system() or island demo setup
+registry.register_component<BoneAnimatedTag>("BoneAnimated", ...);
+```
+
+Where `BoneAnimatedTag` is a trivially-copyable marker struct stored in the archetype, and the full `BoneAnimated` data lives in the side map.
+
+## Scene Loader Changes
+
+### Bone Slot Allocator
+
+In `GsSceneLoader::load()`, before the game object merge loop:
+
+```
+bone_slot_counter = kPlayerBoneReserve (8)
+```
+
+For each game object with a `BoneAnimated` component:
+
+1. Parse `manifest` path from component JSON
+2. Load manifest to get bone count
+3. Assign `first_bone_index = bone_slot_counter`
+4. Advance `bone_slot_counter += bone_count`
+5. Guard: if `bone_slot_counter > 32`, log warning and skip
+
+### PLY Merge with Bone Indices
+
+The existing PLY merge loop in `GsSceneLoader::load()` already iterates game object Gaussians and applies position/rotation/scale transforms. Extend it:
+
+- If the game object has a `BoneAnimated` component, read `first_bone_index` from the allocation
+- For each Gaussian: `g.bone_index = first_bone_index + g.bone_index`
+
+This replaces the per-character merge code in `island_demo_state.cpp`.
+
+### Allocation Storage
+
+The scene loader stores allocations in `SceneLoadContext` so the animation system can access them:
+
+```cpp
+// In SceneLoadContext or a new BoneAllocationMap
+struct BoneAllocation {
+    std::string manifest_path;
+    std::string default_clip;
+    uint32_t first_bone_index;
+    uint32_t bone_count;
+    glm::vec3 spawn_pos;  // for bone transform world-space conversion
+};
+std::unordered_map<ecs::Entity, BoneAllocation> bone_allocations;
+```
+
+## New System: `bone_animation_system`
+
+### Initialization
+
+On first tick (or when a new `BoneAnimated` entity appears), the system:
+
+1. Loads `CharacterData` from the manifest path
+2. Creates `BoneAnimationPlayer` and `BoneAnimationStateMachine`
+3. Plays the `default_clip`
+4. Stores these in a side map keyed by entity
+
+### Per-Frame Update
+
+For each `BoneAnimated` entity:
+
+1. Check `requested_clip` — if different from current, transition
+2. Call `anim_player.update(dt)`
+3. Compute world-space bone transforms:
+   - `world_transform = translate(current_pos) * rotate(facing) * scale`
+   - `bone_world[i] = to_world * bone_local[i] * from_world`
+4. Write transforms into the bone SSBO at `[first_bone_index .. first_bone_index + bone_count)`
+
+### Clip Selection Convention
+
+Behavior components set `requested_clip` on the `BoneAnimated` side map entry:
+
+- `NpcWalker`: `"walk"` when moving, `"idle"` when paused
+- Future components can set any clip name from the manifest
+
+## What Gets Removed from `island_demo_state.cpp`
+
+- `KnightInfo` struct and `knight_info_` member
+- `knight_data_`, `knight_anim_player_`, `knight_anim_sm_` members
+- `NpcInfo` struct and `npc_infos_` member  
+- `next_bone_index_` member
+- Knight spawning code in `on_enter()` (~60 lines)
+- Slime Gaussian merging in `on_enter()` (~40 lines)
+- Knight/slime bone transform gathering in `update_walk_animation()` (~80 lines)
+- All NPC re-spawn code in portal transition (~70 lines)
+
+## What Stays in `island_demo_state.cpp`
+
+- Player character spawning and animation (special root motion, jump arcs, camera coupling)
+- Portal transition logic (simplified: `world.clear()` + `init_scene()` + re-create player entity)
+- Player bone transform upload (bones 0-7)
+
+## Scene JSON Updates
+
+### `seurat_island.json`
+
+Add `BoneAnimated` component to existing knight and slime game objects:
+
+```json
+{
+  "id": "knight_01",
+  "name": "Knight",
+  "position": [202, 0, 187],
+  "ply_file": "assets/characters/knight/knight.ply",
+  "scale": 0.45,
+  "components": {
+    "BoneAnimated": {
+      "manifest": "assets/characters/knight/knight.manifest.json",
+      "default_clip": "idle"
+    },
+    "NpcWalker": { "patrol_radius": 12.0, "speed": 8.0, "pause_duration": 1.5 }
+  }
+}
+```
+
+Slime NPCs similarly get `BoneAnimated` with `"manifest": "assets/characters/slime/slime.manifest.json"`.
+
+### `dungeon.json` / `northern_forest.json`
+
+These scenes can now add animated NPCs by just adding game objects with `BoneAnimated` — no C++ changes needed.
+
+## Testing
+
+1. **Build succeeds** — no compilation errors
+2. **Startup** — Knight and slimes appear with animation on the island
+3. **Portal round-trip** — Enter dungeon, exit back. NPCs present without re-spawn code.
+4. **Bone indices** — Log bone allocations at load time, verify no overlap with player (0-7)
+5. **Animation playback** — Knight patrols with walk/idle transitions, slimes bounce
+6. **No regressions** — Player animation, portal transitions, collision all unchanged

--- a/include/gseurat/demo/bone_animation_registry.hpp
+++ b/include/gseurat/demo/bone_animation_registry.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "gseurat/character/bone_animation_player.hpp"
+#include "gseurat/character/bone_animation_state_machine.hpp"
+#include "gseurat/character/character_manifest.hpp"
+#include "gseurat/engine/ecs/types.hpp"
+
+#include <glm/glm.hpp>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace gseurat {
+
+struct BoneAnimationEntry {
+    std::string manifest_path;
+    std::string default_clip;
+    std::string requested_clip;       // set by behavior systems
+    uint32_t first_bone_index = 0;
+    uint32_t bone_count = 0;
+    float char_scale = 1.0f;         // from game object scale
+    float gs_scale_multiplier = 1.0f; // scene scale_multiplier
+    glm::vec3 spawn_pos{0.0f};       // initial world position (for bone transform anchoring)
+    glm::vec3 current_pos{0.0f};     // updated by walker system
+    float facing_angle = 0.0f;       // updated by walker system
+
+    // Lazy-initialized
+    std::unique_ptr<CharacterData> character_data;
+    std::unique_ptr<BoneAnimationPlayer> anim_player;
+    std::unique_ptr<BoneAnimationStateMachine> anim_sm;
+    bool initialized = false;
+};
+
+class BoneAnimationRegistry {
+public:
+    uint32_t add(ecs::Entity entity, BoneAnimationEntry entry) {
+        uint32_t id = next_id_++;
+        entries_[id] = std::move(entry);
+        entity_to_id_[entity] = id;
+        return id;
+    }
+
+    BoneAnimationEntry* get(uint32_t id) {
+        auto it = entries_.find(id);
+        return it != entries_.end() ? &it->second : nullptr;
+    }
+
+    BoneAnimationEntry* get_by_entity(ecs::Entity entity) {
+        auto it = entity_to_id_.find(entity);
+        if (it == entity_to_id_.end()) return nullptr;
+        return get(it->second);
+    }
+
+    void clear() {
+        entries_.clear();
+        entity_to_id_.clear();
+        next_id_ = 1;
+    }
+
+    const std::unordered_map<uint32_t, BoneAnimationEntry>& entries() const {
+        return entries_;
+    }
+
+private:
+    std::unordered_map<uint32_t, BoneAnimationEntry> entries_;
+    std::unordered_map<ecs::Entity, uint32_t> entity_to_id_;
+    uint32_t next_id_ = 1;
+};
+
+}  // namespace gseurat

--- a/include/gseurat/demo/bone_animation_registry.hpp
+++ b/include/gseurat/demo/bone_animation_registry.hpp
@@ -52,6 +52,12 @@ public:
     }
 
     void clear() {
+        // Leak CharacterData — its destructor crashes on macOS (known allocator issue)
+        for (auto& [id, entry] : entries_) {
+            (void)entry.character_data.release();
+            (void)entry.anim_player.release();
+            (void)entry.anim_sm.release();
+        }
         entries_.clear();
         entity_to_id_.clear();
         next_id_ = 1;

--- a/include/gseurat/demo/island_components.hpp
+++ b/include/gseurat/demo/island_components.hpp
@@ -108,4 +108,9 @@ struct NpcWalker {
     bool paused = true;
 };
 
+/// Marker component for bone-animated entities (actual state in BoneAnimationRegistry).
+struct BoneAnimatedTag {
+    uint32_t registry_id = 0;  // key into BoneAnimationRegistry
+};
+
 }  // namespace gseurat

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -10,6 +10,7 @@
 #include "gseurat/engine/types.hpp"
 #include "gseurat/engine/world_streamer.hpp"
 #include "gseurat/engine/ecs/types.hpp"
+#include "gseurat/demo/bone_animation_registry.hpp"
 
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
@@ -122,6 +123,9 @@ private:
 
     // World streaming
     std::unique_ptr<WorldStreamer> world_streamer_;
+
+    // Bone animation registry (data-driven NPC animation)
+    BoneAnimationRegistry bone_anim_registry_;
 
     // Orbit camera (third-person around player)
     float azimuth_ = 0.0f;

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -17,7 +17,6 @@
 #include <array>
 #include <chrono>
 #include <memory>
-#include <optional>
 #include <string>
 
 namespace gseurat {
@@ -67,39 +66,6 @@ private:
     glm::vec3 character_origin_{0.0f};     // current player position
     float gs_scale_ = 1.0f;               // scene scale_multiplier (for bone coord conversion)
     std::vector<Gaussian> map_gaussians_;  // original map data before character merge
-
-    // NPC tracking (for bone animation)
-    struct NpcInfo {
-        ecs::Entity entity = ecs::kNullEntity;
-        glm::vec3 spawn_pos{0.0f};
-        uint32_t bone_index = 0;
-        float squish_phase = 0.0f;  // per-slime animation phase offset
-        // Slime jump state
-        bool slime_jumping = false;
-        float slime_jump_time = 0.0f;
-        float slime_jump_cooldown = 0.0f;  // time until next possible jump
-    };
-    std::vector<NpcInfo> npc_infos_;
-    uint32_t next_bone_index_ = 0;
-    static constexpr float kSlimeJumpDuration = 0.6f;
-    static constexpr float kSlimeJumpHeight = 2.5f;
-
-    // Knight NPC
-    struct KnightInfo {
-        glm::vec3 spawn_pos{0.0f};
-        glm::vec3 current_pos{0.0f};
-        glm::vec3 walk_target{0.0f};
-        float facing_angle = 0.0f;
-        uint32_t first_bone_index = 0;
-        float anim_cycle_timer = 0.0f;
-        int current_anim = 0;
-    };
-    static constexpr float kKnightSpeed = 8.0f;
-    static constexpr float kKnightPatrolRadius = 12.0f;
-    std::optional<KnightInfo> knight_info_;
-    std::unique_ptr<gseurat::CharacterData> knight_data_;
-    std::unique_ptr<gseurat::BoneAnimationPlayer> knight_anim_player_;
-    std::unique_ptr<gseurat::BoneAnimationStateMachine> knight_anim_sm_;
 
     // Data-driven bone animation
     std::unique_ptr<gseurat::CharacterData> character_data_;

--- a/include/gseurat/demo/island_systems.hpp
+++ b/include/gseurat/demo/island_systems.hpp
@@ -9,5 +9,10 @@ void proximity_trigger_system(ecs::World& world, float dt);
 void linked_trigger_system(ecs::World& world, float dt);
 void emissive_toggle_system(ecs::World& world, float dt);
 void npc_walker_system(ecs::World& world, float dt);
+void bone_animation_system(ecs::World& world, float dt);
+
+class BoneAnimationRegistry;
+void set_bone_animation_registry(BoneAnimationRegistry* reg);
+BoneAnimationRegistry* get_bone_animation_registry();
 
 }  // namespace gseurat

--- a/include/gseurat/engine/gs_terrain_state.hpp
+++ b/include/gseurat/engine/gs_terrain_state.hpp
@@ -6,6 +6,7 @@
 #include "gseurat/engine/scene_loader.hpp"
 
 #include <glm/glm.hpp>
+#include <string>
 #include <vector>
 
 namespace gseurat {
@@ -16,6 +17,21 @@ struct GsTerrainState {
     float cloud_extent = 100.0f;
     std::vector<glm::vec3> pbd_anchors;
     std::vector<PbdConfig> pbd_configs;
+
+    // Bone-animated game object allocations (populated by scene loader)
+    struct BoneAllocation {
+        std::string manifest_path;
+        std::string default_clip;
+        uint32_t first_bone_index = 0;
+        uint32_t bone_count = 0;
+        float char_scale = 1.0f;
+        float gs_scale_multiplier = 1.0f;
+        glm::vec3 world_pos{0.0f};
+        size_t game_object_index = 0;  // index into snapped_objects for entity lookup
+    };
+    std::vector<BoneAllocation> bone_allocations;
+    uint32_t bone_slot_counter = 8;  // first 8 reserved for player
+
     CollisionGrid collision_grid;
     GsParallaxCamera parallax_camera;
     bool parallax_active = false;

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -326,6 +326,9 @@ void IslandDemoState::on_enter(AppBase& app) {
                 cg.position = player_pos + offset + glm::vec3(0, 2.0f, 0);
                 cg.scale *= kCharScale;
                 cg.opacity = std::min(1.0f, cg.opacity * 1.3f);
+                // Offset bone_index by +1 — shader skips bone_index=0 (terrain),
+                // and update_walk_animation writes character bones at [i + 1]
+                cg.bone_index = cg.bone_index + 1;
                 merged.push_back(cg);
             }
         }
@@ -738,6 +741,7 @@ void IslandDemoState::update(AppBase& app, float dt) {
                                 cg.position = spawn + offset + glm::vec3(0, 2.0f, 0);
                                 cg.scale *= kCharScale;
                                 cg.opacity = std::min(1.0f, cg.opacity * 1.3f);
+                                cg.bone_index = cg.bone_index + 1;
                                 merged.push_back(cg);
                             }
                         }

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -330,111 +330,6 @@ void IslandDemoState::on_enter(AppBase& app) {
             }
         }
 
-        // Load knight character manifest and PLY
-        {
-            auto knight_loaded = gseurat::load_character_manifest(
-                "assets/characters/knight/knight.manifest.json");
-            if (knight_loaded) {
-                knight_data_ = std::make_unique<gseurat::CharacterData>(std::move(*knight_loaded));
-                std::fprintf(stderr, "[IslandDemo] Knight manifest loaded: %zu bones, %zu clips\n",
-                             knight_data_->bones.size(), knight_data_->clips.size());
-            }
-        }
-
-        auto knight_cloud = GaussianCloud::load_ply("assets/characters/knight/knight.ply");
-        if (!knight_cloud.empty() && knight_data_) {
-            int player_bone_count = character_data_
-                ? static_cast<int>(character_data_->bones.size()) : 1;
-            next_bone_index_ = static_cast<uint32_t>(player_bone_count + 1);
-
-            KnightInfo ki;
-            // Spawn knight near the house
-            ki.spawn_pos = player_pos + glm::vec3(15.0f, 0.0f, -10.0f);
-            // Snap to elevation
-            if (collision_grid_.width > 0 && !collision_grid_.elevation.empty()) {
-                float lx = ki.spawn_pos.x - grid_origin_.x;
-                float lz = ki.spawn_pos.z - grid_origin_.y;
-                int gx = static_cast<int>(lx / collision_grid_.cell_size);
-                int gz = static_cast<int>(lz / collision_grid_.cell_size);
-                if (gx >= 0 && gx < static_cast<int>(collision_grid_.width) &&
-                    gz >= 0 && gz < static_cast<int>(collision_grid_.height)) {
-                    ki.spawn_pos.y = collision_grid_.get_elevation(
-                        static_cast<uint32_t>(gx), static_cast<uint32_t>(gz));
-                }
-            }
-            ki.first_bone_index = next_bone_index_;
-
-            constexpr float kKnightScale = 0.45f;
-            const auto& knight_gs = knight_cloud.gaussians();
-            for (const auto& g : knight_gs) {
-                Gaussian kg = g;
-                glm::vec3 rotated(-kg.position.x, kg.position.y, -kg.position.z);
-                glm::vec3 offset = rotated * kKnightScale;
-                offset.y *= gs_scale;
-                kg.position = ki.spawn_pos + offset + glm::vec3(0, 2.0f, 0);
-                kg.scale *= kKnightScale;
-                // Assign knight bones — map bone_index from PLY to our bone slot
-                kg.bone_index = next_bone_index_ + kg.bone_index;
-                kg.opacity = std::min(1.0f, kg.opacity * 1.3f);
-                merged.push_back(kg);
-            }
-            next_bone_index_ += static_cast<uint32_t>(knight_data_->bones.size());
-
-            ki.current_pos = ki.spawn_pos;
-            ki.walk_target = ki.spawn_pos;
-            ki.facing_angle = glm::pi<float>() * 0.5f;
-            knight_info_ = ki;
-            std::fprintf(stderr, "[IslandDemo] Knight spawned at (%.1f, %.1f, %.1f) bones=%u-%u +%u gs\n",
-                         ki.spawn_pos.x, ki.spawn_pos.y, ki.spawn_pos.z,
-                         ki.first_bone_index, next_bone_index_ - 1,
-                         static_cast<uint32_t>(knight_gs.size()));
-        }
-
-        // Load NPC slime Gaussians with unique bone indices
-        auto slime_cloud = GaussianCloud::load_ply("assets/characters/slime/slime.ply");
-        std::fprintf(stderr, "[IslandDemo] Slime PLY: %u Gaussians\n",
-                     slime_cloud.count());
-        if (!slime_cloud.empty()) {
-            // next_bone_index_ already set by knight loading above;
-            // if no knight, initialize it now
-            if (!knight_info_) {
-                int player_bone_count = character_data_
-                    ? static_cast<int>(character_data_->bones.size()) : 1;
-                next_bone_index_ = static_cast<uint32_t>(player_bone_count + 1);
-            }
-
-            app.world().view<NpcWalker, ecs::Transform>().each(
-                [&](ecs::Entity entity, NpcWalker&, ecs::Transform& t) {
-                    if (next_bone_index_ >= 31) return;
-
-                    NpcInfo info;
-                    info.entity = entity;
-                    info.spawn_pos = t.position.vec();
-                    info.bone_index = next_bone_index_;
-
-                    constexpr float kSlimeScale = 0.5f;
-                    const auto& slime_gs = slime_cloud.gaussians();
-                    for (const auto& g : slime_gs) {
-                        Gaussian sg = g;
-                        glm::vec3 rotated(-sg.position.x, sg.position.y, -sg.position.z);
-                        sg.position = t.position.vec() + rotated * kSlimeScale + glm::vec3(0, 0.5f, 0);
-                        sg.scale *= kSlimeScale;
-                        sg.bone_index = next_bone_index_;
-                        sg.opacity = std::min(1.0f, sg.opacity * 1.3f);
-                        merged.push_back(sg);
-                    }
-
-                    // Random phase offset so slimes don't bounce in sync
-                    info.squish_phase = static_cast<float>(npc_infos_.size()) * 1.7f;
-                    npc_infos_.push_back(info);
-                    std::fprintf(stderr, "[IslandDemo] NPC bone=%u at (%.1f, %.1f, %.1f) +%u gs\n",
-                                 next_bone_index_,
-                                 t.position.x(), t.position.y(), t.position.z(),
-                                 static_cast<uint32_t>(slime_gs.size()));
-                    next_bone_index_++;
-                });
-        }
-
         uint32_t char_count = static_cast<uint32_t>(merged.size()) - map_count;
         auto cloud = GaussianCloud::from_gaussians(std::move(merged));
 
@@ -479,17 +374,6 @@ void IslandDemoState::on_enter(AppBase& app) {
             anim_sm_->set_state("idle");
         }
 
-        // Initialize knight animation
-        if (knight_data_ && knight_info_) {
-            knight_anim_player_ = std::make_unique<gseurat::BoneAnimationPlayer>(*knight_data_);
-            knight_anim_sm_ = std::make_unique<gseurat::BoneAnimationStateMachine>(*knight_anim_player_);
-            knight_anim_sm_->add_state("idle", "idle");
-            knight_anim_sm_->add_state("walk", "walk");
-            knight_anim_sm_->add_state("attack", "attack");
-            knight_anim_sm_->add_state("jump", "jump");
-            knight_anim_sm_->set_state("idle");
-        }
-
         (void)char_count;
     }
 
@@ -530,8 +414,8 @@ void IslandDemoState::on_exit(AppBase& app) {
     camera_zone_system_.reset();
 
     // Release animation objects before state destruction
-    knight_anim_sm_.reset();
-    knight_anim_player_.reset();
+    bone_anim_registry_.clear();
+    set_bone_animation_registry(nullptr);
     anim_sm_.reset();
     anim_player_.reset();
 
@@ -539,9 +423,6 @@ void IslandDemoState::on_exit(AppBase& app) {
     // macOS allocator hangs when freeing CharacterData with populated vectors
     // during Vulkan/VMA teardown (ASan clean — not heap corruption).
     // Intentionally leak on exit: process teardown reclaims the memory anyway.
-    if (knight_data_) {
-        (void)knight_data_.release();
-    }
     if (character_data_) {
         ShutdownAuditor::remove(character_data_.get());
         (void)character_data_.release();  // leak — delete hangs on macOS
@@ -734,8 +615,6 @@ void IslandDemoState::update(AppBase& app, float dt) {
                     // Clear ECS world first — old game object entities must not persist
                     app.world().clear();
                     player_entity_ = ecs::kNullEntity;
-                    npc_infos_.clear();
-                    knight_info_.reset();
 
                     app.clear_scene();
                     app.init_scene(instance_scene);
@@ -830,83 +709,6 @@ void IslandDemoState::update(AppBase& app, float dt) {
                             distance_ = 20.0f;
                             elevation_ = 0.6f;
 
-                            // Re-spawn knight NPC Gaussians
-                            if (knight_data_) {
-                                auto knight_cloud = GaussianCloud::load_ply("assets/characters/knight/knight.ply");
-                                if (!knight_cloud.empty()) {
-                                    int player_bone_count = character_data_
-                                        ? static_cast<int>(character_data_->bones.size()) : 1;
-                                    next_bone_index_ = static_cast<uint32_t>(player_bone_count + 1);
-
-                                    KnightInfo ki;
-                                    ki.spawn_pos = spawn + glm::vec3(15.0f, 0.0f, -10.0f);
-                                    if (collision_grid_.width > 0 && !collision_grid_.elevation.empty()) {
-                                        float lx = ki.spawn_pos.x - grid_origin_.x;
-                                        float lz = ki.spawn_pos.z - grid_origin_.y;
-                                        int gx = static_cast<int>(lx / collision_grid_.cell_size);
-                                        int gz = static_cast<int>(lz / collision_grid_.cell_size);
-                                        if (gx >= 0 && gx < static_cast<int>(collision_grid_.width) &&
-                                            gz >= 0 && gz < static_cast<int>(collision_grid_.height)) {
-                                            ki.spawn_pos.y = collision_grid_.get_elevation(
-                                                static_cast<uint32_t>(gx), static_cast<uint32_t>(gz));
-                                        }
-                                    }
-                                    ki.first_bone_index = next_bone_index_;
-                                    constexpr float kKnightScale = 0.45f;
-                                    for (const auto& g : knight_cloud.gaussians()) {
-                                        Gaussian kg = g;
-                                        glm::vec3 rotated(-kg.position.x, kg.position.y, -kg.position.z);
-                                        glm::vec3 offset = rotated * kKnightScale;
-                                        offset.y *= gs_scale_;
-                                        kg.position = ki.spawn_pos + offset + glm::vec3(0, 2.0f, 0);
-                                        kg.scale *= kKnightScale;
-                                        kg.bone_index = next_bone_index_ + kg.bone_index;
-                                        kg.opacity = std::min(1.0f, kg.opacity * 1.3f);
-                                        merged.push_back(kg);
-                                    }
-                                    next_bone_index_ += static_cast<uint32_t>(knight_data_->bones.size());
-                                    ki.current_pos = ki.spawn_pos;
-                                    ki.walk_target = ki.spawn_pos;
-                                    ki.facing_angle = glm::pi<float>() * 0.5f;
-                                    knight_info_ = ki;
-                                    std::fprintf(stderr, "[IslandDemo] Re-spawned knight at (%.1f, %.1f, %.1f)\n",
-                                        ki.spawn_pos.x, ki.spawn_pos.y, ki.spawn_pos.z);
-                                }
-                            }
-
-                            // Re-spawn slime NPCs
-                            auto slime_cloud = GaussianCloud::load_ply("assets/characters/slime/slime.ply");
-                            if (!slime_cloud.empty()) {
-                                if (!knight_info_) {
-                                    int player_bone_count = character_data_
-                                        ? static_cast<int>(character_data_->bones.size()) : 1;
-                                    next_bone_index_ = static_cast<uint32_t>(player_bone_count + 1);
-                                }
-                                npc_infos_.clear();
-                                app.world().view<NpcWalker, ecs::Transform>().each(
-                                    [&](ecs::Entity entity, NpcWalker&, ecs::Transform& t) {
-                                        if (next_bone_index_ >= 31) return;
-                                        NpcInfo info;
-                                        info.entity = entity;
-                                        info.spawn_pos = t.position.vec();
-                                        info.bone_index = next_bone_index_;
-                                        constexpr float kSlimeScale = 0.5f;
-                                        for (const auto& g : slime_cloud.gaussians()) {
-                                            Gaussian sg = g;
-                                            glm::vec3 rotated(-sg.position.x, sg.position.y, -sg.position.z);
-                                            sg.position = t.position.vec() + rotated * kSlimeScale + glm::vec3(0, 0.5f, 0);
-                                            sg.scale *= kSlimeScale;
-                                            sg.bone_index = next_bone_index_;
-                                            sg.opacity = std::min(1.0f, sg.opacity * 1.3f);
-                                            merged.push_back(sg);
-                                        }
-                                        info.squish_phase = static_cast<float>(npc_infos_.size()) * 1.7f;
-                                        npc_infos_.push_back(info);
-                                        std::fprintf(stderr, "[IslandDemo] Re-spawned NPC bone=%u at (%.1f, %.1f, %.1f)\n",
-                                            next_bone_index_, t.position.x(), t.position.y(), t.position.z());
-                                        next_bone_index_++;
-                                    });
-                            }
                         }
 
                         auto char_cloud = GaussianCloud::load_ply(
@@ -932,6 +734,28 @@ void IslandDemoState::update(AppBase& app, float dt) {
                         uint32_t gs_h = app.renderer().gs_renderer().output_height();
                         if (gs_w == 0) { gs_w = 320; gs_h = 240; }
                         app.renderer().init_gs(cloud, gs_w, gs_h);
+                    }
+
+                    // Repopulate bone animation registry for the new scene
+                    bone_anim_registry_.clear();
+                    for (const auto& alloc : app.gs_terrain().bone_allocations) {
+                        app.world().view<BoneAnimatedTag, ecs::Transform>().each(
+                            [&](ecs::Entity entity, BoneAnimatedTag& tag, ecs::Transform& t) {
+                                if (tag.registry_id != 0) return;
+                                glm::vec3 diff = t.position.vec() - alloc.world_pos;
+                                if (glm::length(diff) < 1.0f) {
+                                    BoneAnimationEntry entry;
+                                    entry.manifest_path = alloc.manifest_path;
+                                    entry.default_clip = alloc.default_clip;
+                                    entry.first_bone_index = alloc.first_bone_index;
+                                    entry.bone_count = alloc.bone_count;
+                                    entry.char_scale = alloc.char_scale;
+                                    entry.gs_scale_multiplier = alloc.gs_scale_multiplier;
+                                    entry.spawn_pos = alloc.world_pos;
+                                    entry.current_pos = alloc.world_pos;
+                                    tag.registry_id = bone_anim_registry_.add(entity, std::move(entry));
+                                }
+                            });
                     }
 
                     std::fprintf(stderr, "[IslandDemo] Spawned at (%.1f, %.1f, %.1f)\n",
@@ -1466,153 +1290,8 @@ void IslandDemoState::update_walk_animation(AppBase& app, float dt) {
             }
         }
 
-        // NPC bone transforms — translate + squish + random jump
-        for (auto& npc : npc_infos_) {
-            if (npc.bone_index >= 32) continue;
-            auto* npc_t = app.world().try_get<ecs::Transform>(npc.entity);
-            if (!npc_t) continue;
-            glm::vec3 npc_offset = npc_t->position.vec() - npc.spawn_pos;
-
-            // Random jump trigger
-            if (!npc.slime_jumping) {
-                npc.slime_jump_cooldown -= dt;
-                if (npc.slime_jump_cooldown <= 0.0f) {
-                    npc.slime_jumping = true;
-                    npc.slime_jump_time = 0.0f;
-                    // Random cooldown 2-6 seconds
-                    npc.slime_jump_cooldown = 2.0f +
-                        static_cast<float>(std::rand() % 40) * 0.1f;
-                }
-            }
-
-            // Slime squish: periodic bounce (flatten Y, expand XZ)
-            float t = env_anim_time_ + npc.squish_phase;
-            float bounce_cycle = std::fmod(t * 0.8f, 1.0f);
-            float squish = 0.0f;
-            if (bounce_cycle < 0.15f) {
-                float p = bounce_cycle / 0.15f;
-                squish = p * p;
-            } else if (bounce_cycle < 0.35f) {
-                float p = (bounce_cycle - 0.15f) / 0.2f;
-                squish = 1.0f - p * p;
-            }
-            float scale_y = 1.0f - squish * 0.35f;
-            float scale_xz = 1.0f + squish * 0.2f;
-
-            // Jump Y-arc
-            float jump_y = 0.0f;
-            if (npc.slime_jumping) {
-                npc.slime_jump_time += dt;
-                if (npc.slime_jump_time >= kSlimeJumpDuration) {
-                    npc.slime_jumping = false;
-                    npc.slime_jump_time = 0.0f;
-                } else {
-                    float jt = npc.slime_jump_time / kSlimeJumpDuration;
-                    jump_y = 4.0f * kSlimeJumpHeight * jt * (1.0f - jt);
-                    // Extra squish at launch and landing
-                    if (jt < 0.15f || jt > 0.85f) {
-                        squish = std::max(squish, 0.8f);
-                        scale_y = 1.0f - squish * 0.35f;
-                        scale_xz = 1.0f + squish * 0.2f;
-                    }
-                }
-            }
-
-            glm::mat4 bone_tf = glm::translate(glm::mat4(1.0f),
-                npc_offset + glm::vec3(0.0f, jump_y, 0.0f));
-            bone_tf = bone_tf * glm::translate(glm::mat4(1.0f), npc.spawn_pos);
-            bone_tf = bone_tf * glm::scale(glm::mat4(1.0f),
-                                            glm::vec3(scale_xz, scale_y, scale_xz));
-            bone_tf = bone_tf * glm::translate(glm::mat4(1.0f), -npc.spawn_pos);
-            bones[npc.bone_index] = bone_tf;
-        }
-
-        // Knight NPC bone transforms + patrol movement
-        if (knight_info_ && knight_anim_player_ && knight_data_) {
-            auto& ki = *knight_info_;
-            // Cycle through animations
-            static const char* kKnightAnims[] = {"idle", "walk", "attack", "jump"};
-            static const float kKnightAnimDurations[] = {3.0f, 3.0f, 0.8f, 1.2f};
-            static constexpr int kKnightAnimCount = 4;
-
-            ki.anim_cycle_timer += dt;
-            float cur_dur = kKnightAnimDurations[ki.current_anim];
-            if (ki.anim_cycle_timer >= cur_dur) {
-                ki.anim_cycle_timer = 0.0f;
-                ki.current_anim = (ki.current_anim + 1) % kKnightAnimCount;
-                knight_anim_sm_->set_state(kKnightAnims[ki.current_anim]);
-
-                // Pick a new random walk target when entering walk state
-                if (ki.current_anim == 1) {  // walk
-                    float angle = static_cast<float>(std::rand() % 360) * glm::pi<float>() / 180.0f;
-                    float dist = kKnightPatrolRadius * 0.5f +
-                        static_cast<float>(std::rand() % 100) * 0.01f * kKnightPatrolRadius * 0.5f;
-                    ki.walk_target = ki.spawn_pos + glm::vec3(
-                        std::cos(angle) * dist, 0.0f, std::sin(angle) * dist);
-                }
-            }
-
-            // Move toward walk target during walk animation
-            if (ki.current_anim == 1) {  // walk
-                glm::vec3 to_target = ki.walk_target - ki.current_pos;
-                to_target.y = 0.0f;
-                float dist = glm::length(to_target);
-                if (dist > 0.5f) {
-                    glm::vec3 dir = to_target / dist;
-                    ki.current_pos += dir * kKnightSpeed * dt;
-
-                    // Smooth facing toward movement direction
-                    float target_facing = std::atan2(dir.x, dir.z);
-                    float diff = target_facing - ki.facing_angle;
-                    while (diff > glm::pi<float>()) diff -= glm::two_pi<float>();
-                    while (diff < -glm::pi<float>()) diff += glm::two_pi<float>();
-                    ki.facing_angle += diff * std::min(1.0f, 8.0f * dt);
-                }
-
-                // Snap Y to terrain elevation
-                if (collision_grid_.width > 0 && !collision_grid_.elevation.empty()) {
-                    float lx = ki.current_pos.x - grid_origin_.x;
-                    float lz = ki.current_pos.z - grid_origin_.y;
-                    int gx = static_cast<int>(lx / collision_grid_.cell_size);
-                    int gz = static_cast<int>(lz / collision_grid_.cell_size);
-                    if (gx >= 0 && gx < static_cast<int>(collision_grid_.width) &&
-                        gz >= 0 && gz < static_cast<int>(collision_grid_.height)) {
-                        ki.current_pos.y = collision_grid_.get_elevation(
-                            static_cast<uint32_t>(gx), static_cast<uint32_t>(gz));
-                    }
-                }
-            }
-
-            knight_anim_player_->update(dt);
-
-            // Build knight bone transforms using same world↔model pattern
-            constexpr float kKnightScale = 0.45f;
-            const glm::vec3 knight_y_off(0.0f, 2.0f, 0.0f);
-            const glm::vec3 knight_scale(kKnightScale, kKnightScale * gs_scale_, kKnightScale);
-            const glm::vec3 knight_inv_scale(1.0f / knight_scale.x, 1.0f / knight_scale.y, 1.0f / knight_scale.z);
-
-            glm::mat4 knight_from_world =
-                glm::rotate(glm::mat4(1.0f), -glm::pi<float>(), {0, 1, 0}) *
-                glm::scale(glm::mat4(1.0f), knight_inv_scale) *
-                glm::translate(glm::mat4(1.0f), -(ki.spawn_pos + knight_y_off));
-
-            glm::quat knight_rot = glm::angleAxis(ki.facing_angle, glm::vec3(0, 1, 0));
-            glm::mat4 knight_to_world =
-                glm::translate(glm::mat4(1.0f), ki.current_pos + knight_y_off) *
-                glm::mat4_cast(knight_rot) *
-                glm::scale(glm::mat4(1.0f), knight_scale) *
-                glm::rotate(glm::mat4(1.0f), glm::pi<float>(), {0, 1, 0});
-
-            const auto& knight_bones = knight_anim_player_->bone_transforms();
-            int knight_bone_count = static_cast<int>(knight_data_->bones.size());
-            for (int i = 0; i < knight_bone_count && (ki.first_bone_index + i) < 32; ++i) {
-                bones[ki.first_bone_index + i] = knight_to_world * knight_bones[i] * knight_from_world;
-            }
-        }
-
-        int total_bones = static_cast<int>(next_bone_index_);
-        if (total_bones < bone_count + 1) total_bones = bone_count + 1;
-        // Update total bone count to include registry NPCs
+        // Total bones: player bones + registry NPCs
+        int total_bones = bone_count + 1;
         if (app.gs_terrain().bone_slot_counter > static_cast<uint32_t>(total_bones)) {
             total_bones = static_cast<int>(app.gs_terrain().bone_slot_counter);
         }

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -629,8 +629,23 @@ void IslandDemoState::update(AppBase& app, float dt) {
                                 collision_grid_.width, collision_grid_.height);
                         }
 
-                        // When returning to overworld, re-open north bridge + reload forest grid
+                        // When returning to overworld, restore collision patches
                         if (portal.target_instance_id == "overworld") {
+                            // Re-mark house collision (fresh grid from scene doesn't have it)
+                            float house_x = 192.0f, house_z = 175.0f;
+                            float house_hw = 8.0f, house_hd = 7.0f;
+                            for (float wx = house_x - house_hw; wx <= house_x + house_hw; wx += collision_grid_.cell_size * 0.5f) {
+                                for (float wz = house_z - house_hd; wz <= house_z + house_hd; wz += collision_grid_.cell_size * 0.5f) {
+                                    int gx = static_cast<int>(wx / collision_grid_.cell_size);
+                                    int gz = static_cast<int>(wz / collision_grid_.cell_size);
+                                    if (gx >= 0 && gx < static_cast<int>(collision_grid_.width) &&
+                                        gz >= 0 && gz < static_cast<int>(collision_grid_.height)) {
+                                        collision_grid_.solid[gz * collision_grid_.width + gx] = true;
+                                    }
+                                }
+                            }
+
+                            // Re-open north bridge
                             int bridge_cleared = 0;
                             for (float wx = 182.0f; wx <= 202.0f; wx += collision_grid_.cell_size * 0.5f) {
                                 for (float wz = 0.0f; wz <= 50.0f; wz += collision_grid_.cell_size * 0.5f) {

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -256,6 +256,8 @@ void IslandDemoState::on_enter(AppBase& app) {
     app.system_scheduler().add_system({"linked_trigger", linked_trigger_system, {}, {}});
     app.system_scheduler().add_system({"emissive_toggle", emissive_toggle_system, {}, {}});
     app.system_scheduler().add_system({"npc_walker", npc_walker_system, {}, {}});
+    app.system_scheduler().add_system({"bone_animation", bone_animation_system, {}, {}});
+    set_bone_animation_registry(&bone_anim_registry_);
 
     // Capture base scene lights (before dynamic emissive lights are added)
     // Note: GS renderer gets lights during record_gs_prepass, not at init.
@@ -444,6 +446,28 @@ void IslandDemoState::on_enter(AppBase& app) {
         character_spawn_pos_ = player_pos;
         character_origin_ = player_pos;
         character_spawned_ = true;
+
+        // Populate bone animation registry from scene loader allocations
+        bone_anim_registry_.clear();
+        for (const auto& alloc : app.gs_terrain().bone_allocations) {
+            app.world().view<BoneAnimatedTag, ecs::Transform>().each(
+                [&](ecs::Entity entity, BoneAnimatedTag& tag, ecs::Transform& t) {
+                    if (tag.registry_id != 0) return;  // already assigned
+                    glm::vec3 diff = t.position.vec() - alloc.world_pos;
+                    if (glm::length(diff) < 1.0f) {
+                        BoneAnimationEntry entry;
+                        entry.manifest_path = alloc.manifest_path;
+                        entry.default_clip = alloc.default_clip;
+                        entry.first_bone_index = alloc.first_bone_index;
+                        entry.bone_count = alloc.bone_count;
+                        entry.char_scale = alloc.char_scale;
+                        entry.gs_scale_multiplier = alloc.gs_scale_multiplier;
+                        entry.spawn_pos = alloc.world_pos;
+                        entry.current_pos = alloc.world_pos;
+                        tag.registry_id = bone_anim_registry_.add(entity, std::move(entry));
+                    }
+                });
+        }
 
         // Initialize data-driven bone animation
         if (character_data_) {
@@ -1415,6 +1439,33 @@ void IslandDemoState::update_walk_animation(AppBase& app, float dt) {
             bones[i + 1] = to_world * anim_bones[i] * from_world;
         }
 
+        // Gather bone transforms from BoneAnimationRegistry (data-driven NPCs)
+        for (const auto& [id, entry] : bone_anim_registry_.entries()) {
+            if (!entry.initialized || !entry.anim_player) continue;
+
+            const float scale_val = entry.char_scale;
+            const glm::vec3 y_off(0.0f, 2.0f, 0.0f);
+            const glm::vec3 char_scale(scale_val, scale_val * entry.gs_scale_multiplier, scale_val);
+            const glm::vec3 inv_scale(1.0f / char_scale.x, 1.0f / char_scale.y, 1.0f / char_scale.z);
+
+            glm::mat4 from_world_npc =
+                glm::rotate(glm::mat4(1.0f), -glm::pi<float>(), {0, 1, 0}) *
+                glm::scale(glm::mat4(1.0f), inv_scale) *
+                glm::translate(glm::mat4(1.0f), -(entry.spawn_pos + y_off));
+
+            glm::quat rot = glm::angleAxis(entry.facing_angle, glm::vec3(0, 1, 0));
+            glm::mat4 to_world_npc =
+                glm::translate(glm::mat4(1.0f), entry.current_pos + y_off) *
+                glm::mat4_cast(rot) *
+                glm::scale(glm::mat4(1.0f), char_scale) *
+                glm::rotate(glm::mat4(1.0f), glm::pi<float>(), {0, 1, 0});
+
+            const auto& npc_bones = entry.anim_player->bone_transforms();
+            for (uint32_t i = 0; i < entry.bone_count && (entry.first_bone_index + i) < 32; ++i) {
+                bones[entry.first_bone_index + i] = to_world_npc * npc_bones[i] * from_world_npc;
+            }
+        }
+
         // NPC bone transforms — translate + squish + random jump
         for (auto& npc : npc_infos_) {
             if (npc.bone_index >= 32) continue;
@@ -1561,6 +1612,10 @@ void IslandDemoState::update_walk_animation(AppBase& app, float dt) {
 
         int total_bones = static_cast<int>(next_bone_index_);
         if (total_bones < bone_count + 1) total_bones = bone_count + 1;
+        // Update total bone count to include registry NPCs
+        if (app.gs_terrain().bone_slot_counter > static_cast<uint32_t>(total_bones)) {
+            total_bones = static_cast<int>(app.gs_terrain().bone_slot_counter);
+        }
         app.renderer().gs_renderer().upload_bone_transforms(bones, total_bones);
         app.renderer().gs_renderer().set_actor_rotation(character_rotation_);
     } else {

--- a/src/demo/island_systems.cpp
+++ b/src/demo/island_systems.cpp
@@ -172,7 +172,7 @@ void npc_walker_system(ecs::World& world, float dt) {
         });
 
     world.view<NpcWalker, ecs::Transform>().each(
-        [&](ecs::Entity, NpcWalker& npc, ecs::Transform& t) {
+        [&](ecs::Entity entity, NpcWalker& npc, ecs::Transform& t) {
             if (!npc.initialized) {
                 npc.initialized = true;
                 npc.home_x = t.position.x();
@@ -191,6 +191,13 @@ void npc_walker_system(ecs::World& world, float dt) {
                     float dist = static_cast<float>(std::rand()) / RAND_MAX * npc.patrol_radius;
                     npc.target_x = npc.home_x + std::cos(angle) * dist;
                     npc.target_z = npc.home_z + std::sin(angle) * dist;
+                }
+                // Set animation clip based on movement state (paused branch)
+                if (g_bone_anim_registry) {
+                    auto* ba_entry = g_bone_anim_registry->get_by_entity(entity);
+                    if (ba_entry) {
+                        ba_entry->requested_clip = "idle";
+                    }
                 }
                 return;
             }
@@ -225,6 +232,22 @@ void npc_walker_system(ecs::World& world, float dt) {
                     }
                     t.position.vec().y = grid->get_elevation(
                         static_cast<uint32_t>(gx), static_cast<uint32_t>(gz));
+                }
+            }
+
+            // Set animation clip based on movement state
+            if (g_bone_anim_registry) {
+                auto* ba_entry = g_bone_anim_registry->get_by_entity(entity);
+                if (ba_entry) {
+                    ba_entry->requested_clip = npc.paused ? "idle" : "walk";
+                    // Update facing angle from movement direction
+                    if (!npc.paused) {
+                        float ddx = npc.target_x - t.position.x();
+                        float ddz = npc.target_z - t.position.z();
+                        if (ddx * ddx + ddz * ddz > 0.01f) {
+                            ba_entry->facing_angle = std::atan2(ddx, ddz);
+                        }
+                    }
                 }
             }
         });

--- a/src/demo/island_systems.cpp
+++ b/src/demo/island_systems.cpp
@@ -1,11 +1,68 @@
 #include "gseurat/demo/island_systems.hpp"
 #include "gseurat/demo/island_components.hpp"
+#include "gseurat/demo/bone_animation_registry.hpp"
+#include "gseurat/character/character_manifest.hpp"
 #include "gseurat/engine/ecs/default_components.hpp"
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 
 namespace gseurat {
+
+namespace {
+BoneAnimationRegistry* g_bone_anim_registry = nullptr;
+}  // namespace
+
+void set_bone_animation_registry(BoneAnimationRegistry* reg) {
+    g_bone_anim_registry = reg;
+}
+
+BoneAnimationRegistry* get_bone_animation_registry() {
+    return g_bone_anim_registry;
+}
+
+void bone_animation_system(ecs::World& world, float dt) {
+    if (!g_bone_anim_registry) return;
+
+    world.view<BoneAnimatedTag, ecs::Transform>().each(
+        [&](ecs::Entity entity, BoneAnimatedTag& tag, ecs::Transform& t) {
+            auto* entry = g_bone_anim_registry->get(tag.registry_id);
+            if (!entry) return;
+
+            // Lazy initialization
+            if (!entry->initialized) {
+                auto manifest = load_character_manifest(entry->manifest_path);
+                if (!manifest) return;
+                entry->character_data = std::make_unique<CharacterData>(std::move(*manifest));
+                entry->anim_player = std::make_unique<BoneAnimationPlayer>(*entry->character_data);
+                entry->anim_sm = std::make_unique<BoneAnimationStateMachine>(*entry->anim_player);
+
+                // Register clips as states
+                for (const auto& clip : entry->character_data->clips) {
+                    entry->anim_sm->add_state(clip.name, clip.name);
+                }
+                entry->anim_sm->set_state(entry->default_clip);
+
+                entry->spawn_pos = t.position.vec();
+                entry->current_pos = t.position.vec();
+                entry->initialized = true;
+                std::fprintf(stderr, "[BoneAnimSystem] Initialized '%s': %u bones, clip='%s'\n",
+                             entry->manifest_path.c_str(), entry->bone_count, entry->default_clip.c_str());
+            }
+
+            // Update position from Transform (NpcWalker moves this)
+            entry->current_pos = t.position.vec();
+
+            // Check for clip change from behavior systems
+            if (!entry->requested_clip.empty() &&
+                entry->requested_clip != entry->anim_sm->current_state()) {
+                entry->anim_sm->set_state(entry->requested_clip);
+            }
+
+            // Advance animation
+            entry->anim_player->update(dt);
+        });
+}
 
 void proximity_trigger_system(ecs::World& world, float dt) {
     (void)dt;

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -340,6 +340,17 @@ void AppBase::init_game_object_system() {
                     {"speed", c.speed},
                     {"pause_duration", c.pause_duration}};
         });
+
+    component_registry_.register_component<BoneAnimatedTag>("BoneAnimated",
+        [](const nlohmann::json& j) -> BoneAnimatedTag {
+            BoneAnimatedTag c;
+            // registry_id is assigned by scene loader, not from JSON
+            (void)j;
+            return c;
+        },
+        [](const BoneAnimatedTag& c) -> nlohmann::json {
+            return {{"registry_id", c.registry_id}};
+        });
 }
 
 // ── Command context builder ──

--- a/src/engine/gs_scene_loader.cpp
+++ b/src/engine/gs_scene_loader.cpp
@@ -1,5 +1,4 @@
 #include "gseurat/engine/gs_scene_loader.hpp"
-#include "gseurat/character/character_manifest.hpp"
 #include "gseurat/engine/scene_load_context.hpp"
 #include "gseurat/engine/gs_terrain_state.hpp"
 #include "gseurat/engine/scene_object_state.hpp"
@@ -20,6 +19,7 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <fstream>
 
 namespace gseurat {
 
@@ -104,13 +104,24 @@ void GsSceneLoader::load(SceneLoadContext& ctx, const SceneData& scene_data,
             std::string manifest_path = ba_json.value("manifest", std::string{});
             if (manifest_path.empty()) continue;
 
-            auto manifest = load_character_manifest(manifest_path);
-            if (!manifest) {
-                std::fprintf(stderr, "[GS] BoneAnimated: failed to load manifest '%s'\n",
-                             manifest_path.c_str());
-                continue;
+            // Parse manifest JSON directly to get bone count
+            // (avoid constructing CharacterData — its destructor crashes on macOS)
+            uint32_t bone_count = 0;
+            {
+                std::ifstream mf(manifest_path);
+                if (!mf.is_open()) {
+                    std::fprintf(stderr, "[GS] BoneAnimated: failed to open manifest '%s'\n",
+                                 manifest_path.c_str());
+                    continue;
+                }
+                auto mj = nlohmann::json::parse(mf, nullptr, false);
+                if (mj.is_discarded() || !mj.contains("bones") || !mj["bones"].is_array()) {
+                    std::fprintf(stderr, "[GS] BoneAnimated: invalid manifest '%s'\n",
+                                 manifest_path.c_str());
+                    continue;
+                }
+                bone_count = static_cast<uint32_t>(mj["bones"].size());
             }
-            uint32_t bone_count = static_cast<uint32_t>(manifest->bones.size());
             if (ctx.terrain.bone_slot_counter + bone_count > 32) {
                 std::fprintf(stderr, "[GS] BoneAnimated: bone budget exceeded for '%s' (need %u, have %u)\n",
                              go.id.c_str(), bone_count, 32 - ctx.terrain.bone_slot_counter);

--- a/src/engine/gs_scene_loader.cpp
+++ b/src/engine/gs_scene_loader.cpp
@@ -1,4 +1,5 @@
 #include "gseurat/engine/gs_scene_loader.hpp"
+#include "gseurat/character/character_manifest.hpp"
 #include "gseurat/engine/scene_load_context.hpp"
 #include "gseurat/engine/gs_terrain_state.hpp"
 #include "gseurat/engine/scene_object_state.hpp"
@@ -93,6 +94,46 @@ void GsSceneLoader::load(SceneLoadContext& ctx, const SceneData& scene_data,
             world_positions.push_back(coord::to_world(go.position, ctx.terrain.terrain_aabb));
         }
 
+        // Pre-scan: allocate bone slots for BoneAnimated game objects
+        ctx.terrain.bone_allocations.clear();
+        ctx.terrain.bone_slot_counter = 8;  // reserve 0-7 for player
+        for (size_t i = 0; i < snapped_objects.size(); ++i) {
+            const auto& go = snapped_objects[i];
+            if (go.components.is_null() || !go.components.contains("BoneAnimated")) continue;
+            const auto& ba_json = go.components["BoneAnimated"];
+            std::string manifest_path = ba_json.value("manifest", std::string{});
+            if (manifest_path.empty()) continue;
+
+            auto manifest = load_character_manifest(manifest_path);
+            if (!manifest) {
+                std::fprintf(stderr, "[GS] BoneAnimated: failed to load manifest '%s'\n",
+                             manifest_path.c_str());
+                continue;
+            }
+            uint32_t bone_count = static_cast<uint32_t>(manifest->bones.size());
+            if (ctx.terrain.bone_slot_counter + bone_count > 32) {
+                std::fprintf(stderr, "[GS] BoneAnimated: bone budget exceeded for '%s' (need %u, have %u)\n",
+                             go.id.c_str(), bone_count, 32 - ctx.terrain.bone_slot_counter);
+                continue;
+            }
+
+            GsTerrainState::BoneAllocation alloc;
+            alloc.manifest_path = manifest_path;
+            alloc.default_clip = ba_json.value("default_clip", std::string{"idle"});
+            alloc.first_bone_index = ctx.terrain.bone_slot_counter;
+            alloc.bone_count = bone_count;
+            alloc.char_scale = go.scale;
+            alloc.gs_scale_multiplier = gs_scale_multiplier;
+            alloc.world_pos = world_positions[i].vec();
+            alloc.game_object_index = i;
+            ctx.terrain.bone_allocations.push_back(alloc);
+            ctx.terrain.bone_slot_counter += bone_count;
+
+            std::fprintf(stderr, "[GS] BoneAnimated '%s': bones %u-%u (count=%u)\n",
+                         go.id.c_str(), alloc.first_bone_index,
+                         alloc.first_bone_index + bone_count - 1, bone_count);
+        }
+
         // Merge all game objects with PLY visuals into the GS cloud
         ctx.terrain.pbd_anchors.clear();
         ctx.terrain.pbd_configs.clear();
@@ -138,6 +179,17 @@ void GsSceneLoader::load(SceneLoadContext& ctx, const SceneData& scene_data,
                         }
                         float sway_threshold = local_min_y + (local_max_y - local_min_y) * sway_threshold_frac;
 
+                        // Check if this game object has bone animation
+                        uint32_t ba_first_bone = 0;
+                        bool has_bone_anim = false;
+                        for (const auto& alloc : ctx.terrain.bone_allocations) {
+                            if (alloc.game_object_index == i) {
+                                ba_first_bone = alloc.first_bone_index;
+                                has_bone_anim = true;
+                                break;
+                            }
+                        }
+
                         auto placed_gs = placed_cloud.gaussians();
                         uint32_t tagged_count = 0;
                         for (auto& g : placed_gs) {
@@ -149,6 +201,9 @@ void GsSceneLoader::load(SceneLoadContext& ctx, const SceneData& scene_data,
                             if (pbd_idx > 0 && local_y > sway_threshold) {
                                 g.bone_index = pbd_idx;
                                 tagged_count++;
+                            }
+                            if (has_bone_anim) {
+                                g.bone_index = ba_first_bone + g.bone_index;
                             }
                         }
                         if (pbd_idx > 0) {


### PR DESCRIPTION
## Summary
- Move knight and slime NPC spawning from hardcoded C++ into scene JSON with a new `BoneAnimated` component
- Scene loader assigns bone indices during PLY merge (sequential allocation, bones 8+)
- New `bone_animation_system` drives animation playback with lazy initialization
- `NpcWalker` sets walk/idle clips and facing angles on `BoneAnimated` entries
- Portal transitions now handle NPCs automatically via `init_scene` — no manual re-spawn code
- Net ~370 lines of hardcoded NPC code removed, replaced by ~280 lines of data-driven system

### Bug fixes discovered during testing
- Fix player character bone_index=0 body not moving (latent bug — shader skips bone_index=0)
- Fix house collision not restored after portal return
- Fix macOS CharacterData destructor crash in scene loader and registry clear

## Test plan
- [x] Knight and slimes appear on island with animation
- [x] Portal to dungeon — no crash, PC body follows player
- [x] Portal back to overworld — NPCs present, house collision intact
- [x] Walk to Northern Forest — still accessible after portal round-trip
- [x] Release build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)