### PR TITLE
refactor(demo): unify player character with BoneAnimationRegistry

### DIFF
--- a/include/gseurat/engine/bone_animation_registry.hpp
+++ b/include/gseurat/engine/bone_animation_registry.hpp
@@ -23,6 +23,7 @@ struct BoneAnimationEntry {
     glm::vec3 spawn_pos{0.0f};       // initial world position (for bone transform anchoring)
     glm::vec3 current_pos{0.0f};     // updated by walker system
     float facing_angle = 0.0f;       // updated by walker system
+    float y_offset = 0.0f;            // additive visual Y offset (jump arc, bounce)
 
     // Lazy-initialized
     std::unique_ptr<CharacterData> character_data;

--- a/src/engine/bone_animation_system.cpp
+++ b/src/engine/bone_animation_system.cpp
@@ -75,8 +75,10 @@ uint32_t gather_bone_animation_transforms(
             glm::translate(glm::mat4(1.0f), -(entry.spawn_pos + y_off));
 
         glm::quat rot = glm::angleAxis(entry.facing_angle, glm::vec3(0, 1, 0));
+        glm::vec3 effective_pos = entry.current_pos;
+        effective_pos.y += entry.y_offset;
         glm::mat4 to_world =
-            glm::translate(glm::mat4(1.0f), entry.current_pos + y_off) *
+            glm::translate(glm::mat4(1.0f), effective_pos + y_off) *
             glm::mat4_cast(rot) *
             glm::scale(glm::mat4(1.0f), char_scale) *
             glm::rotate(glm::mat4(1.0f), glm::pi<float>(), {0, 1, 0});


### PR DESCRIPTION
## Summary

- Player character now uses a `BoneAnimationEntry` in the engine-level `BoneAnimationRegistry`, same as NPCs
- Removed duplicate `character_data_`, `anim_player_`, `anim_sm_` members from `IslandDemoState`
- Added `y_offset` field to `BoneAnimationEntry` for jump arc visualization
- `gather_bone_animation_transforms()` now handles ALL bone transforms (player + NPCs) in one call
- Player-specific behaviors preserved: jump arc, root motion, bone 0 terrain sway, +1 bone index offset

## Test plan

- [x] Debug build succeeds (105/105 targets)
- [x] Release build succeeds
- [x] All 35 ctest tests pass
- [x] Zero references to old `anim_player_`/`anim_sm_`/`character_data_` members
- [ ] Manual: Player idle/walk/jump animations work
- [ ] Manual: Root motion works correctly
- [ ] Manual: Portal round-trip preserves player animation
- [ ] Manual: NPCs still animate correctly alongside player

🤖 Generated with [Claude Code](https://claude.com/claude-code)