### PR TITLE
perf(gs): disable tile binning on Apple Silicon TBDR

### DIFF
--- a/docs/superpowers/specs/2026-04-13-tile-binning-tbdr-optimization-design.md
+++ b/docs/superpowers/specs/2026-04-13-tile-binning-tbdr-optimization-design.md
@@ -1,0 +1,118 @@
+# Phase 2: TBDR-Optimized Tile Binning Sort — Design Spec
+
+**Goal:** Reduce the tile binning radix sort from 38 pipeline barriers / 27 dispatches per frame to <10 barriers, making tile binning viable on Apple Silicon TBDR GPUs.
+
+**Context:** Tile binning provides 3× rasterize speedup on AMD (2.1ms → 0.7ms) but costs ~18ms on Apple Silicon due to TBDR barrier overhead. Phase 1 (this branch) disables tile binning on Apple GPUs as a quick fix. Phase 2 re-enables it with a barrier-efficient sort.
+
+---
+
+## Current Barrier Analysis
+
+### 8-Pass Radix Sort (dispatch_tile_sort)
+
+| Phase | Dispatches | Barriers | Purpose |
+|-------|-----------|----------|---------|
+| Fill sentinels | 0 | 1 | vkCmdFillBuffer + TRANSFER→COMPUTE |
+| Tile binning | 1 | 1 | Assign Gaussians to tiles |
+| Prepare indirect | 1 | 1 | Write indirect dispatch args |
+| Radix pass ×8 | 3 × 8 = 24 | 4 × 8 = 32 | histogram clear + histogram + scan + scatter |
+| Tile ranges | 1 | 2+1 | Fill + boundary detect |
+| **Total** | **27** | **38** |
+
+### Why TBDR Is Slow
+
+Apple Silicon uses Tile-Based Deferred Rendering. Each `vkCmdPipelineBarrier` with COMPUTE→COMPUTE dependency forces an L2 cache flush and tile memory writeback. The 8-pass radix sort fires 32 of these barriers just for sorting, plus 6 more for setup/teardown. On immediate-mode GPUs (AMD/NVIDIA), these barriers are near-free cache coherency ops.
+
+### Why Apple Subgroup Size Matters
+
+Apple GPU subgroup size = 32. The current radix sort uses workgroup-local shared memory but not subgroup operations. Subgroup shuffle/add can eliminate intermediate shared memory barriers within a workgroup.
+
+---
+
+## Proposed Approaches
+
+### Approach A: Fused 2-Pass Radix Sort (Recommended)
+
+**Core idea:** Sort by 16-bit key chunks instead of 8-bit. Two passes (one for key_lo, one for key_hi) with fused histogram+scatter.
+
+**Barrier reduction:**
+- Current: 4 barriers × 8 passes = 32 sort barriers
+- Proposed: 4 barriers × 2 passes = 8 sort barriers
+- Total with setup: ~12 barriers (vs 38)
+
+**How it works:**
+1. **Fused histogram+prefix sum:** Use `subgroupAdd` to compute partial histograms within subgroups, then shared memory reduction across subgroups. Eliminates the separate scan dispatch.
+2. **16-bit radix digit:** Process 16 bits per pass instead of 8. Requires 65536-bin histogram (256KB per workgroup) — too large for shared memory. Alternative: two-level (8+8) within a single dispatch using subgroup coordination.
+3. **Decoupled lookback:** Use the Onesweep algorithm (Adinets & Merrill, 2022) — single-pass radix sort with decoupled lookback for inter-workgroup prefix sum. Requires atomicAdd for status flags but eliminates global scan dispatch entirely.
+
+**Implementation sketch:**
+```
+Pass 1 (key_lo): fused_histogram_scatter.comp → 1 dispatch + 1 barrier
+Pass 2 (key_hi): fused_histogram_scatter.comp → 1 dispatch + 1 barrier
+```
+
+Each fused pass:
+- Workgroup loads 1024 entries (4 per thread, 256 threads)
+- Local histogram via shared memory (256 bins × workgroup)
+- Subgroup-level prefix sum via `subgroupExclusiveAdd`
+- Inter-workgroup prefix sum via decoupled lookback (atomicAdd on global status buffer)
+- Scatter to output
+
+**Pros:** Minimal barriers, proven algorithm, works with Apple's subgroup size 32
+**Cons:** Complex implementation, requires careful shared memory layout, atomicAdd contention
+
+### Approach B: Hybrid Bitonic Sort
+
+**Core idea:** For small tile entry counts (<32K), use bitonic merge sort instead of radix. Bitonic sort has O(log²N) passes but each pass is a single dispatch with 1 barrier.
+
+**Barrier reduction:**
+- For N=32K: log₂(32K) = 15 passes, each with ~15 sub-passes = ~225 comparisons. But using shared memory, each dispatch handles multiple sub-passes.
+- Practical: ~6-8 dispatches + barriers for 32K entries
+
+**Implementation:** Extend existing `gs_sort.comp` (bitonic) to handle TileSortEntry's 64-bit key.
+
+**Pros:** Simple extension of existing code, predictable performance
+**Cons:** O(N log²N) vs O(N) for radix — poor for large entry counts (>100K). Only viable as fallback for small scenes.
+
+### Approach C: Per-Tile Local Sort (No Global Sort)
+
+**Core idea:** Skip global sort entirely. Each tile collects its Gaussians via tile_bin, then sorts locally in the tile_render shader using shared memory insertion sort or bitonic sort.
+
+**Barrier reduction:**
+- Eliminates all 32 sort barriers
+- Total: ~4 barriers (fill + bin + ranges + render)
+
+**How it works:**
+- `tile_bin.comp` writes per-tile Gaussian lists (unsorted)
+- `tile_render.comp` loads its tile's Gaussians into shared memory, sorts by depth locally, then rasterizes
+
+**Pros:** Dramatic barrier reduction, simple conceptually
+**Cons:** Shared memory limited (~32KB). With 16-byte entries, max ~2048 per tile. Heavy tiles (dense foliage) may exceed this. Requires fallback for overflow tiles.
+
+---
+
+## Recommendation
+
+**Approach A (Fused 2-Pass Radix)** for the general case, with **Approach C (Per-Tile Local Sort)** as an optimization for tiles with <2048 entries (which is the common case at 160×120 output resolution).
+
+### Implementation Order
+
+1. **A-only first:** Implement fused 2-pass radix sort, measure on both Apple Silicon and AMD
+2. **If A alone is sufficient (<3ms on Apple):** Ship it
+3. **If still slow:** Add C as a fast path for small tiles, fall back to A for overflow tiles
+
+### Key Metrics
+
+| Metric | Current (Apple) | Target |
+|--------|----------------|--------|
+| Tile sort barriers | 38 | <10 |
+| Tile sort dispatches | 27 | <6 |
+| Rasterize frame time | ~18ms | <3ms |
+
+---
+
+## References
+
+- Onesweep: "Onesweep: A Faster Least Significant Digit Radix Sort for GPUs" (Adinets & Merrill, 2022)
+- Apple GPU architecture: Metal Best Practices Guide — "Minimize Compute Barriers"
+- Vulkan subgroup operations: VK_KHR_shader_subgroup (Apple supports vote, arithmetic, ballot)

