### PR TITLE
refactor: remove demo dependency from engine layer

### DIFF
--- a/src/demo/demo_app.cpp
+++ b/src/demo/demo_app.cpp
@@ -1,7 +1,9 @@
 #include "gseurat/demo/demo_app.hpp"
 #include "gseurat/demo/gs_demo_state.hpp"
 #include "gseurat/demo/island_demo_state.hpp"
+#include "gseurat/demo/island_components.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
+#include <nlohmann/json.hpp>
 #include "gseurat/engine/gs_parallax_camera.hpp"
 #include "gseurat/engine/scene_loader.hpp"
 #include "gseurat/engine/gs_vfx.hpp"
@@ -73,6 +75,87 @@ void DemoApp::init_game_content() {
 
     ui_ctx_.init(font_atlas_, text_renderer_);
     audio_.init("assets");
+
+    // Register demo-specific components (engine registers generic ones)
+    component_registry_.register_component<PlayerController>("PlayerController",
+        [](const nlohmann::json& j) -> PlayerController {
+            PlayerController c;
+            if (j.contains("speed")) c.speed = j["speed"].get<float>();
+            if (j.contains("acceleration")) c.acceleration = j["acceleration"].get<float>();
+            return c;
+        },
+        [](const PlayerController& c) -> nlohmann::json {
+            return {{"speed", c.speed}, {"acceleration", c.acceleration}};
+        });
+
+    component_registry_.register_component<BurstEffect>("BurstEffect",
+        [](const nlohmann::json& j) -> BurstEffect {
+            BurstEffect c;
+            if (j.contains("emitter_index")) c.emitter_index = j["emitter_index"].get<uint32_t>();
+            return c;
+        },
+        [](const BurstEffect& c) -> nlohmann::json {
+            return {{"emitter_index", c.emitter_index}};
+        });
+
+    component_registry_.register_component<ScatterEffect>("ScatterEffect",
+        [](const nlohmann::json& j) -> ScatterEffect {
+            ScatterEffect c;
+            if (j.contains("radius")) c.radius = j["radius"].get<float>();
+            if (j.contains("lifetime")) c.lifetime = j["lifetime"].get<float>();
+            return c;
+        },
+        [](const ScatterEffect& c) -> nlohmann::json {
+            return {{"radius", c.radius}, {"lifetime", c.lifetime}};
+        });
+
+    component_registry_.register_component<AnimationTrigger>("AnimationTrigger",
+        [](const nlohmann::json& j) -> AnimationTrigger {
+            AnimationTrigger c;
+            if (j.contains("effect_name")) {
+                auto name = j["effect_name"].get<std::string>();
+                std::strncpy(c.effect_name, name.c_str(), sizeof(c.effect_name) - 1);
+                c.effect_name[sizeof(c.effect_name) - 1] = '\0';
+            }
+            if (j.contains("anim_radius")) c.anim_radius = j["anim_radius"].get<float>();
+            if (j.contains("lifetime")) c.lifetime = j["lifetime"].get<float>();
+            if (j.contains("loop")) c.loop = j["loop"].get<bool>();
+            return c;
+        },
+        [](const AnimationTrigger& c) -> nlohmann::json {
+            return {{"effect_name", std::string(c.effect_name)},
+                    {"anim_radius", c.anim_radius},
+                    {"lifetime", c.lifetime},
+                    {"loop", c.loop}};
+        });
+
+    component_registry_.register_component<DiscoveryZone>("DiscoveryZone",
+        [](const nlohmann::json& j) -> DiscoveryZone {
+            DiscoveryZone c;
+            if (j.contains("color_r")) c.color_r = j["color_r"].get<float>();
+            if (j.contains("color_g")) c.color_g = j["color_g"].get<float>();
+            if (j.contains("color_b")) c.color_b = j["color_b"].get<float>();
+            if (j.contains("burst_height")) c.burst_height = j["burst_height"].get<float>();
+            return c;
+        },
+        [](const DiscoveryZone& c) -> nlohmann::json {
+            return {{"color_r", c.color_r}, {"color_g", c.color_g},
+                    {"color_b", c.color_b}, {"burst_height", c.burst_height}};
+        });
+
+    component_registry_.register_component<VfxTrigger>("VfxTrigger",
+        [](const nlohmann::json& j) -> VfxTrigger {
+            VfxTrigger c;
+            if (j.contains("vfx_path")) {
+                auto path = j["vfx_path"].get<std::string>();
+                std::strncpy(c.vfx_path, path.c_str(), sizeof(c.vfx_path) - 1);
+                c.vfx_path[sizeof(c.vfx_path) - 1] = '\0';
+            }
+            return c;
+        },
+        [](const VfxTrigger& c) -> nlohmann::json {
+            return {{"vfx_path", std::string(c.vfx_path)}};
+        });
 }
 
 void DemoApp::init_scene(const std::string& scene_path) {

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -3,7 +3,6 @@
 #include "gseurat/engine/scene_load_context.hpp"
 #include "gseurat/engine/trigger_components.hpp"
 #include "gseurat/engine/trigger_systems.hpp"
-#include "gseurat/demo/island_components.hpp"
 #include "gseurat/engine/bone_animated_component.hpp"
 #include "gseurat/engine/bone_animation_system.hpp"
 #include "gseurat/engine/gs_renderer.hpp"
@@ -208,17 +207,6 @@ void AppBase::init_game_object_system() {
             return {{"direction", dir}};
         });
 
