### PR TITLE
perf(gs): Onesweep radix sort for TBDR-friendly tile binning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,7 @@ function(add_gseurat_test NAME)
 endfunction()
 
 add_gseurat_test(test_feature_flags)
+add_gseurat_test(test_tile_sort_key)
 add_gseurat_test(test_async_loader     src/engine/async_loader.cpp)
 add_gseurat_test(test_character_data   src/engine/character_data.cpp)
 add_gseurat_test(test_gaussian_cloud   src/engine/gaussian_cloud.cpp src/engine/collision_gen.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ endfunction()
 
 add_gseurat_test(test_feature_flags)
 add_gseurat_test(test_tile_sort_key)
+add_gseurat_test(test_onesweep_logic)
 add_gseurat_test(test_async_loader     src/engine/async_loader.cpp)
 add_gseurat_test(test_character_data   src/engine/character_data.cpp)
 add_gseurat_test(test_gaussian_cloud   src/engine/gaussian_cloud.cpp src/engine/collision_gen.cpp

--- a/docs/superpowers/plans/2026-04-13-onesweep-tile-sort.md
+++ b/docs/superpowers/plans/2026-04-13-onesweep-tile-sort.md
@@ -1,0 +1,945 @@
+# Onesweep Tile Sort Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the 8-pass radix sort (38 barriers) with a 4-pass Onesweep radix sort (10 barriers) for tile binning, restoring 60 FPS on Apple Silicon TBDR GPUs.
+
+**Architecture:** New `gs_onesweep.comp` shader performs fused histogram + decoupled-lookback prefix sum + scatter in a single dispatch per pass. `TileSortEntry` shrinks from 16 to 8 bytes with a packed 32-bit key (`tile_id[31:16] | depth_q[15:0]`). Near/far extracted from projection matrix on CPU, passed via UBO. Old sort kept behind `use_onesweep_` toggle for A/B comparison.
+
+**Tech Stack:** C++23, Vulkan 1.1, GLSL 450, glslc (`--target-env=vulkan1.1`)
+
+**Worktree:** `/Users/eccyan/dev/GSeurat-onesweep` (branch `perf/onesweep-tile-sort`)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `shaders/gs_onesweep.comp` | Create | Fused Onesweep sort shader |
+| `shaders/gs_tile_bin.comp` | Modify | 8-byte entry, packed key, UBO near/far |
+| `shaders/gs_tile_ranges.comp` | Modify | 8-byte entry, key>>16 for tile_id |
+| `shaders/gs_tile_render.comp` | Modify | 8-byte entry, sentinel check |
+| `shaders/gs_tile_prepare_indirect.comp` | Modify | Add Onesweep workgroup count to indirect args |
+| `shaders/CMakeLists.txt` | Modify | Add gs_onesweep.comp |
+| `src/engine/gs_renderer.cpp` | Modify | GsUniforms, buffers, pipelines, dispatch |
+| `include/gseurat/engine/gs_renderer.hpp` | Modify | New members for Onesweep pipeline/buffers |
+| `tests/test_tile_sort_key.cpp` | Create | CPU unit tests for key packing |
+| `CMakeLists.txt` | Modify | Add test target |
+
+---
+
+### Task 1: CPU Key-Packing Utility and Tests
+
+**Files:**
+- Create: `tests/test_tile_sort_key.cpp`
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/test_tile_sort_key.cpp`:
+
+```cpp
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+// Key packing logic (will be shared with shader via matching algorithm)
+static uint32_t pack_tile_sort_key(uint32_t tile_id, float depth, float near_z, float far_z) {
+    float t = (depth - near_z) / (far_z - near_z);
+    if (t < 0.0f) t = 0.0f;
+    if (t > 1.0f) t = 1.0f;
+    uint32_t depth_q = static_cast<uint32_t>(t * 65535.0f);
+    if (depth_q > 0xFFFEu) depth_q = 0xFFFEu;  // 0xFFFF reserved for sentinel
+    return (tile_id << 16u) | depth_q;
+}
+
+static void extract_near_far(const glm::mat4& proj, float& near_z, float& far_z) {
+    // Vulkan [0,1] clip depth: proj[2][2] = -far/(far-near), proj[3][2] = -(far*near)/(far-near)
+    float A = proj[2][2];
+    float B = proj[3][2];
+    near_z = B / A;
+    far_z  = B / (A + 1.0f);
+}
+
+int main() {
+    // Test 1: Key packing preserves sort order
+    {
+        uint32_t k1 = pack_tile_sort_key(5, 10.0f, 0.1f, 1000.0f);
+        uint32_t k2 = pack_tile_sort_key(5, 20.0f, 0.1f, 1000.0f);
+        assert(k1 < k2);  // same tile, closer depth sorts first
+    }
+
+    // Test 2: Tile ID is primary sort key
+    {
+        uint32_t k1 = pack_tile_sort_key(3, 500.0f, 0.1f, 1000.0f);
+        uint32_t k2 = pack_tile_sort_key(4, 1.0f, 0.1f, 1000.0f);
+        assert(k1 < k2);  // tile 3 < tile 4 regardless of depth
+    }
+
+    // Test 3: Depth clamping at boundaries
+    {
+        uint32_t k_near = pack_tile_sort_key(0, -5.0f, 0.1f, 1000.0f);
+        uint32_t k_far  = pack_tile_sort_key(0, 9999.0f, 0.1f, 1000.0f);
+        assert((k_near & 0xFFFFu) == 0);       // clamped to 0
+        assert((k_far & 0xFFFFu) == 0xFFFEu);  // clamped to max (0xFFFF reserved)
+    }
+
+    // Test 4: Sentinel key is maximum
+    {
+        uint32_t sentinel = 0xFFFFFFFFu;
+        uint32_t k_max = pack_tile_sort_key(0xFFFFu - 1, 1000.0f, 0.1f, 1000.0f);
+        assert(k_max < sentinel);
+    }
+
+    // Test 5: Near/far extraction from projection matrix
+    {
+        float near_in = 0.1f, far_in = 1000.0f;
+        glm::mat4 proj = glm::perspectiveLH_ZO(glm::radians(60.0f), 1.0f, near_in, far_in);
+        float near_out, far_out;
+        extract_near_far(proj, near_out, far_out);
+        assert(std::abs(near_out - near_in) < 0.01f);
+        assert(std::abs(far_out - far_in) < 1.0f);
+    }
+
+    // Test 6: 16-bit depth has sufficient precision
+    {
+        // Two Gaussians 0.02 apart at depth ~10 should get different keys
+        uint32_t k1 = pack_tile_sort_key(0, 10.0f, 0.1f, 1000.0f);
+        uint32_t k2 = pack_tile_sort_key(0, 10.02f, 0.1f, 1000.0f);
+        assert(k1 != k2);  // 0.02 / 1000 * 65535 ≈ 1.3 — should differ by at least 1
+    }
+
+    std::printf("PASS: test_tile_sort_key (6 tests)\n");
+    return 0;
+}
+```
+
+- [ ] **Step 2: Add test to CMakeLists.txt**
+
+After the `add_gseurat_test(test_feature_flags)` line:
+
+```cmake
+add_gseurat_test(test_tile_sort_key)
+```
+
+- [ ] **Step 3: Build and run test**
+
+Run: `cmake --build --preset macos-debug --target test_tile_sort_key && ctest --test-dir build/macos-debug -R test_tile_sort_key -V`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_tile_sort_key.cpp CMakeLists.txt
+git commit -m "test: key packing and near/far extraction for Onesweep tile sort"
+```
+
+---
+
+### Task 2: Extend GsUniforms with tile_sort_params
+
+**Files:**
+- Modify: `src/engine/gs_renderer.cpp:35-55` (GsUniforms struct)
+- Modify: `src/engine/gs_renderer.cpp:2234-2266` (render() UBO fill)
+- Modify: `shaders/gs_preprocess.comp` (Uniforms block)
+- Modify: `shaders/gs_render.comp` (Uniforms block)
+- Modify: `shaders/gs_tile_render.comp` (Uniforms block)
+
+- [ ] **Step 1: Add tile_sort_params to C++ GsUniforms**
+
+In `src/engine/gs_renderer.cpp`, add after `pl_area` (line 54):
+
+```cpp
+    glm::vec4 tile_sort_params;  // x = near_z, y = far_z, z = tiles_x, w = tiles_y
+```
+
+- [ ] **Step 2: Populate tile_sort_params in render()**
+
+In `src/engine/gs_renderer.cpp`, in the `render()` function, after `uniforms.actor_rotation` is set (around line 2262), add:
+
+```cpp
+    // Extract near/far from Vulkan [0,1] perspective projection
+    float near_z = proj[3][2] / proj[2][2];
+    float far_z  = proj[3][2] / (proj[2][2] + 1.0f);
+    uint32_t tiles_x = (width + 15) / 16;
+    uint32_t tiles_y = (height + 15) / 16;
+    uniforms.tile_sort_params = glm::vec4(near_z, far_z,
+        static_cast<float>(tiles_x), static_cast<float>(tiles_y));
+```
+
+- [ ] **Step 3: Add tile_sort_params to all shader Uniforms blocks**
+
+In each of these shaders, add after the `pl_area[8]` line in the `Uniforms` block:
+
+```glsl
+    vec4 tile_sort_params;  // x = near_z, y = far_z, z = tiles_x, w = tiles_y
+```
+
+Files to modify:
+- `shaders/gs_preprocess.comp` — Uniforms at binding 3
+- `shaders/gs_render.comp` — Uniforms at binding 2
+- `shaders/gs_tile_render.comp` — Uniforms at binding 2
+
+The field must be in the same position in ALL shaders that share this UBO. Even if a shader doesn't use `tile_sort_params`, the struct layout must match for the binding to be valid.
+
+- [ ] **Step 4: Build**
+
+Run: `cmake --build --preset macos-debug`
+Expected: Build succeeds with no errors (shader recompilation + C++ rebuild).
+
+- [ ] **Step 5: Run all tests**
+
+Run: `ctest --test-dir build/macos-debug --output-on-failure`
+Expected: All tests pass (UBO size change doesn't affect CPU-only tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/engine/gs_renderer.cpp shaders/gs_preprocess.comp shaders/gs_render.comp shaders/gs_tile_render.comp
+git commit -m "feat(gs): add tile_sort_params (near/far/tiles) to GsUniforms UBO"
+```
+
+---
+
+### Task 3: Convert TileSortEntry to 8 bytes across shaders
+
+**Files:**
+- Modify: `shaders/gs_tile_bin.comp`
+- Modify: `shaders/gs_tile_ranges.comp`
+- Modify: `shaders/gs_tile_render.comp`
+
+- [ ] **Step 1: Update gs_tile_bin.comp**
+
+Replace the entire `TileSortEntry` struct and key-writing logic. The shader needs access to the UBO for near/far (add Uniforms binding). Replace push constants with just `max_entries` (tiles_x/tiles_y now from UBO).
+
+Full replacement for `gs_tile_bin.comp`:
+
+```glsl
+#version 450
+
+// Tile binning pass: duplicates each visible Gaussian into per-tile sort entries.
+// Each thread processes one visible Gaussian from the merged sort array,
+// computes its tile overlap, and writes one TileSortEntry per overlapping tile.
+layout(local_size_x = 256) in;
+
+struct ProjectedSplat {
+    vec2 center;
+    float depth;
+    float radius;
+    vec4 conic_opacity;
+    vec4 color;
+};
+
+// 8 bytes — packed key + index
+struct TileSortEntry {
+    uint key;    // [31:16] = tile_id, [15:0] = depth_q (linear uint16)
+    uint index;  // index into projected[] buffer
+};
+
+struct SortEntry {
+    uint key;
+    uint index;
+};
+
+layout(set = 0, binding = 0) readonly buffer ProjectedBuffer {
+    ProjectedSplat projected[];
+};
+
+layout(set = 0, binding = 1) readonly buffer MergedSortBuffer {
+    SortEntry merged_entries[];
+};
+
+layout(set = 0, binding = 2) readonly buffer CountsBuffer {
+    uint static_count;
+    uint dynamic_count;
+    uint merged_visible_count;
+};
+
+layout(set = 0, binding = 3) writeonly buffer TileSortBuffer {
+    TileSortEntry tile_entries[];
+};
+
+layout(set = 0, binding = 4) buffer TileSortCountBuffer {
+    uint tile_sort_count;
+};
+
+layout(set = 0, binding = 5) uniform Uniforms {
+    mat4 view;
+    mat4 proj;
+    mat4 inv_view;
+    mat4 inv_proj;
+    uvec4 params;
+    vec4 shadow_box;
+    vec4 cone_dir;
+    vec4 cam_pos;
+    vec4 effect_flags;
+    vec4 light_params;
+    vec4 touch_point;
+    vec4 effect_params;
+    vec4 effect_params2;
+    vec4 point_light_params;
+    vec4 actor_rotation;
+    vec4 pl_pos_rad[8];
+    vec4 pl_color[8];
+    vec4 pl_dir_cone[8];
+    vec4 pl_area[8];
+    vec4 tile_sort_params;  // x = near_z, y = far_z, z = tiles_x, w = tiles_y
+};
+
+layout(push_constant) uniform PushConstants {
+    uint max_entries;
+};
+
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    uint visible = static_count + dynamic_count;
+    if (gid >= visible) return;
+
+    SortEntry entry = merged_entries[gid];
+    if (entry.key == 0xFFFFu) return;
+
+    uint idx = entry.index;
+    ProjectedSplat splat = projected[idx];
+
+    if (splat.radius <= 0.0) return;
+
+    vec2 c = splat.center;
+    float r = splat.radius;
+    uint tiles_x = uint(tile_sort_params.z);
+    uint tiles_y = uint(tile_sort_params.w);
+
+    int tx_min = max(0, int(floor((c.x - r) / 16.0)));
+    int tx_max = min(int(tiles_x) - 1, int(floor((c.x + r) / 16.0)));
+    int ty_min = max(0, int(floor((c.y - r) / 16.0)));
+    int ty_max = min(int(tiles_y) - 1, int(floor((c.y + r) / 16.0)));
+
+    // Quantize depth linearly to uint16
+    float near_z = tile_sort_params.x;
+    float far_z  = tile_sort_params.y;
+    float t = clamp((splat.depth - near_z) / (far_z - near_z), 0.0, 1.0);
+    uint depth_q = min(uint(t * 65535.0), 0xFFFEu);
+
+    for (int ty = ty_min; ty <= ty_max; ty++) {
+        for (int tx = tx_min; tx <= tx_max; tx++) {
+            uint tile_id = uint(ty) * tiles_x + uint(tx);
+            uint sort_key = (tile_id << 16u) | depth_q;
+            uint offset = atomicAdd(tile_sort_count, 1);
+            if (offset < max_entries) {
+                tile_entries[offset].key = sort_key;
+                tile_entries[offset].index = idx;
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update gs_tile_ranges.comp**
+
+Replace `TileSortEntry` struct and update tile_id extraction:
+
+```glsl
+#version 450
+
+layout(local_size_x = 256) in;
+
+struct TileSortEntry {
+    uint key;    // [31:16] = tile_id, [15:0] = depth_q
+    uint index;
+};
+
+layout(set = 0, binding = 0) readonly buffer SortedEntries {
+    TileSortEntry entries[];
+};
+
+layout(set = 0, binding = 1) buffer TileRanges {
+    uint ranges[];
+};
+
+layout(set = 0, binding = 2) readonly buffer TileSortCount {
+    uint tile_count;
+};
+
+layout(push_constant) uniform PushConstants {
+    uint num_tiles;
+    uint max_entries;
+};
+
+void main() {
+    uint i = gl_GlobalInvocationID.x;
+    uint clamped_count = min(tile_count, max_entries);
+    if (i >= clamped_count) return;
+
+    uint tile_id = entries[i].key >> 16u;
+
+    // Skip sentinel entries
+    if (tile_id >= num_tiles) return;
+
+    bool is_first = (i == 0) || ((entries[i - 1].key >> 16u) != tile_id);
+    if (is_first) {
+        ranges[tile_id * 2u] = i;
+    }
+
+    atomicAdd(ranges[tile_id * 2u + 1u], 1u);
+}
+```
+
+- [ ] **Step 3: Update gs_tile_render.comp TileSortEntry**
+
+In `shaders/gs_tile_render.comp`, replace lines 17-22:
+
+```glsl
+struct TileSortEntry {
+    uint key;    // [31:16] = tile_id, [15:0] = depth_q
+    uint index;  // index into projected[]
+};
+```
+
+And update the sentinel check at line 119:
+
+```glsl
+        if (entry.key == 0xFFFFFFFFu) break;  // sentinel
+```
+
+(This line is already checking for 0xFFFFFFFF on key_hi; now it checks on the packed key — sentinels have key=0xFFFFFFFF so this is correct.)
+
+- [ ] **Step 4: Update C++ buffer sizes (16 → 8 bytes per entry)**
+
+In `src/engine/gs_renderer.cpp`, find all places where tile sort entry size is 16 and change to 8.
+
+In `init()` (line 92, dummy buffer):
+```cpp
+        tile_sort_a_ = Buffer::create_storage_gpu_only(allocator_, 8);  // was 16
+```
+
+In `dispatch_tile_sort()` (line 2087, sentinel fill size):
+```cpp
+        vkCmdFillBuffer(cmd, tile_sort_a_.buffer(), 0,
+                        static_cast<VkDeviceSize>(tile_sort_size_) * 8, 0xFFFFFFFF);  // was * 16
+```
+
+Search for `* 16` near `tile_sort` and `entry_buf_size` in both `load_cloud_legacy` and `init_streaming`:
+```cpp
+        VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 8;  // was * 16
+```
+
+- [ ] **Step 5: Update tile_bin descriptor layout (add binding 5 for UBO)**
+
+In `create_descriptor_resources()`, find the tile_bin_layout_ creation (around line 375-387). Add a 6th binding for the uniform buffer:
+
+```cpp
+    // Tile bin layout: { projected(0), merged(1), counts(2), tile_entries(3), tile_sort_count(4), uniforms(5) }
+    {
+        VkDescriptorSetLayoutBinding bindings[] = {
+            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {5, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        };
+        VkDescriptorSetLayoutCreateInfo ci{};
+        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        ci.bindingCount = 6;
+        ci.pBindings = bindings;
+        vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_bin_layout_);
+    }
+```
+
+Update the tile_bin descriptor set write to include the uniform buffer at binding 5.
+
+Update tile_bin push constant size from 12 to 4 (only `max_entries` now):
+```cpp
+    create_pipeline("shaders/gs_tile_bin.comp.spv", tile_bin_layout_, 4,
+                    tile_bin_pipeline_layout_, tile_bin_pipeline_);
+```
+
+Update `dispatch_tile_sort` tile bin push from 12 bytes to 4:
+```cpp
+        uint32_t push_data[1] = {tile_sort_capacity_};
+        vkCmdPushConstants(cmd, tile_bin_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                           0, 4, push_data);
+```
+
+- [ ] **Step 6: Build and test**
+
+Run: `cmake --build --preset macos-debug && ctest --test-dir build/macos-debug --output-on-failure`
+Expected: All tests pass. Shaders recompile. Build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add shaders/gs_tile_bin.comp shaders/gs_tile_ranges.comp shaders/gs_tile_render.comp \
+        src/engine/gs_renderer.cpp include/gseurat/engine/gs_renderer.hpp
+git commit -m "refactor(gs): convert TileSortEntry to 8-byte packed key format"
+```
+
+---
+
+### Task 4: Create gs_onesweep.comp shader
+
+**Files:**
+- Create: `shaders/gs_onesweep.comp`
+- Modify: `shaders/CMakeLists.txt`
+
+- [ ] **Step 1: Create the Onesweep shader**
+
+Create `shaders/gs_onesweep.comp`:
+
+```glsl
+#version 450
+
+// Onesweep radix sort: fused histogram + decoupled-lookback prefix sum + stable scatter.
+// One dispatch per 8-bit radix pass (4 passes for 32-bit key).
+// Uses coherent buffer + memoryBarrierBuffer() for Apple Silicon TBDR compatibility.
+layout(local_size_x = 256) in;
+
+// 8-byte tile sort entry
+struct TileSortEntry {
+    uint key;
+    uint index;
+};
+
+layout(set = 0, binding = 0) readonly buffer InputBuffer {
+    TileSortEntry in_entries[];
+};
+
+layout(set = 0, binding = 1) writeonly buffer OutputBuffer {
+    TileSortEntry out_entries[];
+};
+
+// Per-digit lookback status: status[pass * 256 * max_workgroups + digit * max_workgroups + wg_id]
+// Encoding: bits [31:30] = state (00=NOT_READY, 01=LOCAL, 11=INCLUSIVE), bits [29:0] = sum
+layout(set = 0, binding = 2, std430) coherent buffer StatusBuffer {
+    uint status[];
+};
+
+layout(set = 0, binding = 3) readonly buffer IndirectArgs {
+    uint sort_dispatch_x;   // [0]: sort workgroups
+    uint sort_dispatch_y;   // [1]: 1
+    uint sort_dispatch_z;   // [2]: 1
+    uint ranges_dispatch_x; // [3]: ranges workgroups
+    uint ranges_dispatch_y; // [4]
+    uint ranges_dispatch_z; // [5]
+    uint entry_count;       // [6]: clamped tile_sort_count
+    uint histogram_count;   // [7]: 256 * sort_workgroups (unused by onesweep)
+};
+
+layout(push_constant) uniform PushConstants {
+    uint pass;            // 0..3 (which 8-bit digit to sort on)
+    uint max_workgroups;  // total workgroups dispatched
+};
+
+// Shared memory: 19KB total (under 32KB Apple Silicon limit)
+shared uint s_local_histogram[256];  // 1KB  — per-digit count for this workgroup
+shared uint s_keys[2048];           // 8KB  — loaded sort keys
+shared uint s_indices[2048];        // 8KB  — loaded indices
+shared uint s_prefix[256];          // 1KB  — exclusive prefix of local histogram
+shared uint s_digits[256];          // 1KB  — batch digit scratch for stable rank
+
+const uint ENTRIES_PER_WG = 2048u;
+const uint ENTRIES_PER_THREAD = 8u;
+const uint NOT_READY = 0u;
+const uint LOCAL_FLAG = 1u << 30u;
+const uint INCLUSIVE_FLAG = 3u << 30u;
+const uint VALUE_MASK = 0x3FFFFFFFu;
+
+void main() {
+    uint lid = gl_LocalInvocationID.x;
+    uint wg_id = gl_WorkGroupID.x;
+    uint wg_offset = wg_id * ENTRIES_PER_WG;
+    uint total = entry_count;
+
+    // ========================================
+    // Phase 1: Load entries & build histogram
+    // ========================================
+    s_local_histogram[lid] = 0u;
+    barrier();
+
+    // Load 8 entries per thread into shared memory
+    for (uint t = 0u; t < ENTRIES_PER_THREAD; t++) {
+        uint idx = wg_offset + t * 256u + lid;
+        uint k = 0xFFFFFFFFu;  // sentinel default
+        uint v = 0u;
+        if (idx < total) {
+            k = in_entries[idx].key;
+            v = in_entries[idx].index;
+        }
+        s_keys[t * 256u + lid] = k;
+        s_indices[t * 256u + lid] = v;
+
+        // Extract digit and count
+        uint digit = (k >> (pass * 8u)) & 0xFFu;
+        if (idx < total) {
+            atomicAdd(s_local_histogram[digit], 1u);
+        }
+    }
+    barrier();
+
+    // ========================================
+    // Phase 2: Decoupled lookback prefix sum
+    // ========================================
+    // Each thread handles one digit bin (tid 0..255)
+    uint my_local_count = s_local_histogram[lid];
+
+    // Publish LOCAL status — our partial count for this digit
+    uint status_base = pass * 256u * max_workgroups + lid * max_workgroups;
+    atomicExchange(status[status_base + wg_id], LOCAL_FLAG | my_local_count);
+    memoryBarrierBuffer();
+
+    // Lookback: accumulate prefix from predecessor workgroups
+    uint aggregate = 0u;
+    if (wg_id > 0u) {
+        int pred = int(wg_id) - 1;
+        while (pred >= 0) {
+            uint val;
+            // Spin-read with memory barrier for Apple Silicon weak ordering
+            uint spin_count = 0u;
+            do {
+                memoryBarrierBuffer();
+                val = atomicOr(status[status_base + uint(pred)], 0u);
+                spin_count++;
+                // Safety: if stuck for 1M iterations, break (should never happen)
+                if (spin_count > 1000000u) break;
+            } while ((val >> 30u) == 0u);
+
+            uint state = val >> 30u;
+            uint sum = val & VALUE_MASK;
+            aggregate += sum;
+
+            if (state == 3u) break;  // INCLUSIVE — includes all prior workgroups
+            pred--;
+        }
+    }
+
+    // Publish INCLUSIVE status
+    uint inclusive = aggregate + my_local_count;
+    atomicExchange(status[status_base + wg_id], INCLUSIVE_FLAG | inclusive);
+    memoryBarrierBuffer();
+
+    // Exclusive prefix for this digit in this workgroup
+    s_prefix[lid] = aggregate;
+    barrier();
+
+    // ========================================
+    // Phase 3: Stable scatter
+    // ========================================
+    for (uint batch = 0u; batch < ENTRIES_PER_THREAD; batch++) {
+        uint local_idx = batch * 256u + lid;
+        uint global_idx = wg_offset + local_idx;
+        uint my_key = s_keys[local_idx];
+        uint my_index = s_indices[local_idx];
+        uint digit = (my_key >> (pass * 8u)) & 0xFFu;
+
+        // Store digit for stable rank computation
+        s_digits[lid] = digit;
+        barrier();
+
+        if (global_idx < total) {
+            // Stable rank: count threads before me in this batch with same digit
+            uint rank = 0u;
+            for (uint j = 0u; j < lid; j++) {
+                // Only count entries that are valid (within total)
+                uint j_global = wg_offset + batch * 256u + j;
+                if (j_global < total && s_digits[j] == digit) {
+                    rank++;
+                }
+            }
+
+            uint dst = s_prefix[digit] + rank;
+            out_entries[dst].key = my_key;
+            out_entries[dst].index = my_index;
+        }
+
+        // Advance prefix for next batch
+        barrier();
+
+        // Count entries per digit in this batch (only thread 0..255 increment their own digit)
+        // Reset digit_count (reuse s_local_histogram as scratch)
+        s_local_histogram[lid] = 0u;
+        barrier();
+        if (global_idx < total) {
+            atomicAdd(s_local_histogram[digit], 1u);
+        }
+        barrier();
+        s_prefix[lid] += s_local_histogram[lid];
+        barrier();
+    }
+}
+```
+
+- [ ] **Step 2: Add to shader build**
+
+In `shaders/CMakeLists.txt`, add before `gs_post_process.comp` (line 38):
+
+```cmake
+    ${SHADER_SOURCE_DIR}/gs_onesweep.comp
+```
+
+- [ ] **Step 3: Build to verify shader compiles**
+
+Run: `cmake --build --preset macos-debug`
+Expected: `Compiling shader gs_onesweep.comp` in output. Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add shaders/gs_onesweep.comp shaders/CMakeLists.txt
+git commit -m "feat(gs): Onesweep radix sort compute shader with decoupled lookback"
+```
+
+---
+
+### Task 5: C++ Onesweep pipeline and buffer infrastructure
+
+**Files:**
+- Modify: `include/gseurat/engine/gs_renderer.hpp`
+- Modify: `src/engine/gs_renderer.cpp`
+
+- [ ] **Step 1: Add Onesweep members to GsRenderer header**
+
+In `include/gseurat/engine/gs_renderer.hpp`, add after `tile_scan_set_` (line 409):
+
+```cpp
+    // Onesweep sort (Phase 2 TBDR optimization)
+    VkDescriptorSetLayout onesweep_layout_ = VK_NULL_HANDLE;
+    VkPipelineLayout onesweep_pipeline_layout_ = VK_NULL_HANDLE;
+    VkPipeline onesweep_pipeline_ = VK_NULL_HANDLE;
+    VkDescriptorSet onesweep_set_ab_ = VK_NULL_HANDLE;  // read A → write B
+    VkDescriptorSet onesweep_set_ba_ = VK_NULL_HANDLE;  // read B → write A
+    Buffer onesweep_status_;    // per-digit lookback status buffer
+    bool use_onesweep_ = true;  // A/B toggle (true = onesweep, false = old 8-pass)
+    uint32_t onesweep_max_wg_ = 0;
+```
+
+- [ ] **Step 2: Create Onesweep descriptor set layout**
+
+In `src/engine/gs_renderer.cpp`, in `create_descriptor_resources()`, add after the tile_sort_layout_ creation (after line 401):
+
+```cpp
+    // Onesweep layout: { input(0), output(1), status(2), indirect_args(3) }
+    {
+        VkDescriptorSetLayoutBinding bindings[] = {
+            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        };
+        VkDescriptorSetLayoutCreateInfo ci{};
+        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        ci.bindingCount = 4;
+        ci.pBindings = bindings;
+        vkCreateDescriptorSetLayout(device_, &ci, nullptr, &onesweep_layout_);
+    }
+```
+
+- [ ] **Step 3: Allocate Onesweep descriptor sets in the pool**
+
+Add `onesweep_layout_` twice to the descriptor pool allocation array (for AB and BA sets). Find where tile_sort_layout_ is allocated twice (around line 500-501) and add:
+
+```cpp
+        onesweep_layout_, onesweep_layout_,               // onesweep A→B, B→A
+```
+
+Also increment the pool's `maxSets` count by 2.
+
+- [ ] **Step 4: Create Onesweep pipeline**
+
+In `create_compute_pipelines()`, add after tile_scatter pipeline creation (after line 632):
+
+```cpp
+    // Onesweep pipeline (push: pass + max_workgroups = 8 bytes)
+    create_pipeline("shaders/gs_onesweep.comp.spv", onesweep_layout_, 8,
+                    onesweep_pipeline_layout_, onesweep_pipeline_);
+```
+
+- [ ] **Step 5: Allocate status buffer and write descriptor sets**
+
+In `init_streaming()` (and `load_cloud_legacy` for the non-streaming path), after tile sort buffers are allocated, add:
+
+```cpp
+    // Onesweep status buffer: 4 passes × 256 digits × max_workgroups
+    onesweep_max_wg_ = (tile_sort_capacity_ + 2047) / 2048;
+    if (onesweep_max_wg_ == 0) onesweep_max_wg_ = 1;
+    VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
+    onesweep_status_ = Buffer::create_storage_gpu_only(allocator_, status_size);
+```
+
+Write descriptor sets for onesweep_set_ab_ (input=A, output=B, status, indirect_args) and onesweep_set_ba_ (input=B, output=A, status, indirect_args).
+
+- [ ] **Step 6: Add cleanup for Onesweep resources**
+
+In `shutdown()`, add:
+
+```cpp
+    destroy_pipeline(onesweep_pipeline_);
+    destroy_layout(onesweep_pipeline_layout_);
+    destroy_set_layout(onesweep_layout_);
+    onesweep_status_.destroy(allocator_);
+```
+
+- [ ] **Step 7: Build**
+
+Run: `cmake --build --preset macos-debug`
+Expected: Build succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add include/gseurat/engine/gs_renderer.hpp src/engine/gs_renderer.cpp
+git commit -m "feat(gs): Onesweep pipeline, descriptor sets, and status buffer allocation"
+```
+
+---
+
+### Task 6: Wire Onesweep into dispatch_tile_sort
+
+**Files:**
+- Modify: `src/engine/gs_renderer.cpp`
+
+- [ ] **Step 1: Add Onesweep dispatch path**
+
+In `dispatch_tile_sort()`, after the indirect barrier (line 2134), add an `if (use_onesweep_)` branch that replaces the radix sort loop:
+
+```cpp
+    if (use_onesweep_) {
+        // === Onesweep: clear status buffer ===
+        VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
+        vkCmdFillBuffer(cmd, onesweep_status_.buffer(), 0, status_size, 0);
+        {
+            VkMemoryBarrier sb{};
+            sb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+            sb.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            sb.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+            vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &sb, 0, nullptr, 0, nullptr);
+        }
+
+        // === Onesweep: 4 radix passes ===
+        for (uint32_t pass = 0; pass < 4; pass++) {
+            uint32_t push_data[2] = {pass, onesweep_max_wg_};
+            bool read_from_a = (pass % 2 == 0);
+            VkDescriptorSet set = read_from_a ? onesweep_set_ab_ : onesweep_set_ba_;
+
+            vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, onesweep_pipeline_);
+            vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                    onesweep_pipeline_layout_, 0, 1, &set, 0, nullptr);
+            vkCmdPushConstants(cmd, onesweep_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                               0, 8, push_data);
+            vkCmdDispatchIndirect(cmd, tile_indirect_args_.buffer(), 0);
+
+            insert_compute_barrier(cmd);
+        }
+        // After 4 passes (even), result is in tile_sort_a_
+    } else {
+        // === Old 8-pass radix sort (fallback) ===
+        // ... existing code stays here unchanged ...
+    }
+```
+
+Wrap the existing 8-pass radix loop (lines 2136-2194) in the `else` block.
+
+- [ ] **Step 2: Update gs_tile_prepare_indirect.comp**
+
+The indirect args need to include Onesweep workgroup count at `indirect_args[0]`. Currently `indirect_args[0]` = `ceil(count/1024)` for the old sort. For Onesweep, it should be `ceil(count/2048)`.
+
+Update the prepare_indirect shader to write both:
+
+```glsl
+// indirect_args[0..2]: Onesweep dispatch args (workgroups = ceil(count/2048))
+uint onesweep_wgs = (clamped_count + 2047u) / 2048u;
+if (onesweep_wgs == 0u) onesweep_wgs = 1u;
+indirect_args[0] = onesweep_wgs;
+indirect_args[1] = 1u;
+indirect_args[2] = 1u;
+
+// indirect_args[3..5]: Ranges dispatch args (unchanged)
+indirect_args[3] = (clamped_count + 255u) / 256u;
+indirect_args[4] = 1u;
+indirect_args[5] = 1u;
+
+// indirect_args[6]: clamped entry count
+indirect_args[6] = clamped_count;
+```
+
+(If the old sort needs 1024-based workgroups, we can add a separate field or recalculate. Since Onesweep replaces it, 2048-based is correct.)
+
+- [ ] **Step 3: Add use_onesweep to feature flag control**
+
+In `src/engine/renderer.cpp`, where `gs_renderer_.set_tile_binning(flags.gs_tile_binning)` is called, also expose the onesweep toggle (or hard-wire it to true for now). In `gs_renderer.hpp`, add:
+
+```cpp
+    void set_use_onesweep(bool v) { use_onesweep_ = v; }
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cmake --build --preset macos-debug`
+Expected: Build succeeds. Full pipeline wired.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/engine/gs_renderer.cpp include/gseurat/engine/gs_renderer.hpp \
+        shaders/gs_tile_prepare_indirect.comp
+git commit -m "feat(gs): wire Onesweep dispatch into tile sort pipeline with A/B toggle"
+```
+
+---
+
+### Task 7: Visual verification and Windows build
+
+- [ ] **Step 1: Build macOS debug**
+
+Run: `cmake --build --preset macos-debug`
+Expected: All 36+ tests pass, build clean.
+
+- [ ] **Step 2: Push and build on Windows**
+
+```bash
+git push origin perf/onesweep-tile-sort
+ssh windows "powershell -NoProfile -Command \"cd C:\\Users\\g00ec\\dev\\GSeurat; git fetch origin 2>&1; git checkout perf/onesweep-tile-sort 2>&1; git pull 2>&1; cmake --preset windows-release 2>&1; cmake --build --preset windows-release 2>&1\""
+```
+
+Expected: Windows build succeeds. Console shows tile binning remains enabled on AMD (vendor 0x1002), Onesweep active.
+
+- [ ] **Step 3: Commit (no changes — verification only)**
+
+No commit needed.
+
+---
+
+### Task 8: Control server Onesweep toggle
+
+**Files:**
+- Modify: `src/engine/command_dispatcher.cpp`
+
+- [ ] **Step 1: Add use_onesweep to get/set feature**
+
+In `src/engine/command_dispatcher.cpp`, after `gs_tile_binning` in `get_features`:
+
+```cpp
+        add("gs_onesweep", ctx_.renderer.gs_renderer().use_onesweep(), "Onesweep Sort");
+```
+
+In `set_feature`, after `gs_tile_binning`:
+
+```cpp
+        else if (name == "gs_onesweep") ctx_.renderer.gs_renderer().set_use_onesweep(enabled);
+```
+
+Add `bool use_onesweep() const { return use_onesweep_; }` to `gs_renderer.hpp` public section if not already present.
+
+- [ ] **Step 2: Build**
+
+Run: `cmake --build --preset macos-debug`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/engine/command_dispatcher.cpp include/gseurat/engine/gs_renderer.hpp
+git commit -m "feat(gs): expose use_onesweep toggle in control server"
+```

--- a/docs/superpowers/plans/2026-04-14-engine-promotion-debug-bones-triggers.md
+++ b/docs/superpowers/plans/2026-04-14-engine-promotion-debug-bones-triggers.md
@@ -1,0 +1,1047 @@
+# Engine Promotion: Debug Overlay, Bone Orchestration, Trigger Systems — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote debug visualization, bone animation orchestration, and trigger systems from demo/staging to engine layer.
+
+**Architecture:** Three promotions that touch overlapping files. Part 1 adds line/circle to UIContext and engine-level gizmo/metric utilities. Part 2 moves bone gather+upload into AppBase::update_game(). Part 3 moves trigger components and systems to engine, eliminating demo-layer island_systems entirely.
+
+**Tech Stack:** C++23, GLM, ECS (header-only archetype), Vulkan (SpriteDrawInfo for rendering)
+
+---
+
+### Task 1: UIContext line() and circle() primitives
+
+**Files:**
+- Modify: `include/gseurat/engine/ui/ui_context.hpp`
+- Modify: `src/engine/ui/ui_context.cpp`
+
+- [ ] **Step 1: Add line() and circle() declarations to UIContext**
+
+In `include/gseurat/engine/ui/ui_context.hpp`, add after the `panel()` method (line 48):
+
+```cpp
+void line(float x1, float y1, float x2, float y2, float thickness,
+          glm::vec4 color = {1.0f, 1.0f, 1.0f, 1.0f});
+void circle(float cx, float cy, float radius, int segments,
+            float thickness, glm::vec4 color = {1.0f, 1.0f, 1.0f, 1.0f});
+```
+
+- [ ] **Step 2: Implement line() in UIContext**
+
+In `src/engine/ui/ui_context.cpp`, add after the `panel()` method (after line 144):
+
+```cpp
+void UIContext::line(float x1, float y1, float x2, float y2, float thickness,
+                     glm::vec4 color) {
+    float dx = x2 - x1;
+    float dy = y2 - y1;
+    if (std::abs(dx) < 0.001f && std::abs(dy) < 0.001f) return;
+
+    float cx = (x1 + x2) * 0.5f;
+    float cy = (y1 + y2) * 0.5f;
+
+    // SpriteDrawInfo is axis-aligned, so approximate lines as thin rects.
+    // For debug wireframes (projected box edges, circle segments) this is
+    // sufficient — most segments are near-axis-aligned after 3D→2D projection.
+    if (std::abs(dx) >= std::abs(dy)) {
+        draw_rect(cx, cy, std::abs(dx), std::max(thickness, std::abs(dy)), color);
+    } else {
+        draw_rect(cx, cy, std::max(thickness, std::abs(dx)), std::abs(dy), color);
+    }
+}
+```
+
+- [ ] **Step 3: Implement circle() in UIContext**
+
+In `src/engine/ui/ui_context.cpp`, add after `line()`:
+
+```cpp
+void UIContext::circle(float cx, float cy, float radius, int segments,
+                       float thickness, glm::vec4 color) {
+    if (segments < 3) segments = 3;
+    float step = 2.0f * 3.14159265f / static_cast<float>(segments);
+    for (int i = 0; i < segments; i++) {
+        float a1 = static_cast<float>(i) * step;
+        float a2 = static_cast<float>(i + 1) * step;
+        float x1 = cx + std::cos(a1) * radius;
+        float y1 = cy + std::sin(a1) * radius;
+        float x2 = cx + std::cos(a2) * radius;
+        float y2 = cy + std::sin(a2) * radius;
+        line(x1, y1, x2, y2, thickness, color);
+    }
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add include/gseurat/engine/ui/ui_context.hpp src/engine/ui/ui_context.cpp
+git commit -m "feat(ui): add line() and circle() primitives to UIContext"
+```
+
+---
+
+### Task 2: Engine debug_draw utilities (3D gizmo projection)
+
+**Files:**
+- Create: `include/gseurat/engine/debug_draw.hpp`
+- Create: `src/engine/debug_draw.cpp`
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Create debug_draw.hpp**
+
+Create `include/gseurat/engine/debug_draw.hpp`:
+
+```cpp
+#pragma once
+
+#include "gseurat/engine/gs_animator.hpp"  // GsAnimRegion
+
+#include <glm/glm.hpp>
+#include <functional>
+
+namespace gseurat {
+
+using DrawLineFn = std::function<void(float x1, float y1, float x2, float y2,
+                                       float thickness, glm::vec4 color)>;
+
+// Project a 3D world position to 2D screen coordinates.
+// Returns false if the point is behind the camera.
+bool project_to_screen(const glm::vec3& world_pos, const glm::mat4& vp,
+                        float screen_w, float screen_h,
+                        float& out_x, float& out_y);
+
+// Draw a wireframe sphere (projected circle on screen).
+void draw_sphere_gizmo(const glm::vec3& center, float radius,
+                         const glm::mat4& vp, float sw, float sh,
+                         glm::vec4 color, const DrawLineFn& draw_line);
+
+// Draw a wireframe axis-aligned box (8 corners, 12 edges).
+void draw_box_gizmo(const glm::vec3& center, const glm::vec3& half_extents,
+                      const glm::mat4& vp, float sw, float sh,
+                      glm::vec4 color, const DrawLineFn& draw_line);
+
+// Draw a region wireframe (sphere or box depending on shape).
+void draw_region_gizmo(const GsAnimRegion& region, const glm::vec3& offset,
+                         const glm::mat4& vp, float sw, float sh,
+                         glm::vec4 color, const DrawLineFn& draw_line);
+
+}  // namespace gseurat
+```
+
+- [ ] **Step 2: Create debug_draw.cpp**
+
+Create `src/engine/debug_draw.cpp`:
+
+```cpp
+#include "gseurat/engine/debug_draw.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace gseurat {
+
+bool project_to_screen(const glm::vec3& world_pos, const glm::mat4& vp,
+                        float screen_w, float screen_h,
+                        float& out_x, float& out_y) {
+    glm::vec4 clip = vp * glm::vec4(world_pos, 1.0f);
+    if (clip.w <= 0.001f) return false;
+    glm::vec3 ndc = glm::vec3(clip) / clip.w;
+    if (ndc.z < 0.0f || ndc.z > 1.0f) return false;
+    out_x = (ndc.x * 0.5f + 0.5f) * screen_w;
+    out_y = (1.0f - (ndc.y * 0.5f + 0.5f)) * screen_h;  // Y-down for screen
+    return true;
+}
+
+void draw_sphere_gizmo(const glm::vec3& center, float radius,
+                         const glm::mat4& vp, float sw, float sh,
+                         glm::vec4 color, const DrawLineFn& draw_line) {
+    float cx, cy;
+    if (!project_to_screen(center, vp, sw, sh, cx, cy)) return;
+
+    // Project an edge point to estimate screen-space radius
+    glm::vec3 edge = center + glm::vec3(radius, 0.0f, 0.0f);
+    float ex, ey;
+    float sr = 15.0f;  // fallback screen radius
+    if (project_to_screen(edge, vp, sw, sh, ex, ey)) {
+        sr = std::abs(ex - cx);
+        sr = std::clamp(sr, 3.0f, 300.0f);
+    }
+
+    // Draw circle as line segments
+    constexpr int segments = 24;
+    constexpr float step = 2.0f * 3.14159265f / static_cast<float>(segments);
+    for (int i = 0; i < segments; i++) {
+        float a1 = static_cast<float>(i) * step;
+        float a2 = static_cast<float>(i + 1) * step;
+        float x1 = cx + std::cos(a1) * sr;
+        float y1 = cy + std::sin(a1) * sr;
+        float x2 = cx + std::cos(a2) * sr;
+        float y2 = cy + std::sin(a2) * sr;
+        draw_line(x1, y1, x2, y2, 1.5f, color);
+    }
+}
+
+void draw_box_gizmo(const glm::vec3& center, const glm::vec3& half,
+                      const glm::mat4& vp, float sw, float sh,
+                      glm::vec4 color, const DrawLineFn& draw_line) {
+    glm::vec3 corners[8] = {
+        center + glm::vec3(-half.x, -half.y, -half.z),
+        center + glm::vec3( half.x, -half.y, -half.z),
+        center + glm::vec3( half.x,  half.y, -half.z),
+        center + glm::vec3(-half.x,  half.y, -half.z),
+        center + glm::vec3(-half.x, -half.y,  half.z),
+        center + glm::vec3( half.x, -half.y,  half.z),
+        center + glm::vec3( half.x,  half.y,  half.z),
+        center + glm::vec3(-half.x,  half.y,  half.z),
+    };
+    float pts_x[8], pts_y[8];
+    bool vis[8];
+    for (int i = 0; i < 8; i++) {
+        vis[i] = project_to_screen(corners[i], vp, sw, sh, pts_x[i], pts_y[i]);
+    }
+    constexpr int edges[12][2] = {
+        {0,1},{1,2},{2,3},{3,0}, {4,5},{5,6},{6,7},{7,4}, {0,4},{1,5},{2,6},{3,7}
+    };
+    for (const auto& e : edges) {
+        if (vis[e[0]] && vis[e[1]]) {
+            draw_line(pts_x[e[0]], pts_y[e[0]], pts_x[e[1]], pts_y[e[1]], 1.0f, color);
+        }
+    }
+}
+
+void draw_region_gizmo(const GsAnimRegion& region, const glm::vec3& offset,
+                         const glm::mat4& vp, float sw, float sh,
+                         glm::vec4 color, const DrawLineFn& draw_line) {
+    glm::vec3 center = region.center + offset;
+    if (region.shape == GsAnimRegion::Shape::Box) {
+        draw_box_gizmo(center, region.half_extents, vp, sw, sh, color, draw_line);
+    } else {
+        draw_sphere_gizmo(center, region.radius, vp, sw, sh, color, draw_line);
+    }
+}
+
+}  // namespace gseurat
+```
+
+- [ ] **Step 3: Add debug_draw.cpp to CMakeLists.txt**
+
+In `CMakeLists.txt`, add after the `src/engine/bone_animation_system.cpp` line (line 190):
+
+```cmake
+    src/engine/debug_draw.cpp
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add include/gseurat/engine/debug_draw.hpp src/engine/debug_draw.cpp CMakeLists.txt
+git commit -m "feat(engine): add debug_draw gizmo projection utilities"
+```
+
+---
+
+### Task 3: DebugMetrics in AppBase
+
+**Files:**
+- Modify: `include/gseurat/engine/app_base.hpp`
+- Modify: `src/engine/app_base.cpp`
+- Modify: `include/gseurat/demo/island_demo_state.hpp`
+- Modify: `src/demo/island_demo_state.cpp`
+- Modify: `include/gseurat/staging/staging_state.hpp`
+- Modify: `src/staging/staging_state.cpp`
+
+- [ ] **Step 1: Add DebugMetrics struct and member to AppBase**
+
+In `include/gseurat/engine/app_base.hpp`, add before the `class AppBase` declaration (before line 52):
+
+```cpp
+struct DebugMetrics {
+    float fps = 0.0f;
+    float frame_times[300]{};
+    int frame_time_idx = 0;
+    int frame_count = 0;
+    float timer = 0.0f;
+    static constexpr float kUpdateInterval = 0.5f;
+
+    void update(float dt) {
+        frame_count++;
+        timer += dt;
+        if (timer >= kUpdateInterval) {
+            fps = static_cast<float>(frame_count) / timer;
+            frame_count = 0;
+            timer = 0.0f;
+        }
+        frame_times[frame_time_idx] = dt * 1000.0f;
+        frame_time_idx = (frame_time_idx + 1) % 300;
+    }
+};
+```
+
+Add a public accessor in `AppBase` (after the `screen_effects()` accessor, around line 128):
+
+```cpp
+DebugMetrics& debug_metrics() { return debug_metrics_; }
+const DebugMetrics& debug_metrics() const { return debug_metrics_; }
+```
+
+Add the member in the protected section (after `screen_effects_`, around line 194):
+
+```cpp
+DebugMetrics debug_metrics_;
+```
+
+- [ ] **Step 2: Call debug_metrics_.update(dt) in main_loop()**
+
+In `src/engine/app_base.cpp`, in `main_loop()`, add after the dt clamp (after line 83 `if (dt > 0.1f) dt = 0.1f;`):
+
+```cpp
+        debug_metrics_.update(dt);
+```
+
+- [ ] **Step 3: Remove FPS tracking from IslandDemoState**
+
+In `include/gseurat/demo/island_demo_state.hpp`, remove these members (lines 126-129):
+
+```cpp
+    // FPS tracking
+    std::chrono::steady_clock::time_point fps_clock_{};
+    int fps_frame_count_ = 0;
+    float fps_ = 0.0f;
+```
+
+Also remove the `<chrono>` include if no longer needed (line 17). Check: `fps_clock_` was the only chrono usage — yes, remove it.
+
+In `src/demo/island_demo_state.cpp`, find and remove the FPS computation block (around lines 593-601):
+
+```cpp
+        auto now = std::chrono::steady_clock::now();
+        if (fps_frame_count_ == 0) fps_clock_ = now;
+        fps_frame_count_++;
+        float elapsed = std::chrono::duration<float>(now - fps_clock_).count();
+        if (elapsed >= 0.5f) {
+            fps_ = static_cast<float>(fps_frame_count_) / elapsed;
+            fps_frame_count_ = 0;
+            fps_clock_ = now;
+        }
+```
+
+Replace all `fps_` references in `build_draw_lists()` with `app.debug_metrics().fps`:
+
+- Line 1672: `glm::vec4 fps_color = fps_ >= 30.0f ? green : red;` → `float fps_val = app.debug_metrics().fps; glm::vec4 fps_color = fps_val >= 30.0f ? green : red;`
+- Line 1713: `ui.label(f1(fps_) + " FPS", ...)` → `ui.label(f1(fps_val) + " FPS", ...)`
+- Line 1765: `ui.label(f1(fps_) + " FPS", ...)` → `ui.label(f1(fps_val) + " FPS", ...)`
+
+- [ ] **Step 4: Remove FPS tracking from StagingState**
+
+In `include/gseurat/staging/staging_state.hpp`, remove these members (lines 68-72):
+
+```cpp
+    float fps_ = 0.0f;
+    float fps_timer_ = 0.0f;
+    uint32_t frame_count_ = 0;
+    std::array<float, 300> frame_times_{};
+    int frame_time_idx_ = 0;
+```
+
+Also remove the `<array>` include (line 13) if no longer needed. Check: `frame_times_` was the only `std::array` usage — yes, remove it.
+
+In `src/staging/staging_state.cpp`, find the FPS update block (around lines 331-339) and remove it:
+
+```cpp
+    frame_count_++;
+    fps_timer_ += dt;
+    if (fps_timer_ >= 0.5f) {
+        fps_ = static_cast<float>(frame_count_) / fps_timer_;
+        frame_count_ = 0;
+        fps_timer_ = 0.0f;
+    }
+    frame_times_[frame_time_idx_] = dt * 1000.0f;
+    frame_time_idx_ = (frame_time_idx_ + 1) % frame_times_.size();
+```
+
+Replace all `fps_` references with `app.debug_metrics().fps`:
+
+- In `draw_performance()` (line 1061): `ImGui::Text("FPS: %.1f (%.2f ms)", fps_, ...)` → `ImGui::Text("FPS: %.1f (%.2f ms)", app.debug_metrics().fps, ...)`
+- In `draw_viewport_info()` (line 670): `ImGui::Text("FPS: %.1f", fps_)` → `ImGui::Text("FPS: %.1f", app.debug_metrics().fps)`
+
+Replace `frame_times_` and `frame_time_idx_` references with `app.debug_metrics().frame_times` and `app.debug_metrics().frame_time_idx`:
+
+- In `draw_performance()` (line 1066): `ordered[i] = frame_times_[(frame_time_idx_ + i) % 300]` → `ordered[i] = app.debug_metrics().frame_times[(app.debug_metrics().frame_time_idx + i) % 300]`
+
+Note: `draw_performance()` and `draw_viewport_info()` don't receive `AppBase&` — they need it. Check the signatures. They already receive `AppBase& app` as parameter (see staging_state.hpp line 45-54 — all `draw_*` methods take `AppBase& app`). Good.
+
+- [ ] **Step 5: Build and verify**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add include/gseurat/engine/app_base.hpp src/engine/app_base.cpp \
+        include/gseurat/demo/island_demo_state.hpp src/demo/island_demo_state.cpp \
+        include/gseurat/staging/staging_state.hpp src/staging/staging_state.cpp
+git commit -m "refactor(engine): promote DebugMetrics to AppBase, remove demo/staging FPS tracking"
+```
+
+---
+
+### Task 4: Promote trigger components to engine
+
+**Files:**
+- Create: `include/gseurat/engine/trigger_components.hpp`
+- Modify: `include/gseurat/demo/island_components.hpp`
+
+- [ ] **Step 1: Create engine/trigger_components.hpp**
+
+Create `include/gseurat/engine/trigger_components.hpp`:
+
+```cpp
+#pragma once
+
+#include "gseurat/engine/collision_gen.hpp"
+
+#include <cstdint>
+
+namespace gseurat {
+
+struct ProximityTrigger {
+    float radius = 5.0f;
+    bool one_shot = false;
+    bool triggered = false;
+    bool was_triggered = false;
+};
+
+struct EmitterToggle {
+    uint32_t emitter_index = 0;
+    bool active = false;
+};
+
+struct LightToggle {
+    float color_r = 1.0f;
+    float color_g = 1.0f;
+    float color_b = 1.0f;
+    float radius = 10.0f;
+    float intensity = 1.0f;
+    bool active = false;
+};
+
+struct EmissiveToggle {
+    float emission = 2.0f;
+    float color_r = 1.0f;
+    float color_g = 1.0f;
+    float color_b = 1.0f;
+    float effect_radius = 3.0f;
+    float current_emission = 0.0f;
+    bool applied = false;
+};
+
+struct LinkedTrigger {
+    uint32_t target_entity = 0;
+    bool fired = false;
+};
+
+// Singleton: stores collision grid pointer for NPC systems.
+struct CollisionGridRef {
+    const CollisionGrid* grid = nullptr;
+    float origin_x = 0.0f;
+    float origin_z = 0.0f;
+};
+
+// Patrolling NPC — wanders randomly within patrol_radius of home position.
+struct NpcWalker {
+    float patrol_radius = 8.0f;
+    float speed = 5.0f;
+    float pause_duration = 2.0f;
+    float home_x = 0.0f;
+    float home_z = 0.0f;
+    float target_x = 0.0f;
+    float target_z = 0.0f;
+    float pause_timer = 0.0f;
+    bool initialized = false;
+    bool paused = true;
+};
+
+}  // namespace gseurat
+```
+
+- [ ] **Step 2: Slim down island_components.hpp**
+
+Replace the entire content of `include/gseurat/demo/island_components.hpp` with:
+
+```cpp
+#pragma once
+
+#include "gseurat/engine/trigger_components.hpp"
+#include "gseurat/engine/bone_animated_component.hpp"
+
+#include <cstdint>
+
+namespace gseurat {
+
+struct PlayerController {
+    float speed = 10.0f;
+    float acceleration = 10.0f;
+    float velocity_x = 0.0f;
+    float velocity_z = 0.0f;
+};
+
+struct BurstEffect {
+    uint32_t emitter_index = 0;
+    bool fired = false;
+};
+
+struct ScatterEffect {
+    float radius = 2.0f;
+    float lifetime = 2.0f;
+    bool fired = false;
+};
+
+// Triggers a GS animation effect on nearby Gaussians when player approaches.
+struct AnimationTrigger {
+    char effect_name[16] = "pulse";
+    float anim_radius = 5.0f;
+    float lifetime = 3.0f;
+    bool loop = false;
+    bool fired = false;
+};
+
+// Hidden discovery zone — rewards exploration with a celebration burst.
+struct DiscoveryZone {
+    float color_r = 1.0f;
+    float color_g = 0.8f;
+    float color_b = 0.2f;
+    float burst_height = 8.0f;
+    bool discovered = false;
+};
+
+// Triggers a VFX instance (multi-element composition) on proximity.
+struct VfxTrigger {
+    char vfx_path[64] = "";
+    bool fired = false;
+};
+
+}  // namespace gseurat
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds (all existing code still compiles — island_components.hpp re-exports trigger types via the include)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add include/gseurat/engine/trigger_components.hpp include/gseurat/demo/island_components.hpp
+git commit -m "refactor(engine): promote trigger components to engine layer"
+```
+
+---
+
+### Task 5: Promote trigger systems to engine
+
+**Files:**
+- Create: `include/gseurat/engine/trigger_systems.hpp`
+- Create: `src/engine/trigger_systems.cpp`
+- Delete: `include/gseurat/demo/island_systems.hpp`
+- Delete: `src/demo/island_systems.cpp`
+- Modify: `src/engine/app_base.cpp`
+- Modify: `src/demo/island_demo_state.cpp`
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Create engine/trigger_systems.hpp**
+
+Create `include/gseurat/engine/trigger_systems.hpp`:
+
+```cpp
+#pragma once
+
+#include "gseurat/engine/ecs/world.hpp"
+
+namespace gseurat {
+
+class BoneAnimationRegistry;
+
+void proximity_trigger_system(ecs::World& world, float dt);
+void linked_trigger_system(ecs::World& world, float dt);
+void emissive_toggle_system(ecs::World& world, float dt);
+void npc_walker_system(ecs::World& world, float dt, BoneAnimationRegistry& registry);
+
+}  // namespace gseurat
+```
+
+- [ ] **Step 2: Add PlayerTag to trigger_components.hpp and create engine/trigger_systems.cpp**
+
+The original `proximity_trigger_system` queried `PlayerController` to find the player. Since `PlayerController` stays in demo, we add a trivial `PlayerTag` to the engine. Demo attaches both `PlayerController` and `PlayerTag` to the player entity.
+
+Add to the end of `include/gseurat/engine/trigger_components.hpp` (before closing `}`):
+
+```cpp
+// Marks the player entity for engine systems that need player position.
+struct PlayerTag {};
+```
+
+Create `src/engine/trigger_systems.cpp`:
+
+```cpp
+#include "gseurat/engine/trigger_systems.hpp"
+#include "gseurat/engine/trigger_components.hpp"
+#include "gseurat/engine/bone_animation_registry.hpp"
+#include "gseurat/engine/ecs/default_components.hpp"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+namespace gseurat {
+
+void proximity_trigger_system(ecs::World& world, float dt) {
+    (void)dt;
+    glm::vec3 player_pos{0.0f};
+    bool found = false;
+    world.view<PlayerTag, ecs::Transform>().each(
+        [&](ecs::Entity, PlayerTag&, ecs::Transform& t) {
+            player_pos = t.position.vec();
+            found = true;
+        });
+    if (!found) return;
+
+    world.view<ProximityTrigger, ecs::Transform>().each(
+        [&](ecs::Entity, ProximityTrigger& pt, ecs::Transform& t) {
+            if (pt.one_shot && pt.was_triggered) {
+                pt.triggered = true;
+                return;
+            }
+            float dx = t.position.x() - player_pos.x;
+            float dz = t.position.z() - player_pos.z;
+            float dist = std::sqrt(dx * dx + dz * dz);
+            bool was = pt.triggered;
+            pt.triggered = dist < pt.radius;
+            if (pt.triggered && !was) {
+                std::fprintf(stderr, "[ProximityTrigger] ENTER at (%.1f, %.1f, %.1f) dist=%.1f\n",
+                    t.position.x(), t.position.y(), t.position.z(), dist);
+            }
+            if (pt.triggered && pt.one_shot) {
+                pt.was_triggered = true;
+            }
+        });
+}
+
+void linked_trigger_system(ecs::World& world, float dt) {
+    (void)dt;
+    world.view<LinkedTrigger, ProximityTrigger>().each(
+        [&](ecs::Entity, LinkedTrigger& lt, ProximityTrigger& pt) {
+            if (!pt.triggered || lt.fired) return;
+            lt.fired = true;
+            ecs::Entity target{lt.target_entity};
+            auto* target_pt = world.try_get<ProximityTrigger>(target);
+            if (target_pt) {
+                target_pt->triggered = true;
+                target_pt->was_triggered = true;
+            }
+            auto* target_et = world.try_get<EmissiveToggle>(target);
+            if (target_et) {
+                target_et->current_emission = target_et->emission;
+            }
+        });
+}
+
+void emissive_toggle_system(ecs::World& world, float dt) {
+    world.view<EmissiveToggle, ProximityTrigger>().each(
+        [&](ecs::Entity, EmissiveToggle& et, ProximityTrigger& pt) {
+            float target = pt.triggered ? et.emission : 0.0f;
+            et.current_emission += (target - et.current_emission) * std::min(1.0f, dt * 3.0f);
+        });
+}
+
+void npc_walker_system(ecs::World& world, float dt, BoneAnimationRegistry& registry) {
+    const CollisionGrid* grid = nullptr;
+    float grid_ox = 0.0f, grid_oz = 0.0f;
+    world.view<CollisionGridRef>().each(
+        [&](ecs::Entity, CollisionGridRef& ref) {
+            grid = ref.grid;
+            grid_ox = ref.origin_x;
+            grid_oz = ref.origin_z;
+        });
+
+    world.view<NpcWalker, ecs::Transform>().each(
+        [&](ecs::Entity entity, NpcWalker& npc, ecs::Transform& t) {
+            if (!npc.initialized) {
+                npc.initialized = true;
+                npc.home_x = t.position.x();
+                npc.home_z = t.position.z();
+                npc.target_x = npc.home_x;
+                npc.target_z = npc.home_z;
+                npc.paused = true;
+                npc.pause_timer = 0.5f;
+            }
+
+            if (npc.paused) {
+                npc.pause_timer -= dt;
+                if (npc.pause_timer <= 0.0f) {
+                    npc.paused = false;
+                    float angle = static_cast<float>(std::rand()) / RAND_MAX * 6.28318f;
+                    float dist = static_cast<float>(std::rand()) / RAND_MAX * npc.patrol_radius;
+                    npc.target_x = npc.home_x + std::cos(angle) * dist;
+                    npc.target_z = npc.home_z + std::sin(angle) * dist;
+                }
+                auto* ba_entry = registry.get_by_entity(entity);
+                if (ba_entry) {
+                    ba_entry->requested_clip = "idle";
+                }
+                return;
+            }
+
+            float dx = npc.target_x - t.position.x();
+            float dz = npc.target_z - t.position.z();
+            float dist = std::sqrt(dx * dx + dz * dz);
+
+            if (dist < 1.0f) {
+                npc.paused = true;
+                npc.pause_timer = npc.pause_duration;
+                return;
+            }
+
+            float step = npc.speed * dt;
+            if (step > dist) step = dist;
+            t.position.vec().x += (dx / dist) * step;
+            t.position.vec().z += (dz / dist) * step;
+
+            if (grid && grid->width > 0 && !grid->elevation.empty()) {
+                int gx = static_cast<int>((t.position.x() - grid_ox) / grid->cell_size);
+                int gz = static_cast<int>((t.position.z() - grid_oz) / grid->cell_size);
+                if (gx >= 0 && gx < static_cast<int>(grid->width) &&
+                    gz >= 0 && gz < static_cast<int>(grid->height)) {
+                    if (grid->is_solid(static_cast<uint32_t>(gx),
+                                       static_cast<uint32_t>(gz))) {
+                        t.position.vec().x -= (dx / dist) * step;
+                        t.position.vec().z -= (dz / dist) * step;
+                        npc.paused = true;
+                        npc.pause_timer = 0.5f;
+                        return;
+                    }
+                    t.position.vec().y = grid->get_elevation(
+                        static_cast<uint32_t>(gx), static_cast<uint32_t>(gz));
+                }
+            }
+
+            auto* ba_entry = registry.get_by_entity(entity);
+            if (ba_entry) {
+                ba_entry->requested_clip = npc.paused ? "idle" : "walk";
+                if (!npc.paused) {
+                    float ddx = npc.target_x - t.position.x();
+                    float ddz = npc.target_z - t.position.z();
+                    if (ddx * ddx + ddz * ddz > 0.01f) {
+                        ba_entry->facing_angle = std::atan2(ddx, ddz);
+                    }
+                }
+            }
+        });
+}
+
+}  // namespace gseurat
+```
+
+- [ ] **Step 3: Delete island_systems files**
+
+Delete `include/gseurat/demo/island_systems.hpp` and `src/demo/island_systems.cpp`.
+
+- [ ] **Step 4: Update app_base.cpp — replace demo includes with engine includes and register all systems**
+
+In `src/engine/app_base.cpp`:
+
+Replace `#include "gseurat/demo/island_components.hpp"` (line 4) with:
+```cpp
+#include "gseurat/engine/trigger_components.hpp"
+#include "gseurat/engine/trigger_systems.hpp"
+```
+
+In `init_game_object_system()`, register `PlayerTag`:
+
+```cpp
+    component_registry_.register_component<PlayerTag>("PlayerTag",
+        [](const nlohmann::json&) -> PlayerTag { return {}; },
+        [](const PlayerTag&) -> nlohmann::json { return {}; });
+```
+
+Add the four trigger systems after the existing `bone_animation` system registration (after line 363):
+
+```cpp
+    system_scheduler_.add_system({"proximity_trigger",
+        [](ecs::World& w, float dt) {
+            proximity_trigger_system(w, dt);
+        }, {}, {}});
+
+    system_scheduler_.add_system({"linked_trigger",
+        [](ecs::World& w, float dt) {
+            linked_trigger_system(w, dt);
+        }, {}, {}});
+
+    system_scheduler_.add_system({"emissive_toggle",
+        [](ecs::World& w, float dt) {
+            emissive_toggle_system(w, dt);
+        }, {}, {}});
+
+    system_scheduler_.add_system({"npc_walker",
+        [this](ecs::World& w, float dt) {
+            npc_walker_system(w, dt, bone_anim_registry_);
+        }, {}, {}});
+```
+
+- [ ] **Step 5: Update island_demo_state.cpp — remove island_systems include, add PlayerTag to player entity**
+
+In `src/demo/island_demo_state.cpp`:
+
+Remove `#include "gseurat/demo/island_systems.hpp"` (line 10).
+
+Add `#include "gseurat/engine/trigger_systems.hpp"` (not strictly needed if no direct calls remain, but good for clarity — actually not needed since systems are registered via app_base).
+
+Remove the `set_npc_bone_registry(&app.bone_animation_registry())` call in `on_enter()` (line 262).
+
+Remove the `set_npc_bone_registry(nullptr)` call in `on_exit()` (line 527).
+
+Find where the player entity is created and add `PlayerTag`. Search for where `PlayerController` is added to the player entity. The player entity gets `PlayerController` via `app.world().add<PlayerController>(...)`. Add `PlayerTag` there too:
+
+```cpp
+app.world().add<PlayerTag>(player_entity_);
+```
+
+- [ ] **Step 6: Update CMakeLists.txt**
+
+Add `src/engine/trigger_systems.cpp` after `src/engine/bone_animation_system.cpp` (around line 190).
+
+Remove `src/demo/island_systems.cpp` from the demo sources list.
+
+- [ ] **Step 7: Build and verify**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add include/gseurat/engine/trigger_components.hpp \
+        include/gseurat/engine/trigger_systems.hpp \
+        src/engine/trigger_systems.cpp \
+        src/engine/app_base.cpp \
+        src/demo/island_demo_state.cpp \
+        CMakeLists.txt
+git rm include/gseurat/demo/island_systems.hpp src/demo/island_systems.cpp
+git commit -m "refactor(engine): promote trigger systems to engine, eliminate island_systems"
+```
+
+---
+
+### Task 6: Bone animation orchestration in AppBase
+
+**Files:**
+- Modify: `include/gseurat/engine/app_base.hpp`
+- Modify: `src/engine/app_base.cpp`
+- Modify: `src/demo/island_demo_state.cpp`
+- Modify: `include/gseurat/demo/island_demo_state.hpp`
+
+- [ ] **Step 1: Add bone_pre_upload_hook to AppBase**
+
+In `include/gseurat/engine/app_base.hpp`, add a public setter and protected member.
+
+Public (after `debug_metrics()` accessor):
+
+```cpp
+    // Hook called before bone transforms are uploaded — allows overriding bone 0 etc.
+    void set_bone_pre_upload_hook(std::function<void(glm::mat4*, uint32_t)> hook) {
+        bone_pre_upload_hook_ = std::move(hook);
+    }
+```
+
+Protected (after `debug_metrics_`):
+
+```cpp
+    std::function<void(glm::mat4*, uint32_t)> bone_pre_upload_hook_;
+```
+
+- [ ] **Step 2: Add bone orchestration to update_game()**
+
+In `src/engine/app_base.cpp`, replace the `update_game` one-liner (line 159):
+
+```cpp
+void AppBase::update_game(float dt) { system_scheduler_.run_all(world_, dt); }
+```
+
+With:
+
+```cpp
+void AppBase::update_game(float dt) {
+    system_scheduler_.run_all(world_, dt);
+
+    // Bone animation orchestration: gather transforms and upload to GPU
+    if (!bone_anim_registry_.entries().empty()) {
+        glm::mat4 bones[32];
+        bones[0] = glm::mat4(1.0f);  // identity — hook can override
+
+        if (bone_pre_upload_hook_) {
+            bone_pre_upload_hook_(bones, 32);
+        }
+
+        uint32_t highest = gather_bone_animation_transforms(
+            bone_anim_registry_, bones, 32);
+        uint32_t total = std::max(highest, gs_terrain_.bone_slot_counter);
+        renderer_.gs_renderer().upload_bone_transforms(
+            bones, static_cast<int>(total));
+    }
+}
+```
+
+Add required include at top of `app_base.cpp` if not already present:
+
+```cpp
+#include "gseurat/engine/gs_renderer.hpp"
+```
+
+(Check: `gs_renderer()` is accessed via `renderer_` which returns `GsRenderer&` — the include is likely already pulled in via `renderer.hpp`. Verify at build time.)
+
+- [ ] **Step 3: Simplify island_demo_state update_walk_animation()**
+
+In `src/demo/island_demo_state.cpp`, replace `update_walk_animation()` (lines 1415-1501) with:
+
+```cpp
+void IslandDemoState::update_walk_animation(AppBase& app, float dt) {
+    if (!character_spawned_) return;
+
+    // Terrain sway (bone 0) — written via pre-upload hook
+    env_anim_time_ += dt;
+
+    auto* pe = app.bone_animation_registry().get(player_registry_id_);
+    if (!pe || !pe->anim_player) return;
+
+    // Set requested clip based on movement speed (if not jumping)
+    if (!jumping_) {
+        float speed = glm::length(glm::vec2(player_velocity_.x, player_velocity_.z));
+        pe->requested_clip = speed > 0.1f ? "walk" : "idle";
+    }
+
+    // Update entry position and facing
+    glm::vec3 ground_pos = character_origin_;
+    float jump_y_offset = 0.0f;
+    if (jumping_) {
+        float t = jump_time_ / kJumpDuration;
+        jump_y_offset = 4.0f * kJumpHeight * t * (1.0f - t);
+        ground_pos.y -= jump_y_offset;
+    }
+    pe->current_pos = ground_pos;
+    pe->facing_angle = facing_angle_;
+    pe->y_offset = jump_y_offset;
+
+    // Root motion consumer
+    if (pe->anim_player->current_clip_index() >= 0) {
+        const auto& current_clip = pe->character_data->clips[
+            pe->anim_player->current_clip_index()];
+        if (current_clip.root_motion) {
+            glm::vec3 world_delta = character_rotation_ * pe->anim_player->delta_position();
+            character_origin_ += world_delta;
+            character_rotation_ = glm::normalize(
+                character_rotation_ * pe->anim_player->delta_rotation());
+            glm::vec3 forward = character_rotation_ * glm::vec3(0.0f, 0.0f, -1.0f);
+            facing_angle_ = std::atan2(forward.x, -forward.z);
+            pe->current_pos = character_origin_;
+            pe->facing_angle = facing_angle_;
+        }
+    }
+
+    // Actor rotation (for GS preprocess shader)
+    app.renderer().gs_renderer().set_actor_rotation(character_rotation_);
+}
+```
+
+- [ ] **Step 4: Set up bone_pre_upload_hook in on_enter() and clear in on_exit()**
+
+In `on_enter()`, after the player entity is created and character is spawned, add:
+
+```cpp
+    app.set_bone_pre_upload_hook([this](glm::mat4* bones, uint32_t) {
+        float sway_y = std::sin(env_anim_time_ * 1.0f) * 0.05f;
+        float sway_x = std::sin(env_anim_time_ * 0.6f) * 0.02f;
+        bones[0] = glm::translate(glm::mat4(1.0f),
+            glm::vec3(sway_x, sway_y, 0.0f));
+    });
+```
+
+In `on_exit()`, add:
+
+```cpp
+    app.set_bone_pre_upload_hook(nullptr);
+```
+
+- [ ] **Step 5: Remove update_environment_animation if it only did terrain sway**
+
+Check: `update_environment_animation()` may have done more than terrain sway. If it only computed terrain sway and updated `env_anim_time_`, its body can be inlined into the hook. If it did other things, keep it. The implementer should check and decide.
+
+- [ ] **Step 6: Remove gather/upload includes no longer needed in island_demo_state.cpp**
+
+Remove `#include "gseurat/engine/bone_animation_system.hpp"` from island_demo_state.cpp if `gather_bone_animation_transforms` is no longer called there.
+
+- [ ] **Step 7: Build and verify**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add include/gseurat/engine/app_base.hpp src/engine/app_base.cpp \
+        src/demo/island_demo_state.cpp include/gseurat/demo/island_demo_state.hpp
+git commit -m "refactor(engine): promote bone animation orchestration to AppBase"
+```
+
+---
+
+### Task 7: Final build verification and cleanup
+
+**Files:**
+- Possibly modify any files with leftover references
+
+- [ ] **Step 1: Full debug build**
+
+Run: `cmake --build --preset macos-debug 2>&1 | tail -10`
+Expected: Build succeeds with no errors
+
+- [ ] **Step 2: Full release build**
+
+Run: `cmake --build --preset macos-release 2>&1 | tail -10`
+Expected: Build succeeds with no errors
+
+- [ ] **Step 3: Verify no references to deleted files**
+
+Run: `grep -r 'island_systems' include/ src/ --include='*.hpp' --include='*.cpp'`
+Expected: No matches (all references removed)
+
+Run: `grep -r 'set_npc_bone_registry' include/ src/ --include='*.hpp' --include='*.cpp'`
+Expected: No matches
+
+Run: `grep -r 'g_npc_bone_registry' include/ src/ --include='*.hpp' --include='*.cpp'`
+Expected: No matches
+
+- [ ] **Step 4: Verify no demo includes in engine layer**
+
+Run: `grep -r 'demo/' src/engine/ include/gseurat/engine/ --include='*.hpp' --include='*.cpp'`
+Expected: No matches (engine must not depend on demo)
+
+- [ ] **Step 5: Commit any cleanup fixes**
+
+```bash
+git add -A
+git commit -m "chore: cleanup stale references after engine promotion"
+```
+
+(Only if there are changes to commit.)

--- a/docs/superpowers/specs/2026-04-14-engine-promotion-debug-bones-triggers-design.md
+++ b/docs/superpowers/specs/2026-04-14-engine-promotion-debug-bones-triggers-design.md
@@ -1,0 +1,284 @@
+# Engine Promotion: Debug Overlay, Bone Orchestration, Trigger Systems
+
+**Date:** 2026-04-14
+**Status:** Draft
+
+## Problem
+
+Three categories of functionality live in the demo/staging layer but are general-purpose engine concerns:
+
+1. **Debug visualization** — Staging has 3D gizmos (wireframe spheres, boxes, region shapes) and performance metrics via ImGui. The demo app has no gizmo support and duplicates FPS tracking logic. Developers debugging the demo must switch to Staging or add ad-hoc logging.
+
+2. **Bone animation orchestration** — `IslandDemoState::update_walk_animation()` directly calls `gather_bone_animation_transforms()` and `upload_bone_transforms()` every frame (~25 lines). Any app with characters must duplicate this orchestration.
+
+3. **Trigger systems** — `ProximityTrigger`, `LinkedTrigger`, `EmissiveToggle`, `NpcWalker`, `CollisionGridRef` are demo-only components with systems in `island_systems.cpp`. These are generic ECS patterns, not island-specific.
+
+## Goal
+
+Promote all three to the engine layer so both demo and staging (and future apps) get them for free.
+
+---
+
+## Part 1: Engine Debug Overlay
+
+### UIContext Line/Circle Primitives
+
+Add two methods to `UIContext`:
+
+```cpp
+void line(float x1, float y1, float x2, float y2, float thickness,
+          glm::vec4 color = {1.0f, 1.0f, 1.0f, 1.0f});
+void circle(float cx, float cy, float radius, int segments,
+            float thickness, glm::vec4 color = {1.0f, 1.0f, 1.0f, 1.0f});
+```
+
+`line()` emits a thin rotated quad (two triangles) via `SpriteDrawInfo` with a 1x1 white pixel UV region. `circle()` calls `line()` N times around the perimeter.
+
+### Engine Debug Draw Utilities
+
+New file: `include/gseurat/engine/debug_draw.hpp`
+
+Pure functions for 3D-to-2D projected gizmos. No dependency on ImGui or UIContext — they accept a callback for line drawing:
+
+```cpp
+using DrawLineFn = std::function<void(float x1, float y1, float x2, float y2,
+                                       float thickness, glm::vec4 color)>;
+
+bool project_to_screen(const glm::vec3& world_pos, const glm::mat4& vp,
+                        float screen_w, float screen_h, float& sx, float& sy);
+
+void draw_sphere_gizmo(const glm::vec3& center, float radius,
+                         const glm::mat4& vp, float sw, float sh,
+                         glm::vec4 color, const DrawLineFn& draw_line);
+
+void draw_box_gizmo(const glm::vec3& center, const glm::vec3& half_extents,
+                      const glm::mat4& vp, float sw, float sh,
+                      glm::vec4 color, const DrawLineFn& draw_line);
+
+void draw_region_gizmo(const GsAnimRegion& region, const glm::vec3& offset,
+                         const glm::mat4& vp, float sw, float sh,
+                         glm::vec4 color, const DrawLineFn& draw_line);
+```
+
+Staging's `draw_gizmos()` can switch to calling these with an ImGui-backed `DrawLineFn`. Demo can call them with a UIContext-backed `DrawLineFn`. The math moves from `staging_state.cpp` to the engine.
+
+### DebugMetrics in AppBase
+
+New struct in `app_base.hpp`:
+
+```cpp
+struct DebugMetrics {
+    float fps = 0.0f;
+    float frame_times[300]{};
+    int frame_time_idx = 0;
+    int frame_count = 0;
+    std::chrono::steady_clock::time_point fps_clock{};
+    static constexpr float kFpsUpdateInterval = 0.5f;
+
+    void update(float dt);  // advance ring buffer, compute FPS
+};
+```
+
+`AppBase` owns a `DebugMetrics debug_metrics_` member and calls `debug_metrics_.update(dt)` in `main_loop()`. Both demo HUD and staging performance panel read from it instead of maintaining their own FPS counters.
+
+**Removed from demo:** `fps_`, `fps_frame_count_`, `fps_clock_` members from `IslandDemoState`.
+**Removed from staging:** `fps_`, `fps_timer_`, `frame_times_`, `frame_time_idx_`, `frame_count_` members from `StagingState`.
+
+---
+
+## Part 2: Bone Animation Orchestration
+
+### Current Flow (demo)
+
+```
+IslandDemoState::update_walk_animation():
+  1. Write bone 0 (terrain sway)
+  2. Set entry->current_pos, facing_angle, y_offset, requested_clip
+  3. Read root motion delta from entry->anim_player
+  4. Call gather_bone_animation_transforms() into local bones[32]
+  5. Call upload_bone_transforms()
+```
+
+Steps 4-5 are pure engine work. Steps 1-3 are player behavior.
+
+### New Flow
+
+`AppBase::update_game(dt)` gains a bone orchestration step after `system_scheduler_.run_all()`:
+
+```cpp
+void AppBase::update_game(float dt) {
+    system_scheduler_.run_all(world_, dt);
+
+    // Bone animation orchestration (after all behavior systems have set
+    // requested_clip, current_pos, facing_angle, y_offset on their entries)
+    if (!bone_anim_registry_.entries().empty()) {
+        glm::mat4 bones[32];
+        // Bone 0 left as identity — demo overrides it before upload if needed
+        bones[0] = glm::mat4(1.0f);
+        uint32_t highest = gather_bone_animation_transforms(
+            bone_anim_registry_, bones, 32);
+        uint32_t total = std::max(highest, gs_terrain_.bone_slot_counter);
+        renderer_.gs_renderer().upload_bone_transforms(bones, static_cast<int>(total));
+    }
+}
+```
+
+### Demo Changes
+
+`update_walk_animation()` simplifies to:
+
+1. Compute terrain sway → write `bones_override_[0]` (new member, or pass to AppBase)
+2. Set player entry fields: `current_pos`, `facing_angle`, `y_offset`, `requested_clip`
+3. Read root motion from `entry->anim_player`
+
+No more `gather_bone_animation_transforms()` or `upload_bone_transforms()` calls in demo.
+
+### Bone 0 Override Mechanism
+
+The demo needs to write bone 0 (terrain sway) before upload. Add a hook:
+
+```cpp
+// In AppBase:
+std::function<void(glm::mat4* bones, uint32_t count)> bone_pre_upload_hook_;
+```
+
+Demo sets this in `on_enter()`:
+```cpp
+app.set_bone_pre_upload_hook([this](glm::mat4* bones, uint32_t) {
+    float sway_y = std::sin(env_anim_time_ * 1.0f) * 0.05f;
+    float sway_x = std::sin(env_anim_time_ * 0.6f) * 0.02f;
+    bones[0] = glm::translate(glm::mat4(1.0f), glm::vec3(sway_x, sway_y, 0.0f));
+});
+```
+
+And clears it in `on_exit()`:
+```cpp
+app.set_bone_pre_upload_hook(nullptr);
+```
+
+### Actor Rotation
+
+`set_actor_rotation(character_rotation_)` stays in demo's `update_walk_animation()` — it's player-specific state that the engine doesn't need to know about.
+
+Wait — the engine orchestration needs it too since it affects the GS preprocess shader. Two options:
+
+**Option chosen:** Add `actor_rotation` to `AppBase` or let the demo call `set_actor_rotation()` after `update_game()`. Since `update_walk_animation()` runs before `build_draw_lists()`, the demo can call `set_actor_rotation()` in its update pass. The engine upload happens in `update_game()`, the rotation is set separately — both happen before render. This keeps it simple.
+
+---
+
+## Part 3: Generic Trigger Systems
+
+### Component Migration
+
+Move from `island_components.hpp` to new `engine/trigger_components.hpp`:
+
+| Component | Why engine-level |
+|-----------|-----------------|
+| `ProximityTrigger` | Generic spatial trigger, used by any game |
+| `LinkedTrigger` | Generic chain reaction, reusable |
+| `EmissiveToggle` | Generic glow-on-proximity, reusable |
+| `NpcWalker` | Generic patrol AI, reusable |
+| `CollisionGridRef` | Singleton for grid access, any app needs it |
+| `EmitterToggle` | Generic emitter activation, reusable |
+| `LightToggle` | Generic light activation, reusable |
+
+**Stay in demo** (island-specific):
+
+| Component | Why demo-specific |
+|-----------|------------------|
+| `PlayerController` | Game-specific player movement tuning |
+| `BurstEffect` | Island celebration effect |
+| `ScatterEffect` | Island scatter effect |
+| `AnimationTrigger` | Island GS animation effect (references GsAnimEffect names) |
+| `DiscoveryZone` | Island exploration mechanic |
+| `VfxTrigger` | Island VFX composition trigger |
+
+### System Migration
+
+Move from `island_systems.cpp` to new `engine/trigger_systems.cpp`:
+
+```cpp
+void proximity_trigger_system(ecs::World& world, float dt);
+void linked_trigger_system(ecs::World& world, float dt);
+void emissive_toggle_system(ecs::World& world, float dt);
+void npc_walker_system(ecs::World& world, float dt, BoneAnimationRegistry& registry);
+```
+
+`npc_walker_system` signature changes: takes `BoneAnimationRegistry&` parameter instead of using the `g_npc_bone_registry` global. This matches the pattern established for `bone_animation_system`.
+
+### Registration
+
+`AppBase::init_game_object_system()` registers:
+- All 7 promoted components (ProximityTrigger, LinkedTrigger, EmissiveToggle, NpcWalker, CollisionGridRef, EmitterToggle, LightToggle)
+- All 4 systems as engine-level systems
+
+Component registrations move from `app_base.cpp` (where they currently live referencing demo headers) to the same function but now referencing engine headers.
+
+### Header Changes
+
+- `island_components.hpp` keeps only: `PlayerController`, `BurstEffect`, `ScatterEffect`, `AnimationTrigger`, `DiscoveryZone`, `VfxTrigger`
+- `island_components.hpp` adds: `#include "gseurat/engine/trigger_components.hpp"` for backward compatibility (demo code that includes island_components still sees ProximityTrigger etc.)
+- `island_systems.hpp` — delete entirely (all four systems promoted to engine)
+- `app_base.cpp` drops `#include "gseurat/demo/island_components.hpp"` — uses engine headers only
+
+### Global State Elimination
+
+`set_npc_bone_registry()` and `g_npc_bone_registry` are removed. The system registration lambda captures `this`:
+
+```cpp
+system_scheduler_.add_system({"npc_walker",
+    [this](ecs::World& w, float dt) {
+        npc_walker_system(w, dt, bone_anim_registry_);
+    }, {}, {}});
+```
+
+Same pattern as the existing `bone_animation_system` registration.
+
+---
+
+## File Summary
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `include/gseurat/engine/debug_draw.hpp` | 3D gizmo projection utilities |
+| `src/engine/debug_draw.cpp` | Implementation |
+| `include/gseurat/engine/trigger_components.hpp` | Promoted trigger/walker components |
+| `include/gseurat/engine/trigger_systems.hpp` | Promoted system declarations |
+| `src/engine/trigger_systems.cpp` | Promoted system implementations |
+
+### Modified Files
+| File | Changes |
+|------|---------|
+| `include/gseurat/engine/ui/ui_context.hpp` | Add `line()`, `circle()` |
+| `src/engine/ui/ui_context.cpp` | Implement line/circle rendering |
+| `include/gseurat/engine/app_base.hpp` | Add `DebugMetrics`, `bone_pre_upload_hook_`, accessor |
+| `src/engine/app_base.cpp` | Bone orchestration in `update_game()`, register promoted systems, use engine headers |
+| `include/gseurat/demo/island_components.hpp` | Remove promoted components, add include |
+| `include/gseurat/demo/island_systems.hpp` | Remove promoted systems (or delete file) |
+| `src/demo/island_systems.cpp` | Remove promoted systems, remove global registry |
+| `src/demo/island_demo_state.cpp` | Remove bone gather/upload, remove FPS tracking, simplify update_walk_animation |
+| `include/gseurat/demo/island_demo_state.hpp` | Remove FPS members |
+| `src/staging/staging_state.cpp` | Optionally call engine gizmo helpers, remove FPS members |
+| `include/gseurat/staging/staging_state.hpp` | Remove FPS members |
+| `CMakeLists.txt` | Add new engine source files |
+
+### Deleted Files
+| File | Reason |
+|------|--------|
+| `include/gseurat/demo/island_systems.hpp` | All systems promoted to engine |
+| `src/demo/island_systems.cpp` | All systems promoted to engine |
+
+## Testing
+
+1. **Build succeeds** — debug and release
+2. **Demo startup** — Player appears, idle animation, NPCs patrol
+3. **Demo HUD** — Tab cycles HUD modes, FPS reads from `DebugMetrics`
+4. **NPC patrol** — Knight and slimes walk, animate, respect collision
+5. **Proximity triggers** — Torches, crystals, animation triggers all fire
+6. **Linked triggers** — Chain reactions still work
+7. **Emissive toggle** — Crystal glow on/off with proximity
+8. **Jump** — Player jump arc with y_offset works via bone orchestration
+9. **Portal round-trip** — Animation works after dungeon entry/exit
+10. **Staging gizmos** — Staging still renders gizmos (can optionally use engine helpers)
+11. **No regressions** — Camera, particles, collision, audio unchanged

--- a/include/gseurat/engine/buffer.hpp
+++ b/include/gseurat/engine/buffer.hpp
@@ -37,6 +37,7 @@ public:
     static Buffer create_index(VmaAllocator allocator, VkDeviceSize size);
     static Buffer create_uniform(VmaAllocator allocator, VkDeviceSize size);
     static Buffer create_storage(VmaAllocator allocator, VkDeviceSize size);
+    static Buffer create_storage_indirect(VmaAllocator allocator, VkDeviceSize size);
     static Buffer create_storage_gpu_only(VmaAllocator allocator, VkDeviceSize size);
     static Buffer create_storage_readback(VmaAllocator allocator, VkDeviceSize size);
     static Buffer create_staging(VmaAllocator allocator, VkDeviceSize size);

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -192,6 +192,9 @@ public:
     void set_tile_binning(bool enabled) { tile_binning_enabled_ = enabled; }
     bool tile_binning() const { return tile_binning_enabled_; }
 
+    void set_use_onesweep(bool v) { use_onesweep_ = v; }
+    bool use_onesweep() const { return use_onesweep_; }
+
     // World manifest (Phase 3 streaming)
     void load_world(const WorldManifest& manifest);
     const WorldManifest& world_manifest() const { return world_manifest_; }
@@ -407,6 +410,16 @@ private:
     VkDescriptorSet tile_scatter_set_ab_ = VK_NULL_HANDLE;
     VkDescriptorSet tile_scatter_set_ba_ = VK_NULL_HANDLE;
     VkDescriptorSet tile_scan_set_ = VK_NULL_HANDLE;
+
+    // Onesweep sort (Phase 2 TBDR optimization)
+    VkDescriptorSetLayout onesweep_layout_ = VK_NULL_HANDLE;
+    VkPipelineLayout onesweep_pipeline_layout_ = VK_NULL_HANDLE;
+    VkPipeline onesweep_pipeline_ = VK_NULL_HANDLE;
+    VkDescriptorSet onesweep_set_ab_ = VK_NULL_HANDLE;  // read A → write B
+    VkDescriptorSet onesweep_set_ba_ = VK_NULL_HANDLE;  // read B → write A
+    Buffer onesweep_status_;    // per-digit lookback status buffer
+    bool use_onesweep_ = true;  // A/B toggle (true = onesweep, false = old 8-pass)
+    uint32_t onesweep_max_wg_ = 0;
 
     // Tile sort buffers
     Buffer tile_sort_a_;              // TileSortEntry ping buffer (16 bytes/entry)

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -418,7 +418,7 @@ private:
     VkDescriptorSet onesweep_set_ab_ = VK_NULL_HANDLE;  // read A → write B
     VkDescriptorSet onesweep_set_ba_ = VK_NULL_HANDLE;  // read B → write A
     Buffer onesweep_status_;    // per-digit lookback status buffer
-    bool use_onesweep_ = true;  // A/B toggle (true = onesweep, false = old 8-pass)
+    bool use_onesweep_ = false;  // A/B toggle (true = onesweep, false = old 8-pass)
     uint32_t onesweep_max_wg_ = 0;
 
     // Tile sort buffers

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -418,7 +418,7 @@ private:
     VkDescriptorSet onesweep_set_ab_ = VK_NULL_HANDLE;  // read A → write B
     VkDescriptorSet onesweep_set_ba_ = VK_NULL_HANDLE;  // read B → write A
     Buffer onesweep_status_;    // per-digit lookback status buffer
-    bool use_onesweep_ = true;  // A/B toggle (true = onesweep, false = old 8-pass)
+    bool use_onesweep_ = false;  // A/B toggle — disabled until 2-dispatch Onesweep is implemented
     uint32_t onesweep_max_wg_ = 0;
 
     // Tile sort buffers
@@ -432,7 +432,7 @@ private:
     uint32_t tile_sort_capacity_ = 0;    // max entries in tile sort buffers
     uint32_t tile_sort_size_ = 0;        // workgroup-aligned count for radix sort
     uint32_t tile_sort_workgroups_ = 0;
-    static constexpr uint32_t kTileSortPasses = 8;  // 4 for key_lo + 4 for key_hi
+    static constexpr uint32_t kTileSortPasses = 4;  // 4 for key_lo only (key_hi is always 0)
     bool tile_binning_enabled_ = true;
 
     bool initialized_ = false;

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -418,7 +418,7 @@ private:
     VkDescriptorSet onesweep_set_ab_ = VK_NULL_HANDLE;  // read A → write B
     VkDescriptorSet onesweep_set_ba_ = VK_NULL_HANDLE;  // read B → write A
     Buffer onesweep_status_;    // per-digit lookback status buffer
-    bool use_onesweep_ = false;  // A/B toggle (true = onesweep, false = old 8-pass)
+    bool use_onesweep_ = true;  // A/B toggle (true = onesweep, false = old 8-pass)
     uint32_t onesweep_max_wg_ = 0;
 
     // Tile sort buffers

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SHADER_SOURCES
     ${SHADER_SOURCE_DIR}/gs_tile_ranges.comp
     ${SHADER_SOURCE_DIR}/gs_tile_render.comp
     ${SHADER_SOURCE_DIR}/gs_tile_prepare_indirect.comp
+    ${SHADER_SOURCE_DIR}/gs_onesweep.comp
     ${SHADER_SOURCE_DIR}/gs_post_process.comp
     ${SHADER_SOURCE_DIR}/pbd_solver.comp
 )

--- a/shaders/gs_onesweep.comp
+++ b/shaders/gs_onesweep.comp
@@ -38,7 +38,6 @@ layout(set = 0, binding = 3) readonly buffer IndirectArgs {
 
 layout(push_constant) uniform PushConstants {
     uint pass;            // 0..3 (which 8-bit digit to sort on)
-    uint max_workgroups;  // total workgroups dispatched
 };
 
 // Shared memory: ~19KB total (under 32KB Apple Silicon limit)
@@ -60,6 +59,7 @@ void main() {
     uint wg_id = gl_WorkGroupID.x;
     uint wg_offset = wg_id * ENTRIES_PER_WG;
     uint total = entry_count;
+    uint max_workgroups = sort_dispatch_x;  // actual dispatched workgroup count
 
     // ========================================
     // Phase 1: Load entries & build histogram

--- a/shaders/gs_onesweep.comp
+++ b/shaders/gs_onesweep.comp
@@ -5,10 +5,12 @@
 // Uses coherent buffer + memoryBarrierBuffer() for Apple Silicon TBDR compatibility.
 layout(local_size_x = 256) in;
 
-// 8-byte tile sort entry
+// 16-byte tile sort entry (matches old radix sort format)
 struct TileSortEntry {
-    uint key;
+    uint key_hi;
+    uint key_lo;
     uint index;
+    uint _pad;
 };
 
 layout(set = 0, binding = 0) readonly buffer InputBuffer {
@@ -73,7 +75,7 @@ void main() {
         uint k = 0xFFFFFFFFu;  // sentinel default
         uint v = 0u;
         if (idx < total) {
-            k = in_entries[idx].key;
+            k = in_entries[idx].key_lo;
             v = in_entries[idx].index;
         }
         s_keys[t * 256u + lid] = k;
@@ -158,8 +160,10 @@ void main() {
             }
 
             uint dst = s_prefix[digit] + rank;
-            out_entries[dst].key = my_key;
+            out_entries[dst].key_hi = 0u;
+            out_entries[dst].key_lo = my_key;
             out_entries[dst].index = my_index;
+            out_entries[dst]._pad = 0u;
         }
 
         // Advance prefix for next batch

--- a/shaders/gs_onesweep.comp
+++ b/shaders/gs_onesweep.comp
@@ -130,8 +130,25 @@ void main() {
     atomicExchange(status[status_base + wg_id], INCLUSIVE_FLAG | inclusive);
     memoryBarrierBuffer();
 
-    // Exclusive prefix for this digit in this workgroup
+    // Exclusive prefix for this digit in this workgroup:
+    // s_prefix[d] = (inter-workgroup aggregate for digit d) + (intra-workgroup exclusive prefix for digit d)
+    // The aggregate gives "how many entries of digit d exist in ALL prior workgroups".
+    // The intra-workgroup exclusive prefix gives "how many entries of digits 0..d-1 exist in THIS workgroup".
+    // Together, they give the correct global starting position for digit d's entries in this workgroup.
     s_prefix[lid] = aggregate;
+    barrier();
+
+    // Compute intra-workgroup exclusive prefix sum of local histogram (thread 0 serial scan)
+    if (lid == 0u) {
+        uint running = 0u;
+        for (uint d = 0u; d < 256u; d++) {
+            uint count = s_local_histogram[d];
+            s_local_histogram[d] = running;
+            running += count;
+        }
+    }
+    barrier();
+    s_prefix[lid] += s_local_histogram[lid];
     barrier();
 
     // ========================================

--- a/shaders/gs_onesweep.comp
+++ b/shaders/gs_onesweep.comp
@@ -1,0 +1,178 @@
+#version 450
+
+// Onesweep radix sort: fused histogram + decoupled-lookback prefix sum + stable scatter.
+// One dispatch per 8-bit radix pass (4 passes for 32-bit key).
+// Uses coherent buffer + memoryBarrierBuffer() for Apple Silicon TBDR compatibility.
+layout(local_size_x = 256) in;
+
+// 8-byte tile sort entry
+struct TileSortEntry {
+    uint key;
+    uint index;
+};
+
+layout(set = 0, binding = 0) readonly buffer InputBuffer {
+    TileSortEntry in_entries[];
+};
+
+layout(set = 0, binding = 1) writeonly buffer OutputBuffer {
+    TileSortEntry out_entries[];
+};
+
+// Per-digit lookback status: status[pass * 256 * max_workgroups + digit * max_workgroups + wg_id]
+// Encoding: bits [31:30] = state (00=NOT_READY, 01=LOCAL, 11=INCLUSIVE), bits [29:0] = sum
+layout(set = 0, binding = 2, std430) coherent buffer StatusBuffer {
+    uint status[];
+};
+
+layout(set = 0, binding = 3) readonly buffer IndirectArgs {
+    uint sort_dispatch_x;   // [0]: sort workgroups
+    uint sort_dispatch_y;   // [1]: 1
+    uint sort_dispatch_z;   // [2]: 1
+    uint ranges_dispatch_x; // [3]: ranges workgroups
+    uint ranges_dispatch_y; // [4]
+    uint ranges_dispatch_z; // [5]
+    uint entry_count;       // [6]: clamped tile_sort_count
+    uint histogram_count;   // [7]: 256 * sort_workgroups (unused by onesweep)
+};
+
+layout(push_constant) uniform PushConstants {
+    uint pass;            // 0..3 (which 8-bit digit to sort on)
+    uint max_workgroups;  // total workgroups dispatched
+};
+
+// Shared memory: ~19KB total (under 32KB Apple Silicon limit)
+shared uint s_local_histogram[256];  // 1KB  — per-digit count for this workgroup
+shared uint s_keys[2048];           // 8KB  — loaded sort keys
+shared uint s_indices[2048];        // 8KB  — loaded indices
+shared uint s_prefix[256];          // 1KB  — exclusive prefix of local histogram
+shared uint s_digits[256];          // 1KB  — batch digit scratch for stable rank
+
+const uint ENTRIES_PER_WG = 2048u;
+const uint ENTRIES_PER_THREAD = 8u;
+const uint NOT_READY = 0u;
+const uint LOCAL_FLAG = 1u << 30u;
+const uint INCLUSIVE_FLAG = 3u << 30u;
+const uint VALUE_MASK = 0x3FFFFFFFu;
+
+void main() {
+    uint lid = gl_LocalInvocationID.x;
+    uint wg_id = gl_WorkGroupID.x;
+    uint wg_offset = wg_id * ENTRIES_PER_WG;
+    uint total = entry_count;
+
+    // ========================================
+    // Phase 1: Load entries & build histogram
+    // ========================================
+    s_local_histogram[lid] = 0u;
+    barrier();
+
+    // Load 8 entries per thread into shared memory
+    for (uint t = 0u; t < ENTRIES_PER_THREAD; t++) {
+        uint idx = wg_offset + t * 256u + lid;
+        uint k = 0xFFFFFFFFu;  // sentinel default
+        uint v = 0u;
+        if (idx < total) {
+            k = in_entries[idx].key;
+            v = in_entries[idx].index;
+        }
+        s_keys[t * 256u + lid] = k;
+        s_indices[t * 256u + lid] = v;
+
+        // Extract digit and count
+        uint digit = (k >> (pass * 8u)) & 0xFFu;
+        if (idx < total) {
+            atomicAdd(s_local_histogram[digit], 1u);
+        }
+    }
+    barrier();
+
+    // ========================================
+    // Phase 2: Decoupled lookback prefix sum
+    // ========================================
+    // Each thread handles one digit bin (tid 0..255)
+    uint my_local_count = s_local_histogram[lid];
+
+    // Publish LOCAL status — our partial count for this digit
+    uint status_base = pass * 256u * max_workgroups + lid * max_workgroups;
+    atomicExchange(status[status_base + wg_id], LOCAL_FLAG | my_local_count);
+    memoryBarrierBuffer();
+
+    // Lookback: accumulate prefix from predecessor workgroups
+    uint aggregate = 0u;
+    if (wg_id > 0u) {
+        int pred = int(wg_id) - 1;
+        while (pred >= 0) {
+            uint val;
+            // Spin-read with memory barrier for Apple Silicon weak ordering
+            uint spin_count = 0u;
+            do {
+                memoryBarrierBuffer();
+                val = atomicOr(status[status_base + uint(pred)], 0u);
+                spin_count++;
+                // Safety: if stuck for 1M iterations, break (should never happen)
+                if (spin_count > 1000000u) break;
+            } while ((val >> 30u) == 0u);
+
+            uint state = val >> 30u;
+            uint sum = val & VALUE_MASK;
+            aggregate += sum;
+
+            if (state == 3u) break;  // INCLUSIVE — includes all prior workgroups
+            pred--;
+        }
+    }
+
+    // Publish INCLUSIVE status
+    uint inclusive = aggregate + my_local_count;
+    atomicExchange(status[status_base + wg_id], INCLUSIVE_FLAG | inclusive);
+    memoryBarrierBuffer();
+
+    // Exclusive prefix for this digit in this workgroup
+    s_prefix[lid] = aggregate;
+    barrier();
+
+    // ========================================
+    // Phase 3: Stable scatter
+    // ========================================
+    for (uint batch = 0u; batch < ENTRIES_PER_THREAD; batch++) {
+        uint local_idx = batch * 256u + lid;
+        uint global_idx = wg_offset + local_idx;
+        uint my_key = s_keys[local_idx];
+        uint my_index = s_indices[local_idx];
+        uint digit = (my_key >> (pass * 8u)) & 0xFFu;
+
+        // Store digit for stable rank computation
+        s_digits[lid] = digit;
+        barrier();
+
+        if (global_idx < total) {
+            // Stable rank: count threads before me in this batch with same digit
+            uint rank = 0u;
+            for (uint j = 0u; j < lid; j++) {
+                // Only count entries that are valid (within total)
+                uint j_global = wg_offset + batch * 256u + j;
+                if (j_global < total && s_digits[j] == digit) {
+                    rank++;
+                }
+            }
+
+            uint dst = s_prefix[digit] + rank;
+            out_entries[dst].key = my_key;
+            out_entries[dst].index = my_index;
+        }
+
+        // Advance prefix for next batch
+        barrier();
+
+        // Count entries per digit in this batch (reuse s_local_histogram as scratch)
+        s_local_histogram[lid] = 0u;
+        barrier();
+        if (global_idx < total) {
+            atomicAdd(s_local_histogram[digit], 1u);
+        }
+        barrier();
+        s_prefix[lid] += s_local_histogram[lid];
+        barrier();
+    }
+}

--- a/shaders/gs_onesweep.comp
+++ b/shaders/gs_onesweep.comp
@@ -2,7 +2,10 @@
 
 // Onesweep radix sort: fused histogram + decoupled-lookback prefix sum + stable scatter.
 // One dispatch per 8-bit radix pass (4 passes for 32-bit key).
-// Uses coherent buffer + memoryBarrierBuffer() for Apple Silicon TBDR compatibility.
+//
+// The lookback gives per-digit aggregate (count of digit D in prior workgroups).
+// A global barrier + atomic histogram computes the cross-digit prefix (where each
+// digit's section starts in the output). Combined: correct global scatter position.
 layout(local_size_x = 256) in;
 
 // 16-byte tile sort entry (matches old radix sort format)
@@ -21,8 +24,11 @@ layout(set = 0, binding = 1) writeonly buffer OutputBuffer {
     TileSortEntry out_entries[];
 };
 
-// Per-digit lookback status: status[pass * 256 * max_workgroups + digit * max_workgroups + wg_id]
-// Encoding: bits [31:30] = state (00=NOT_READY, 01=LOCAL, 11=INCLUSIVE), bits [29:0] = sum
+// Layout:
+//   [0, 4*256*max_wg): per-digit lookback status
+//   [4*256*max_wg, 4*256*max_wg+256): global histogram (per-digit totals)
+//   [4*256*max_wg+256]: done_count (blocks finished)
+//   [4*256*max_wg+257, +513): global exclusive prefix
 layout(set = 0, binding = 2, std430) coherent buffer StatusBuffer {
     uint status[];
 };
@@ -35,7 +41,7 @@ layout(set = 0, binding = 3) readonly buffer IndirectArgs {
     uint ranges_dispatch_y; // [4]
     uint ranges_dispatch_z; // [5]
     uint entry_count;       // [6]: clamped tile_sort_count
-    uint histogram_count;   // [7]: 256 * sort_workgroups (unused by onesweep)
+    uint histogram_count;   // [7]: unused by onesweep
 };
 
 layout(push_constant) uniform PushConstants {
@@ -46,7 +52,7 @@ layout(push_constant) uniform PushConstants {
 shared uint s_local_histogram[256];  // 1KB  — per-digit count for this workgroup
 shared uint s_keys[2048];           // 8KB  — loaded sort keys
 shared uint s_indices[2048];        // 8KB  — loaded indices
-shared uint s_prefix[256];          // 1KB  — exclusive prefix of local histogram
+shared uint s_prefix[256];          // 1KB  — global exclusive prefix for scatter
 shared uint s_digits[256];          // 1KB  — batch digit scratch for stable rank
 
 const uint ENTRIES_PER_WG = 2048u;
@@ -61,7 +67,12 @@ void main() {
     uint wg_id = gl_WorkGroupID.x;
     uint wg_offset = wg_id * ENTRIES_PER_WG;
     uint total = entry_count;
-    uint max_workgroups = sort_dispatch_x;  // actual dispatched workgroup count
+    uint max_workgroups = sort_dispatch_x;
+
+    // Offsets into status buffer for global histogram/prefix
+    uint global_hist_base = 4u * 256u * max_workgroups;
+    uint done_count_idx = global_hist_base + 256u;
+    uint global_prefix_base = global_hist_base + 257u;
 
     // ========================================
     // Phase 1: Load entries & build histogram
@@ -69,10 +80,9 @@ void main() {
     s_local_histogram[lid] = 0u;
     barrier();
 
-    // Load 8 entries per thread into shared memory
     for (uint t = 0u; t < ENTRIES_PER_THREAD; t++) {
         uint idx = wg_offset + t * 256u + lid;
-        uint k = 0xFFFFFFFFu;  // sentinel default
+        uint k = 0xFFFFFFFFu;
         uint v = 0u;
         if (idx < total) {
             k = in_entries[idx].key_lo;
@@ -81,7 +91,6 @@ void main() {
         s_keys[t * 256u + lid] = k;
         s_indices[t * 256u + lid] = v;
 
-        // Extract digit and count
         uint digit = (k >> (pass * 8u)) & 0xFFu;
         if (idx < total) {
             atomicAdd(s_local_histogram[digit], 1u);
@@ -90,65 +99,92 @@ void main() {
     barrier();
 
     // ========================================
-    // Phase 2: Decoupled lookback prefix sum
+    // Phase 2: Decoupled lookback (per-digit)
     // ========================================
-    // Each thread handles one digit bin (tid 0..255)
     uint my_local_count = s_local_histogram[lid];
 
-    // Publish LOCAL status — our partial count for this digit
+    // Publish LOCAL status
     uint status_base = pass * 256u * max_workgroups + lid * max_workgroups;
     atomicExchange(status[status_base + wg_id], LOCAL_FLAG | my_local_count);
     memoryBarrierBuffer();
 
-    // Lookback: accumulate prefix from predecessor workgroups
-    uint aggregate = 0u;
+    // Lookback: count of digit `lid` in prior workgroups
+    uint digit_aggregate = 0u;
     if (wg_id > 0u) {
         int pred = int(wg_id) - 1;
         while (pred >= 0) {
             uint val;
-            // Spin-read with memory barrier for Apple Silicon weak ordering
             uint spin_count = 0u;
             do {
                 memoryBarrierBuffer();
                 val = atomicOr(status[status_base + uint(pred)], 0u);
                 spin_count++;
-                // Safety: if stuck for 1M iterations, break (should never happen)
                 if (spin_count > 1000000u) break;
             } while ((val >> 30u) == 0u);
 
             uint state = val >> 30u;
             uint sum = val & VALUE_MASK;
-            aggregate += sum;
+            digit_aggregate += sum;
 
-            if (state == 3u) break;  // INCLUSIVE — includes all prior workgroups
+            if (state == 3u) break;
             pred--;
         }
     }
 
     // Publish INCLUSIVE status
-    uint inclusive = aggregate + my_local_count;
+    uint inclusive = digit_aggregate + my_local_count;
     atomicExchange(status[status_base + wg_id], INCLUSIVE_FLAG | inclusive);
     memoryBarrierBuffer();
 
-    // Exclusive prefix for this digit in this workgroup:
-    // s_prefix[d] = (inter-workgroup aggregate for digit d) + (intra-workgroup exclusive prefix for digit d)
-    // The aggregate gives "how many entries of digit d exist in ALL prior workgroups".
-    // The intra-workgroup exclusive prefix gives "how many entries of digits 0..d-1 exist in THIS workgroup".
-    // Together, they give the correct global starting position for digit d's entries in this workgroup.
-    s_prefix[lid] = aggregate;
-    barrier();
+    // ========================================
+    // Phase 2.5: Global histogram + prefix
+    // ========================================
+    // Each workgroup atomically adds its local histogram to the global histogram.
+    // The last workgroup to finish computes the exclusive prefix sum.
+    atomicAdd(status[global_hist_base + lid], my_local_count);
+    memoryBarrierBuffer();
 
-    // Compute intra-workgroup exclusive prefix sum of local histogram (thread 0 serial scan)
+    // Signal this workgroup is done
+    uint old_done;
     if (lid == 0u) {
+        old_done = atomicAdd(status[done_count_idx], 1u);
+    }
+    // Broadcast done status to all threads in workgroup
+    barrier();
+    // Thread 0 checks if this was the last workgroup
+    if (lid == 0u && old_done == max_workgroups - 1u) {
+        // Last workgroup: compute exclusive prefix sum of global histogram
         uint running = 0u;
         for (uint d = 0u; d < 256u; d++) {
-            uint count = s_local_histogram[d];
-            s_local_histogram[d] = running;
+            uint count = status[global_hist_base + d];
+            status[global_prefix_base + d] = running;
             running += count;
+        }
+        // Signal prefix is ready (use done_count as flag: set to max_workgroups + 1)
+        memoryBarrierBuffer();
+        atomicExchange(status[done_count_idx], max_workgroups + 1u);
+    }
+    memoryBarrierBuffer();
+
+    // All workgroups spin until global prefix is ready
+    if (lid == 0u) {
+        uint spin = 0u;
+        while (true) {
+            memoryBarrierBuffer();
+            uint val = atomicOr(status[done_count_idx], 0u);
+            if (val > max_workgroups) break;
+            spin++;
+            if (spin > 10000000u) break;
         }
     }
     barrier();
-    s_prefix[lid] += s_local_histogram[lid];
+
+    // Read global exclusive prefix for each digit
+    uint global_digit_prefix = status[global_prefix_base + lid];
+
+    // Final scatter prefix: global_prefix[D] + digit_aggregate[D]
+    // = (total count of digits 0..D-1 across ALL workgroups) + (count of digit D in prior workgroups)
+    s_prefix[lid] = global_digit_prefix + digit_aggregate;
     barrier();
 
     // ========================================
@@ -161,15 +197,12 @@ void main() {
         uint my_index = s_indices[local_idx];
         uint digit = (my_key >> (pass * 8u)) & 0xFFu;
 
-        // Store digit for stable rank computation
         s_digits[lid] = digit;
         barrier();
 
         if (global_idx < total) {
-            // Stable rank: count threads before me in this batch with same digit
             uint rank = 0u;
             for (uint j = 0u; j < lid; j++) {
-                // Only count entries that are valid (within total)
                 uint j_global = wg_offset + batch * 256u + j;
                 if (j_global < total && s_digits[j] == digit) {
                     rank++;
@@ -185,8 +218,6 @@ void main() {
 
         // Advance prefix for next batch
         barrier();
-
-        // Count entries per digit in this batch (reuse s_local_histogram as scratch)
         s_local_histogram[lid] = 0u;
         barrier();
         if (global_idx < total) {

--- a/shaders/gs_preprocess.comp
+++ b/shaders/gs_preprocess.comp
@@ -57,6 +57,7 @@ layout(set = 0, binding = 3) uniform Uniforms {
     vec4 pl_color[8];
     vec4 pl_dir_cone[8];  // spot direction + cone (unused in preprocess, must match layout)
     vec4 pl_area[8];  // area size + normal (unused in preprocess, must match layout)
+    vec4 tile_sort_params;  // x = near_z, y = far_z, z = tiles_x, w = tiles_y
 };
 
 layout(set = 0, binding = 4) buffer CountsBuffer {

--- a/shaders/gs_render.comp
+++ b/shaders/gs_render.comp
@@ -46,6 +46,7 @@ layout(set = 0, binding = 2) uniform Uniforms {
     vec4 pl_color[8];       // per-light: rgb = color, a = intensity
     vec4 pl_dir_cone[8];    // per-light: xyz = spot direction, w = cos(cone_half_angle); -1 = point
     vec4 pl_area[8];        // per-light: xy = area size (0=point), zw = normal XZ
+    vec4 tile_sort_params;  // x = near_z, y = far_z, z = tiles_x, w = tiles_y
 };
 
 layout(set = 0, binding = 3, rgba16f) uniform writeonly image2D output_image;

--- a/shaders/gs_sort.comp
+++ b/shaders/gs_sort.comp
@@ -15,9 +15,24 @@ layout(set = 0, binding = 0) buffer SortBuffer {
 layout(set = 0, binding = 1) uniform Uniforms {
     mat4 view;
     mat4 proj;
-    mat4 inv_view;  // must match layout (unused in sort)
-    mat4 inv_proj;  // must match layout (unused in sort)
-    uvec4 params;   // w = sort_size
+    mat4 inv_view;
+    mat4 inv_proj;
+    uvec4 params;       // w = sort_size
+    vec4 shadow_box;
+    vec4 cone_dir;
+    vec4 cam_pos;
+    vec4 effect_flags;
+    vec4 light_params;
+    vec4 touch_point;
+    vec4 effect_params;
+    vec4 effect_params2;
+    vec4 point_light_params;
+    vec4 actor_rotation;
+    vec4 pl_pos_rad[8];
+    vec4 pl_color[8];
+    vec4 pl_dir_cone[8];
+    vec4 pl_area[8];
+    vec4 tile_sort_params;
 };
 
 layout(push_constant) uniform PushConstants {

--- a/shaders/gs_tile_bin.comp
+++ b/shaders/gs_tile_bin.comp
@@ -1,8 +1,5 @@
 #version 450
 
-// Tile binning pass: duplicates each visible Gaussian into per-tile sort entries.
-// Each thread processes one visible Gaussian from the merged sort array,
-// computes its tile overlap, and writes one TileSortEntry per overlapping tile.
 layout(local_size_x = 256) in;
 
 struct ProjectedSplat {
@@ -13,12 +10,9 @@ struct ProjectedSplat {
     vec4 color;
 };
 
-// 16 bytes, uvec4-aligned for std430 (no implicit padding)
 struct TileSortEntry {
-    uint key_hi;   // tile_id (tile_y * tiles_x + tile_x)
-    uint key_lo;   // floatBitsToUint(depth) — positive floats sort correctly as uints
-    uint index;    // index into projected[] buffer
-    uint _pad;
+    uint key;
+    uint index;
 };
 
 struct SortEntry {
@@ -48,10 +42,31 @@ layout(set = 0, binding = 4) buffer TileSortCountBuffer {
     uint tile_sort_count;
 };
 
+layout(set = 0, binding = 5) uniform Uniforms {
+    mat4 view;
+    mat4 proj;
+    mat4 inv_view;
+    mat4 inv_proj;
+    uvec4 params;
+    vec4 shadow_box;
+    vec4 cone_dir;
+    vec4 cam_pos;
+    vec4 effect_flags;
+    vec4 light_params;
+    vec4 touch_point;
+    vec4 effect_params;
+    vec4 effect_params2;
+    vec4 point_light_params;
+    vec4 actor_rotation;
+    vec4 pl_pos_rad[8];
+    vec4 pl_color[8];
+    vec4 pl_dir_cone[8];
+    vec4 pl_area[8];
+    vec4 tile_sort_params;
+};
+
 layout(push_constant) uniform PushConstants {
-    uint max_entries;   // capacity of tile_entries[] buffer
-    uint tiles_x;       // number of tiles horizontally
-    uint tiles_y;       // number of tiles vertically
+    uint max_entries;
 };
 
 void main() {
@@ -60,33 +75,36 @@ void main() {
     if (gid >= visible) return;
 
     SortEntry entry = merged_entries[gid];
-    if (entry.key == 0xFFFFu) return;  // culled sentinel — skip
+    if (entry.key == 0xFFFFu) return;
 
     uint idx = entry.index;
     ProjectedSplat splat = projected[idx];
 
-    if (splat.radius <= 0.0) return;  // frustum-culled or degenerate
+    if (splat.radius <= 0.0) return;
 
-    // Compute tile AABB from screen-space bounding circle
     vec2 c = splat.center;
     float r = splat.radius;
+    uint tiles_x = uint(tile_sort_params.z);
+    uint tiles_y = uint(tile_sort_params.w);
 
     int tx_min = max(0, int(floor((c.x - r) / 16.0)));
     int tx_max = min(int(tiles_x) - 1, int(floor((c.x + r) / 16.0)));
     int ty_min = max(0, int(floor((c.y - r) / 16.0)));
     int ty_max = min(int(tiles_y) - 1, int(floor((c.y + r) / 16.0)));
 
-    uint depth_bits = floatBitsToUint(splat.depth);
+    float near_z = tile_sort_params.x;
+    float far_z  = tile_sort_params.y;
+    float t = clamp((splat.depth - near_z) / (far_z - near_z), 0.0, 1.0);
+    uint depth_q = min(uint(t * 65535.0), 0xFFFEu);
 
     for (int ty = ty_min; ty <= ty_max; ty++) {
         for (int tx = tx_min; tx <= tx_max; tx++) {
             uint tile_id = uint(ty) * tiles_x + uint(tx);
+            uint sort_key = (tile_id << 16u) | depth_q;
             uint offset = atomicAdd(tile_sort_count, 1);
             if (offset < max_entries) {
-                tile_entries[offset].key_hi = tile_id;
-                tile_entries[offset].key_lo = depth_bits;
+                tile_entries[offset].key = sort_key;
                 tile_entries[offset].index = idx;
-                tile_entries[offset]._pad = 0;
             }
         }
     }

--- a/shaders/gs_tile_bin.comp
+++ b/shaders/gs_tile_bin.comp
@@ -11,8 +11,10 @@ struct ProjectedSplat {
 };
 
 struct TileSortEntry {
-    uint key;
+    uint key_hi;
+    uint key_lo;
     uint index;
+    uint _pad;
 };
 
 struct SortEntry {
@@ -103,8 +105,10 @@ void main() {
             uint sort_key = (tile_id << 16u) | depth_q;
             uint offset = atomicAdd(tile_sort_count, 1);
             if (offset < max_entries) {
-                tile_entries[offset].key = sort_key;
+                tile_entries[offset].key_hi = 0u;
+                tile_entries[offset].key_lo = sort_key;
                 tile_entries[offset].index = idx;
+                tile_entries[offset]._pad = 0u;
             }
         }
     }

--- a/shaders/gs_tile_prepare_indirect.comp
+++ b/shaders/gs_tile_prepare_indirect.comp
@@ -25,8 +25,8 @@ layout(push_constant) uniform PushConstants {
 void main() {
     uint count = min(tile_sort_count, max_entries);
 
-    // Sort: 1024 elements per workgroup
-    uint sort_wg = (count + 1023u) / 1024u;
+    // Sort: 2048 elements per workgroup (Onesweep processes 2048 keys/wg)
+    uint sort_wg = (count + 2047u) / 2048u;
     if (sort_wg == 0) sort_wg = 1;  // need at least 1 for scan to work
     args[0] = sort_wg;
     args[1] = 1;

--- a/shaders/gs_tile_ranges.comp
+++ b/shaders/gs_tile_ranges.comp
@@ -1,25 +1,16 @@
 #version 450
 
-// Tile range detection: scans sorted tile_sort_entries and records
-// per-tile {start, count}.
-//
-// Pre-condition: tile_ranges cleared to 0 (all counts = 0).
-// Each thread processes one entry. Boundary detection writes start;
-// every valid entry atomicAdds count.
 layout(local_size_x = 256) in;
 
 struct TileSortEntry {
-    uint key_hi;   // tile_id
-    uint key_lo;   // depth
+    uint key;
     uint index;
-    uint _pad;
 };
 
 layout(set = 0, binding = 0) readonly buffer SortedEntries {
     TileSortEntry entries[];
 };
 
-// Flat uint array: ranges[tile_id * 2] = start, ranges[tile_id * 2 + 1] = count
 layout(set = 0, binding = 1) buffer TileRanges {
     uint ranges[];
 };
@@ -29,29 +20,23 @@ layout(set = 0, binding = 2) readonly buffer TileSortCount {
 };
 
 layout(push_constant) uniform PushConstants {
-    uint num_tiles;      // tiles_x * tiles_y
-    uint max_entries;    // tile sort buffer capacity (clamp tile_count)
+    uint num_tiles;
+    uint max_entries;
 };
 
 void main() {
     uint i = gl_GlobalInvocationID.x;
-    // Clamp to buffer capacity — atomicAdd in binning can overshoot
     uint clamped_count = min(tile_count, max_entries);
     if (i >= clamped_count) return;
 
-    uint tile_id = entries[i].key_hi;
+    uint tile_id = entries[i].key >> 16u;
 
-    // Skip sentinel entries (key_hi = 0xFFFFFFFF from buffer fill)
     if (tile_id >= num_tiles) return;
 
-    // Boundary detection: if this is the first entry for this tile, record start.
-    // The sorted order guarantees that all entries for the same tile are contiguous,
-    // so the first thread with a new tile_id writes the start index.
-    bool is_first = (i == 0) || (entries[i - 1].key_hi != tile_id);
+    bool is_first = (i == 0) || ((entries[i - 1].key >> 16u) != tile_id);
     if (is_first) {
         ranges[tile_id * 2u] = i;
     }
 
-    // Count: every entry increments its tile's count
     atomicAdd(ranges[tile_id * 2u + 1u], 1u);
 }

--- a/shaders/gs_tile_ranges.comp
+++ b/shaders/gs_tile_ranges.comp
@@ -3,8 +3,10 @@
 layout(local_size_x = 256) in;
 
 struct TileSortEntry {
-    uint key;
+    uint key_hi;
+    uint key_lo;
     uint index;
+    uint _pad;
 };
 
 layout(set = 0, binding = 0) readonly buffer SortedEntries {
@@ -29,11 +31,11 @@ void main() {
     uint clamped_count = min(tile_count, max_entries);
     if (i >= clamped_count) return;
 
-    uint tile_id = entries[i].key >> 16u;
+    uint tile_id = entries[i].key_lo >> 16u;
 
     if (tile_id >= num_tiles) return;
 
-    bool is_first = (i == 0) || ((entries[i - 1].key >> 16u) != tile_id);
+    bool is_first = (i == 0) || ((entries[i - 1].key_lo >> 16u) != tile_id);
     if (is_first) {
         ranges[tile_id * 2u] = i;
     }

--- a/shaders/gs_tile_render.comp
+++ b/shaders/gs_tile_render.comp
@@ -15,10 +15,8 @@ struct ProjectedSplat {
 };
 
 struct TileSortEntry {
-    uint key_hi;   // tile_id
-    uint key_lo;   // depth
-    uint index;    // index into projected[]
-    uint _pad;
+    uint key;    // [31:16] = tile_id, [15:0] = depth_q
+    uint index;  // index into projected[]
 };
 
 layout(set = 0, binding = 0) readonly buffer ProjectedBuffer {
@@ -117,7 +115,7 @@ void main() {
     // Iterate through Gaussians assigned to this tile (sorted by depth within tile)
     for (uint s = 0; s < (valid_pixel ? tile_count : 0u); ++s) {
         TileSortEntry entry = tile_entries[tile_start + s];
-        if (entry.key_hi == 0xFFFFFFFFu) break;  // sentinel
+        if (entry.key == 0xFFFFFFFFu) break;  // sentinel
         uint idx = entry.index;
 
         ProjectedSplat splat = projected[idx];

--- a/shaders/gs_tile_render.comp
+++ b/shaders/gs_tile_render.comp
@@ -15,8 +15,10 @@ struct ProjectedSplat {
 };
 
 struct TileSortEntry {
-    uint key;    // [31:16] = tile_id, [15:0] = depth_q
-    uint index;  // index into projected[]
+    uint key_hi;
+    uint key_lo;    // [31:16] = tile_id, [15:0] = depth_q
+    uint index;     // index into projected[]
+    uint _pad;
 };
 
 layout(set = 0, binding = 0) readonly buffer ProjectedBuffer {
@@ -115,7 +117,7 @@ void main() {
     // Iterate through Gaussians assigned to this tile (sorted by depth within tile)
     for (uint s = 0; s < (valid_pixel ? tile_count : 0u); ++s) {
         TileSortEntry entry = tile_entries[tile_start + s];
-        if (entry.key == 0xFFFFFFFFu) break;  // sentinel
+        if (entry.key_lo == 0xFFFFFFFFu) break;  // sentinel
         uint idx = entry.index;
 
         ProjectedSplat splat = projected[idx];

--- a/shaders/gs_tile_render.comp
+++ b/shaders/gs_tile_render.comp
@@ -49,6 +49,7 @@ layout(set = 0, binding = 2) uniform Uniforms {
     vec4 pl_color[8];       // per-light: rgb = color, a = intensity
     vec4 pl_dir_cone[8];    // per-light: xyz = spot direction, w = cos(cone_half_angle); -1 = point
     vec4 pl_area[8];        // per-light: xy = area size (0=point), zw = normal XZ
+    vec4 tile_sort_params;  // x = near_z, y = far_z, z = tiles_x, w = tiles_y
 };
 
 layout(set = 0, binding = 3, rgba16f) uniform writeonly image2D output_image;

--- a/src/demo/gs_demo_state.cpp
+++ b/src/demo/gs_demo_state.cpp
@@ -22,6 +22,7 @@ namespace gseurat {
 
 void GsDemoState::on_enter(AppBase& app) {
     app.feature_flags() = FeatureFlags::gs_viewer();
+    app.feature_flags().apply_platform_defaults(app.renderer().context().is_apple_gpu());
     app.init_scene(app.scene_objects().current_scene_path);
 
     // Disable app-level parallax — demo manages its own camera

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -54,6 +54,7 @@ namespace gseurat {
 void IslandDemoState::on_enter(AppBase& app) {
     if (scene_path_.empty()) scene_path_ = "assets/scenes/seurat_island.json";
     app.feature_flags() = FeatureFlags::gs_viewer();
+    app.feature_flags().apply_platform_defaults(app.renderer().context().is_apple_gpu());
     app.init_scene(scene_path_);
 
     // Disable app-level parallax — we manage our own camera

--- a/src/engine/buffer.cpp
+++ b/src/engine/buffer.cpp
@@ -89,7 +89,7 @@ Buffer Buffer::create_storage(VmaAllocator allocator, VkDeviceSize size) {
     VkBufferCreateInfo buf_info{};
     buf_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
     buf_info.size = size;
-    buf_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
+    buf_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VmaAllocationCreateInfo alloc_info{};
@@ -102,6 +102,28 @@ Buffer Buffer::create_storage(VmaAllocator allocator, VkDeviceSize size) {
     if (vmaCreateBuffer(allocator, &buf_info, &alloc_info, &buf.buffer_, &buf.allocation_,
                         &info) != VK_SUCCESS) {
         throw std::runtime_error("Failed to create storage buffer");
+    }
+    buf.mapped_ = info.pMappedData;
+    return buf;
+}
+
+Buffer Buffer::create_storage_indirect(VmaAllocator allocator, VkDeviceSize size) {
+    VkBufferCreateInfo buf_info{};
+    buf_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    buf_info.size = size;
+    buf_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
+    buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo alloc_info{};
+    alloc_info.usage = VMA_MEMORY_USAGE_AUTO;
+    alloc_info.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                       VMA_ALLOCATION_CREATE_MAPPED_BIT;
+
+    Buffer buf;
+    VmaAllocationInfo info;
+    if (vmaCreateBuffer(allocator, &buf_info, &alloc_info, &buf.buffer_, &buf.allocation_,
+                        &info) != VK_SUCCESS) {
+        throw std::runtime_error("Failed to create storage+indirect buffer");
     }
     buf.mapped_ = info.pMappedData;
     return buf;

--- a/src/engine/buffer.cpp
+++ b/src/engine/buffer.cpp
@@ -89,7 +89,7 @@ Buffer Buffer::create_storage(VmaAllocator allocator, VkDeviceSize size) {
     VkBufferCreateInfo buf_info{};
     buf_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
     buf_info.size = size;
-    buf_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+    buf_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VmaAllocationCreateInfo alloc_info{};

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -63,6 +63,7 @@ void CommandDispatcher::register_default_commands() {
         add("gs_adaptive_budget", f.gs_adaptive_budget, "Adaptive Budget");
         add("gs_parallax", f.gs_parallax, "Parallax");
         add("gs_tile_binning", f.gs_tile_binning, "Tile Binning");
+        add("gs_onesweep", ctx_.renderer.gs_renderer().use_onesweep(), "Onesweep Sort");
         add("bloom", f.bloom, "Bloom");
         add("depth_of_field", f.depth_of_field, "Depth of Field");
         add("vignette", f.vignette, "Vignette");
@@ -87,6 +88,7 @@ void CommandDispatcher::register_default_commands() {
         else if (name == "gs_adaptive_budget") f.gs_adaptive_budget = enabled;
         else if (name == "gs_parallax") f.gs_parallax = enabled;
         else if (name == "gs_tile_binning") f.gs_tile_binning = enabled;
+        else if (name == "gs_onesweep") ctx_.renderer.gs_renderer().set_use_onesweep(enabled);
         else if (name == "bloom") f.bloom = enabled;
         else if (name == "depth_of_field") f.depth_of_field = enabled;
         else if (name == "vignette") f.vignette = enabled;

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -842,7 +842,7 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
         onesweep_status_.destroy(allocator_);
         onesweep_max_wg_ = (tile_sort_capacity_ + 2047) / 2048;
         if (onesweep_max_wg_ == 0) onesweep_max_wg_ = 1;
-        VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
+        VkDeviceSize status_size = (4ull * 256ull * onesweep_max_wg_ + 513ull) * sizeof(uint32_t);
         onesweep_status_ = Buffer::create_storage_gpu_only(allocator_, status_size);
     }
 
@@ -1334,7 +1334,7 @@ void GsRenderer::load_cloud_legacy(const GaussianCloud& cloud) {
         onesweep_status_.destroy(allocator_);
         onesweep_max_wg_ = (tile_sort_capacity_ + 2047) / 2048;
         if (onesweep_max_wg_ == 0) onesweep_max_wg_ = 1;
-        VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
+        VkDeviceSize status_size = (4ull * 256ull * onesweep_max_wg_ + 513ull) * sizeof(uint32_t);
         onesweep_status_ = Buffer::create_storage_gpu_only(allocator_, status_size);
     }
 
@@ -2218,7 +2218,7 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd) {
 
     if (use_onesweep_ && onesweep_status_.buffer()) {
         // === Onesweep: clear status buffer ===
-        VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
+        VkDeviceSize status_size = (4ull * 256ull * onesweep_max_wg_ + 513ull) * sizeof(uint32_t);
         vkCmdFillBuffer(cmd, onesweep_status_.buffer(), 0, status_size, 0);
         {
             VkMemoryBarrier sb{};

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -811,7 +811,7 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
         if (tile_sort_workgroups_ == 0) tile_sort_workgroups_ = 1;
         tile_sort_size_ = tile_sort_workgroups_ * 1024;
 
-        VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 8;  // 8 bytes/entry
+        VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 16;  // 16 bytes/entry
         VkDeviceSize hist_buf_size = static_cast<VkDeviceSize>(256) * tile_sort_workgroups_ * sizeof(uint32_t);
         // Allocate tile_ranges for max possible resolution (output_width_ may not
         // reflect final size at allocation time). Generous upper bound.
@@ -1302,7 +1302,7 @@ void GsRenderer::load_cloud_legacy(const GaussianCloud& cloud) {
         if (tile_sort_workgroups_ == 0) tile_sort_workgroups_ = 1;
         tile_sort_size_ = tile_sort_workgroups_ * 1024;
 
-        VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 8;  // 8 bytes/entry
+        VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 16;  // 16 bytes/entry
         VkDeviceSize hist_buf_size = static_cast<VkDeviceSize>(256) * tile_sort_workgroups_ * sizeof(uint32_t);
         // Allocate tile_ranges for max possible resolution (output_width_ may not
         // reflect final size at allocation time). Generous upper bound.
@@ -2167,7 +2167,7 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd) {
     // at [0, tile_sort_count). At 256K cap this is only 4MB — well within TDR budget.
     vkCmdFillBuffer(cmd, tile_sort_count_ssbo_.buffer(), 0, sizeof(uint32_t), 0);
     vkCmdFillBuffer(cmd, tile_sort_a_.buffer(), 0,
-                    static_cast<VkDeviceSize>(tile_sort_size_) * 8, 0xFFFFFFFF);
+                    static_cast<VkDeviceSize>(tile_sort_size_) * 16, 0xFFFFFFFF);
 
     {
         VkMemoryBarrier fill_barrier{};
@@ -2652,6 +2652,7 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
 
         // Barrier: tile rasterize → post-process (output+depth readable)
         insert_compute_barrier(cmd);
+
     }
 
     // Pass 4: Post-process (always runs — params like fade_amount change every frame)

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -52,6 +52,7 @@ struct GsUniforms {
     glm::vec4 pl_color[kMaxGsPointLights];      // per-light: rgb = color, a = intensity
     glm::vec4 pl_dir_cone[kMaxGsPointLights];   // per-light: xyz = direction, w = cos(cone_half_angle)
     glm::vec4 pl_area[kMaxGsPointLights];       // per-light: xy = area size (0=point), zw = normal XZ
+    glm::vec4 tile_sort_params;  // x = near_z, y = far_z, z = tiles_x, w = tiles_y
 };
 
 // Sort key: depth packed with index
@@ -2262,6 +2263,14 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
         uniforms.pl_dir_cone[i] = point_lights_[i].direction_and_cone;
         uniforms.pl_area[i] = point_lights_[i].area_params;
     }
+
+    // Extract near/far from Vulkan [0,1] perspective projection
+    float near_z = proj[3][2] / proj[2][2];
+    float far_z  = proj[3][2] / (proj[2][2] + 1.0f);
+    uint32_t tiles_x = (width + 15) / 16;
+    uint32_t tiles_y = (height + 15) / 16;
+    uniforms.tile_sort_params = glm::vec4(near_z, far_z,
+        static_cast<float>(tiles_x), static_cast<float>(tiles_y));
 
     std::memcpy(uniform_buffer_.mapped(), &uniforms, sizeof(uniforms));
 

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -418,6 +418,21 @@ void GsRenderer::create_descriptor_resources() {
         vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_scatter_layout_);
     }
 
+    // Onesweep layout: { input(0), output(1), status(2), indirect_args(3) }
+    {
+        VkDescriptorSetLayoutBinding bindings[] = {
+            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        };
+        VkDescriptorSetLayoutCreateInfo ci{};
+        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        ci.bindingCount = 4;
+        ci.pBindings = bindings;
+        vkCreateDescriptorSetLayout(device_, &ci, nullptr, &onesweep_layout_);
+    }
+
     // Tile indirect dispatch layout: { tile_sort_count(0), indirect_args(1) }
     {
         VkDescriptorSetLayoutBinding bindings[] = {
@@ -506,8 +521,9 @@ void GsRenderer::create_descriptor_resources() {
         tile_ranges_layout_,                               // tile range detection
         tile_indirect_layout_,                             // indirect dispatch prep
         tile_render_layout_,                               // tile render
+        onesweep_layout_, onesweep_layout_,                // onesweep A→B, B→A
     };
-    constexpr uint32_t kSetCount = 33;
+    constexpr uint32_t kSetCount = 35;
     VkDescriptorSet sets[kSetCount];
     VkDescriptorSetAllocateInfo alloc_info{};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -553,6 +569,8 @@ void GsRenderer::create_descriptor_resources() {
     tile_ranges_set_ = sets[30];
     tile_indirect_set_ = sets[31];
     tile_render_set_ = sets[32];
+    onesweep_set_ab_ = sets[33];
+    onesweep_set_ba_ = sets[34];
 }
 
 void GsRenderer::create_compute_pipelines() {
@@ -641,6 +659,10 @@ void GsRenderer::create_compute_pipelines() {
     // Indirect dispatch preparation (push: max_entries = 4 bytes)
     create_pipeline("shaders/gs_tile_prepare_indirect.comp.spv", tile_indirect_layout_, 4,
                     tile_indirect_pipeline_layout_, tile_indirect_pipeline_);
+
+    // Onesweep pipeline (push: pass + max_workgroups = 8 bytes)
+    create_pipeline("shaders/gs_onesweep.comp.spv", onesweep_layout_, 8,
+                    onesweep_pipeline_layout_, onesweep_pipeline_);
 
     // Tile render pipeline (separate from render — uses tile_entries + tile_ranges)
     create_pipeline("shaders/gs_tile_render.comp.spv", tile_render_layout_, 0,
@@ -815,6 +837,13 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
                      tile_sort_size_, tile_sort_workgroups_,
                      output_width_, output_height_,
                      static_cast<float>(entry_buf_size * 2) / (1024.0f * 1024.0f));
+
+        // Onesweep status buffer: 4 passes × 256 digits × max_workgroups
+        onesweep_status_.destroy(allocator_);
+        onesweep_max_wg_ = (tile_sort_capacity_ + 2047) / 2048;
+        if (onesweep_max_wg_ == 0) onesweep_max_wg_ = 1;
+        VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
+        onesweep_status_ = Buffer::create_storage_gpu_only(allocator_, status_size);
     }
 
     // Page table: one uint32 per slab, initialized to 0xFFFFFFFF (invalid)
@@ -1300,6 +1329,13 @@ void GsRenderer::load_cloud_legacy(const GaussianCloud& cloud) {
                      tile_sort_size_, tile_sort_workgroups_,
                      output_width_, output_height_,
                      static_cast<float>(entry_buf_size * 2) / (1024.0f * 1024.0f));
+
+        // Onesweep status buffer: 4 passes × 256 digits × max_workgroups
+        onesweep_status_.destroy(allocator_);
+        onesweep_max_wg_ = (tile_sort_capacity_ + 2047) / 2048;
+        if (onesweep_max_wg_ == 0) onesweep_max_wg_ = 1;
+        VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
+        onesweep_status_ = Buffer::create_storage_gpu_only(allocator_, status_size);
     }
 
     update_descriptors();
@@ -1979,6 +2015,48 @@ void GsRenderer::update_descriptors() {
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
             };
             vkUpdateDescriptorSets(device_, 2, writes, 0, nullptr);
+        }
+
+        // Onesweep descriptor sets (ping-pong: A→B and B→A)
+        if (onesweep_status_.buffer()) {
+            // A→B: read from tile_sort_a_, write to tile_sort_b_
+            {
+                VkDescriptorBufferInfo in_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
+                VkDescriptorBufferInfo out_info{tile_sort_b_.buffer(), 0, VK_WHOLE_SIZE};
+                VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
+                VkDescriptorBufferInfo args_info{tile_indirect_args_.buffer(), 0, VK_WHOLE_SIZE};
+
+                VkWriteDescriptorSet writes[] = {
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_set_ab_, 0, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_set_ab_, 1, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &out_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_set_ab_, 2, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_set_ab_, 3, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
+                };
+                vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
+            }
+            // B→A: read from tile_sort_b_, write to tile_sort_a_
+            {
+                VkDescriptorBufferInfo in_info{tile_sort_b_.buffer(), 0, VK_WHOLE_SIZE};
+                VkDescriptorBufferInfo out_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
+                VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
+                VkDescriptorBufferInfo args_info{tile_indirect_args_.buffer(), 0, VK_WHOLE_SIZE};
+
+                VkWriteDescriptorSet writes[] = {
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_set_ba_, 0, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_set_ba_, 1, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &out_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_set_ba_, 2, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_set_ba_, 3, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
+                };
+                vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
+            }
         }
 
         // Tile render set: projected(0), tile_entries(1), uniforms(2), output_image(3), tile_ranges(4), depth_image(5)
@@ -2742,6 +2820,7 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     tile_histogram_ssbo_.destroy(allocator);
     tile_ranges_ssbo_.destroy(allocator);
     tile_indirect_args_.destroy(allocator);
+    onesweep_status_.destroy(allocator);
 
     pp_ubo_buffer_.destroy(allocator);
 
@@ -2772,6 +2851,7 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     destroy_pipeline(tile_ranges_pipeline_);
     destroy_pipeline(tile_indirect_pipeline_);
     destroy_pipeline(tile_render_pipeline_);
+    destroy_pipeline(onesweep_pipeline_);
 
     destroy_layout(preprocess_pipeline_layout_);
     destroy_layout(sort_pipeline_layout_);
@@ -2788,6 +2868,7 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     destroy_layout(tile_ranges_pipeline_layout_);
     destroy_layout(tile_indirect_pipeline_layout_);
     destroy_layout(tile_render_pipeline_layout_);
+    destroy_layout(onesweep_pipeline_layout_);
 
     destroy_set_layout(preprocess_layout_);
     destroy_set_layout(sort_layout_);
@@ -2804,6 +2885,7 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     destroy_set_layout(tile_scatter_layout_);
     destroy_set_layout(tile_indirect_layout_);
     destroy_set_layout(tile_render_layout_);
+    destroy_set_layout(onesweep_layout_);
 
     if (timestamp_pool_) { vkDestroyQueryPool(device_, timestamp_pool_, nullptr); timestamp_pool_ = VK_NULL_HANDLE; }
     if (gs_pool_) vkDestroyDescriptorPool(device_, gs_pool_, nullptr);

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -2216,66 +2216,97 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd) {
             0, 1, &barrier, 0, nullptr, 0, nullptr);
     }
 
-    // === Tile radix sort (8 passes, indirect dispatch) ===
-    // Pre-compute fixed histogram_count for scan (uses capacity-based upper bound).
-    // Histogram buffer must be cleared before each pass so the scan reads zeros
-    // for workgroups that weren't dispatched (indirect count < max_workgroups).
-    uint32_t max_workgroups = (tile_sort_capacity_ + 1023) / 1024;
-    if (max_workgroups == 0) max_workgroups = 1;
-    uint32_t histogram_count = 256 * max_workgroups;
-    VkDeviceSize hist_clear_size = static_cast<VkDeviceSize>(histogram_count) * sizeof(uint32_t);
-
-    for (uint32_t pass = 0; pass < kTileSortPasses; ++pass) {
-        uint32_t digit_shift = (pass % 4) * 8;
-        uint32_t use_hi = (pass < 4) ? 0 : 1;
-        bool read_from_a = (pass % 2 == 0);
-        uint32_t push_data[2] = {digit_shift, use_hi};
-
-        // Clear histogram buffer to 0 (ensures unused workgroup slots are zero for scan)
-        vkCmdFillBuffer(cmd, tile_histogram_ssbo_.buffer(), 0, hist_clear_size, 0);
+    if (use_onesweep_ && onesweep_status_.buffer()) {
+        // === Onesweep: clear status buffer ===
+        VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
+        vkCmdFillBuffer(cmd, onesweep_status_.buffer(), 0, status_size, 0);
         {
-            VkMemoryBarrier hb{};
-            hb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-            hb.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            hb.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+            VkMemoryBarrier sb{};
+            sb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+            sb.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            sb.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
             vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
-                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &hb, 0, nullptr, 0, nullptr);
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &sb, 0, nullptr, 0, nullptr);
         }
 
-        // Histogram — fixed workgroup count (must match scan stride).
-        // Extra workgroups produce zeros since shaders check num_elements from indirect_args[6].
-        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_histogram_pipeline_);
-        auto hist_set = read_from_a ? tile_histogram_set_a_ : tile_histogram_set_b_;
-        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                tile_histogram_pipeline_layout_, 0, 1, &hist_set, 0, nullptr);
-        vkCmdPushConstants(cmd, tile_histogram_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
-                           0, 8, push_data);
-        vkCmdDispatch(cmd, max_workgroups, 1, 1);
+        // === Onesweep: 4 radix passes ===
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, onesweep_pipeline_);
+        for (uint32_t pass = 0; pass < 4; pass++) {
+            uint32_t push_data[2] = {pass, onesweep_max_wg_};
+            bool read_from_a = (pass % 2 == 0);
+            VkDescriptorSet set = read_from_a ? onesweep_set_ab_ : onesweep_set_ba_;
 
-        insert_compute_barrier(cmd);
+            vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                    onesweep_pipeline_layout_, 0, 1, &set, 0, nullptr);
+            vkCmdPushConstants(cmd, onesweep_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                               0, 8, push_data);
+            vkCmdDispatchIndirect(cmd, tile_indirect_args_.buffer(), 0);
 
-        // Prefix scan — uses fixed upper bound for histogram_count
-        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, radix_scan_pipeline_);
-        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                radix_scan_pipeline_layout_, 0, 1, &tile_scan_set_, 0, nullptr);
-        vkCmdPushConstants(cmd, radix_scan_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
-                           0, 4, &histogram_count);
-        vkCmdDispatch(cmd, 1, 1, 1);
+            insert_compute_barrier(cmd);
+        }
+        // After 4 passes (even count), sorted result is in tile_sort_a_
+    } else {
+        // === Old 8-pass radix sort (fallback) ===
+        // Pre-compute fixed histogram_count for scan (uses capacity-based upper bound).
+        // Histogram buffer must be cleared before each pass so the scan reads zeros
+        // for workgroups that weren't dispatched (indirect count < max_workgroups).
+        uint32_t max_workgroups = (tile_sort_capacity_ + 1023) / 1024;
+        if (max_workgroups == 0) max_workgroups = 1;
+        uint32_t histogram_count = 256 * max_workgroups;
+        VkDeviceSize hist_clear_size = static_cast<VkDeviceSize>(histogram_count) * sizeof(uint32_t);
 
-        insert_compute_barrier(cmd);
+        for (uint32_t pass = 0; pass < kTileSortPasses; ++pass) {
+            uint32_t digit_shift = (pass % 4) * 8;
+            uint32_t use_hi = (pass < 4) ? 0 : 1;
+            bool read_from_a = (pass % 2 == 0);
+            uint32_t push_data[2] = {digit_shift, use_hi};
 
-        // Scatter — fixed workgroup count (must match histogram stride for scan consistency)
-        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_scatter_pipeline_);
-        auto scatter_set = read_from_a ? tile_scatter_set_ab_ : tile_scatter_set_ba_;
-        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                tile_scatter_pipeline_layout_, 0, 1, &scatter_set, 0, nullptr);
-        vkCmdPushConstants(cmd, tile_scatter_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
-                           0, 8, push_data);
-        vkCmdDispatch(cmd, max_workgroups, 1, 1);
+            // Clear histogram buffer to 0 (ensures unused workgroup slots are zero for scan)
+            vkCmdFillBuffer(cmd, tile_histogram_ssbo_.buffer(), 0, hist_clear_size, 0);
+            {
+                VkMemoryBarrier hb{};
+                hb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+                hb.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                hb.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+                vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                    VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &hb, 0, nullptr, 0, nullptr);
+            }
 
-        insert_compute_barrier(cmd);
+            // Histogram — fixed workgroup count (must match scan stride).
+            // Extra workgroups produce zeros since shaders check num_elements from indirect_args[6].
+            vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_histogram_pipeline_);
+            auto hist_set = read_from_a ? tile_histogram_set_a_ : tile_histogram_set_b_;
+            vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                    tile_histogram_pipeline_layout_, 0, 1, &hist_set, 0, nullptr);
+            vkCmdPushConstants(cmd, tile_histogram_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                               0, 8, push_data);
+            vkCmdDispatch(cmd, max_workgroups, 1, 1);
+
+            insert_compute_barrier(cmd);
+
+            // Prefix scan — uses fixed upper bound for histogram_count
+            vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, radix_scan_pipeline_);
+            vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                    radix_scan_pipeline_layout_, 0, 1, &tile_scan_set_, 0, nullptr);
+            vkCmdPushConstants(cmd, radix_scan_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                               0, 4, &histogram_count);
+            vkCmdDispatch(cmd, 1, 1, 1);
+
+            insert_compute_barrier(cmd);
+
+            // Scatter — fixed workgroup count (must match histogram stride for scan consistency)
+            vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_scatter_pipeline_);
+            auto scatter_set = read_from_a ? tile_scatter_set_ab_ : tile_scatter_set_ba_;
+            vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                    tile_scatter_pipeline_layout_, 0, 1, &scatter_set, 0, nullptr);
+            vkCmdPushConstants(cmd, tile_scatter_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                               0, 8, push_data);
+            vkCmdDispatch(cmd, max_workgroups, 1, 1);
+
+            insert_compute_barrier(cmd);
+        }
+        // After 8 passes (even count), sorted result is in tile_sort_a_
     }
-    // After 8 passes (even count), sorted result is in tile_sort_a_
 
     // === Tile range detection ===
     {

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -89,8 +89,8 @@ void GsRenderer::init(VkDevice device, VkPhysicalDevice physical_device,
         tile_ranges_ssbo_ = Buffer::create_storage_gpu_only(allocator_,
             static_cast<VkDeviceSize>(kMaxTiles) * 2 * sizeof(uint32_t));
         // GPU-only: zeroed by vkCmdFillBuffer at dispatch time
-        // Tiny dummy tile sort buffer (16 bytes) — just for descriptor binding validity
-        tile_sort_a_ = Buffer::create_storage_gpu_only(allocator_, 16);
+        // Tiny dummy tile sort buffer (8 bytes) — just for descriptor binding validity
+        tile_sort_a_ = Buffer::create_storage_gpu_only(allocator_, 8);
         tile_sort_count_ssbo_ = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
         std::memset(tile_sort_count_ssbo_.mapped(), 0, sizeof(uint32_t));
         tile_indirect_args_ = Buffer::create_storage(allocator_, 8 * sizeof(uint32_t));
@@ -372,7 +372,7 @@ void GsRenderer::create_descriptor_resources() {
         vkCreateDescriptorSetLayout(device_, &ci, nullptr, &merge_layout_);
     }
 
-    // Tile binning layout: { projected(0), merged_sort(1), counts(2), tile_entries(3), tile_count(4) }
+    // Tile binning layout: { projected(0), merged_sort(1), counts(2), tile_entries(3), tile_count(4), uniforms(5) }
     {
         VkDescriptorSetLayoutBinding bindings[] = {
             {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
@@ -380,10 +380,11 @@ void GsRenderer::create_descriptor_resources() {
             {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
             {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
             {4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {5, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
         };
         VkDescriptorSetLayoutCreateInfo ci{};
         ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        ci.bindingCount = 5;
+        ci.bindingCount = 6;
         ci.pBindings = bindings;
         vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_bin_layout_);
     }
@@ -622,8 +623,8 @@ void GsRenderer::create_compute_pipelines() {
     create_pipeline("shaders/gs_radix_scatter.comp.spv", radix_scatter_layout_, 8,
                     radix_scatter_pipeline_layout_, radix_scatter_pipeline_);
 
-    // Tile binning pipeline (push: max_entries, tiles_x, tiles_y = 12 bytes)
-    create_pipeline("shaders/gs_tile_bin.comp.spv", tile_bin_layout_, 12,
+    // Tile binning pipeline (push: max_entries = 4 bytes; tiles_x/tiles_y now in UBO)
+    create_pipeline("shaders/gs_tile_bin.comp.spv", tile_bin_layout_, 4,
                     tile_bin_pipeline_layout_, tile_bin_pipeline_);
 
     // Tile sort pipelines (push: digit_shift, use_hi = 8 bytes — num_elements from indirect_args)
@@ -788,7 +789,7 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
         if (tile_sort_workgroups_ == 0) tile_sort_workgroups_ = 1;
         tile_sort_size_ = tile_sort_workgroups_ * 1024;
 
-        VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 16;  // 16 bytes/entry
+        VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 8;  // 8 bytes/entry
         VkDeviceSize hist_buf_size = static_cast<VkDeviceSize>(256) * tile_sort_workgroups_ * sizeof(uint32_t);
         // Allocate tile_ranges for max possible resolution (output_width_ may not
         // reflect final size at allocation time). Generous upper bound.
@@ -1272,7 +1273,7 @@ void GsRenderer::load_cloud_legacy(const GaussianCloud& cloud) {
         if (tile_sort_workgroups_ == 0) tile_sort_workgroups_ = 1;
         tile_sort_size_ = tile_sort_workgroups_ * 1024;
 
-        VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 16;
+        VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 8;  // 8 bytes/entry
         VkDeviceSize hist_buf_size = static_cast<VkDeviceSize>(256) * tile_sort_workgroups_ * sizeof(uint32_t);
         // Allocate tile_ranges for max possible resolution (output_width_ may not
         // reflect final size at allocation time). Generous upper bound.
@@ -1863,6 +1864,7 @@ void GsRenderer::update_descriptors() {
             VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo tile_entries_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo tile_count_info{tile_sort_count_ssbo_.buffer(), 0, sizeof(uint32_t)};
+            VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
 
             VkWriteDescriptorSet writes[] = {
                 {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set_, 0, 0, 1,
@@ -1875,8 +1877,10 @@ void GsRenderer::update_descriptors() {
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &tile_entries_info, nullptr},
                 {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set_, 4, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &tile_count_info, nullptr},
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set_, 5, 0, 1,
+                 VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
             };
-            vkUpdateDescriptorSets(device_, 5, writes, 0, nullptr);
+            vkUpdateDescriptorSets(device_, 6, writes, 0, nullptr);
         }
 
         // Tile range detection set: sorted_entries(0), tile_ranges(1), tile_count(2)
@@ -2085,7 +2089,7 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd) {
     // at [0, tile_sort_count). At 256K cap this is only 4MB — well within TDR budget.
     vkCmdFillBuffer(cmd, tile_sort_count_ssbo_.buffer(), 0, sizeof(uint32_t), 0);
     vkCmdFillBuffer(cmd, tile_sort_a_.buffer(), 0,
-                    static_cast<VkDeviceSize>(tile_sort_size_) * 16, 0xFFFFFFFF);
+                    static_cast<VkDeviceSize>(tile_sort_size_) * 8, 0xFFFFFFFF);
 
     {
         VkMemoryBarrier fill_barrier{};
@@ -2103,9 +2107,9 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd) {
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_bin_pipeline_);
         vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
                                 tile_bin_pipeline_layout_, 0, 1, &tile_bin_set_, 0, nullptr);
-        uint32_t push_data[3] = {tile_sort_capacity_, tiles_x, tiles_y};
+        uint32_t push_data[1] = {tile_sort_capacity_};
         vkCmdPushConstants(cmd, tile_bin_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
-                           0, 12, push_data);
+                           0, 4, push_data);
         uint32_t visible_upper = static_sort_size_ + dynamic_sort_size_;
         vkCmdDispatch(cmd, (visible_upper + 255) / 256, 1, 1);
     }

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -661,7 +661,7 @@ void GsRenderer::create_compute_pipelines() {
                     tile_indirect_pipeline_layout_, tile_indirect_pipeline_);
 
     // Onesweep pipeline (push: pass + max_workgroups = 8 bytes)
-    create_pipeline("shaders/gs_onesweep.comp.spv", onesweep_layout_, 8,
+    create_pipeline("shaders/gs_onesweep.comp.spv", onesweep_layout_, 4,
                     onesweep_pipeline_layout_, onesweep_pipeline_);
 
     // Tile render pipeline (separate from render — uses tile_entries + tile_ranges)
@@ -2232,14 +2232,14 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd) {
         // === Onesweep: 4 radix passes ===
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, onesweep_pipeline_);
         for (uint32_t pass = 0; pass < 4; pass++) {
-            uint32_t push_data[2] = {pass, onesweep_max_wg_};
+            uint32_t push_data[1] = {pass};
             bool read_from_a = (pass % 2 == 0);
             VkDescriptorSet set = read_from_a ? onesweep_set_ab_ : onesweep_set_ba_;
 
             vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
                                     onesweep_pipeline_layout_, 0, 1, &set, 0, nullptr);
             vkCmdPushConstants(cmd, onesweep_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
-                               0, 8, push_data);
+                               0, 4, push_data);
             vkCmdDispatchIndirect(cmd, tile_indirect_args_.buffer(), 0);
 
             insert_compute_barrier(cmd);

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -93,7 +93,7 @@ void GsRenderer::init(VkDevice device, VkPhysicalDevice physical_device,
         tile_sort_a_ = Buffer::create_storage_gpu_only(allocator_, 8);
         tile_sort_count_ssbo_ = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
         std::memset(tile_sort_count_ssbo_.mapped(), 0, sizeof(uint32_t));
-        tile_indirect_args_ = Buffer::create_storage(allocator_, 8 * sizeof(uint32_t));
+        tile_indirect_args_ = Buffer::create_storage_indirect(allocator_, 8 * sizeof(uint32_t));
         std::memset(tile_indirect_args_.mapped(), 0, 8 * sizeof(uint32_t));
     }
 
@@ -830,7 +830,7 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
         tile_sort_count_ssbo_ = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
         tile_histogram_ssbo_ = Buffer::create_storage_gpu_only(allocator_, hist_buf_size);
         tile_ranges_ssbo_ = Buffer::create_storage_gpu_only(allocator_, ranges_buf_size);
-        tile_indirect_args_ = Buffer::create_storage(allocator_, 8 * sizeof(uint32_t));
+        tile_indirect_args_ = Buffer::create_storage_indirect(allocator_, 8 * sizeof(uint32_t));
 
         std::fprintf(stderr, "GS: Tile sort -- capacity=%u entries (%u workgroups), "
                      "output=%ux%u, buf=%.1f MB\n",
@@ -1321,7 +1321,7 @@ void GsRenderer::load_cloud_legacy(const GaussianCloud& cloud) {
         tile_sort_count_ssbo_ = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
         tile_histogram_ssbo_ = Buffer::create_storage_gpu_only(allocator_, hist_buf_size);
         tile_ranges_ssbo_ = Buffer::create_storage_gpu_only(allocator_, ranges_buf_size);
-        tile_indirect_args_ = Buffer::create_storage(allocator_, 8 * sizeof(uint32_t));
+        tile_indirect_args_ = Buffer::create_storage_indirect(allocator_, 8 * sizeof(uint32_t));
         std::memset(tile_indirect_args_.mapped(), 0, 8 * sizeof(uint32_t));
 
         std::fprintf(stderr, "GS: Tile sort -- capacity=%u entries (%u workgroups), "

--- a/tests/test_onesweep_logic.cpp
+++ b/tests/test_onesweep_logic.cpp
@@ -1,0 +1,228 @@
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstddef>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+// ============================================================
+// Key Packing Logic (mirrors gs_tile_bin.comp)
+// ============================================================
+
+static uint32_t pack_tile_sort_key(uint32_t tile_id, float depth, float near_z, float far_z) {
+    float t = (depth - near_z) / (far_z - near_z);
+    if (t < 0.0f) t = 0.0f;
+    if (t > 1.0f) t = 1.0f;
+    uint32_t depth_q = static_cast<uint32_t>(t * 65535.0f);
+    if (depth_q > 0xFFFEu) depth_q = 0xFFFEu;
+    return (tile_id << 16u) | depth_q;
+}
+
+static void extract_near_far(const glm::mat4& proj, float& near_z, float& far_z) {
+    float A = proj[2][2];
+    float B = proj[3][2];
+    near_z = B / A;
+    far_z  = B / (A + 1.0f);
+}
+
+// ============================================================
+// Status Buffer Encoding (mirrors gs_onesweep.comp)
+// ============================================================
+
+static constexpr uint32_t LOCAL_FLAG    = 1u << 30u;
+static constexpr uint32_t INCLUSIVE_FLAG = 3u << 30u;
+static constexpr uint32_t VALUE_MASK    = 0x3FFFFFFFu;
+
+static uint32_t encode_local(uint32_t sum) {
+    return LOCAL_FLAG | (sum & VALUE_MASK);
+}
+
+static uint32_t encode_inclusive(uint32_t sum) {
+    return INCLUSIVE_FLAG | (sum & VALUE_MASK);
+}
+
+static uint32_t decode_state(uint32_t val) {
+    return val >> 30u;
+}
+
+static uint32_t decode_sum(uint32_t val) {
+    return val & VALUE_MASK;
+}
+
+// ============================================================
+// GsUniforms UBO Layout Audit (must match GLSL std140)
+// ============================================================
+
+inline constexpr uint32_t kMaxGsPointLights = 8;
+
+struct GsUniforms {
+    glm::mat4 view;
+    glm::mat4 proj;
+    glm::mat4 inv_view;
+    glm::mat4 inv_proj;
+    glm::uvec4 params;
+    glm::vec4 shadow_box;
+    glm::vec4 cone_dir;
+    glm::vec4 cam_pos;
+    glm::vec4 effect_flags;
+    glm::vec4 light_params;
+    glm::vec4 touch_point;
+    glm::vec4 effect_params;
+    glm::vec4 effect_params2;
+    glm::vec4 point_light_params;
+    glm::vec4 actor_rotation;
+    glm::vec4 pl_pos_rad[kMaxGsPointLights];
+    glm::vec4 pl_color[kMaxGsPointLights];
+    glm::vec4 pl_dir_cone[kMaxGsPointLights];
+    glm::vec4 pl_area[kMaxGsPointLights];
+    glm::vec4 tile_sort_params;
+};
+
+int main() {
+    // ========================================
+    // Task 1: Key Packing Tests
+    // ========================================
+
+    // 1a: Sort order preserved within same tile
+    {
+        uint32_t k1 = pack_tile_sort_key(5, 10.0f, 0.1f, 1000.0f);
+        uint32_t k2 = pack_tile_sort_key(5, 20.0f, 0.1f, 1000.0f);
+        assert(k1 < k2 && "same tile, closer depth should sort first");
+    }
+
+    // 1b: Tile ID is primary sort key
+    {
+        uint32_t k1 = pack_tile_sort_key(3, 500.0f, 0.1f, 1000.0f);
+        uint32_t k2 = pack_tile_sort_key(4, 1.0f, 0.1f, 1000.0f);
+        assert(k1 < k2 && "lower tile_id sorts first regardless of depth");
+    }
+
+    // 1c: Depth clamping
+    {
+        uint32_t k_near = pack_tile_sort_key(0, -5.0f, 0.1f, 1000.0f);
+        uint32_t k_far  = pack_tile_sort_key(0, 9999.0f, 0.1f, 1000.0f);
+        assert((k_near & 0xFFFFu) == 0 && "below near clamped to 0");
+        assert((k_far & 0xFFFFu) == 0xFFFEu && "above far clamped to 0xFFFE");
+    }
+
+    // 1d: Sentinel is maximum
+    {
+        uint32_t sentinel = 0xFFFFFFFFu;
+        uint32_t k_max = pack_tile_sort_key(0xFFFFu - 1, 1000.0f, 0.1f, 1000.0f);
+        assert(k_max < sentinel && "sentinel must sort after all valid keys");
+    }
+
+    // 1e: Near/far extraction from perspective matrix
+    {
+        float near_in = 0.1f, far_in = 1000.0f;
+        glm::mat4 proj = glm::perspectiveRH_ZO(glm::radians(60.0f), 16.0f/9.0f, near_in, far_in);
+        float near_out, far_out;
+        extract_near_far(proj, near_out, far_out);
+        assert(std::abs(near_out - near_in) < 0.001f && "near plane extraction");
+        assert(std::abs(far_out - far_in) < 1.0f && "far plane extraction");
+        std::printf("  near: in=%.4f out=%.4f  far: in=%.1f out=%.1f\n",
+                    near_in, near_out, far_in, far_out);
+    }
+
+    // 1f: 16-bit depth precision
+    {
+        uint32_t k1 = pack_tile_sort_key(0, 10.0f, 0.1f, 1000.0f);
+        uint32_t k2 = pack_tile_sort_key(0, 10.02f, 0.1f, 1000.0f);
+        assert(k1 != k2 && "0.02 apart at depth 10 should produce different keys");
+    }
+
+    std::printf("PASS: key packing (6 tests)\n");
+
+    // ========================================
+    // Task 1: Status Encoding Tests
+    // ========================================
+
+    // 2a: LOCAL encoding
+    {
+        uint32_t encoded = encode_local(42);
+        assert(decode_state(encoded) == 1 && "LOCAL state = 1");
+        assert(decode_sum(encoded) == 42 && "LOCAL sum preserved");
+    }
+
+    // 2b: INCLUSIVE encoding
+    {
+        uint32_t encoded = encode_inclusive(12345);
+        assert(decode_state(encoded) == 3 && "INCLUSIVE state = 3");
+        assert(decode_sum(encoded) == 12345 && "INCLUSIVE sum preserved");
+    }
+
+    // 2c: NOT_READY is 0
+    {
+        uint32_t not_ready = 0u;
+        assert(decode_state(not_ready) == 0 && "NOT_READY state = 0");
+        assert(decode_sum(not_ready) == 0 && "NOT_READY sum = 0");
+    }
+
+    // 2d: Max value fits in 30 bits
+    {
+        uint32_t max_val = VALUE_MASK;  // 0x3FFFFFFF = 1073741823
+        uint32_t encoded = encode_inclusive(max_val);
+        assert(decode_sum(encoded) == max_val && "max 30-bit value preserved");
+        assert(decode_state(encoded) == 3 && "state bits intact with max value");
+    }
+
+    // 2e: Value overflow is masked
+    {
+        uint32_t overflow = 0xFFFFFFFFu;
+        uint32_t encoded = encode_local(overflow);
+        assert(decode_sum(encoded) == VALUE_MASK && "overflow masked to 30 bits");
+        assert(decode_state(encoded) == 1 && "LOCAL state preserved despite overflow");
+    }
+
+    std::printf("PASS: status encoding (5 tests)\n");
+
+    // ========================================
+    // Task 2: UBO Layout Audit
+    // ========================================
+
+    std::printf("\n=== GsUniforms Layout Audit ===\n");
+    std::printf("sizeof(GsUniforms) = %zu bytes\n", sizeof(GsUniforms));
+
+    // Expected offsets per std140:
+    // 4 × mat4 = 256 bytes, then 11 × vec4 = 176, then 4 × vec4[8] = 512, then tile_sort_params = 16
+    // Total = 256 + 176 + 512 + 16 = 960
+    std::printf("  view:              offset=%3zu  (expected=  0)\n", offsetof(GsUniforms, view));
+    std::printf("  proj:              offset=%3zu  (expected= 64)\n", offsetof(GsUniforms, proj));
+    std::printf("  inv_view:          offset=%3zu  (expected=128)\n", offsetof(GsUniforms, inv_view));
+    std::printf("  inv_proj:          offset=%3zu  (expected=192)\n", offsetof(GsUniforms, inv_proj));
+    std::printf("  params:            offset=%3zu  (expected=256)\n", offsetof(GsUniforms, params));
+    std::printf("  shadow_box:        offset=%3zu  (expected=272)\n", offsetof(GsUniforms, shadow_box));
+    std::printf("  cone_dir:          offset=%3zu  (expected=288)\n", offsetof(GsUniforms, cone_dir));
+    std::printf("  cam_pos:           offset=%3zu  (expected=304)\n", offsetof(GsUniforms, cam_pos));
+    std::printf("  effect_flags:      offset=%3zu  (expected=320)\n", offsetof(GsUniforms, effect_flags));
+    std::printf("  light_params:      offset=%3zu  (expected=336)\n", offsetof(GsUniforms, light_params));
+    std::printf("  touch_point:       offset=%3zu  (expected=352)\n", offsetof(GsUniforms, touch_point));
+    std::printf("  effect_params:     offset=%3zu  (expected=368)\n", offsetof(GsUniforms, effect_params));
+    std::printf("  effect_params2:    offset=%3zu  (expected=384)\n", offsetof(GsUniforms, effect_params2));
+    std::printf("  point_light_params:offset=%3zu  (expected=400)\n", offsetof(GsUniforms, point_light_params));
+    std::printf("  actor_rotation:    offset=%3zu  (expected=416)\n", offsetof(GsUniforms, actor_rotation));
+    std::printf("  pl_pos_rad:        offset=%3zu  (expected=432)\n", offsetof(GsUniforms, pl_pos_rad));
+    std::printf("  pl_color:          offset=%3zu  (expected=560)\n", offsetof(GsUniforms, pl_color));
+    std::printf("  pl_dir_cone:       offset=%3zu  (expected=688)\n", offsetof(GsUniforms, pl_dir_cone));
+    std::printf("  pl_area:           offset=%3zu  (expected=816)\n", offsetof(GsUniforms, pl_area));
+    std::printf("  tile_sort_params:  offset=%3zu  (expected=944)\n", offsetof(GsUniforms, tile_sort_params));
+
+    // Static assertions for critical offsets
+    static_assert(offsetof(GsUniforms, view) == 0, "view offset mismatch");
+    static_assert(offsetof(GsUniforms, proj) == 64, "proj offset mismatch");
+    static_assert(offsetof(GsUniforms, inv_view) == 128, "inv_view offset mismatch");
+    static_assert(offsetof(GsUniforms, inv_proj) == 192, "inv_proj offset mismatch");
+    static_assert(offsetof(GsUniforms, params) == 256, "params offset mismatch");
+    static_assert(offsetof(GsUniforms, shadow_box) == 272, "shadow_box offset mismatch");
+    static_assert(offsetof(GsUniforms, cam_pos) == 304, "cam_pos offset mismatch");
+    static_assert(offsetof(GsUniforms, pl_pos_rad) == 432, "pl_pos_rad offset mismatch");
+    static_assert(offsetof(GsUniforms, pl_area) == 816, "pl_area offset mismatch");
+    static_assert(offsetof(GsUniforms, tile_sort_params) == 944, "tile_sort_params offset mismatch");
+    static_assert(sizeof(GsUniforms) == 960, "GsUniforms total size mismatch (expected 960)");
+
+    std::printf("\nALL static_assert passed — C++ layout matches std140 expectations\n");
+    std::printf("PASS: UBO layout audit\n");
+
+    return 0;
+}

--- a/tests/test_tile_sort_key.cpp
+++ b/tests/test_tile_sort_key.cpp
@@ -1,0 +1,78 @@
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+// Key packing logic (will be shared with shader via matching algorithm)
+static uint32_t pack_tile_sort_key(uint32_t tile_id, float depth, float near_z, float far_z) {
+    float t = (depth - near_z) / (far_z - near_z);
+    if (t < 0.0f) t = 0.0f;
+    if (t > 1.0f) t = 1.0f;
+    uint32_t depth_q = static_cast<uint32_t>(t * 65535.0f);
+    if (depth_q > 0xFFFEu) depth_q = 0xFFFEu;  // 0xFFFF reserved for sentinel
+    return (tile_id << 16u) | depth_q;
+}
+
+static void extract_near_far(const glm::mat4& proj, float& near_z, float& far_z) {
+    // glm::perspective with GLM_FORCE_DEPTH_ZERO_TO_ONE → perspectiveRH_ZO
+    // proj[2][2] = -far/(far-near), proj[3][2] = -far*near/(far-near)
+    // near = B / A,  far = B / (A + 1)  (matches renderer.cpp gs_pp extraction)
+    float A = proj[2][2];
+    float B = proj[3][2];
+    near_z = B / A;
+    far_z  = B / (A + 1.0f);
+}
+
+int main() {
+    // Test 1: Key packing preserves sort order
+    {
+        uint32_t k1 = pack_tile_sort_key(5, 10.0f, 0.1f, 1000.0f);
+        uint32_t k2 = pack_tile_sort_key(5, 20.0f, 0.1f, 1000.0f);
+        assert(k1 < k2);  // same tile, closer depth sorts first
+    }
+
+    // Test 2: Tile ID is primary sort key
+    {
+        uint32_t k1 = pack_tile_sort_key(3, 500.0f, 0.1f, 1000.0f);
+        uint32_t k2 = pack_tile_sort_key(4, 1.0f, 0.1f, 1000.0f);
+        assert(k1 < k2);  // tile 3 < tile 4 regardless of depth
+    }
+
+    // Test 3: Depth clamping at boundaries
+    {
+        uint32_t k_near = pack_tile_sort_key(0, -5.0f, 0.1f, 1000.0f);
+        uint32_t k_far  = pack_tile_sort_key(0, 9999.0f, 0.1f, 1000.0f);
+        assert((k_near & 0xFFFFu) == 0);       // clamped to 0
+        assert((k_far & 0xFFFFu) == 0xFFFEu);  // clamped to max (0xFFFF reserved)
+    }
+
+    // Test 4: Sentinel key is maximum
+    {
+        uint32_t sentinel = 0xFFFFFFFFu;
+        uint32_t k_max = pack_tile_sort_key(0xFFFFu - 1, 1000.0f, 0.1f, 1000.0f);
+        assert(k_max < sentinel);
+    }
+
+    // Test 5: Near/far extraction from projection matrix
+    {
+        float near_in = 0.1f, far_in = 1000.0f;
+        glm::mat4 proj = glm::perspective(glm::radians(60.0f), 1.0f, near_in, far_in);
+        float near_out, far_out;
+        extract_near_far(proj, near_out, far_out);
+        assert(std::abs(near_out - near_in) < 0.01f);
+        assert(std::abs(far_out - far_in) < 1.0f);
+    }
+
+    // Test 6: 16-bit depth has sufficient precision
+    {
+        // Two Gaussians 0.02 apart at depth ~10 should get different keys
+        uint32_t k1 = pack_tile_sort_key(0, 10.0f, 0.1f, 1000.0f);
+        uint32_t k2 = pack_tile_sort_key(0, 10.02f, 0.1f, 1000.0f);
+        assert(k1 != k2);  // 0.02 / 1000 * 65535 ≈ 1.3 — should differ by at least 1
+    }
+
+    std::printf("PASS: test_tile_sort_key (6 tests)\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Onesweep radix sort for tile binning — replaces the 8-pass radix sort (38 pipeline barriers) with a single-pass decoupled-lookback sort (10 barriers), making tile binning viable on Apple Silicon TBDR GPUs.

### Changes
- **gs_onesweep.comp**: Fused histogram + decoupled lookback prefix sum + stable scatter (256 threads, 2048 entries/wg, ~19KB shared memory)
- **gs_tile_bin.comp**: Rewritten with UBO-based near/far/tiles params (was push constants)
- **gs_tile_ranges.comp / gs_tile_render.comp**: Updated for key_lo-based tile_id extraction
- **gs_tile_prepare_indirect.comp**: 2048 entries/wg for Onesweep workgroup calc
- **GsRenderer**: Onesweep pipeline, descriptor sets, status buffer, A/B toggle dispatch
- **GsUniforms**: Added `tile_sort_params` (near_z, far_z, tiles_x, tiles_y) at offset 944
- **Buffer**: Added `create_storage_indirect()` for tile_indirect_args
- **Feature flags**: `apply_platform_defaults()` re-applied after state resets to prevent tile binning on Apple Silicon

### Bug fixes in this PR
- Reverted TileSortEntry to 16 bytes (old radix sort shaders expect 16-byte stride)
- Fixed IslandDemoState/GsDemoState overriding platform defaults (gs_tile_binning=true on Apple)
- Fixed Onesweep max_workgroups reading from indirect args (was using stale capacity-based value)
- Added INDIRECT_BUFFER_BIT to tile_indirect_args buffer
- Expanded gs_sort.comp Uniforms to match full GsUniforms layout

### Validation status
- [x] CPU tests pass (tile sort key packing, onesweep status encoding, UBO layout audit)
- [x] macOS Apple Silicon: non-tile path renders correctly (tile binning disabled by default)
- [ ] Windows AMD/NVIDIA: tile binning + Onesweep visual verification
- [ ] Apple Silicon: force-enable tile binning, verify sort correctness
- [ ] Performance measurement (target: <3ms tile sort on Apple Silicon)

### Test plan
- Pull branch on Windows, build release, run gseurat_demo — scene should render without artifacts
- On macOS: `set_feature gs_tile_binning true` via control server, verify visual output
- GPU timestamp profiling to confirm barrier reduction benefit

🤖 Generated with [Claude Code](https://claude.com/claude-code)