### PR TITLE
feat(engine): DevOverlay — ImGui developer mode in engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,10 @@ option(GSEURAT_DEV_MODE "Enable ImGui developer overlay" ON)
 if(GSEURAT_DEV_MODE)
     target_link_libraries(gseurat_core PUBLIC imgui_lib)
     target_compile_definitions(gseurat_core PUBLIC GSEURAT_DEV_MODE)
+    target_sources(gseurat_core PRIVATE
+        src/engine/dev_overlay.cpp
+        src/engine/dev_panels.cpp
+    )
 endif()
 
 # --- Demo executable --------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,15 @@ if(APPLE)
     )
 endif()
 
+# --- Developer overlay (ImGui) -----------------------------------------------
+
+option(GSEURAT_DEV_MODE "Enable ImGui developer overlay" ON)
+
+if(GSEURAT_DEV_MODE)
+    target_link_libraries(gseurat_core PUBLIC imgui_lib)
+    target_compile_definitions(gseurat_core PUBLIC GSEURAT_DEV_MODE)
+endif()
+
 # --- Demo executable --------------------------------------------------------
 
 add_executable(gseurat_demo
@@ -262,7 +271,7 @@ add_executable(gseurat_staging
     src/staging/staging_state.cpp
     src/staging/camera_review_state.cpp
 )
-target_link_libraries(gseurat_staging PRIVATE gseurat_core imgui_lib)
+target_link_libraries(gseurat_staging PRIVATE gseurat_core)
 add_dependencies(gseurat_staging shaders)
 
 

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -98,10 +98,9 @@ private:
     enum class HudMode { kOff, kCompact, kFull };
     HudMode hud_mode_ = HudMode::kOff;
 
-    // Toggle flags (P = particles, N = animation, J = PBD chain, G = gizmos)
+    // Toggle flags (P = particles, N = animation, J = PBD chain)
     bool anim_enabled_ = true;
     bool pbd_chain_active_ = false;
-    bool show_gizmos_ = false;
 
     // Cached VP matrix for gizmo projection (without Vulkan Y-flip)
     glm::mat4 gizmo_vp_{1.0f};

--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -8,6 +8,7 @@
 #include "gseurat/engine/collision_gen.hpp"
 #include "gseurat/engine/command_context.hpp"
 #include "gseurat/engine/command_dispatcher.hpp"
+#include "gseurat/engine/dev_overlay.hpp"
 #include "gseurat/engine/coordinate.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/gs_scene_loader.hpp"
@@ -150,6 +151,10 @@ public:
     DebugMetrics& debug_metrics() { return debug_metrics_; }
     const DebugMetrics& debug_metrics() const { return debug_metrics_; }
 
+    // Developer overlay accessor
+    DevOverlay& dev_overlay() { return dev_overlay_; }
+    const DevOverlay& dev_overlay() const { return dev_overlay_; }
+
     // Bone pre-upload hook (e.g., terrain sway on bone 0)
     void set_bone_pre_upload_hook(std::function<void(glm::mat4*, uint32_t)> hook) {
         bone_pre_upload_hook_ = std::move(hook);
@@ -228,6 +233,9 @@ protected:
 
     // Bone pre-upload hook
     std::function<void(glm::mat4*, uint32_t)> bone_pre_upload_hook_;
+
+    // Developer overlay
+    DevOverlay dev_overlay_;
 
     // Minimap
     Minimap minimap_;

--- a/include/gseurat/engine/dev_overlay.hpp
+++ b/include/gseurat/engine/dev_overlay.hpp
@@ -43,6 +43,9 @@ public:
     bool show_gizmo_vfx = true;
     bool show_gizmo_game_objects = true;
     bool show_gizmo_triggers = true;
+    bool show_gizmo_camera_zones = true;
+    bool show_gizmo_portals = true;
+    bool show_gizmo_world = true;
 
 private:
     struct PanelEntry {

--- a/include/gseurat/engine/dev_overlay.hpp
+++ b/include/gseurat/engine/dev_overlay.hpp
@@ -37,6 +37,13 @@ public:
 
     void register_panel(const std::string& name, PanelDrawFn fn, bool visible = true);
 
+    // Gizmo visibility (read by app gizmo rendering code)
+    bool show_gizmo_lights = true;
+    bool show_gizmo_emitters = true;
+    bool show_gizmo_vfx = true;
+    bool show_gizmo_game_objects = true;
+    bool show_gizmo_triggers = true;
+
 private:
     struct PanelEntry {
         std::string name;

--- a/include/gseurat/engine/dev_overlay.hpp
+++ b/include/gseurat/engine/dev_overlay.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <string>
+
+#ifdef GSEURAT_DEV_MODE
+#include <imgui.h>
+#include <vulkan/vulkan.h>
+#include <functional>
+#include <vector>
+#endif
+
+struct GLFWwindow;
+
+namespace gseurat {
+
+class AppBase;
+class Renderer;
+
+#ifdef GSEURAT_DEV_MODE
+
+using PanelDrawFn = std::function<void(AppBase&)>;
+
+class DevOverlay {
+public:
+    void init(GLFWwindow* window, Renderer& renderer);
+    void shutdown(Renderer& renderer);
+
+    void begin_frame();
+    void end_frame();
+
+    void toggle() { visible_ = !visible_; }
+    bool visible() const { return visible_; }
+    bool wants_mouse() const;
+    bool wants_keyboard() const;
+
+    void draw(AppBase& app);
+
+    void register_panel(const std::string& name, PanelDrawFn fn, bool visible = true);
+
+private:
+    struct PanelEntry {
+        std::string name;
+        PanelDrawFn draw_fn;
+        bool visible = true;
+    };
+
+    bool visible_ = false;
+    std::vector<PanelEntry> panels_;
+
+    VkDescriptorPool imgui_pool_ = VK_NULL_HANDLE;
+    VkRenderPass imgui_render_pass_ = VK_NULL_HANDLE;
+    std::vector<VkFramebuffer> imgui_framebuffers_;
+
+    void create_render_pass(Renderer& renderer);
+    void create_framebuffers(Renderer& renderer);
+    void draw_menu_bar();
+};
+
+#else  // !GSEURAT_DEV_MODE — no-op stubs
+
+using PanelDrawFn = int;  // placeholder type, never used
+
+class DevOverlay {
+public:
+    void init(GLFWwindow*, Renderer&) {}
+    void shutdown(Renderer&) {}
+    void begin_frame() {}
+    void end_frame() {}
+    void toggle() {}
+    bool visible() const { return false; }
+    bool wants_mouse() const { return false; }
+    bool wants_keyboard() const { return false; }
+    void draw(AppBase&) {}
+    void register_panel(const std::string&, PanelDrawFn, bool = true) {}
+};
+
+#endif
+
+}  // namespace gseurat

--- a/include/gseurat/engine/dev_overlay.hpp
+++ b/include/gseurat/engine/dev_overlay.hpp
@@ -58,8 +58,6 @@ private:
 
 #else  // !GSEURAT_DEV_MODE — no-op stubs
 
-using PanelDrawFn = int;  // placeholder type, never used
-
 class DevOverlay {
 public:
     void init(GLFWwindow*, Renderer&) {}
@@ -71,7 +69,8 @@ public:
     bool wants_mouse() const { return false; }
     bool wants_keyboard() const { return false; }
     void draw(AppBase&) {}
-    void register_panel(const std::string&, PanelDrawFn, bool = true) {}
+    template<typename F>
+    void register_panel(const std::string&, F&&, bool = true) {}
 };
 
 #endif

--- a/include/gseurat/engine/dev_panels.hpp
+++ b/include/gseurat/engine/dev_panels.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef GSEURAT_DEV_MODE
+
+namespace gseurat {
+
+class AppBase;
+
+// Built-in engine panels (registered by DevOverlay::init)
+void draw_performance_panel(AppBase& app);
+void draw_render_settings_panel(AppBase& app);
+void draw_gs_params_panel(AppBase& app);
+void draw_feature_toggles_panel(AppBase& app);
+void draw_lighting_panel(AppBase& app);
+void draw_camera_info_panel(AppBase& app);
+
+}  // namespace gseurat
+
+#endif  // GSEURAT_DEV_MODE

--- a/include/gseurat/staging/camera_review_state.hpp
+++ b/include/gseurat/staging/camera_review_state.hpp
@@ -58,10 +58,12 @@ public:
     MoveReference move_reference() const { return move_ref_; }
     void set_move_reference(MoveReference ref) { move_ref_ = ref; }
 
+#ifdef GSEURAT_DEV_MODE
     // Gizmo rendering
     void draw_gizmos(const glm::mat4& vp, float screen_w, float screen_h, ImDrawList* draw_list,
                      bool (*proj_fn)(const glm::vec3&, const glm::mat4&, float, float, float&, float&, const void*),
                      const void* proj_self) const;
+#endif
 
     // Speed (public for ImGui slider)
     float& player_speed() { return player_speed_; }

--- a/include/gseurat/staging/staging_app.hpp
+++ b/include/gseurat/staging/staging_app.hpp
@@ -1,34 +1,17 @@
 #pragma once
-
 #include "gseurat/engine/app_base.hpp"
-
-#include <vulkan/vulkan.h>
 #include <string>
 
 namespace gseurat {
-
 class StagingApp : public AppBase {
 public:
     void parse_args(int argc, char* argv[]);
-
+    void run() override;
 protected:
     void init_game_content() override;
-    void main_loop() override;
-    void cleanup() override;
     void init_scene(const std::string& scene_path) override;
     void clear_scene() override;
-
 private:
-    void init_imgui();
-    void shutdown_imgui();
-    void create_imgui_render_pass();
-
     std::string scene_path_;
-
-    // ImGui Vulkan resources
-    VkDescriptorPool imgui_pool_ = VK_NULL_HANDLE;
-    VkRenderPass imgui_render_pass_ = VK_NULL_HANDLE;
-    std::vector<VkFramebuffer> imgui_framebuffers_;
 };
-
 }  // namespace gseurat

--- a/include/gseurat/staging/staging_state.hpp
+++ b/include/gseurat/staging/staging_state.hpp
@@ -40,15 +40,8 @@ public:
                            float& out_x, float& out_y) const;
 
 private:
-    void draw_imgui(AppBase& app);
-    void draw_viewport_info(AppBase& app);
-    void draw_render_settings(AppBase& app);
-    void draw_gs_params(AppBase& app);
-    void draw_feature_toggles(AppBase& app);
-    void draw_lighting(AppBase& app);
     void draw_camera_panel(AppBase& app);
     void draw_scene_panel(AppBase& app);
-    void draw_performance(AppBase& app);
     void draw_gizmos(AppBase& app);
     void draw_character_panel(AppBase& app);
 
@@ -76,27 +69,6 @@ private:
 
     // Camera bookmarks
     std::vector<CameraBookmark> bookmarks_;
-
-    // Panel visibility
-    bool show_viewport_info_ = true;
-    bool show_render_settings_ = true;
-    bool show_gs_params_ = true;
-    bool show_feature_toggles_ = true;
-    bool show_lighting_ = true;
-    bool show_camera_ = true;
-    bool show_performance_ = true;
-
-    // Gizmo visibility
-    bool show_gizmo_lights_ = true;
-    bool show_gizmo_emitters_ = true;
-    bool show_gizmo_vfx_ = true;
-    bool show_gizmo_game_objects_ = true;
-    bool show_gizmo_camera_zones_ = true;
-    bool show_gizmo_portals_ = true;
-    bool show_gizmo_world_ = true;
-
-    // Hide all UI (Tab key toggle)
-    bool hide_ui_ = false;
 
     // Track scene path for auto-recentering camera on load_scene_json
     std::string last_scene_path_;

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -568,11 +568,6 @@ void IslandDemoState::update(AppBase& app, float dt) {
             anim_enabled_ = !anim_enabled_;
         }
 
-        // G → toggle debug gizmos (lights, emitters, triggers)
-        if (app.input().was_key_pressed(GLFW_KEY_G)) {
-            show_gizmos_ = !show_gizmos_;
-            std::fprintf(stderr, "[IslandDemo] Debug gizmos %s\n", show_gizmos_ ? "ON" : "OFF");
-        }
 
         // J → toggle PBD chain demo (CPU-side, rendered as dynamic Gaussians)
         if (app.input().was_key_pressed(GLFW_KEY_J)) {
@@ -1828,15 +1823,12 @@ void IslandDemoState::build_draw_lists(AppBase& app) {
     glm::vec4 trig_col = triggered_count > 0 ? green : dim;
     ui.label("Triggers", lx, y, s, dim);
     ui.label(std::to_string(triggered_count) + "/" + std::to_string(total_triggers), vx, y, s, trig_col);
-    y -= line;
-    ui.label("Gizmos [G]", lx, y, s, dim);
-    ui.label(show_gizmos_ ? "ON" : "OFF", vx, y, s, show_gizmos_ ? green : red);
 }
 
 // ── Debug gizmos (G key toggle) ──
 
 void IslandDemoState::draw_gizmos(AppBase& app) {
-    if ((!show_gizmos_ && !app.dev_overlay().visible()) || !app.renderer().has_gs_cloud()) return;
+    if (!app.dev_overlay().visible() || !app.renderer().has_gs_cloud()) return;
 
     auto& ui = app.ui_ctx();
     constexpr float sw = 1280.0f;

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1851,9 +1851,10 @@ void IslandDemoState::draw_gizmos(AppBase& app) {
     };
 
     auto& gs = app.renderer().gs_renderer();
+    auto& ov = app.dev_overlay();
 
     // ── Light gizmos (yellow circles at light positions) ──
-    {
+    if (ov.show_gizmo_lights) {
         glm::vec4 col{1.0f, 0.9f, 0.3f, 0.8f};
         const auto& lights = gs.point_lights();
         for (size_t i = 0; i < lights.size(); i++) {
@@ -1873,7 +1874,7 @@ void IslandDemoState::draw_gizmos(AppBase& app) {
     }
 
     // ── Emitter gizmos (pink circles at emitter positions + spawn regions) ──
-    {
+    if (ov.show_gizmo_emitters) {
         glm::vec4 col{0.93f, 0.28f, 0.60f, 0.8f};  // pink
         auto& emitters = app.renderer().gs_particle_emitters();
         for (size_t i = 0; i < emitters.size(); i++) {
@@ -1890,7 +1891,7 @@ void IslandDemoState::draw_gizmos(AppBase& app) {
     }
 
     // ── Animation region gizmos (cyan wireframes) ──
-    {
+    if (ov.show_gizmo_vfx) {
         glm::vec4 col{0.0f, 0.72f, 0.83f, 0.7f};  // cyan
         const auto& anims = app.renderer().gs_scene_animations();
         for (size_t i = 0; i < anims.size(); i++) {
@@ -1904,7 +1905,7 @@ void IslandDemoState::draw_gizmos(AppBase& app) {
     }
 
     // ── Proximity trigger gizmos (green/red circles) ──
-    {
+    if (ov.show_gizmo_triggers) {
         app.world().view<ProximityTrigger, ecs::Transform>().each(
             [&](ecs::Entity, ProximityTrigger& pt, ecs::Transform& t) {
                 glm::vec4 col = pt.triggered

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -19,6 +19,9 @@
 #include "gseurat/engine/bone_animation_registry.hpp"
 #include "gseurat/engine/bone_animation_system.hpp"
 #include "gseurat/engine/debug_draw.hpp"
+#ifdef GSEURAT_DEV_MODE
+#include <imgui.h>
+#endif
 #include "gseurat/engine/bone_animated_component.hpp"
 
 #define GLFW_INCLUDE_VULKAN
@@ -1825,88 +1828,113 @@ void IslandDemoState::build_draw_lists(AppBase& app) {
     ui.label(std::to_string(triggered_count) + "/" + std::to_string(total_triggers), vx, y, s, trig_col);
 }
 
-// ── Debug gizmos (G key toggle) ──
+// ── Debug gizmos (ImGui foreground draw list, same style as Staging) ──
+
+#ifdef GSEURAT_DEV_MODE
+namespace {
+void imgui_sphere(ImDrawList* dl, const glm::vec3& center, float radius,
+                   const glm::mat4& vp, float sw, float sh, ImU32 col) {
+    float cx, cy;
+    if (!gseurat::project_to_screen(center, vp, sw, sh, cx, cy)) return;
+    glm::vec3 edge = center + glm::vec3(radius, 0.0f, 0.0f);
+    float ex, ey, sr = 15.0f;
+    if (gseurat::project_to_screen(edge, vp, sw, sh, ex, ey))
+        sr = std::clamp(std::abs(ex - cx), 3.0f, 300.0f);
+    dl->AddCircle(ImVec2(cx, cy), sr, col, 24, 1.5f);
+}
+void imgui_box(ImDrawList* dl, const glm::vec3& center, const glm::vec3& half,
+                const glm::mat4& vp, float sw, float sh, ImU32 col) {
+    glm::vec3 c[8]={
+        center+glm::vec3(-half.x,-half.y,-half.z),center+glm::vec3(half.x,-half.y,-half.z),
+        center+glm::vec3(half.x,half.y,-half.z),  center+glm::vec3(-half.x,half.y,-half.z),
+        center+glm::vec3(-half.x,-half.y,half.z), center+glm::vec3(half.x,-half.y,half.z),
+        center+glm::vec3(half.x,half.y,half.z),   center+glm::vec3(-half.x,half.y,half.z),
+    };
+    ImVec2 p[8]; bool v[8];
+    for(int i=0;i<8;i++) v[i]=gseurat::project_to_screen(c[i],vp,sw,sh,p[i].x,p[i].y);
+    constexpr int e[12][2]={{0,1},{1,2},{2,3},{3,0},{4,5},{5,6},{6,7},{7,4},{0,4},{1,5},{2,6},{3,7}};
+    for(auto& ed:e) if(v[ed[0]]&&v[ed[1]]) dl->AddLine(p[ed[0]],p[ed[1]],col,1.0f);
+}
+void imgui_region(ImDrawList* dl, const gseurat::GsAnimRegion& r, const glm::vec3& off,
+                   const glm::mat4& vp, float sw, float sh, ImU32 col) {
+    glm::vec3 center = r.center + off;
+    if (r.shape == gseurat::GsAnimRegion::Shape::Box)
+        imgui_box(dl, center, r.half_extents, vp, sw, sh, col);
+    else
+        imgui_sphere(dl, center, r.radius, vp, sw, sh, col);
+}
+}  // anonymous namespace
+#endif
 
 void IslandDemoState::draw_gizmos(AppBase& app) {
+#ifdef GSEURAT_DEV_MODE
     if (!app.dev_overlay().visible() || !app.renderer().has_gs_cloud()) return;
 
-    auto& ui = app.ui_ctx();
-    constexpr float sw = 1280.0f;
-    constexpr float sh = 720.0f;
-
-    // UIContext line adapter for engine debug_draw functions
-    // Note: UIContext uses Y-up, but project_to_screen returns Y-down screen coords.
-    // Convert Y: ui_y = sh - screen_y
-    DrawLineFn draw_line = [&](float x1, float y1, float x2, float y2,
-                                float thickness, glm::vec4 color) {
-        ui.line(x1, sh - y1, x2, sh - y2, thickness, color);
-    };
-
+    const glm::mat4& vp = gizmo_vp_;
     auto& gs = app.renderer().gs_renderer();
     auto& ov = app.dev_overlay();
+    auto& io = ImGui::GetIO();
+    float sw = io.DisplaySize.x, sh = io.DisplaySize.y;
+    ImDrawList* dl = ImGui::GetForegroundDrawList();
 
-    // ── Light gizmos (yellow circles at light positions) ──
+    // ── Light gizmos ──
     if (ov.show_gizmo_lights) {
-        glm::vec4 col{1.0f, 0.9f, 0.3f, 0.8f};
         const auto& lights = gs.point_lights();
         for (size_t i = 0; i < lights.size(); i++) {
             glm::vec3 pos(lights[i].position_and_radius.x,
                           lights[i].position_and_radius.z,
                           lights[i].position_and_radius.y);
-            draw_sphere_gizmo(pos, lights[i].position_and_radius.w,
-                              gizmo_vp_, sw, sh, col, draw_line);
-            // Label
             float sx, sy;
-            if (project_to_screen(pos, gizmo_vp_, sw, sh, sx, sy)) {
-                char label[16];
-                std::snprintf(label, sizeof(label), "L%zu", i);
-                ui.label(label, sx + 6.0f, sh - sy + 8.0f, 0.3f, col);
-            }
+            if (!project_to_screen(pos, vp, sw, sh, sx, sy)) continue;
+            ImU32 col = ImGui::ColorConvertFloat4ToU32(
+                ImVec4(lights[i].color.r, lights[i].color.g, lights[i].color.b, 0.8f));
+            imgui_sphere(dl, pos, lights[i].position_and_radius.w, vp, sw, sh, col);
+            dl->AddCircleFilled(ImVec2(sx, sy), 4.0f, col);
+            char label[32]; std::snprintf(label, sizeof(label), "L%zu", i);
+            dl->AddText(ImVec2(sx + 6, sy - 12), col, label);
         }
     }
 
-    // ── Emitter gizmos (pink circles at emitter positions + spawn regions) ──
+    // ── Emitter gizmos ──
     if (ov.show_gizmo_emitters) {
-        glm::vec4 col{0.93f, 0.28f, 0.60f, 0.8f};  // pink
+        ImU32 col = IM_COL32(236, 72, 153, 200);
         auto& emitters = app.renderer().gs_particle_emitters();
         for (size_t i = 0; i < emitters.size(); i++) {
             auto& cfg = emitters[i].config();
-            draw_region_gizmo(cfg.spawn_region, cfg.position,
-                              gizmo_vp_, sw, sh, col, draw_line);
             float sx, sy;
-            if (project_to_screen(cfg.position, gizmo_vp_, sw, sh, sx, sy)) {
-                char label[16];
-                std::snprintf(label, sizeof(label), "E%zu", i);
-                ui.label(label, sx + 6.0f, sh - sy + 8.0f, 0.3f, col);
-            }
+            if (!project_to_screen(cfg.position, vp, sw, sh, sx, sy)) continue;
+            dl->AddCircleFilled(ImVec2(sx, sy), 5.0f, col);
+            imgui_region(dl, cfg.spawn_region, cfg.position, vp, sw, sh, col);
+            char label[32]; std::snprintf(label, sizeof(label), "E%zu", i);
+            dl->AddText(ImVec2(sx + 8, sy - 10), col, label);
         }
     }
 
-    // ── Animation region gizmos (cyan wireframes) ──
+    // ── Animation region gizmos ──
     if (ov.show_gizmo_vfx) {
-        glm::vec4 col{0.0f, 0.72f, 0.83f, 0.7f};  // cyan
+        ImU32 col = IM_COL32(6, 182, 212, 180);
         const auto& anims = app.renderer().gs_scene_animations();
         for (size_t i = 0; i < anims.size(); i++) {
-            draw_region_gizmo(anims[i].region, glm::vec3(0.0f),
-                              gizmo_vp_, sw, sh, col, draw_line);
             float sx, sy;
-            if (project_to_screen(anims[i].region.center, gizmo_vp_, sw, sh, sx, sy)) {
-                ui.label("Anim", sx + 6.0f, sh - sy + 8.0f, 0.3f, col);
-            }
+            if (!project_to_screen(anims[i].region.center, vp, sw, sh, sx, sy)) continue;
+            imgui_region(dl, anims[i].region, glm::vec3(0.0f), vp, sw, sh, col);
+            dl->AddCircleFilled(ImVec2(sx, sy), 3.0f, col);
+            char label[64]; std::snprintf(label, sizeof(label), "Anim:%s", anims[i].effect.c_str());
+            dl->AddText(ImVec2(sx + 6, sy - 10), col, label);
         }
     }
 
-    // ── Proximity trigger gizmos (green/red circles) ──
+    // ── Proximity trigger gizmos ──
     if (ov.show_gizmo_triggers) {
         app.world().view<ProximityTrigger, ecs::Transform>().each(
             [&](ecs::Entity, ProximityTrigger& pt, ecs::Transform& t) {
-                glm::vec4 col = pt.triggered
-                    ? glm::vec4{0.2f, 1.0f, 0.3f, 0.6f}   // green when active
-                    : glm::vec4{0.5f, 0.5f, 0.5f, 0.4f};   // dim when idle
-                draw_sphere_gizmo(t.position.vec(), pt.radius,
-                                  gizmo_vp_, sw, sh, col, draw_line);
+                ImU32 col = pt.triggered ? IM_COL32(51,255,76,153) : IM_COL32(128,128,128,100);
+                imgui_sphere(dl, t.position.vec(), pt.radius, vp, sw, sh, col);
             });
     }
+#else
+    (void)app;
+#endif
 }
 
 }  // namespace gseurat

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1836,7 +1836,7 @@ void IslandDemoState::build_draw_lists(AppBase& app) {
 // ── Debug gizmos (G key toggle) ──
 
 void IslandDemoState::draw_gizmos(AppBase& app) {
-    if (!show_gizmos_ || !app.renderer().has_gs_cloud()) return;
+    if ((!show_gizmos_ && !app.dev_overlay().visible()) || !app.renderer().has_gs_cloud()) return;
 
     auto& ui = app.ui_ctx();
     constexpr float sw = 1280.0f;

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -549,61 +549,63 @@ void IslandDemoState::update(AppBase& app, float dt) {
         return;
     }
 
-    // Tab → cycle HUD mode: OFF → COMPACT → FULL → OFF
-    if (app.input().was_key_pressed(GLFW_KEY_TAB)) {
-        hud_mode_ = static_cast<HudMode>(
-            (static_cast<int>(hud_mode_) + 1) % 3);
-    }
-
-    // P → toggle particles/emitters
-    if (app.input().was_key_pressed(GLFW_KEY_P)) {
-        auto& f = app.feature_flags();
-        f.particles = !f.particles;
-    }
-
-    // N → toggle terrain sway + walk animation
-    if (app.input().was_key_pressed(GLFW_KEY_N)) {
-        anim_enabled_ = !anim_enabled_;
-    }
-
-    // G → toggle debug gizmos (lights, emitters, triggers)
-    if (app.input().was_key_pressed(GLFW_KEY_G)) {
-        show_gizmos_ = !show_gizmos_;
-        std::fprintf(stderr, "[IslandDemo] Debug gizmos %s\n", show_gizmos_ ? "ON" : "OFF");
-    }
-
-    // J → toggle PBD chain demo (CPU-side, rendered as dynamic Gaussians)
-    if (app.input().was_key_pressed(GLFW_KEY_J)) {
-        if (pbd_chain_active_) {
-            pbd_chain_active_ = false;
-            std::fprintf(stderr, "[IslandDemo] PBD chain demo OFF\n");
-        } else {
-            glm::vec3 top = character_origin_ + glm::vec3(3.0f, 8.0f, 0.0f);
-            for (int i = 0; i < kPbdNodeCount; ++i) {
-                glm::vec3 p = top - glm::vec3(0.0f, static_cast<float>(i) * 3.0f, 0.0f);
-                pbd_nodes_[i].position = p;
-                pbd_nodes_[i].prev_position = p;
-                pbd_nodes_[i].velocity = glm::vec3(0.0f);
-                pbd_nodes_[i].inv_mass = (i == 0) ? 0.0f : 1.0f;
-            }
-            pbd_links_[0] = {0, 1, 3.0f, 0.8f};
-            pbd_links_[1] = {1, 2, 3.0f, 0.8f};
-            pbd_chain_active_ = true;
-            std::fprintf(stderr, "[IslandDemo] PBD chain demo ON (CPU, 3 nodes, 2 links)\n");
+    // Skip keyboard shortcuts when dev overlay has focus
+    if (!app.dev_overlay().wants_keyboard()) {
+        // Tab → cycle HUD mode: OFF → COMPACT → FULL → OFF
+        if (app.input().was_key_pressed(GLFW_KEY_TAB)) {
+            hud_mode_ = static_cast<HudMode>(
+                (static_cast<int>(hud_mode_) + 1) % 3);
         }
-    }
 
-    // Space → jump (if not already jumping)
-    if (app.input().was_key_pressed(GLFW_KEY_SPACE) && !jumping_) {
-        jumping_ = true;
-        jump_time_ = 0.0f;
-        auto* pe = app.bone_animation_registry().get(player_registry_id_);
-        if (pe) pe->requested_clip = "jump";
-    }
+        // P → toggle particles/emitters
+        if (app.input().was_key_pressed(GLFW_KEY_P)) {
+            auto& f = app.feature_flags();
+            f.particles = !f.particles;
+        }
 
+        // N → toggle terrain sway + walk animation
+        if (app.input().was_key_pressed(GLFW_KEY_N)) {
+            anim_enabled_ = !anim_enabled_;
+        }
 
-    // Handle mouse input for camera orbit
-    {
+        // G → toggle debug gizmos (lights, emitters, triggers)
+        if (app.input().was_key_pressed(GLFW_KEY_G)) {
+            show_gizmos_ = !show_gizmos_;
+            std::fprintf(stderr, "[IslandDemo] Debug gizmos %s\n", show_gizmos_ ? "ON" : "OFF");
+        }
+
+        // J → toggle PBD chain demo (CPU-side, rendered as dynamic Gaussians)
+        if (app.input().was_key_pressed(GLFW_KEY_J)) {
+            if (pbd_chain_active_) {
+                pbd_chain_active_ = false;
+                std::fprintf(stderr, "[IslandDemo] PBD chain demo OFF\n");
+            } else {
+                glm::vec3 top = character_origin_ + glm::vec3(3.0f, 8.0f, 0.0f);
+                for (int i = 0; i < kPbdNodeCount; ++i) {
+                    glm::vec3 p = top - glm::vec3(0.0f, static_cast<float>(i) * 3.0f, 0.0f);
+                    pbd_nodes_[i].position = p;
+                    pbd_nodes_[i].prev_position = p;
+                    pbd_nodes_[i].velocity = glm::vec3(0.0f);
+                    pbd_nodes_[i].inv_mass = (i == 0) ? 0.0f : 1.0f;
+                }
+                pbd_links_[0] = {0, 1, 3.0f, 0.8f};
+                pbd_links_[1] = {1, 2, 3.0f, 0.8f};
+                pbd_chain_active_ = true;
+                std::fprintf(stderr, "[IslandDemo] PBD chain demo ON (CPU, 3 nodes, 2 links)\n");
+            }
+        }
+
+        // Space → jump (if not already jumping)
+        if (app.input().was_key_pressed(GLFW_KEY_SPACE) && !jumping_) {
+            jumping_ = true;
+            jump_time_ = 0.0f;
+            auto* pe = app.bone_animation_registry().get(player_registry_id_);
+            if (pe) pe->requested_clip = "jump";
+        }
+    }  // end keyboard gating
+
+    // Handle mouse input for camera orbit (skip when dev overlay has mouse focus)
+    if (!app.dev_overlay().wants_mouse()) {
         auto& input = app.input();
         glm::vec2 mouse = input.mouse_pos();
         if (input.is_mouse_down(0)) {
@@ -628,8 +630,10 @@ void IslandDemoState::update(AppBase& app, float dt) {
         }
     }
 
-    // Player movement
-    update_player(app, dt);
+    // Player movement (skip when dev overlay has keyboard focus)
+    if (!app.dev_overlay().wants_keyboard()) {
+        update_player(app, dt);
+    }
 
     // Run ECS systems (proximity triggers, linked triggers, emissive toggle, NPC walker, bone animation)
     app.update_game(dt);

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -62,6 +62,9 @@ void AppBase::main_loop() {
     // Start control server for bridge integration
     control_server_.start();
 
+    // Initialize developer overlay (ImGui — no-op when GSEURAT_DEV_MODE is off)
+    dev_overlay_.init(window_, renderer_);
+
     while (!glfwWindowShouldClose(window_)) {
         glfwPollEvents();
 
@@ -86,6 +89,12 @@ void AppBase::main_loop() {
 
         debug_metrics_.update(dt);
 
+        // F1 → toggle developer overlay
+        if (input_.was_key_pressed(GLFW_KEY_F1)) {
+            dev_overlay_.toggle();
+        }
+        dev_overlay_.begin_frame();
+
         state_stack_.update(*this, dt);
         upload_bone_transforms();
         gameplay_.play_time += dt;
@@ -108,6 +117,12 @@ void AppBase::main_loop() {
 
         // Let states build their draw lists
         state_stack_.build_draw_lists(*this);
+
+        // Developer overlay (after states have drawn their content)
+        if (dev_overlay_.visible()) {
+            dev_overlay_.draw(*this);
+        }
+        dev_overlay_.end_frame();
 
         // Always render
         std::vector<SpriteDrawInfo> particle_sprites;
@@ -143,6 +158,7 @@ void AppBase::main_loop() {
 }
 
 void AppBase::cleanup() {
+    dev_overlay_.shutdown(renderer_);
     while (!state_stack_.empty()) {
         state_stack_.pop(*this);
     }

--- a/src/engine/dev_overlay.cpp
+++ b/src/engine/dev_overlay.cpp
@@ -1,0 +1,223 @@
+#ifdef GSEURAT_DEV_MODE
+
+#include "gseurat/engine/dev_overlay.hpp"
+#include "gseurat/engine/app_base.hpp"
+#include "gseurat/engine/renderer.hpp"
+#include "gseurat/engine/dev_panels.hpp"
+
+#include <imgui_impl_glfw.h>
+#include <imgui_impl_vulkan.h>
+
+#include <cstdio>
+
+namespace gseurat {
+
+void DevOverlay::init(GLFWwindow* window, Renderer& renderer) {
+    auto device = renderer.context().device();
+
+    // Descriptor pool for ImGui
+    VkDescriptorPoolSize pool_sizes[] = {
+        { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 100 },
+    };
+    VkDescriptorPoolCreateInfo pool_info{};
+    pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+    pool_info.maxSets = 100;
+    pool_info.poolSizeCount = 1;
+    pool_info.pPoolSizes = pool_sizes;
+    vkCreateDescriptorPool(device, &pool_info, nullptr, &imgui_pool_);
+
+    create_render_pass(renderer);
+    create_framebuffers(renderer);
+
+    // ImGui context + style
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO();
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+
+    ImGui::StyleColorsDark();
+    auto& style = ImGui::GetStyle();
+    style.WindowRounding = 4.0f;
+    style.FrameRounding = 2.0f;
+    style.Alpha = 0.95f;
+
+    // Platform/renderer backends
+    ImGui_ImplGlfw_InitForVulkan(window, true);
+
+    auto& swapchain = renderer.swapchain();
+    ImGui_ImplVulkan_InitInfo init_info{};
+    init_info.Instance = renderer.context().instance();
+    init_info.PhysicalDevice = renderer.context().physical_device();
+    init_info.Device = device;
+    init_info.QueueFamily = renderer.context().graphics_queue_family();
+    init_info.Queue = renderer.context().graphics_queue();
+    init_info.DescriptorPool = imgui_pool_;
+    init_info.MinImageCount = 2;
+    init_info.ImageCount = swapchain.image_count();
+    init_info.RenderPass = imgui_render_pass_;
+    ImGui_ImplVulkan_Init(&init_info);
+
+    // Set overlay callback on renderer
+    renderer.set_overlay_callback([this, &renderer](VkCommandBuffer cmd, uint32_t image_index) {
+        VkRenderPassBeginInfo rp_info{};
+        rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+        rp_info.renderPass = imgui_render_pass_;
+        rp_info.framebuffer = imgui_framebuffers_[image_index];
+        rp_info.renderArea.extent = renderer.swapchain().extent();
+        vkCmdBeginRenderPass(cmd, &rp_info, VK_SUBPASS_CONTENTS_INLINE);
+        ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), cmd);
+        vkCmdEndRenderPass(cmd);
+    });
+
+    // Register built-in engine panels
+    register_panel("Performance", draw_performance_panel);
+    register_panel("Render Settings", draw_render_settings_panel);
+    register_panel("GS Parameters", draw_gs_params_panel);
+    register_panel("Feature Toggles", draw_feature_toggles_panel);
+    register_panel("Lighting", draw_lighting_panel);
+    register_panel("Camera Info", draw_camera_info_panel);
+
+    std::fprintf(stderr, "[DevOverlay] Initialized (F1 to toggle)\n");
+}
+
+void DevOverlay::shutdown(Renderer& renderer) {
+    auto device = renderer.context().device();
+    vkDeviceWaitIdle(device);
+
+    renderer.set_overlay_callback(nullptr);
+
+    ImGui_ImplVulkan_Shutdown();
+    ImGui_ImplGlfw_Shutdown();
+    ImGui::DestroyContext();
+
+    for (auto fb : imgui_framebuffers_) {
+        vkDestroyFramebuffer(device, fb, nullptr);
+    }
+    imgui_framebuffers_.clear();
+
+    if (imgui_render_pass_ != VK_NULL_HANDLE) {
+        vkDestroyRenderPass(device, imgui_render_pass_, nullptr);
+        imgui_render_pass_ = VK_NULL_HANDLE;
+    }
+    if (imgui_pool_ != VK_NULL_HANDLE) {
+        vkDestroyDescriptorPool(device, imgui_pool_, nullptr);
+        imgui_pool_ = VK_NULL_HANDLE;
+    }
+}
+
+void DevOverlay::begin_frame() {
+    ImGui_ImplVulkan_NewFrame();
+    ImGui_ImplGlfw_NewFrame();
+    ImGui::NewFrame();
+}
+
+void DevOverlay::end_frame() {
+    ImGui::Render();
+}
+
+bool DevOverlay::wants_mouse() const {
+    return visible_ && ImGui::GetIO().WantCaptureMouse;
+}
+
+bool DevOverlay::wants_keyboard() const {
+    return visible_ && ImGui::GetIO().WantCaptureKeyboard;
+}
+
+void DevOverlay::draw(AppBase& app) {
+    if (!visible_) return;
+    draw_menu_bar();
+    for (auto& panel : panels_) {
+        if (panel.visible) {
+            panel.draw_fn(app);
+        }
+    }
+}
+
+void DevOverlay::register_panel(const std::string& name, PanelDrawFn fn, bool visible) {
+    panels_.push_back({name, std::move(fn), visible});
+}
+
+void DevOverlay::draw_menu_bar() {
+    if (ImGui::BeginMainMenuBar()) {
+        if (ImGui::BeginMenu("View")) {
+            for (auto& panel : panels_) {
+                ImGui::MenuItem(panel.name.c_str(), nullptr, &panel.visible);
+            }
+            ImGui::Separator();
+            if (ImGui::MenuItem("Show All")) {
+                for (auto& p : panels_) p.visible = true;
+            }
+            if (ImGui::MenuItem("Hide All")) {
+                for (auto& p : panels_) p.visible = false;
+            }
+            ImGui::EndMenu();
+        }
+        ImGui::EndMainMenuBar();
+    }
+}
+
+void DevOverlay::create_render_pass(Renderer& renderer) {
+    auto device = renderer.context().device();
+    auto format = renderer.swapchain().image_format();
+
+    VkAttachmentDescription attachment{};
+    attachment.format = format;
+    attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+    attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass{};
+    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass.colorAttachmentCount = 1;
+    subpass.pColorAttachments = &color_ref;
+
+    VkSubpassDependency dependency{};
+    dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+    dependency.dstSubpass = 0;
+    dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+
+    VkRenderPassCreateInfo rp_info{};
+    rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    rp_info.attachmentCount = 1;
+    rp_info.pAttachments = &attachment;
+    rp_info.subpassCount = 1;
+    rp_info.pSubpasses = &subpass;
+    rp_info.dependencyCount = 1;
+    rp_info.pDependencies = &dependency;
+
+    vkCreateRenderPass(device, &rp_info, nullptr, &imgui_render_pass_);
+}
+
+void DevOverlay::create_framebuffers(Renderer& renderer) {
+    auto device = renderer.context().device();
+    auto& swapchain = renderer.swapchain();
+
+    imgui_framebuffers_.resize(swapchain.image_count());
+    for (uint32_t i = 0; i < swapchain.image_count(); i++) {
+        VkFramebufferCreateInfo fb_info{};
+        fb_info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+        fb_info.renderPass = imgui_render_pass_;
+        fb_info.attachmentCount = 1;
+        fb_info.pAttachments = &swapchain.image_views()[i];
+        fb_info.width = swapchain.extent().width;
+        fb_info.height = swapchain.extent().height;
+        fb_info.layers = 1;
+        vkCreateFramebuffer(device, &fb_info, nullptr, &imgui_framebuffers_[i]);
+    }
+}
+
+}  // namespace gseurat
+
+#endif  // GSEURAT_DEV_MODE

--- a/src/engine/dev_overlay.cpp
+++ b/src/engine/dev_overlay.cpp
@@ -153,9 +153,13 @@ void DevOverlay::draw_menu_bar() {
             ImGui::Separator();
             if (ImGui::MenuItem("Show All")) {
                 for (auto& p : panels_) p.visible = true;
+                show_gizmo_lights = show_gizmo_emitters = show_gizmo_vfx = true;
+                show_gizmo_game_objects = show_gizmo_triggers = true;
             }
             if (ImGui::MenuItem("Hide All")) {
                 for (auto& p : panels_) p.visible = false;
+                show_gizmo_lights = show_gizmo_emitters = show_gizmo_vfx = false;
+                show_gizmo_game_objects = show_gizmo_triggers = false;
             }
             ImGui::EndMenu();
         }

--- a/src/engine/dev_overlay.cpp
+++ b/src/engine/dev_overlay.cpp
@@ -150,16 +150,21 @@ void DevOverlay::draw_menu_bar() {
             ImGui::MenuItem("Gizmo: VFX", nullptr, &show_gizmo_vfx);
             ImGui::MenuItem("Gizmo: Game Objects", nullptr, &show_gizmo_game_objects);
             ImGui::MenuItem("Gizmo: Triggers", nullptr, &show_gizmo_triggers);
+            ImGui::MenuItem("Gizmo: Camera Zones", nullptr, &show_gizmo_camera_zones);
+            ImGui::MenuItem("Gizmo: Portals", nullptr, &show_gizmo_portals);
+            ImGui::MenuItem("Gizmo: World", nullptr, &show_gizmo_world);
             ImGui::Separator();
             if (ImGui::MenuItem("Show All")) {
                 for (auto& p : panels_) p.visible = true;
                 show_gizmo_lights = show_gizmo_emitters = show_gizmo_vfx = true;
                 show_gizmo_game_objects = show_gizmo_triggers = true;
+                show_gizmo_camera_zones = show_gizmo_portals = show_gizmo_world = true;
             }
             if (ImGui::MenuItem("Hide All")) {
                 for (auto& p : panels_) p.visible = false;
                 show_gizmo_lights = show_gizmo_emitters = show_gizmo_vfx = false;
                 show_gizmo_game_objects = show_gizmo_triggers = false;
+                show_gizmo_camera_zones = show_gizmo_portals = show_gizmo_world = false;
             }
             ImGui::EndMenu();
         }

--- a/src/engine/dev_overlay.cpp
+++ b/src/engine/dev_overlay.cpp
@@ -145,6 +145,12 @@ void DevOverlay::draw_menu_bar() {
                 ImGui::MenuItem(panel.name.c_str(), nullptr, &panel.visible);
             }
             ImGui::Separator();
+            ImGui::MenuItem("Gizmo: Lights", nullptr, &show_gizmo_lights);
+            ImGui::MenuItem("Gizmo: Emitters", nullptr, &show_gizmo_emitters);
+            ImGui::MenuItem("Gizmo: VFX", nullptr, &show_gizmo_vfx);
+            ImGui::MenuItem("Gizmo: Game Objects", nullptr, &show_gizmo_game_objects);
+            ImGui::MenuItem("Gizmo: Triggers", nullptr, &show_gizmo_triggers);
+            ImGui::Separator();
             if (ImGui::MenuItem("Show All")) {
                 for (auto& p : panels_) p.visible = true;
             }

--- a/src/engine/dev_panels.cpp
+++ b/src/engine/dev_panels.cpp
@@ -1,0 +1,263 @@
+#ifdef GSEURAT_DEV_MODE
+
+#include "gseurat/engine/dev_panels.hpp"
+#include "gseurat/engine/app_base.hpp"
+#include "gseurat/engine/renderer.hpp"
+#include "gseurat/engine/gs_renderer.hpp"
+
+#include <imgui.h>
+#include <filesystem>
+
+namespace gseurat {
+
+void draw_performance_panel(AppBase& app) {
+    ImGui::SetNextWindowPos(ImVec2(10, 160), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(250, 200), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Performance")) {
+        ImGui::End();
+        return;
+    }
+
+    float fps_val = app.debug_metrics().fps;
+    ImGui::Text("FPS: %.1f (%.2f ms)", fps_val, fps_val > 0.0f ? 1000.0f / fps_val : 0.0f);
+
+    const auto& dm = app.debug_metrics();
+    float ordered[300];
+    for (int i = 0; i < 300; i++) {
+        ordered[i] = dm.frame_times[(dm.frame_time_idx + i) % 300];
+    }
+    ImGui::PlotLines("Frame Time", ordered, 300, 0, nullptr, 0.0f, 50.0f, ImVec2(0, 80));
+
+    if (app.renderer().has_gs_cloud()) {
+        auto& gs = app.renderer().gs_renderer();
+        ImGui::Text("Gaussian Count: %u", gs.gaussian_count());
+        ImGui::Text("Visible: %u", gs.visible_count());
+        ImGui::Text("Max Capacity: %u", gs.max_gaussian_count());
+    }
+
+    ImGui::End();
+}
+
+void draw_render_settings_panel(AppBase& app) {
+    ImGui::SetNextWindowPos(ImVec2(1020, 30), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(250, 400), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Render Settings")) {
+        ImGui::End();
+        return;
+    }
+
+    auto& pp = app.renderer().post_process_params();
+
+    if (ImGui::CollapsingHeader("Bloom", ImGuiTreeNodeFlags_DefaultOpen)) {
+        ImGui::SliderFloat("Threshold##bloom", &pp.bloom_threshold, 0.0f, 5.0f, "%.3f", ImGuiSliderFlags_NoInput);
+        ImGui::SliderFloat("Soft Knee##bloom", &pp.bloom_soft_knee, 0.0f, 1.0f, "%.3f", ImGuiSliderFlags_NoInput);
+        ImGui::SliderFloat("Intensity##bloom", &pp.bloom_intensity, 0.0f, 2.0f, "%.3f", ImGuiSliderFlags_NoInput);
+    }
+    if (ImGui::CollapsingHeader("Exposure")) {
+        ImGui::SliderFloat("Exposure##pp", &pp.exposure, 0.1f, 5.0f, "%.3f", ImGuiSliderFlags_NoInput);
+    }
+    if (ImGui::CollapsingHeader("Depth of Field")) {
+        ImGui::SliderFloat("Focus Distance##dof", &pp.dof_focus_distance, 0.1f, 200.0f, "%.3f", ImGuiSliderFlags_NoInput);
+        ImGui::SliderFloat("Focus Range##dof", &pp.dof_focus_range, 0.1f, 50.0f, "%.3f", ImGuiSliderFlags_NoInput);
+        ImGui::SliderFloat("Max Blur##dof", &pp.dof_max_blur, 0.0f, 2.0f, "%.3f", ImGuiSliderFlags_NoInput);
+    }
+    if (ImGui::CollapsingHeader("Vignette")) {
+        ImGui::SliderFloat("Radius##vig", &pp.vignette_radius, 0.0f, 1.5f, "%.3f", ImGuiSliderFlags_NoInput);
+        ImGui::SliderFloat("Softness##vig", &pp.vignette_softness, 0.0f, 1.0f, "%.3f", ImGuiSliderFlags_NoInput);
+    }
+    if (ImGui::CollapsingHeader("God Rays")) {
+        float gr = app.renderer().god_rays_intensity();
+        if (ImGui::SliderFloat("Intensity##godrays", &gr, 0.0f, 3.0f, "%.3f", ImGuiSliderFlags_NoInput)) {
+            app.renderer().set_god_rays_intensity(gr);
+        }
+    }
+
+    ImGui::End();
+}
+
+void draw_gs_params_panel(AppBase& app) {
+    if (!app.renderer().has_gs_cloud()) return;
+
+    ImGui::SetNextWindowPos(ImVec2(1020, 440), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(250, 250), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("GS Parameters")) {
+        ImGui::End();
+        return;
+    }
+
+    auto& gs = app.renderer().gs_renderer();
+
+    float scale = gs.scale_multiplier();
+    if (ImGui::SliderFloat("Scale", &scale, 0.1f, 10.0f, "%.3f", ImGuiSliderFlags_NoInput)) {
+        gs.set_scale_multiplier(scale);
+    }
+
+    int toon = gs.toon_bands();
+    if (ImGui::SliderInt("Toon Bands", &toon, 0, 5, "%d", ImGuiSliderFlags_NoInput)) {
+        gs.set_toon_bands(toon);
+    }
+
+    float pixel_intensity = gs.pixel_art_intensity();
+    if (ImGui::SliderFloat("Pixel Art", &pixel_intensity, 0.0f, 1.0f, "%.2f", ImGuiSliderFlags_NoInput)) {
+        gs.set_pixel_art_intensity(pixel_intensity);
+    }
+
+    ImGui::Separator();
+
+    int budget = static_cast<int>(app.renderer().gs_gaussian_budget());
+    if (ImGui::SliderInt("LOD Budget", &budget, 0, 500000, "%d", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoInput)) {
+        app.renderer().set_gs_gaussian_budget(static_cast<uint32_t>(budget));
+    }
+    ImGui::SameLine();
+    ImGui::TextDisabled("(0 = unlimited)");
+
+    if (budget > 0 && app.renderer().has_gs_cloud()) {
+        ImGui::Text("Active: %u / %u", gs.gaussian_count(), gs.max_gaussian_count());
+    }
+
+    ImGui::End();
+}
+
+void draw_feature_toggles_panel(AppBase& app) {
+    ImGui::SetNextWindowPos(ImVec2(10, 400), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(250, 350), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Feature Toggles")) {
+        ImGui::End();
+        return;
+    }
+
+    auto& f = app.feature_flags();
+
+    if (ImGui::CollapsingHeader("Post-Process", ImGuiTreeNodeFlags_DefaultOpen)) {
+        ImGui::Checkbox("Bloom", &f.bloom);
+        ImGui::Checkbox("Depth of Field", &f.depth_of_field);
+        ImGui::Checkbox("Vignette", &f.vignette);
+        ImGui::Checkbox("Tone Mapping", &f.tone_mapping);
+        ImGui::Checkbox("Screen Effects", &f.screen_effects);
+    }
+    if (ImGui::CollapsingHeader("GS Pipeline")) {
+        ImGui::Checkbox("GS Rendering", &f.gs_rendering);
+        ImGui::Checkbox("Chunk Culling", &f.gs_chunk_culling);
+        ImGui::Checkbox("LOD", &f.gs_lod);
+        ImGui::Checkbox("Adaptive Budget", &f.gs_adaptive_budget);
+    }
+    if (ImGui::CollapsingHeader("Scene")) {
+        ImGui::Checkbox("Particles", &f.particles);
+        ImGui::Checkbox("Animation", &f.animation);
+    }
+
+    ImGui::End();
+}
+
+void draw_lighting_panel(AppBase& app) {
+    if (!app.renderer().has_gs_cloud()) return;
+
+    ImGui::SetNextWindowPos(ImVec2(270, 30), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(300, 400), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Lighting")) {
+        ImGui::End();
+        return;
+    }
+
+    auto& gs = app.renderer().gs_renderer();
+
+    int light_mode = gs.light_mode();
+    const char* light_modes[] = {"Off", "Directional", "Point Lights"};
+    if (ImGui::Combo("Light Mode", &light_mode, light_modes, 3)) {
+        gs.set_light_mode(light_mode);
+    }
+
+    float intensity = gs.light_intensity();
+    if (ImGui::SliderFloat("Global Intensity", &intensity, 0.0f, 5.0f, "%.3f", ImGuiSliderFlags_NoInput)) {
+        gs.set_light_intensity(intensity);
+    }
+
+    ImGui::Separator();
+
+    auto ambient = app.scene().ambient_color();
+    float amb[4] = {ambient.r, ambient.g, ambient.b, ambient.a};
+    if (ImGui::ColorEdit4("Ambient", amb)) {
+        app.scene().set_ambient_color({amb[0], amb[1], amb[2], amb[3]});
+    }
+
+    ImGui::Separator();
+
+    auto lights = gs.point_lights();
+    bool lights_changed = false;
+    ImGui::Text("Point Lights: %zu / 8", lights.size());
+
+    for (size_t i = 0; i < lights.size(); i++) {
+        ImGui::PushID(static_cast<int>(i));
+        if (ImGui::CollapsingHeader(("Light " + std::to_string(i)).c_str())) {
+            float pos[3] = {lights[i].position_and_radius.x,
+                            lights[i].position_and_radius.y,
+                            lights[i].position_and_radius.z};
+            if (ImGui::DragFloat3("Position", pos, 0.5f)) {
+                lights[i].position_and_radius.x = pos[0];
+                lights[i].position_and_radius.y = pos[1];
+                lights[i].position_and_radius.z = pos[2];
+                lights_changed = true;
+            }
+            if (ImGui::DragFloat("Radius", &lights[i].position_and_radius.w, 0.5f, 0.1f, 500.0f)) {
+                lights_changed = true;
+            }
+            float col[3] = {lights[i].color.r, lights[i].color.g, lights[i].color.b};
+            if (ImGui::ColorEdit3("Color", col)) {
+                lights[i].color.r = col[0];
+                lights[i].color.g = col[1];
+                lights[i].color.b = col[2];
+                lights_changed = true;
+            }
+            if (ImGui::DragFloat("Intensity##light", &lights[i].color.a, 0.1f, 0.0f, 20.0f)) {
+                lights_changed = true;
+            }
+            if (ImGui::Button("Remove")) {
+                lights.erase(lights.begin() + static_cast<ptrdiff_t>(i));
+                lights_changed = true;
+                ImGui::PopID();
+                break;
+            }
+        }
+        ImGui::PopID();
+    }
+
+    if (lights.size() < 8 && ImGui::Button("+ Add Light")) {
+        PointLight new_light;
+        new_light.position_and_radius = glm::vec4(0.0f, 0.0f, 0.0f, 50.0f);
+        new_light.color = glm::vec4(1.0f, 1.0f, 1.0f, 5.0f);
+        lights.push_back(new_light);
+        lights_changed = true;
+        if (light_mode == 0) {
+            gs.set_light_mode(2);
+        }
+    }
+
+    if (lights_changed) {
+        gs.set_point_lights(lights);
+    }
+
+    ImGui::End();
+}
+
+void draw_camera_info_panel(AppBase& app) {
+    ImGui::SetNextWindowPos(ImVec2(10, 30), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(250, 120), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Camera Info")) {
+        ImGui::End();
+        return;
+    }
+
+    ImGui::Text("FPS: %.1f", app.debug_metrics().fps);
+    if (app.renderer().has_gs_cloud()) {
+        auto& gs = app.renderer().gs_renderer();
+        ImGui::Text("Gaussians: %u / %u", gs.visible_count(), gs.gaussian_count());
+    }
+    ImGui::Text("Scene: %s",
+        std::filesystem::path(app.scene_objects().current_scene_path).filename().string().c_str());
+
+    ImGui::End();
+}
+
+}  // namespace gseurat
+
+#endif  // GSEURAT_DEV_MODE

--- a/src/staging/camera_review_state.cpp
+++ b/src/staging/camera_review_state.cpp
@@ -4,8 +4,6 @@
 #include "gseurat/staging/camera_review_state.hpp"
 #include "gseurat/engine/input_manager.hpp"
 
-#include <imgui.h>
-
 #include <algorithm>
 #include <cmath>
 
@@ -317,6 +315,13 @@ int CameraReviewState::rail_count() const {
     return static_cast<int>(rails_.size());
 }
 
+}  // namespace gseurat (temporarily close for imgui include)
+
+#ifdef GSEURAT_DEV_MODE
+#include <imgui.h>
+
+namespace gseurat {
+
 // ── Gizmo rendering ─────────────────────────────────────────────────────────
 
 void CameraReviewState::draw_gizmos(const glm::mat4& vp, float screen_w,
@@ -547,3 +552,5 @@ void CameraReviewState::draw_gizmos(const glm::mat4& vp, float screen_w,
 }
 
 }  // namespace gseurat
+
+#endif  // GSEURAT_DEV_MODE

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -33,7 +33,7 @@ void StagingApp::run() {
     init_game_object_system();
     init_game_content();
     scene_objects_.current_scene_path = scene_path_;
-    set_start_state(std::make_unique<StagingState>());
+    state_stack_.push(std::make_unique<StagingState>(), *this);
     main_loop();
     cleanup();
 }

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -8,10 +8,6 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 
-#include <imgui.h>
-#include <imgui_impl_glfw.h>
-#include <imgui_impl_vulkan.h>
-
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
@@ -30,6 +26,16 @@ void StagingApp::parse_args(int argc, char* argv[]) {
             scene_path_ = argv[++i];
         }
     }
+}
+
+void StagingApp::run() {
+    command_dispatcher_.register_default_commands();
+    init_game_object_system();
+    init_game_content();
+    scene_objects_.current_scene_path = scene_path_;
+    set_start_state(std::make_unique<StagingState>());
+    main_loop();
+    cleanup();
 }
 
 void StagingApp::init_game_content() {
@@ -55,256 +61,6 @@ void StagingApp::init_game_content() {
     feature_flags_.animation = true;
     feature_flags_.fog = true;
     feature_flags_.apply_platform_defaults(renderer_.context().is_apple_gpu());
-
-    init_imgui();
-}
-
-void StagingApp::main_loop() {
-    scene_objects_.current_scene_path = scene_path_;
-    state_stack_.push(std::make_unique<StagingState>(), *this);
-
-    last_update_time_ = std::chrono::steady_clock::now();
-
-    // Initialize async loading subsystems
-    async_loader_.init();
-    staging_uploader_.init(
-        renderer_.context().device(), renderer_.context().allocator(),
-        renderer_.command_pool().pool(), renderer_.context().graphics_queue(),
-        [this](const std::string& cache_key, Texture tex) {
-            auto sp = std::make_shared<Texture>(std::move(tex));
-            resources_.texture_cache().insert(cache_key, std::move(sp));
-        });
-
-    // Start control server for bridge integration
-    control_server_.start();
-
-    while (!glfwWindowShouldClose(window_)) {
-        glfwPollEvents();
-
-        // Poll control server for bridge commands
-        poll_control_server();
-
-        resources_.process_async_results(async_loader_, staging_uploader_);
-        staging_uploader_.flush();
-
-        draw_lists_.overlay.clear();
-        draw_lists_.ui.clear();
-
-        input_.update();
-
-        auto now = std::chrono::steady_clock::now();
-        float dt = std::chrono::duration<float>(now - last_update_time_).count();
-        last_update_time_ = now;
-        if (dt > 0.1f) dt = 0.1f;
-
-        // ImGui new frame
-        ImGui_ImplVulkan_NewFrame();
-        ImGui_ImplGlfw_NewFrame();
-        ImGui::NewFrame();
-
-        state_stack_.update(*this, dt);
-        gameplay_.play_time += dt;
-        tick_++;
-
-        // Feed UI context
-        {
-            ui::UIInput ui_input;
-            ui_input.mouse_pos = input_.mouse_pos();
-            ui_input.mouse_down = input_.is_mouse_down(0);
-            ui_input.mouse_pressed = input_.was_mouse_pressed(0);
-            ui_input.key_up = false;
-            ui_input.key_down_nav = false;
-            ui_input.key_enter = false;
-            ui_input.key_escape = false;
-            ui_input.scroll_delta = 0.0f;
-            ui_ctx_.set_screen_height(720.0f);
-            ui_ctx_.begin_frame(ui_input);
-        }
-
-        state_stack_.build_draw_lists(*this);
-
-        std::vector<SpriteDrawInfo> particle_sprites;
-        particles_.generate_draw_infos(particle_sprites);
-
-        std::vector<ui::UIDrawBatch> ui_batches;
-
-        // Screen effects
-        if (feature_flags_.screen_effects) {
-            auto fc = screen_effects_.flash_color() * screen_effects_.flash_alpha();
-            renderer_.set_ca_intensity(screen_effects_.ca_intensity());
-            renderer_.set_flash_color(fc.r, fc.g, fc.b);
-        } else {
-            renderer_.set_ca_intensity(0.0f);
-            renderer_.set_flash_color(0.0f, 0.0f, 0.0f);
-        }
-
-        // Finalize ImGui (before draw_scene so overlay callback can render it)
-        ImGui::Render();
-
-        renderer_.draw_scene(scene_, draw_lists_.entity, draw_lists_.outline, draw_lists_.reflection,
-                             draw_lists_.shadow, particle_sprites, draw_lists_.overlay, ui_batches,
-                             feature_flags_);
-    }
-}
-
-void StagingApp::cleanup() {
-    vkDeviceWaitIdle(renderer_.context().device());
-    shutdown_imgui();
-
-    while (!state_stack_.empty()) {
-        state_stack_.pop(*this);
-    }
-    control_server_.stop();
-    async_loader_.shutdown();
-    staging_uploader_.shutdown();
-    audio_.shutdown();
-    // ResourceManager must shut down before Renderer, because Renderer::shutdown()
-    // destroys the VMA allocator — any textures still in cache would leak.
-    resources_.shutdown();
-    renderer_.shutdown();
-    glfwDestroyWindow(window_);
-    glfwTerminate();
-}
-
-void StagingApp::init_imgui() {
-    auto device = renderer_.context().device();
-
-    // Create descriptor pool for ImGui
-    VkDescriptorPoolSize pool_sizes[] = {
-        { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 100 },
-    };
-    VkDescriptorPoolCreateInfo pool_info{};
-    pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
-    pool_info.maxSets = 100;
-    pool_info.poolSizeCount = 1;
-    pool_info.pPoolSizes = pool_sizes;
-    vkCreateDescriptorPool(device, &pool_info, nullptr, &imgui_pool_);
-
-    // Create render pass that renders on top of swapchain images
-    create_imgui_render_pass();
-
-    // Create framebuffers for ImGui render pass
-    auto& swapchain = renderer_.swapchain();
-    imgui_framebuffers_.resize(swapchain.image_count());
-    for (uint32_t i = 0; i < swapchain.image_count(); i++) {
-        VkFramebufferCreateInfo fb_info{};
-        fb_info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-        fb_info.renderPass = imgui_render_pass_;
-        fb_info.attachmentCount = 1;
-        fb_info.pAttachments = &swapchain.image_views()[i];
-        fb_info.width = swapchain.extent().width;
-        fb_info.height = swapchain.extent().height;
-        fb_info.layers = 1;
-        vkCreateFramebuffer(device, &fb_info, nullptr, &imgui_framebuffers_[i]);
-    }
-
-    // Initialize ImGui
-    IMGUI_CHECKVERSION();
-    ImGui::CreateContext();
-    ImGuiIO& io = ImGui::GetIO();
-    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
-
-    // Style
-    ImGui::StyleColorsDark();
-    auto& style = ImGui::GetStyle();
-    style.WindowRounding = 4.0f;
-    style.FrameRounding = 2.0f;
-    style.Alpha = 0.95f;
-
-    // Init platform/renderer backends
-    ImGui_ImplGlfw_InitForVulkan(window_, true);
-
-    ImGui_ImplVulkan_InitInfo init_info{};
-    init_info.Instance = renderer_.context().instance();
-    init_info.PhysicalDevice = renderer_.context().physical_device();
-    init_info.Device = device;
-    init_info.QueueFamily = renderer_.context().graphics_queue_family();
-    init_info.Queue = renderer_.context().graphics_queue();
-    init_info.DescriptorPool = imgui_pool_;
-    init_info.MinImageCount = 2;
-    init_info.ImageCount = swapchain.image_count();
-    init_info.RenderPass = imgui_render_pass_;
-    ImGui_ImplVulkan_Init(&init_info);
-
-    // Set overlay callback on the renderer
-    renderer_.set_overlay_callback([this](VkCommandBuffer cmd, uint32_t image_index) {
-        VkRenderPassBeginInfo rp_info{};
-        rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-        rp_info.renderPass = imgui_render_pass_;
-        rp_info.framebuffer = imgui_framebuffers_[image_index];
-        rp_info.renderArea.extent = renderer_.swapchain().extent();
-        vkCmdBeginRenderPass(cmd, &rp_info, VK_SUBPASS_CONTENTS_INLINE);
-        ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), cmd);
-        vkCmdEndRenderPass(cmd);
-    });
-
-    std::fprintf(stderr, "[Staging] ImGui initialized\n");
-}
-
-void StagingApp::create_imgui_render_pass() {
-    auto device = renderer_.context().device();
-    auto format = renderer_.swapchain().image_format();
-
-    VkAttachmentDescription attachment{};
-    attachment.format = format;
-    attachment.samples = VK_SAMPLE_COUNT_1_BIT;
-    attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;  // preserve existing content
-    attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-    attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachment.initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-    attachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-
-    VkAttachmentReference color_ref{};
-    color_ref.attachment = 0;
-    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-    VkSubpassDescription subpass{};
-    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    subpass.colorAttachmentCount = 1;
-    subpass.pColorAttachments = &color_ref;
-
-    VkSubpassDependency dependency{};
-    dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependency.dstSubpass = 0;
-    dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependency.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-    dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-
-    VkRenderPassCreateInfo rp_info{};
-    rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-    rp_info.attachmentCount = 1;
-    rp_info.pAttachments = &attachment;
-    rp_info.subpassCount = 1;
-    rp_info.pSubpasses = &subpass;
-    rp_info.dependencyCount = 1;
-    rp_info.pDependencies = &dependency;
-
-    vkCreateRenderPass(device, &rp_info, nullptr, &imgui_render_pass_);
-}
-
-void StagingApp::shutdown_imgui() {
-    auto device = renderer_.context().device();
-
-    ImGui_ImplVulkan_Shutdown();
-    ImGui_ImplGlfw_Shutdown();
-    ImGui::DestroyContext();
-
-    for (auto fb : imgui_framebuffers_) {
-        vkDestroyFramebuffer(device, fb, nullptr);
-    }
-    imgui_framebuffers_.clear();
-
-    if (imgui_render_pass_) {
-        vkDestroyRenderPass(device, imgui_render_pass_, nullptr);
-        imgui_render_pass_ = VK_NULL_HANDLE;
-    }
-    if (imgui_pool_) {
-        vkDestroyDescriptorPool(device, imgui_pool_, nullptr);
-        imgui_pool_ = VK_NULL_HANDLE;
-    }
 }
 
 // ── Scene loading (reuse from DemoApp pattern) ──

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -8,7 +8,9 @@
 #include "gseurat/engine/world_manifest.hpp"
 #include "gseurat/engine/project_root.hpp"
 
+#ifdef GSEURAT_DEV_MODE
 #include <imgui.h>
+#endif
 
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
@@ -178,10 +180,15 @@ void StagingState::on_enter(AppBase& app) {
         [this, &app](const json& /*cmd*/) -> CommandResult {
             VisualState vs;
 
-            // Display size from ImGui
+            // Display size
+#ifdef GSEURAT_DEV_MODE
             auto& io = ImGui::GetIO();
             float dw = io.DisplaySize.x;
             float dh = io.DisplaySize.y;
+#else
+            float dw = 1280.0f;
+            float dh = 720.0f;
+#endif
 
             // Panels — DevOverlay manages visibility now; report overlay state
             bool overlay_vis = app.dev_overlay().visible();
@@ -357,10 +364,12 @@ void StagingState::update(AppBase& app, float dt) {
         last_mouse_x_ = mx;
         last_mouse_y_ = my;
 
-        // Only block WASD when user is actively typing in an ImGui text field,
-        // not just when a window has focus (WantCaptureKeyboard is too broad).
-        auto& io = ImGui::GetIO();
-        bool typing_in_widget = ImGui::IsAnyItemActive() && io.WantTextInput;
+        // Only block WASD when user is actively typing in an ImGui text field
+#ifdef GSEURAT_DEV_MODE
+        bool typing_in_widget = ImGui::IsAnyItemActive() && ImGui::GetIO().WantTextInput;
+#else
+        bool typing_in_widget = false;
+#endif
         camera_review_->update(dt, app.input(), wants_mouse, typing_in_widget,
                                mouse_dx, mouse_dy);
 
@@ -391,11 +400,12 @@ void StagingState::update(AppBase& app, float dt) {
         bool right_pressed = right_down && !right_click_prev_;
         right_click_prev_ = right_down;
         if (!wants_mouse && right_pressed) {
-            auto& io2 = ImGui::GetIO();
             double tmx, tmy;
             glfwGetCursorPos(app.window(), &tmx, &tmy);
-            float ndc_x = (2.0f * static_cast<float>(tmx) / io2.DisplaySize.x) - 1.0f;
-            float ndc_y = 1.0f - (2.0f * static_cast<float>(tmy) / io2.DisplaySize.y);
+            int win_w, win_h;
+            glfwGetWindowSize(app.window(), &win_w, &win_h);
+            float ndc_x = (2.0f * static_cast<float>(tmx) / static_cast<float>(win_w)) - 1.0f;
+            float ndc_y = 1.0f - (2.0f * static_cast<float>(tmy) / static_cast<float>(win_h));
             glm::mat4 inv_vp = glm::inverse(gs_vp_);
             glm::vec4 near_clip = inv_vp * glm::vec4(ndc_x, ndc_y, 0.0f, 1.0f);
             glm::vec4 far_clip  = inv_vp * glm::vec4(ndc_x, ndc_y, 1.0f, 1.0f);
@@ -565,8 +575,10 @@ void StagingState::update(AppBase& app, float dt) {
         }
     }
 
+#ifdef GSEURAT_DEV_MODE
     // Draw gizmos (always, DevOverlay handles panel visibility)
     draw_gizmos(app);
+#endif
 
     // Update screen effects
     app.screen_effects().update(dt);
@@ -575,6 +587,8 @@ void StagingState::update(AppBase& app, float dt) {
 void StagingState::build_draw_lists(AppBase& /*app*/) {
     // No sprite draw lists — ImGui handles everything
 }
+
+#ifdef GSEURAT_DEV_MODE
 
 // ── Staging-specific panels ──
 
@@ -1151,6 +1165,8 @@ void StagingState::draw_gizmos(AppBase& app) {
         }
     }
 }
+
+#endif  // GSEURAT_DEV_MODE
 
 void StagingState::load_character(const std::string& manifest_path, AppBase& app) {
     auto data = load_character_manifest(manifest_path);

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -915,13 +915,7 @@ static void draw_region_gizmo(ImDrawList* dl, const GsAnimRegion& region,
 void StagingState::draw_gizmos(AppBase& app) {
     if (!app.renderer().has_gs_cloud()) return;
 
-    static bool show_lights = true;
-    static bool show_emitters = true;
-    static bool show_vfx = true;
-    static bool show_game_objects = true;
-    static bool show_camera_zones = true;
-    static bool show_portals = true;
-    static bool show_world = true;
+    auto& ov = app.dev_overlay();
 
     const glm::mat4& vp = gs_vp_;  // computed once in update()
     auto& gs = app.renderer().gs_renderer();
@@ -933,7 +927,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     ImDrawList* dl = ImGui::GetForegroundDrawList();
 
     // ── Light gizmos ──
-    if (show_lights) {
+    if (ov.show_gizmo_lights) {
         const auto& lights = gs.point_lights();
         for (size_t i = 0; i < lights.size(); i++) {
             glm::vec3 pos(lights[i].position_and_radius.x,
@@ -956,7 +950,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     }
 
     // ── Standalone emitter gizmos (with spawn region) ──
-    if (show_emitters) {
+    if (ov.show_gizmo_emitters) {
         ImU32 emitter_col = IM_COL32(236, 72, 153, 200);  // pink
         auto& emitters = app.renderer().gs_particle_emitters();
         for (size_t i = 0; i < emitters.size(); i++) {
@@ -976,7 +970,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     }
 
     // ── Scene animation gizmos (region wireframes) ──
-    if (show_vfx) {
+    if (ov.show_gizmo_vfx) {
         ImU32 anim_col = IM_COL32(6, 182, 212, 180);  // cyan
         const auto& anims = app.renderer().gs_scene_animations();
         for (size_t i = 0; i < anims.size(); i++) {
@@ -993,7 +987,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     }
 
     // ── VFX instance gizmos (with element details) ──
-    if (show_vfx) {
+    if (ov.show_gizmo_vfx) {
         const auto& vfx = app.renderer().vfx_instances();
         for (size_t i = 0; i < vfx.size(); i++) {
             auto inst_pos = vfx[i].position();
@@ -1049,7 +1043,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     }
 
     // ── Game Object gizmos ──
-    if (show_game_objects) {
+    if (ov.show_gizmo_game_objects) {
         ImU32 go_col = IM_COL32(68, 136, 255, 200);       // blue
         ImU32 go_col_static = IM_COL32(136, 136, 136, 150); // gray for no-component
         const auto& game_objects = app.scene_objects().game_objects;
@@ -1078,7 +1072,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     }
 
     // ── Portal gizmos ──
-    if (show_portals) {
+    if (ov.show_gizmo_portals) {
         ImU32 portal_col = IM_COL32(0, 220, 220, 200);  // cyan
         const auto& portals = app.scene_objects().portals;
         auto terrain_aabb = app.gs_terrain().terrain_aabb;
@@ -1110,12 +1104,12 @@ void StagingState::draw_gizmos(AppBase& app) {
     }
 
     // ── Camera Zone gizmos (visible in both orbit and review modes) ──
-    if (show_camera_zones && camera_review_ && camera_review_->has_zone_data()) {
+    if (ov.show_gizmo_camera_zones && camera_review_ && camera_review_->has_zone_data()) {
         camera_review_->draw_gizmos(vp, sw, sh, dl, project_wrapper, this);
     }
 
     // ── World manifest gizmos ──
-    if (show_world && app.scene_objects().world_manifest.has_value()) {
+    if (ov.show_gizmo_world && app.scene_objects().world_manifest.has_value()) {
         const auto& wm = *app.scene_objects().world_manifest;
 
         // Chunk wireframes (green)

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -79,6 +79,16 @@ void StagingState::on_enter(AppBase& app) {
     }
     std::fprintf(stderr, "[Staging] Ready\n");
 
+    // Register staging-specific panels
+    app.dev_overlay().register_panel("Scene", [this](AppBase& a) { draw_scene_panel(a); });
+    app.dev_overlay().register_panel("Character", [this](AppBase& a) { draw_character_panel(a); });
+    app.dev_overlay().register_panel("Camera", [this](AppBase& a) { draw_camera_panel(a); });
+
+    // Auto-show dev overlay in staging
+    if (!app.dev_overlay().visible()) {
+        app.dev_overlay().toggle();
+    }
+
     // ── Register camera review control-server commands ──
     using json = nlohmann::json;
 
@@ -173,34 +183,34 @@ void StagingState::on_enter(AppBase& app) {
             float dw = io.DisplaySize.x;
             float dh = io.DisplaySize.y;
 
-            // Panels — report visibility; geometry is 0 since imgui_internal.h
-            // is not included (FindWindowByName unavailable).
+            // Panels — DevOverlay manages visibility now; report overlay state
+            bool overlay_vis = app.dev_overlay().visible();
             auto add_panel = [&](const char* name, bool visible) {
                 vs.panels.push_back({name, visible, 0, 0, 0, 0, dw, dh});
             };
-            add_panel("Viewport Info", show_viewport_info_);
-            add_panel("Render Settings", show_render_settings_);
-            add_panel("GS Parameters", show_gs_params_);
-            add_panel("Feature Toggles", show_feature_toggles_);
-            add_panel("Lighting", show_lighting_);
-            add_panel("Camera", show_camera_);
-            add_panel("Performance", show_performance_);
+            add_panel("Viewport Info", overlay_vis);
+            add_panel("Render Settings", overlay_vis);
+            add_panel("GS Parameters", overlay_vis);
+            add_panel("Feature Toggles", overlay_vis);
+            add_panel("Lighting", overlay_vis);
+            add_panel("Camera", overlay_vis);
+            add_panel("Performance", overlay_vis);
             add_panel("Character", show_character_);
 
-            // Gizmos
+            // Gizmos — always visible (managed by static bools in draw_gizmos)
             auto& sd = last_scene_data_;
-            vs.gizmos.push_back({"lights", show_gizmo_lights_,
+            vs.gizmos.push_back({"lights", true,
                 sd ? static_cast<int>(sd->static_lights.size()) : 0});
-            vs.gizmos.push_back({"emitters", show_gizmo_emitters_,
+            vs.gizmos.push_back({"emitters", true,
                 sd ? static_cast<int>(sd->gs_particle_emitters.size()) : 0});
-            vs.gizmos.push_back({"vfx_instances", show_gizmo_vfx_,
+            vs.gizmos.push_back({"vfx_instances", true,
                 sd ? static_cast<int>(sd->vfx_instances.size()) : 0});
-            vs.gizmos.push_back({"game_objects", show_gizmo_game_objects_,
+            vs.gizmos.push_back({"game_objects", true,
                 sd ? static_cast<int>(sd->game_objects.size()) : 0});
-            vs.gizmos.push_back({"camera_zones", show_gizmo_camera_zones_,
+            vs.gizmos.push_back({"camera_zones", true,
                 sd && sd->camera_zones
                     ? static_cast<int>(sd->camera_zones->volumes.size()) : 0});
-            vs.gizmos.push_back({"portals", show_gizmo_portals_,
+            vs.gizmos.push_back({"portals", true,
                 sd ? static_cast<int>(sd->portals.size()) : 0});
 
             // Scene
@@ -327,7 +337,8 @@ void StagingState::update(AppBase& app, float dt) {
     anim_time_ += dt;
     app.renderer().gs_renderer().set_effect_time(anim_time_);
 
-    auto& io = ImGui::GetIO();
+    bool wants_mouse = app.dev_overlay().wants_mouse();
+    bool wants_keyboard = app.dev_overlay().wants_keyboard();
 
     if (camera_review_ && camera_review_->is_active()) {
         // ── Camera Review Mode ──
@@ -338,7 +349,7 @@ void StagingState::update(AppBase& app, float dt) {
         // Only pass mouse delta when left-dragging (like orbit camera)
         float mouse_dx = 0.0f;
         float mouse_dy = 0.0f;
-        if (!io.WantCaptureMouse &&
+        if (!wants_mouse &&
             glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS) {
             mouse_dx = static_cast<float>(mx - last_mouse_x_) * kOrbitSensitivity;
             mouse_dy = static_cast<float>(my - last_mouse_y_) * kOrbitSensitivity;
@@ -348,8 +359,9 @@ void StagingState::update(AppBase& app, float dt) {
 
         // Only block WASD when user is actively typing in an ImGui text field,
         // not just when a window has focus (WantCaptureKeyboard is too broad).
+        auto& io = ImGui::GetIO();
         bool typing_in_widget = ImGui::IsAnyItemActive() && io.WantTextInput;
-        camera_review_->update(dt, app.input(), io.WantCaptureMouse, typing_in_widget,
+        camera_review_->update(dt, app.input(), wants_mouse, typing_in_widget,
                                mouse_dx, mouse_dy);
 
         // Build view/proj from CameraState
@@ -370,24 +382,20 @@ void StagingState::update(AppBase& app, float dt) {
         }
 
         // R key → reset player
-        if (!io.WantCaptureKeyboard && app.input().was_key_pressed(GLFW_KEY_R)) {
+        if (!wants_keyboard && app.input().was_key_pressed(GLFW_KEY_R)) {
             camera_review_->reset_player();
-        }
-
-        // Toggle UI visibility (Tab)
-        if (!io.WantCaptureKeyboard && app.input().was_key_pressed(GLFW_KEY_TAB)) {
-            hide_ui_ = !hide_ui_;
         }
 
         // Right-click teleport via ground plane raycast (edge-triggered)
         bool right_down = glfwGetMouseButton(app.window(), GLFW_MOUSE_BUTTON_RIGHT) == GLFW_PRESS;
         bool right_pressed = right_down && !right_click_prev_;
         right_click_prev_ = right_down;
-        if (!io.WantCaptureMouse && right_pressed) {
+        if (!wants_mouse && right_pressed) {
+            auto& io2 = ImGui::GetIO();
             double tmx, tmy;
             glfwGetCursorPos(app.window(), &tmx, &tmy);
-            float ndc_x = (2.0f * static_cast<float>(tmx) / io.DisplaySize.x) - 1.0f;
-            float ndc_y = 1.0f - (2.0f * static_cast<float>(tmy) / io.DisplaySize.y);
+            float ndc_x = (2.0f * static_cast<float>(tmx) / io2.DisplaySize.x) - 1.0f;
+            float ndc_y = 1.0f - (2.0f * static_cast<float>(tmy) / io2.DisplaySize.y);
             glm::mat4 inv_vp = glm::inverse(gs_vp_);
             glm::vec4 near_clip = inv_vp * glm::vec4(ndc_x, ndc_y, 0.0f, 1.0f);
             glm::vec4 far_clip  = inv_vp * glm::vec4(ndc_x, ndc_y, 1.0f, 1.0f);
@@ -406,7 +414,7 @@ void StagingState::update(AppBase& app, float dt) {
     } else {
         // ── Orbit Camera (default) ──
         // Camera orbit — only when ImGui doesn't want the mouse
-        if (!io.WantCaptureMouse) {
+        if (!wants_mouse) {
             auto* window = app.window();
             double mx, my;
             glfwGetCursorPos(window, &mx, &my);
@@ -447,13 +455,8 @@ void StagingState::update(AppBase& app, float dt) {
                 distance_ = std::max(1.0f, distance_);
             }
 
-            // Toggle UI visibility (Tab)
-            if (app.input().was_key_pressed(GLFW_KEY_TAB)) {
-                hide_ui_ = !hide_ui_;
-            }
-
             // Reset camera
-            if (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS && !io.WantCaptureKeyboard) {
+            if (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS && !wants_keyboard) {
                 azimuth_ = 0.0f;
                 elevation_ = 0.3f;
                 distance_ = 100.0f;
@@ -562,10 +565,8 @@ void StagingState::update(AppBase& app, float dt) {
         }
     }
 
-    // Draw ImGui (hidden with Tab)
-    if (!hide_ui_) {
-        draw_imgui(app);
-    }
+    // Draw gizmos (always, DevOverlay handles panel visibility)
+    draw_gizmos(app);
 
     // Update screen effects
     app.screen_effects().update(dt);
@@ -575,314 +576,31 @@ void StagingState::build_draw_lists(AppBase& /*app*/) {
     // No sprite draw lists — ImGui handles everything
 }
 
-// ── ImGui Panels ──
+// ── Staging-specific panels ──
 
-void StagingState::draw_imgui(AppBase& app) {
-    // Main menu bar
-    if (ImGui::BeginMainMenuBar()) {
-        if (ImGui::BeginMenu("Scene")) {
-            if (ImGui::MenuItem("Reload")) {
-                app.clear_scene();
-                app.init_scene(app.scene_objects().current_scene_path);
-                camera_initialized_ = false;
-            }
-            ImGui::Separator();
-            for (const auto& path : scene_files_) {
-                auto name = std::filesystem::path(path).filename().string();
-                if (ImGui::MenuItem(name.c_str())) {
-                    app.clear_scene();
-                    app.init_scene(path);
-                    camera_initialized_ = false;
-                }
-            }
-            ImGui::EndMenu();
-        }
-        if (ImGui::BeginMenu("View")) {
-            ImGui::MenuItem("Viewport Info", nullptr, &show_viewport_info_);
-            ImGui::MenuItem("Render Settings", nullptr, &show_render_settings_);
-            ImGui::MenuItem("GS Parameters", nullptr, &show_gs_params_);
-            ImGui::MenuItem("Feature Toggles", nullptr, &show_feature_toggles_);
-            ImGui::MenuItem("Lighting", nullptr, &show_lighting_);
-            ImGui::MenuItem("Camera", nullptr, &show_camera_);
-            ImGui::MenuItem("Performance", nullptr, &show_performance_);
-            ImGui::MenuItem("Character", nullptr, &show_character_);
-            ImGui::Separator();
-            ImGui::MenuItem("Gizmo: Lights", nullptr, &show_gizmo_lights_);
-            ImGui::MenuItem("Gizmo: Emitters", nullptr, &show_gizmo_emitters_);
-            ImGui::MenuItem("Gizmo: VFX", nullptr, &show_gizmo_vfx_);
-            ImGui::MenuItem("Gizmo: Game Objects", nullptr, &show_gizmo_game_objects_);
-            ImGui::MenuItem("Gizmo: Camera Zones", nullptr, &show_gizmo_camera_zones_);
-            ImGui::MenuItem("Gizmo: Portals", nullptr, &show_gizmo_portals_);
-            ImGui::MenuItem("Gizmo: World", nullptr, &show_gizmo_world_);
-            ImGui::Separator();
-            if (ImGui::MenuItem("Deselect All")) {
-                show_viewport_info_ = false;
-                show_render_settings_ = false;
-                show_gs_params_ = false;
-                show_feature_toggles_ = false;
-                show_lighting_ = false;
-                show_camera_ = false;
-                show_performance_ = false;
-                show_character_ = false;
-                show_gizmo_lights_ = false;
-                show_gizmo_emitters_ = false;
-                show_gizmo_vfx_ = false;
-                show_gizmo_game_objects_ = false;
-                show_gizmo_camera_zones_ = false;
-                show_gizmo_portals_ = false;
-                show_gizmo_world_ = false;
-            }
-            ImGui::EndMenu();
-        }
-        ImGui::EndMainMenuBar();
-    }
-
-    if (show_viewport_info_) draw_viewport_info(app);
-    if (show_render_settings_) draw_render_settings(app);
-    if (show_gs_params_) draw_gs_params(app);
-    if (show_feature_toggles_) draw_feature_toggles(app);
-    if (show_lighting_) draw_lighting(app);
-    if (show_camera_) draw_camera_panel(app);
-    if (show_performance_) draw_performance(app);
-    if (show_character_) draw_character_panel(app);
-    draw_gizmos(app);
-}
-
-void StagingState::draw_viewport_info(AppBase& app) {
+void StagingState::draw_scene_panel(AppBase& app) {
     ImGui::SetNextWindowPos(ImVec2(10, 30), ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(250, 120), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Viewport Info", nullptr, ImGuiWindowFlags_NoCollapse)) {
+    ImGui::SetNextWindowSize(ImVec2(250, 150), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Scene")) {
         ImGui::End();
         return;
     }
-
-    ImGui::Text("FPS: %.1f", app.debug_metrics().fps);
-    if (app.renderer().has_gs_cloud()) {
-        auto& gs = app.renderer().gs_renderer();
-        ImGui::Text("Gaussians: %u / %u", gs.visible_count(), gs.gaussian_count());
+    ImGui::Text("Scene: %s",
+        std::filesystem::path(app.scene_objects().current_scene_path).filename().string().c_str());
+    if (ImGui::Button("Reload")) {
+        app.clear_scene();
+        app.init_scene(app.scene_objects().current_scene_path);
+        camera_initialized_ = false;
     }
-    ImGui::Text("Scene: %s", std::filesystem::path(app.scene_objects().current_scene_path).filename().string().c_str());
     ImGui::Separator();
-    if (camera_review_ && camera_review_->is_active()) {
-        auto pos = camera_review_->player_position();
-        ImGui::Text("Player: %.1f, %.1f, %.1f", pos.x, pos.y, pos.z);
-        auto zone = camera_review_->active_zone_name();
-        ImGui::Text("Zone: %s", zone.c_str());
-        ImGui::Separator();
-        ImGui::TextDisabled("WASD: Move  Right-click: Teleport");
-        ImGui::TextDisabled("R: Reset  Tab: Hide UI");
-    } else {
-        ImGui::Text("Az: %.1f  El: %.1f  Dist: %.1f", azimuth_ * 57.2958f, elevation_ * 57.2958f, distance_);
-        ImGui::Text("Target: %.1f, %.1f, %.1f", target_.x, target_.y, target_.z);
-        ImGui::Separator();
-        ImGui::TextDisabled("Drag: Orbit  Shift+Drag: Pan  Scroll: Zoom");
-        ImGui::TextDisabled("R: Reset  Tab: Hide UI");
-    }
-
-    ImGui::End();
-}
-
-void StagingState::draw_render_settings(AppBase& app) {
-    ImGui::SetNextWindowPos(ImVec2(1020, 30), ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(250, 400), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Render Settings")) {
-        ImGui::End();
-        return;
-    }
-
-    auto& pp = app.renderer().post_process_params();
-
-    if (ImGui::CollapsingHeader("Bloom", ImGuiTreeNodeFlags_DefaultOpen)) {
-        ImGui::SliderFloat("Threshold##bloom", &pp.bloom_threshold, 0.0f, 5.0f, "%.3f", ImGuiSliderFlags_NoInput);
-        ImGui::SliderFloat("Soft Knee##bloom", &pp.bloom_soft_knee, 0.0f, 1.0f, "%.3f", ImGuiSliderFlags_NoInput);
-        ImGui::SliderFloat("Intensity##bloom", &pp.bloom_intensity, 0.0f, 2.0f, "%.3f", ImGuiSliderFlags_NoInput);
-    }
-    if (ImGui::CollapsingHeader("Exposure")) {
-        ImGui::SliderFloat("Exposure##pp", &pp.exposure, 0.1f, 5.0f, "%.3f", ImGuiSliderFlags_NoInput);
-    }
-    if (ImGui::CollapsingHeader("Depth of Field")) {
-        ImGui::SliderFloat("Focus Distance##dof", &pp.dof_focus_distance, 0.1f, 200.0f, "%.3f", ImGuiSliderFlags_NoInput);
-        ImGui::SliderFloat("Focus Range##dof", &pp.dof_focus_range, 0.1f, 50.0f, "%.3f", ImGuiSliderFlags_NoInput);
-        ImGui::SliderFloat("Max Blur##dof", &pp.dof_max_blur, 0.0f, 2.0f, "%.3f", ImGuiSliderFlags_NoInput);
-    }
-    if (ImGui::CollapsingHeader("Vignette")) {
-        ImGui::SliderFloat("Radius##vig", &pp.vignette_radius, 0.0f, 1.5f, "%.3f", ImGuiSliderFlags_NoInput);
-        ImGui::SliderFloat("Softness##vig", &pp.vignette_softness, 0.0f, 1.0f, "%.3f", ImGuiSliderFlags_NoInput);
-    }
-    if (ImGui::CollapsingHeader("God Rays")) {
-        float gr = app.renderer().god_rays_intensity();
-        if (ImGui::SliderFloat("Intensity##godrays", &gr, 0.0f, 3.0f, "%.3f", ImGuiSliderFlags_NoInput)) {
-            app.renderer().set_god_rays_intensity(gr);
+    for (const auto& path : scene_files_) {
+        auto name = std::filesystem::path(path).filename().string();
+        if (ImGui::MenuItem(name.c_str())) {
+            app.clear_scene();
+            app.init_scene(path);
+            camera_initialized_ = false;
         }
     }
-
-    ImGui::End();
-}
-
-void StagingState::draw_gs_params(AppBase& app) {
-    if (!app.renderer().has_gs_cloud()) return;
-
-    ImGui::SetNextWindowPos(ImVec2(1020, 440), ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(250, 250), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("GS Parameters")) {
-        ImGui::End();
-        return;
-    }
-
-    auto& gs = app.renderer().gs_renderer();
-
-    float scale = gs.scale_multiplier();
-    if (ImGui::SliderFloat("Scale", &scale, 0.1f, 10.0f, "%.3f", ImGuiSliderFlags_NoInput)) {
-        gs.set_scale_multiplier(scale);
-    }
-
-    int toon = gs.toon_bands();
-    if (ImGui::SliderInt("Toon Bands", &toon, 0, 5, "%d", ImGuiSliderFlags_NoInput)) {
-        gs.set_toon_bands(toon);
-    }
-
-    float pixel_intensity = gs.pixel_art_intensity();
-    if (ImGui::SliderFloat("Pixel Art", &pixel_intensity, 0.0f, 1.0f, "%.2f", ImGuiSliderFlags_NoInput)) {
-        gs.set_pixel_art_intensity(pixel_intensity);
-    }
-
-    ImGui::Separator();
-
-    int budget = static_cast<int>(app.renderer().gs_gaussian_budget());
-    if (ImGui::SliderInt("LOD Budget", &budget, 0, 500000, "%d", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoInput)) {
-        app.renderer().set_gs_gaussian_budget(static_cast<uint32_t>(budget));
-    }
-    ImGui::SameLine();
-    ImGui::TextDisabled("(0 = unlimited)");
-
-    if (budget > 0 && app.renderer().has_gs_cloud()) {
-        ImGui::Text("Active: %u / %u", gs.gaussian_count(), gs.max_gaussian_count());
-    }
-
-    ImGui::End();
-}
-
-void StagingState::draw_feature_toggles(AppBase& app) {
-    ImGui::SetNextWindowPos(ImVec2(10, 400), ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(250, 350), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Feature Toggles")) {
-        ImGui::End();
-        return;
-    }
-
-    auto& f = app.feature_flags();
-
-    if (ImGui::CollapsingHeader("Post-Process", ImGuiTreeNodeFlags_DefaultOpen)) {
-        ImGui::Checkbox("Bloom", &f.bloom);
-        ImGui::Checkbox("Depth of Field", &f.depth_of_field);
-        ImGui::Checkbox("Vignette", &f.vignette);
-        ImGui::Checkbox("Tone Mapping", &f.tone_mapping);
-        ImGui::Checkbox("Screen Effects", &f.screen_effects);
-    }
-    if (ImGui::CollapsingHeader("GS Pipeline")) {
-        ImGui::Checkbox("GS Rendering", &f.gs_rendering);
-        ImGui::Checkbox("Chunk Culling", &f.gs_chunk_culling);
-        ImGui::Checkbox("LOD", &f.gs_lod);
-        ImGui::Checkbox("Adaptive Budget", &f.gs_adaptive_budget);
-    }
-    if (ImGui::CollapsingHeader("Scene")) {
-        ImGui::Checkbox("Particles", &f.particles);
-        ImGui::Checkbox("Animation", &f.animation);
-    }
-
-    ImGui::End();
-}
-
-void StagingState::draw_lighting(AppBase& app) {
-    if (!app.renderer().has_gs_cloud()) return;
-
-    ImGui::SetNextWindowPos(ImVec2(270, 30), ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(300, 400), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Lighting")) {
-        ImGui::End();
-        return;
-    }
-
-    auto& gs = app.renderer().gs_renderer();
-
-    // Light mode
-    int light_mode = gs.light_mode();
-    const char* light_modes[] = {"Off", "Directional", "Point Lights"};
-    if (ImGui::Combo("Light Mode", &light_mode, light_modes, 3)) {
-        gs.set_light_mode(light_mode);
-    }
-
-    float intensity = gs.light_intensity();
-    if (ImGui::SliderFloat("Global Intensity", &intensity, 0.0f, 5.0f, "%.3f", ImGuiSliderFlags_NoInput)) {
-        gs.set_light_intensity(intensity);
-    }
-
-    ImGui::Separator();
-
-    // Ambient
-    auto ambient = app.scene().ambient_color();
-    float amb[4] = {ambient.r, ambient.g, ambient.b, ambient.a};
-    if (ImGui::ColorEdit4("Ambient", amb)) {
-        app.scene().set_ambient_color({amb[0], amb[1], amb[2], amb[3]});
-    }
-
-    ImGui::Separator();
-
-    // Point lights list
-    auto lights = gs.point_lights();  // copy for editing
-    bool lights_changed = false;
-    ImGui::Text("Point Lights: %zu / 8", lights.size());
-
-    for (size_t i = 0; i < lights.size(); i++) {
-        ImGui::PushID(static_cast<int>(i));
-        if (ImGui::CollapsingHeader(("Light " + std::to_string(i)).c_str())) {
-            float pos[3] = {lights[i].position_and_radius.x,
-                            lights[i].position_and_radius.y,
-                            lights[i].position_and_radius.z};
-            if (ImGui::DragFloat3("Position", pos, 0.5f)) {
-                lights[i].position_and_radius.x = pos[0];
-                lights[i].position_and_radius.y = pos[1];
-                lights[i].position_and_radius.z = pos[2];
-                lights_changed = true;
-            }
-            if (ImGui::DragFloat("Radius", &lights[i].position_and_radius.w, 0.5f, 0.1f, 500.0f)) {
-                lights_changed = true;
-            }
-            float col[3] = {lights[i].color.r, lights[i].color.g, lights[i].color.b};
-            if (ImGui::ColorEdit3("Color", col)) {
-                lights[i].color.r = col[0];
-                lights[i].color.g = col[1];
-                lights[i].color.b = col[2];
-                lights_changed = true;
-            }
-            if (ImGui::DragFloat("Intensity##light", &lights[i].color.a, 0.1f, 0.0f, 20.0f)) {
-                lights_changed = true;
-            }
-            if (ImGui::Button("Remove")) {
-                lights.erase(lights.begin() + static_cast<ptrdiff_t>(i));
-                lights_changed = true;
-                ImGui::PopID();
-                break;
-            }
-        }
-        ImGui::PopID();
-    }
-
-    if (lights.size() < 8 && ImGui::Button("+ Add Light")) {
-        PointLight new_light;
-        new_light.position_and_radius = glm::vec4(0.0f, 0.0f, 0.0f, 50.0f);
-        new_light.color = glm::vec4(1.0f, 1.0f, 1.0f, 5.0f);
-        lights.push_back(new_light);
-        lights_changed = true;
-        if (light_mode == 0) {
-            gs.set_light_mode(2);
-        }
-    }
-
-    if (lights_changed) {
-        gs.set_point_lights(lights);
-    }
-
     ImGui::End();
 }
 
@@ -1039,30 +757,64 @@ void StagingState::draw_camera_panel(AppBase& app) {
     ImGui::End();
 }
 
-void StagingState::draw_performance(AppBase& app) {
-    ImGui::SetNextWindowPos(ImVec2(10, 160), ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(250, 200), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Performance")) {
+void StagingState::draw_character_panel(AppBase& app) {
+    ImGui::SetNextWindowPos(ImVec2(10, 500), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(280, 200), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Character Animation", &show_character_)) {
         ImGui::End();
         return;
     }
 
-    float fps_val = app.debug_metrics().fps;
-    ImGui::Text("FPS: %.1f (%.2f ms)", fps_val, fps_val > 0.0f ? 1000.0f / fps_val : 0.0f);
-
-    // Reorder ring buffer for ImGui::PlotLines
-    const auto& dm = app.debug_metrics();
-    float ordered[300];
-    for (int i = 0; i < 300; i++) {
-        ordered[i] = dm.frame_times[(dm.frame_time_idx + i) % 300];
+    if (!character_data_) {
+        ImGui::TextColored(ImVec4(0.6f, 0.6f, 0.6f, 1.0f), "No character loaded.");
+        ImGui::TextWrapped("Use 'Preview in Staging' from Echidna, or send load_character command.");
+        ImGui::End();
+        return;
     }
-    ImGui::PlotLines("Frame Time", ordered, 300, 0, nullptr, 0.0f, 50.0f, ImVec2(0, 80));
 
-    if (app.renderer().has_gs_cloud()) {
-        auto& gs = app.renderer().gs_renderer();
-        ImGui::Text("Gaussian Count: %u", gs.gaussian_count());
-        ImGui::Text("Visible: %u", gs.visible_count());
-        ImGui::Text("Max Capacity: %u", gs.max_gaussian_count());
+    ImGui::Text("Character: %s", character_data_->name.c_str());
+    ImGui::Text("Bones: %zu", character_data_->bones.size());
+    ImGui::Separator();
+
+    // Animation clip selection
+    if (!character_data_->clips.empty()) {
+        ImGui::Text("Animation Clips:");
+        for (int i = 0; i < static_cast<int>(character_data_->clips.size()); i++) {
+            const auto& clip = character_data_->clips[i];
+            bool is_selected = (i == selected_clip_);
+            if (ImGui::Selectable(clip.name.c_str(), is_selected)) {
+                selected_clip_ = i;
+                anim_player_->play(clip.name);
+                anim_playing_ = true;
+            }
+        }
+
+        ImGui::Separator();
+
+        // Playback controls
+        if (ImGui::Button(anim_playing_ ? "Pause" : "Play")) {
+            anim_playing_ = !anim_playing_;
+            if (anim_playing_ && anim_player_ && !anim_player_->is_playing()) {
+                if (selected_clip_ >= 0 && selected_clip_ < static_cast<int>(character_data_->clips.size())) {
+                    anim_player_->play(character_data_->clips[selected_clip_].name);
+                }
+            }
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Stop")) {
+            anim_playing_ = false;
+            app.renderer().gs_renderer().clear_bone_transforms();
+        }
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(80);
+        ImGui::SliderFloat("Speed", &anim_speed_, 0.25f, 2.0f, "%.2fx");
+
+        // Show current clip info
+        if (anim_player_ && anim_player_->is_playing()) {
+            ImGui::Text("Playing: %s", anim_player_->current_clip().c_str());
+        }
+    } else {
+        ImGui::TextColored(ImVec4(0.8f, 0.6f, 0.3f, 1.0f), "No animation clips defined.");
     }
 
     ImGui::End();
@@ -1149,6 +901,14 @@ static void draw_region_gizmo(ImDrawList* dl, const GsAnimRegion& region,
 void StagingState::draw_gizmos(AppBase& app) {
     if (!app.renderer().has_gs_cloud()) return;
 
+    static bool show_lights = true;
+    static bool show_emitters = true;
+    static bool show_vfx = true;
+    static bool show_game_objects = true;
+    static bool show_camera_zones = true;
+    static bool show_portals = true;
+    static bool show_world = true;
+
     const glm::mat4& vp = gs_vp_;  // computed once in update()
     auto& gs = app.renderer().gs_renderer();
 
@@ -1159,7 +919,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     ImDrawList* dl = ImGui::GetForegroundDrawList();
 
     // ── Light gizmos ──
-    if (show_gizmo_lights_) {
+    if (show_lights) {
         const auto& lights = gs.point_lights();
         for (size_t i = 0; i < lights.size(); i++) {
             glm::vec3 pos(lights[i].position_and_radius.x,
@@ -1182,7 +942,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     }
 
     // ── Standalone emitter gizmos (with spawn region) ──
-    if (show_gizmo_emitters_) {
+    if (show_emitters) {
         ImU32 emitter_col = IM_COL32(236, 72, 153, 200);  // pink
         auto& emitters = app.renderer().gs_particle_emitters();
         for (size_t i = 0; i < emitters.size(); i++) {
@@ -1202,7 +962,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     }
 
     // ── Scene animation gizmos (region wireframes) ──
-    if (show_gizmo_vfx_) {
+    if (show_vfx) {
         ImU32 anim_col = IM_COL32(6, 182, 212, 180);  // cyan
         const auto& anims = app.renderer().gs_scene_animations();
         for (size_t i = 0; i < anims.size(); i++) {
@@ -1219,7 +979,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     }
 
     // ── VFX instance gizmos (with element details) ──
-    if (show_gizmo_vfx_) {
+    if (show_vfx) {
         const auto& vfx = app.renderer().vfx_instances();
         for (size_t i = 0; i < vfx.size(); i++) {
             auto inst_pos = vfx[i].position();
@@ -1275,7 +1035,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     }
 
     // ── Game Object gizmos ──
-    if (show_gizmo_game_objects_) {
+    if (show_game_objects) {
         ImU32 go_col = IM_COL32(68, 136, 255, 200);       // blue
         ImU32 go_col_static = IM_COL32(136, 136, 136, 150); // gray for no-component
         const auto& game_objects = app.scene_objects().game_objects;
@@ -1304,7 +1064,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     }
 
     // ── Portal gizmos ──
-    if (show_gizmo_portals_) {
+    if (show_portals) {
         ImU32 portal_col = IM_COL32(0, 220, 220, 200);  // cyan
         const auto& portals = app.scene_objects().portals;
         auto terrain_aabb = app.gs_terrain().terrain_aabb;
@@ -1336,12 +1096,12 @@ void StagingState::draw_gizmos(AppBase& app) {
     }
 
     // ── Camera Zone gizmos (visible in both orbit and review modes) ──
-    if (show_gizmo_camera_zones_ && camera_review_ && camera_review_->has_zone_data()) {
+    if (show_camera_zones && camera_review_ && camera_review_->has_zone_data()) {
         camera_review_->draw_gizmos(vp, sw, sh, dl, project_wrapper, this);
     }
 
     // ── World manifest gizmos ──
-    if (show_gizmo_world_ && app.scene_objects().world_manifest.has_value()) {
+    if (show_world && app.scene_objects().world_manifest.has_value()) {
         const auto& wm = *app.scene_objects().world_manifest;
 
         // Chunk wireframes (green)
@@ -1425,71 +1185,6 @@ void StagingState::load_character(const std::string& manifest_path, AppBase& app
 
     // Clear bone transforms (identity) until animation starts
     app.renderer().gs_renderer().clear_bone_transforms();
-}
-
-void StagingState::draw_character_panel(AppBase& app) {
-    if (!show_character_) return;
-
-    ImGui::SetNextWindowPos(ImVec2(10, 500), ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(280, 200), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Character Animation", &show_character_)) {
-        ImGui::End();
-        return;
-    }
-
-    if (!character_data_) {
-        ImGui::TextColored(ImVec4(0.6f, 0.6f, 0.6f, 1.0f), "No character loaded.");
-        ImGui::TextWrapped("Use 'Preview in Staging' from Echidna, or send load_character command.");
-        ImGui::End();
-        return;
-    }
-
-    ImGui::Text("Character: %s", character_data_->name.c_str());
-    ImGui::Text("Bones: %zu", character_data_->bones.size());
-    ImGui::Separator();
-
-    // Animation clip selection
-    if (!character_data_->clips.empty()) {
-        ImGui::Text("Animation Clips:");
-        for (int i = 0; i < static_cast<int>(character_data_->clips.size()); i++) {
-            const auto& clip = character_data_->clips[i];
-            bool is_selected = (i == selected_clip_);
-            if (ImGui::Selectable(clip.name.c_str(), is_selected)) {
-                selected_clip_ = i;
-                anim_player_->play(clip.name);
-                anim_playing_ = true;
-            }
-        }
-
-        ImGui::Separator();
-
-        // Playback controls
-        if (ImGui::Button(anim_playing_ ? "Pause" : "Play")) {
-            anim_playing_ = !anim_playing_;
-            if (anim_playing_ && anim_player_ && !anim_player_->is_playing()) {
-                if (selected_clip_ >= 0 && selected_clip_ < static_cast<int>(character_data_->clips.size())) {
-                    anim_player_->play(character_data_->clips[selected_clip_].name);
-                }
-            }
-        }
-        ImGui::SameLine();
-        if (ImGui::Button("Stop")) {
-            anim_playing_ = false;
-            app.renderer().gs_renderer().clear_bone_transforms();
-        }
-        ImGui::SameLine();
-        ImGui::SetNextItemWidth(80);
-        ImGui::SliderFloat("Speed", &anim_speed_, 0.25f, 2.0f, "%.2fx");
-
-        // Show current clip info
-        if (anim_player_ && anim_player_->is_playing()) {
-            ImGui::Text("Playing: %s", anim_player_->current_clip().c_str());
-        }
-    } else {
-        ImGui::TextColored(ImVec4(0.8f, 0.6f, 0.3f, 1.0f), "No animation clips defined.");
-    }
-
-    ImGui::End();
 }
 
 }  // namespace gseurat


### PR DESCRIPTION
## Summary

- **DevOverlay class** in engine layer with `GSEURAT_DEV_MODE` compile flag (ON by default, OFF for shipping)
- **6 built-in panels**: Performance, Render Settings, GS Parameters, Feature Toggles, Lighting, Camera Info
- **Panel registration API**: `dev_overlay().register_panel(name, fn)` — apps add custom panels
- **F1 toggle** in any app — handled by AppBase::main_loop()
- **Input gating** — mouse/keyboard blocked from game when ImGui has focus
- **Staging simplified**: ~600 lines removed, uses DevOverlay + registers Scene/Character/Camera as custom panels
- **Both builds pass**: `GSEURAT_DEV_MODE=ON` (full ImGui) and `GSEURAT_DEV_MODE=OFF` (no-op stubs, zero overhead)

## Test plan

- [x] Debug build succeeds (DEV_MODE=ON)
- [x] Release build succeeds (DEV_MODE=ON)
- [x] Build succeeds with DEV_MODE=OFF (no ImGui symbols)
- [ ] Demo: F1 toggles dev overlay with all 6 panels
- [ ] Demo: clicking ImGui panels doesn't move player/camera
- [ ] Staging: F1 shows 6 engine panels + Scene/Character/Camera custom panels
- [ ] Staging: scene load/reload works via Scene panel
- [ ] Staging: gizmos still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)