-    component_registry_.register_component<PlayerController>("PlayerController",
-        [](const nlohmann::json& j) -> PlayerController {
-            PlayerController c;
-            if (j.contains("speed")) c.speed = j["speed"].get<float>();
-            if (j.contains("acceleration")) c.acceleration = j["acceleration"].get<float>();
-            return c;
-        },
-        [](const PlayerController& c) -> nlohmann::json {
-            return {{"speed", c.speed}, {"acceleration", c.acceleration}};
-        });
-
     component_registry_.register_component<ProximityTrigger>("ProximityTrigger",
         [](const nlohmann::json& j) -> ProximityTrigger {
             ProximityTrigger c;
@@ -275,27 +263,6 @@ void AppBase::init_game_object_system() {
             };
         });
 
-    component_registry_.register_component<BurstEffect>("BurstEffect",
-        [](const nlohmann::json& j) -> BurstEffect {
-            BurstEffect c;
-            if (j.contains("emitter_index")) c.emitter_index = j["emitter_index"].get<uint32_t>();
-            return c;
-        },
-        [](const BurstEffect& c) -> nlohmann::json {
-            return {{"emitter_index", c.emitter_index}};
-        });
-
-    component_registry_.register_component<ScatterEffect>("ScatterEffect",
-        [](const nlohmann::json& j) -> ScatterEffect {
-            ScatterEffect c;
-            if (j.contains("radius")) c.radius = j["radius"].get<float>();
-            if (j.contains("lifetime")) c.lifetime = j["lifetime"].get<float>();
-            return c;
-        },
-        [](const ScatterEffect& c) -> nlohmann::json {
-            return {{"radius", c.radius}, {"lifetime", c.lifetime}};
-        });
-
     component_registry_.register_component<LinkedTrigger>("LinkedTrigger",
         [](const nlohmann::json& j) -> LinkedTrigger {
             LinkedTrigger c;
@@ -304,54 +271,6 @@ void AppBase::init_game_object_system() {
         },
         [](const LinkedTrigger& c) -> nlohmann::json {
             return {{"target_entity", c.target_entity}};
-        });
-
-    component_registry_.register_component<AnimationTrigger>("AnimationTrigger",
-        [](const nlohmann::json& j) -> AnimationTrigger {
-            AnimationTrigger c;
-            if (j.contains("effect_name")) {
-                auto name = j["effect_name"].get<std::string>();
-                std::strncpy(c.effect_name, name.c_str(), sizeof(c.effect_name) - 1);
-                c.effect_name[sizeof(c.effect_name) - 1] = '\0';
-            }
-            if (j.contains("anim_radius")) c.anim_radius = j["anim_radius"].get<float>();
-            if (j.contains("lifetime")) c.lifetime = j["lifetime"].get<float>();
-            if (j.contains("loop")) c.loop = j["loop"].get<bool>();
-            return c;
-        },
-        [](const AnimationTrigger& c) -> nlohmann::json {
-            return {{"effect_name", std::string(c.effect_name)},
-                    {"anim_radius", c.anim_radius},
-                    {"lifetime", c.lifetime},
-                    {"loop", c.loop}};
-        });
-
-    component_registry_.register_component<DiscoveryZone>("DiscoveryZone",
-        [](const nlohmann::json& j) -> DiscoveryZone {
-            DiscoveryZone c;
-            if (j.contains("color_r")) c.color_r = j["color_r"].get<float>();
-            if (j.contains("color_g")) c.color_g = j["color_g"].get<float>();
-            if (j.contains("color_b")) c.color_b = j["color_b"].get<float>();
-            if (j.contains("burst_height")) c.burst_height = j["burst_height"].get<float>();
-            return c;
-        },
-        [](const DiscoveryZone& c) -> nlohmann::json {
-            return {{"color_r", c.color_r}, {"color_g", c.color_g},
-                    {"color_b", c.color_b}, {"burst_height", c.burst_height}};
-        });
-
-    component_registry_.register_component<VfxTrigger>("VfxTrigger",
-        [](const nlohmann::json& j) -> VfxTrigger {
-            VfxTrigger c;
-            if (j.contains("vfx_path")) {
-                auto path = j["vfx_path"].get<std::string>();
-                std::strncpy(c.vfx_path, path.c_str(), sizeof(c.vfx_path) - 1);
-                c.vfx_path[sizeof(c.vfx_path) - 1] = '\0';
-            }
-            return c;
-        },
-        [](const VfxTrigger& c) -> nlohmann::json {
-            return {{"vfx_path", std::string(c.vfx_path)}};
         });
 
     component_registry_.register_component<NpcWalker>("NpcWalker",

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -13,7 +13,7 @@
 #include "gseurat/engine/scene_loader.hpp"
 #include "gseurat/engine/scene_object_state.hpp"
 #include "gseurat/engine/world_manifest.hpp"
-#include "gseurat/demo/island_components.hpp"
+#include "gseurat/engine/trigger_components.hpp"
 
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
@@ -469,8 +469,8 @@ void CommandDispatcher::register_default_commands() {
         json response;
         response["type"] = "player_state";
         bool found = false;
-        ctx_.world.view<ecs::Transform, PlayerController>().each(
-            [&](ecs::Entity, ecs::Transform& t, PlayerController&) {
+        ctx_.world.view<ecs::Transform, PlayerTag>().each(
+            [&](ecs::Entity, ecs::Transform& t, PlayerTag&) {
                 response["position"] = {t.position.x(), t.position.y(), t.position.z()};
                 found = true;
             });


### PR DESCRIPTION
## Summary

- Move 6 demo-specific component registrations (PlayerController, BurstEffect, ScatterEffect, AnimationTrigger, DiscoveryZone, VfxTrigger) from `app_base.cpp` to `demo_app.cpp`
- Replace `PlayerController` query in `command_dispatcher.cpp` with engine-level `PlayerTag`
- Remove `#include "gseurat/demo/island_components.hpp"` from both engine files
- Engine layer now has zero includes from demo layer

## Test plan

- [x] Debug build succeeds
- [x] No demo includes in engine (`rg demo/ src/engine/ include/gseurat/engine/` — only a comment)
- [ ] Demo runs correctly (all components still registered via demo_app)
- [ ] Game Director `player` command works (uses PlayerTag now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)