### PR TITLE
refactor(demo): use app.update_game() instead of direct scheduler call

### DIFF
--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -630,8 +630,8 @@ void IslandDemoState::update(AppBase& app, float dt) {
     // Player movement
     update_player(app, dt);
 
-    // Run ECS systems (proximity triggers, linked triggers, emissive toggle)
-    app.system_scheduler().run_all(app.world(), dt);
+    // Run ECS systems (proximity triggers, linked triggers, emissive toggle, NPC walker, bone animation)
+    app.update_game(dt);
 
     // Effect systems (EmitterToggle, LightToggle)
     update_effects(app, dt);


### PR DESCRIPTION
## Summary

- Replace `app.system_scheduler().run_all(app.world(), dt)` with `app.update_game(dt)` in IslandDemoState
- Aligns demo with standard AppBase update flow
- Future engine-level work in `update_game()` automatically applies to the demo

## Test plan

- [x] Debug build succeeds
- [ ] Demo runs correctly (player, NPCs, triggers all work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)