--- a/include/gseurat/engine/feature_flags.hpp
+++ b/include/gseurat/engine/feature_flags.hpp
@@ -59,6 +59,7 @@ struct FeatureFlags {
     bool gs_lod = true;             // Distance-based LOD budget decimation
     bool gs_adaptive_budget = true; // Auto-tuning LOD budget to target FPS
     bool gs_parallax = true;        // Shadow-box parallax camera
+    bool gs_tile_binning = true;    // Per-tile Gaussian binning (disable on Apple TBDR)
 
     struct Entry {
         std::string_view name;
@@ -75,11 +76,11 @@ struct FeatureFlags {
             false, false, false, false, false,                       // Effects 9-13
             false, false, false, false,                              // Gameplay (4)
             false, false,                                            // Audio (2)
-            true, true, true, true, false
+            true, true, true, true, false, true   // GS (6): rendering, chunk_cull, lod, budget, parallax=off, tile_binning
         };
     }
 
-    static constexpr std::array<Entry, 32> entries() {
+    static constexpr std::array<Entry, 33> entries() {
         return {{
             {"Parallax BG",    "24",  "RENDERING", &FeatureFlags::parallax_backgrounds},
             {"Point Lights",   "11",  "RENDERING", &FeatureFlags::point_lights},
@@ -113,6 +114,7 @@ struct FeatureFlags {
             {"GS LOD",         "GS10","3DGS",      &FeatureFlags::gs_lod},
             {"GS Budget",      "GS10","3DGS",      &FeatureFlags::gs_adaptive_budget},
             {"GS Parallax",    "GS9", "3DGS",     &FeatureFlags::gs_parallax},
+            {"GS Tile Bin",    "GS9", "3DGS",     &FeatureFlags::gs_tile_binning},
         }};
     }
 };

--- a/include/gseurat/engine/feature_flags.hpp
+++ b/include/gseurat/engine/feature_flags.hpp
@@ -80,6 +80,13 @@ struct FeatureFlags {
         };
     }
 
+    // Apply platform-specific defaults (call once after GPU detection)
+    void apply_platform_defaults(bool apple_gpu) {
+        if (apple_gpu) {
+            gs_tile_binning = false;  // TBDR barrier overhead ~25x slower
+        }
+    }
+
     static constexpr std::array<Entry, 33> entries() {
         return {{
             {"Parallax BG",    "24",  "RENDERING", &FeatureFlags::parallax_backgrounds},

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -189,6 +189,9 @@ public:
     void set_post_process_params(const GsPostProcessParams& p) { gs_pp_params_ = p; }
     const GsPostProcessParams& post_process_params() const { return gs_pp_params_; }
 
+    void set_tile_binning(bool enabled) { tile_binning_enabled_ = enabled; }
+    bool tile_binning() const { return tile_binning_enabled_; }
+
     // World manifest (Phase 3 streaming)
     void load_world(const WorldManifest& manifest);
     const WorldManifest& world_manifest() const { return world_manifest_; }
@@ -417,6 +420,7 @@ private:
     uint32_t tile_sort_size_ = 0;        // workgroup-aligned count for radix sort
     uint32_t tile_sort_workgroups_ = 0;
     static constexpr uint32_t kTileSortPasses = 8;  // 4 for key_lo + 4 for key_hi
+    bool tile_binning_enabled_ = true;
 
     bool initialized_ = false;
 

--- a/include/gseurat/engine/vk_context.hpp
+++ b/include/gseurat/engine/vk_context.hpp
@@ -21,6 +21,7 @@ public:
     VkQueue transfer_queue() const { return transfer_queue_; }
     uint32_t transfer_queue_family() const { return transfer_queue_family_; }
     bool has_dedicated_transfer() const { return has_dedicated_transfer_; }
+    bool is_apple_gpu() const { return is_apple_gpu_; }
     VkSurfaceKHR surface() const { return surface_; }
     VmaAllocator allocator() const { return allocator_; }
 
@@ -45,6 +46,7 @@ private:
     VkQueue transfer_queue_{VK_NULL_HANDLE};
     uint32_t transfer_queue_family_{0};
     bool has_dedicated_transfer_{false};
+    bool is_apple_gpu_{false};
     VmaAllocator allocator_ = VK_NULL_HANDLE;
 };
 

--- a/src/demo/demo_app.cpp
+++ b/src/demo/demo_app.cpp
@@ -66,6 +66,7 @@ void DemoApp::init_game_content() {
     text_renderer_.init(font_atlas_);
 
     renderer_.init(window_, resources_);
+    feature_flags_.apply_platform_defaults(renderer_.context().is_apple_gpu());
     renderer_.init_font(font_atlas_, resources_);
     renderer_.init_particles(resources_);
     renderer_.init_shadows(resources_);

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -62,6 +62,7 @@ void CommandDispatcher::register_default_commands() {
         add("gs_lod", f.gs_lod, "LOD");
         add("gs_adaptive_budget", f.gs_adaptive_budget, "Adaptive Budget");
         add("gs_parallax", f.gs_parallax, "Parallax");
+        add("gs_tile_binning", f.gs_tile_binning, "Tile Binning");
         add("bloom", f.bloom, "Bloom");
         add("depth_of_field", f.depth_of_field, "Depth of Field");
         add("vignette", f.vignette, "Vignette");
@@ -85,6 +86,7 @@ void CommandDispatcher::register_default_commands() {
         else if (name == "gs_lod") f.gs_lod = enabled;
         else if (name == "gs_adaptive_budget") f.gs_adaptive_budget = enabled;
         else if (name == "gs_parallax") f.gs_parallax = enabled;
+        else if (name == "gs_tile_binning") f.gs_tile_binning = enabled;
         else if (name == "bloom") f.bloom = enabled;
         else if (name == "depth_of_field") f.depth_of_field = enabled;
         else if (name == "vignette") f.vignette = enabled;

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -2069,7 +2069,7 @@ void GsRenderer::dispatch_radix_sort(
 }
 
 void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd) {
-    if (!tile_sort_a_.buffer() || tile_sort_capacity_ == 0) return;
+    if (!tile_binning_enabled_ || !tile_sort_a_.buffer() || tile_sort_capacity_ == 0) return;
 
     uint32_t width = output_width_;
     uint32_t height = output_height_;
@@ -2451,7 +2451,7 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
 
             // === Phase 4: Tile-based rasterization ===
             {
-                bool use_tile = (tile_sort_a_.buffer() && tile_sort_capacity_ > 0);
+                bool use_tile = (tile_binning_enabled_ && tile_sort_a_.buffer() && tile_sort_capacity_ > 0);
                 if (use_tile) {
                     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_render_pipeline_);
                     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -1028,6 +1028,7 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             gs_renderer_.update_dynamic_gaussians(gs_dynamic_buffer_.data(), count);
         }
 
+        gs_renderer_.set_tile_binning(flags.gs_tile_binning);
         gs_renderer_.render(cmd, gs_view_, gs_proj_);
     }
 }

--- a/src/engine/vk_context.cpp
+++ b/src/engine/vk_context.cpp
@@ -185,6 +185,17 @@ void VkContext::pick_physical_device() {
     } else {
         throw std::runtime_error("No suitable GPU found");
     }
+
+    // Detect Apple GPU (MoltenVK on Apple Silicon)
+    {
+        VkPhysicalDeviceProperties props;
+        vkGetPhysicalDeviceProperties(physical_device_, &props);
+        // Apple vendor ID = 0x106B
+        is_apple_gpu_ = (props.vendorID == 0x106B);
+        std::printf("[vk_context] GPU: %s (vendor 0x%04X)%s\n",
+                    props.deviceName, props.vendorID,
+                    is_apple_gpu_ ? " [Apple — tile binning disabled by default]" : "");
+    }
 }
 
 void VkContext::create_logical_device() {

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -54,6 +54,7 @@ void StagingApp::init_game_content() {
     feature_flags_.particles = true;
     feature_flags_.animation = true;
     feature_flags_.fog = true;
+    feature_flags_.apply_platform_defaults(renderer_.context().is_apple_gpu());
 
     init_imgui();
 }

--- a/tests/test_feature_flags.cpp
+++ b/tests/test_feature_flags.cpp
@@ -44,10 +44,10 @@ int main() {
         std::printf("PASS: gs_viewer() profile\n");
     }
 
-    // 3. Entry count == 32
+    // 3. Entry count == 33
     {
-        assert(FeatureFlags::entries().size() == 32);
-        std::printf("PASS: entry count == 32\n");
+        assert(FeatureFlags::entries().size() == 33);
+        std::printf("PASS: entry count == 33\n");
     }
 
     // 4. Pointer-to-member round-trip
@@ -62,14 +62,14 @@ int main() {
         std::printf("PASS: pointer-to-member round-trip\n");
     }
 
-    // 5. Exactly 5 entries with category "3DGS"
+    // 5. Exactly 6 entries with category "3DGS"
     {
         int gs_count = 0;
         for (const auto& e : FeatureFlags::entries()) {
             if (e.category == "3DGS") gs_count++;
         }
-        assert(gs_count == 5);
-        std::printf("PASS: GS category entries == 5\n");
+        assert(gs_count == 6);
+        std::printf("PASS: GS category entries == 6\n");
     }
 
     // 6. Individual flag toggle — set one GS flag false, others unaffected
@@ -81,10 +81,35 @@ int main() {
         assert(flags.gs_lod == true);
         assert(flags.gs_adaptive_budget == true);
         assert(flags.gs_parallax == true);
+        assert(flags.gs_tile_binning == true);
         // Non-GS flags still true
         assert(flags.bloom == true);
         assert(flags.music == true);
         std::printf("PASS: individual flag toggle\n");
+    }
+
+    // 9. gs_tile_binning: default true, gs_viewer() also true
+    {
+        FeatureFlags f{};
+        assert(f.gs_tile_binning == true);
+
+        auto gv = FeatureFlags::gs_viewer();
+        assert(gv.gs_tile_binning == true);
+        std::printf("PASS: gs_tile_binning default and gs_viewer()\n");
+    }
+
+    // 10. GS Tile Bin entry exists in entries() table with correct fields
+    {
+        bool found = false;
+        for (auto& e : FeatureFlags::entries()) {
+            if (e.name == "GS Tile Bin") {
+                found = true;
+                assert(e.category == "3DGS");
+                break;
+            }
+        }
+        assert(found);
+        std::printf("PASS: GS Tile Bin entry found in entries()\n");
     }
 
     // 7. New tilemap flags default true


### PR DESCRIPTION
## Summary
- Add `gs_tile_binning` feature flag, auto-disabled on Apple GPUs (vendorID `0x106B`) to avoid ~18ms TBDR barrier overhead from the 8-pass radix sort (38 barriers/frame)
- Falls back to the original non-tile-binned rasterizer (~2.1ms) on macOS; tile binning remains enabled on AMD/NVIDIA (~0.7ms)
- Toggleable at runtime via control server `set_feature` for testing on any platform
- Phase 2 design spec for barrier-efficient sort (fused 2-pass radix, per-tile local sort) to eventually re-enable tile binning on Apple

## Test plan
- [x] `test_feature_flags` — new flag defaults, gs_viewer(), entries() table
- [x] All 35 ctest pass on macOS debug
- [x] Clean build on Windows release (286/286 targets, `ssh windows`)
- [x] Console prints `[Apple — tile binning disabled by default]` on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)