### PR TITLE
feat(gs): distance-based chunk culling and LOD zero-floor

### DIFF
--- a/include/gseurat/engine/gs_chunk_grid.hpp
+++ b/include/gseurat/engine/gs_chunk_grid.hpp
@@ -18,7 +18,9 @@ struct GsChunk {
 class GsChunkGrid {
 public:
     void build(const GaussianCloud& cloud, float chunk_size = 32.0f);
-    std::vector<uint32_t> visible_chunks(const glm::mat4& view_proj) const;
+    std::vector<uint32_t> visible_chunks(const glm::mat4& view_proj,
+                                        const glm::vec3& camera_pos,
+                                        float max_distance = 0.0f) const;
     uint32_t gather(const std::vector<uint32_t>& chunk_indices,
                     std::vector<Gaussian>& out) const;
     uint32_t gather_lod(const std::vector<uint32_t>& chunk_indices,

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -65,6 +65,8 @@ public:
     bool gs_bg_colors_enabled() const { return gs_bg_colors_enabled_; }
     void set_gs_gaussian_budget(uint32_t b) { gs_gaussian_budget_ = b; }
     uint32_t gs_gaussian_budget() const { return gs_gaussian_budget_; }
+    void set_gs_max_render_distance(float d) { gs_max_render_distance_ = d; }
+    float gs_max_render_distance() const { return gs_max_render_distance_; }
     void set_gs_lod_focus(const glm::vec3& pos) { gs_lod_focus_pos_ = pos; gs_has_lod_focus_ = true; }
     void clear_gs_lod_focus() { gs_has_lod_focus_ = false; }
 
@@ -245,6 +247,7 @@ private:
     std::vector<uint32_t> gs_prev_visible_;
     bool gs_skip_chunk_cull_ = false;
     uint32_t gs_gaussian_budget_ = 0;  // 0 = unlimited (no LOD decimation)
+    float gs_max_render_distance_ = 0.0f;  // 0 = unlimited (no distance culling)
     uint32_t gs_total_gaussian_count_ = 0;  // total Gaussians in loaded cloud
     bool gs_adaptive_budget_ = false;
     bool gs_budget_locked_ = false;

--- a/src/demo/gs_demo_state.cpp
+++ b/src/demo/gs_demo_state.cpp
@@ -779,7 +779,8 @@ void GsDemoState::enter_streaming_mode(AppBase& app) {
     auto all_visible = grid.visible_chunks(
         glm::perspective(glm::radians(179.0f), 1.0f, 0.1f, 100000.0f) *
         glm::lookAt(grid.cloud_bounds().center() + glm::vec3(0, 0, 10000),
-                    grid.cloud_bounds().center(), glm::vec3(0, 1, 0)));
+                    grid.cloud_bounds().center(), glm::vec3(0, 1, 0)),
+        grid.cloud_bounds().center());
 
     // Build manifest by gathering each chunk individually
     ChunkManifest manifest;

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -94,6 +94,7 @@ void IslandDemoState::on_enter(AppBase& app) {
     pp.vignette_softness = 0.4f;   // soft falloff
     pp.ca_intensity = 0.15f;       // subtle chromatic aberration at edges
     app.renderer().set_gs_skip_chunk_cull(false);
+    app.renderer().set_gs_max_render_distance(200.0f);  // cull distant chunks to preserve nearby quality
     app.renderer().gs_renderer().set_skip_sort(false);
 
     // Load world manifest if world.json exists at project root

--- a/src/engine/gs_chunk_grid.cpp
+++ b/src/engine/gs_chunk_grid.cpp
@@ -141,17 +141,28 @@ static bool aabb_in_frustum(const AABB& aabb, const std::array<glm::vec4, 6>& pl
     return true;
 }
 
-std::vector<uint32_t> GsChunkGrid::visible_chunks(const glm::mat4& view_proj) const {
+std::vector<uint32_t> GsChunkGrid::visible_chunks(const glm::mat4& view_proj,
+                                                   const glm::vec3& camera_pos,
+                                                   float max_distance) const {
     auto planes = extract_frustum_planes(view_proj);
 
     // Safety margin: account for scale compensation (up to kMaxScaleComp = 2.0x)
     // expanding Gaussians beyond their original chunk bounds.
     float margin = chunk_size_ * 2.0f;
 
+    float max_dist_sq = (max_distance > 0.0f) ? max_distance * max_distance : 0.0f;
+
     std::vector<uint32_t> result;
     result.reserve(chunks_.size());
 
     for (uint32_t i = 0; i < chunks_.size(); ++i) {
+        // Distance cull: skip chunks beyond max render distance
+        if (max_dist_sq > 0.0f) {
+            glm::vec3 center = chunks_[i].bounds.center();
+            float dist_sq = glm::dot(center - camera_pos, center - camera_pos);
+            if (dist_sq > max_dist_sq) continue;
+        }
+
         if (aabb_in_frustum(chunks_[i].bounds, planes, margin)) {
             result.push_back(i);
         }
@@ -196,7 +207,7 @@ uint32_t GsChunkGrid::gather_lod(const std::vector<uint32_t>& chunk_indices,
     // Distance thresholds based on chunk size
     float near_dist = 2.0f * chunk_size_;
     float far_dist = 8.0f * chunk_size_;
-    float min_ratio = 0.1f;  // 10% kept at far distance
+    float cull_dist = 12.0f * chunk_size_;  // beyond this, keep_count drops to 0
 
     // Player-centric LOD: use player position for distance if provided,
     // camera position otherwise.
@@ -209,7 +220,8 @@ uint32_t GsChunkGrid::gather_lod(const std::vector<uint32_t>& chunk_indices,
         float ratio;
         uint32_t keep_count;
     };
-    std::vector<ChunkLod> lods(chunk_indices.size());
+    std::vector<ChunkLod> lods;
+    lods.reserve(chunk_indices.size());
 
     uint32_t total_wanted = 0;
     for (size_t i = 0; i < chunk_indices.size(); ++i) {
@@ -220,15 +232,21 @@ uint32_t GsChunkGrid::gather_lod(const std::vector<uint32_t>& chunk_indices,
         float ratio;
         if (dist <= near_dist) {
             ratio = 1.0f;
+        } else if (dist >= cull_dist) {
+            ratio = 0.0f;  // fully culled beyond cull distance
         } else if (dist >= far_dist) {
-            ratio = min_ratio;
+            // Linear fade from 0.1 to 0.0 between far_dist and cull_dist
+            float t = (dist - far_dist) / (cull_dist - far_dist);
+            ratio = 0.1f * (1.0f - t);
         } else {
             float t = (dist - near_dist) / (far_dist - near_dist);
-            ratio = 1.0f - t * (1.0f - min_ratio);
+            ratio = 1.0f - t * 0.9f;  // 1.0 → 0.1
         }
 
+        if (ratio <= 0.0f) continue;  // skip fully culled chunks
+
         uint32_t keep = std::max(1u, static_cast<uint32_t>(chunk.count * ratio));
-        lods[i] = {chunk_indices[i], dist, ratio, keep};
+        lods.push_back({chunk_indices[i], dist, ratio, keep});
         total_wanted += keep;
     }
 

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -872,7 +872,8 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
 
         if (camera_dirty && flags.gs_chunk_culling && !gs_skip_chunk_cull_ && !gs_chunk_grid_.empty()) {
             glm::mat4 gs_vp = gs_proj_ * gs_view_;
-            auto visible = gs_chunk_grid_.visible_chunks(gs_vp);
+            glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
+            auto visible = gs_chunk_grid_.visible_chunks(gs_vp, cam_pos, gs_max_render_distance_);
 
             if ((visible != gs_prev_visible_ || budget_changed) && gs_budget_locked_) {
                 gs_budget_locked_ = false;

--- a/tests/test_gs_chunk_grid.cpp
+++ b/tests/test_gs_chunk_grid.cpp
@@ -85,7 +85,7 @@ int main() {
             glm::vec3(50.0f, 0.0f, 0.0f),
             glm::vec3(0.0f, 1.0f, 0.0f));
         glm::mat4 proj = glm::perspective(glm::radians(90.0f), 1.0f, 0.1f, 500.0f);
-        auto visible = grid.visible_chunks(proj * view);
+        auto visible = grid.visible_chunks(proj * view, glm::vec3(50.0f, 0.0f, 200.0f));
         assert(visible.size() >= 2);
         std::printf("PASS: multi-chunk\n");
     }
@@ -109,7 +109,7 @@ int main() {
             glm::vec3(0.0f, 1.0f, 0.0f));
         glm::mat4 proj = glm::perspective(glm::radians(60.0f), 1.0f, 0.1f, 500.0f);
         auto vp = proj * view;
-        auto visible = grid.visible_chunks(vp);
+        auto visible = grid.visible_chunks(vp, glm::vec3(32.0f, 32.0f, 100.0f));
         assert(!visible.empty());
         std::printf("PASS: visible_chunks returns results\n");
     }
@@ -133,8 +133,9 @@ int main() {
         glm::mat4 proj = glm::perspective(glm::radians(30.0f), 1.0f, 0.1f, 200.0f);
         auto vp = proj * view;
 
-        auto all = grid.visible_chunks(wide_vp(glm::vec3(500.0f, 0.0f, 0.0f)));
-        auto culled = grid.visible_chunks(vp);
+        auto all = grid.visible_chunks(wide_vp(glm::vec3(500.0f, 0.0f, 0.0f)),
+                                        glm::vec3(500.0f, 0.0f, 500.0f));
+        auto culled = grid.visible_chunks(vp, glm::vec3(0.0f, 0.0f, 50.0f));
         assert(culled.size() < all.size());
         std::printf("PASS: frustum culling\n");
     }
@@ -149,7 +150,8 @@ int main() {
         GsChunkGrid grid;
         grid.build(cloud, 32.0f);
 
-        auto visible = grid.visible_chunks(wide_vp(glm::vec3(50.0f, 0.0f, 0.0f)));
+        auto visible = grid.visible_chunks(wide_vp(glm::vec3(50.0f, 0.0f, 0.0f)),
+                                           glm::vec3(50.0f, 0.0f, 500.0f));
         std::vector<Gaussian> out;
         uint32_t count = grid.gather(visible, out);
         assert(count == static_cast<uint32_t>(out.size()));
@@ -169,7 +171,8 @@ int main() {
         GsChunkGrid grid;
         grid.build(cloud, 16.0f);
 
-        auto visible = grid.visible_chunks(wide_vp(glm::vec3(25.0f, 10.0f, 0.0f)));
+        auto visible = grid.visible_chunks(wide_vp(glm::vec3(25.0f, 10.0f, 0.0f)),
+                                           glm::vec3(25.0f, 10.0f, 500.0f));
         std::vector<Gaussian> out;
         glm::vec3 cam_pos(25.0f, 10.0f, 50.0f);
         uint32_t count = grid.gather_lod(visible, cam_pos, 200, out);
@@ -189,7 +192,8 @@ int main() {
         GsChunkGrid grid;
         grid.build(cloud, 32.0f);
 
-        auto visible = grid.visible_chunks(wide_vp(glm::vec3(50.0f, 0.0f, 0.0f)));
+        auto visible = grid.visible_chunks(wide_vp(glm::vec3(50.0f, 0.0f, 0.0f)),
+                                           glm::vec3(50.0f, 0.0f, 500.0f));
         std::vector<Gaussian> out;
         glm::vec3 cam_pos(50.0f, 0.0f, 50.0f);  // far enough for LOD
         grid.gather_lod(visible, cam_pos, 20, out);


### PR DESCRIPTION
## Summary
- Add max render distance to `visible_chunks()` — chunks beyond threshold are skipped entirely
- LOD `gather_lod()` now fades density from 10% to 0% between `far_dist` and `cull_dist`, fully dropping chunks beyond `cull_dist`
- Island demo sets max render distance to 200 units

## Motivation
When viewing the house from NorthForest, distant chunks (house area) consumed tile entry budget and Gaussian LOD budget, causing nearby Gaussians to be thinned out. These two features work together: max distance gives a hard cutoff, and the LOD zero-floor provides a smooth fade before that cutoff.

## Test plan
- [x] All 37 tests pass
- [x] Build succeeds (macos-debug)
- [ ] Visual verification: nearby quality maintained when viewing from NorthForest

🤖 Generated with [Claude Code](https://claude.com/claude-code)