### PR TITLE
fix(gs): increase tile sort capacity to prevent distant Gaussian dropout

### DIFF
--- a/include/gseurat/engine/feature_flags.hpp
+++ b/include/gseurat/engine/feature_flags.hpp
@@ -82,8 +82,7 @@ struct FeatureFlags {
 
     // Apply platform-specific defaults (call once after GPU detection)
     void apply_platform_defaults(bool apple_gpu) {
-        // Tile binning now viable on Apple Silicon with 2-dispatch Onesweep
-        // (reduced from ~38 barriers to ~14). Benchmark: 32.5ms → 3.6ms on M5.
+        // Tile binning viable on all platforms with 2-dispatch Onesweep
         (void)apple_gpu;
     }
 

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -725,12 +725,12 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
     // Capacity: visible Gaussians × avg tile overlap. Cap at 1M entries (16MB per buffer).
     {
         uint32_t visible_upper = static_sort_size_ + dynamic_sort_size_;
-        tile_sort_capacity_ = std::min(visible_upper * 4, 1u << 19);  // cap at 512K (8MB per buffer)
+        tile_sort_capacity_ = std::min(visible_upper * 4, 1u << 21);  // cap at 2M (16MB per buffer)
         // Align to 1024 (workgroup size for radix sort)
-        tile_sort_size_ = ((tile_sort_capacity_ + 1023) / 1024) * 1024;
-        tile_sort_workgroups_ = tile_sort_size_ / 1024;
+        tile_sort_size_ = ((tile_sort_capacity_ + 2047) / 2048) * 2048;
+        tile_sort_workgroups_ = tile_sort_size_ / 2048;
         if (tile_sort_workgroups_ == 0) tile_sort_workgroups_ = 1;
-        tile_sort_size_ = tile_sort_workgroups_ * 1024;
+        tile_sort_size_ = tile_sort_workgroups_ * 2048;
 
         VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 8;  // 8 bytes/entry
         // Allocate tile_ranges for max possible resolution (output_width_ may not
@@ -1229,11 +1229,11 @@ void GsRenderer::load_cloud_legacy(const GaussianCloud& cloud) {
     // ── Tile binning buffers (same logic as init_streaming) ──
     {
         uint32_t visible_upper = static_sort_size_ + dynamic_sort_size_;
-        tile_sort_capacity_ = std::min(visible_upper * 4, 1u << 19);  // cap at 512K (8MB per buffer)
-        tile_sort_size_ = ((tile_sort_capacity_ + 1023) / 1024) * 1024;
-        tile_sort_workgroups_ = tile_sort_size_ / 1024;
+        tile_sort_capacity_ = std::min(visible_upper * 4, 1u << 21);  // cap at 2M (16MB per buffer)
+        tile_sort_size_ = ((tile_sort_capacity_ + 2047) / 2048) * 2048;
+        tile_sort_workgroups_ = tile_sort_size_ / 2048;
         if (tile_sort_workgroups_ == 0) tile_sort_workgroups_ = 1;
-        tile_sort_size_ = tile_sort_workgroups_ * 1024;
+        tile_sort_size_ = tile_sort_workgroups_ * 2048;
 
         VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 8;  // 8 bytes/entry
         // Allocate tile_ranges for max possible resolution (output_width_ may not
@@ -2099,9 +2099,9 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd) {
     // Clear tile sort counter to 0 and fill tile_sort_a with sentinels (0xFFFFFFFF).
     // Sentinels are essential: the sort processes max_workgroups*1024 entries, but only
     // tile_sort_count are real. Without sentinels, garbage data gets sorted alongside
-    // real entries, scattering them to unpredictable positions. With sentinels (key_hi=
-    // key_lo=0xFFFFFFFF), unused entries sort to the END, keeping real entries contiguous
-    // at [0, tile_sort_count). At 256K cap this is only 4MB — well within TDR budget.
+    // real entries, scattering them to unpredictable positions. With sentinels (key=
+    // 0xFFFFFFFF), unused entries sort to the END, keeping real entries contiguous
+    // at [0, tile_sort_count).
     vkCmdFillBuffer(cmd, tile_sort_count_ssbo_.buffer(), 0, sizeof(uint32_t), 0);
     vkCmdFillBuffer(cmd, tile_sort_a_.buffer(), 0,
                     static_cast<VkDeviceSize>(tile_sort_size_) * 8, 0xFFFFFFFF);

--- a/src/engine/vk_context.cpp
+++ b/src/engine/vk_context.cpp
@@ -194,7 +194,7 @@ void VkContext::pick_physical_device() {
         is_apple_gpu_ = (props.vendorID == 0x106B);
         std::printf("[vk_context] GPU: %s (vendor 0x%04X)%s\n",
                     props.deviceName, props.vendorID,
-                    is_apple_gpu_ ? " [Apple — tile binning disabled by default]" : "");
+                    is_apple_gpu_ ? " [Apple — TBDR]" : "");
     }
 }
 


### PR DESCRIPTION
## Summary
- Tile sort entry buffer was silently overflowing (512K cap) on 2.4M Gaussian scenes, causing distant scenery to fade into the background clear color
- Increased tile sort capacity from 512K to 2M entries (16MB per buffer)
- Aligned tile sort size to 2048 to match Onesweep ENTRIES_PER_WG
- Updated stale Apple GPU log string

## Root Cause
When tile binning was enabled on Apple Silicon (4e5e755e), the 512K tile entry cap wasn't large enough for the island scene. Each visible Gaussian emits one tile entry per overlapping tile, and with ~200K visible Gaussians × ~3 tiles average overlap, the buffer exceeded 512K. Overflow entries were silently dropped, making distant Gaussians disappear.

## Test plan
- [x] macOS release build — distant scenery renders correctly with tile binning
- [x] Dungeon portal transition works (capacity scales down for small scenes)
- [x] GPU timestamps healthy: DepthSort ~6ms, TileSort ~0.9ms, Rasterize ~2-4ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)