### PR TITLE
feat(staging): collision grid overlay in Developer Mode

### DIFF
--- a/include/gseurat/engine/debug_draw.hpp
+++ b/include/gseurat/engine/debug_draw.hpp
@@ -5,7 +5,13 @@
 #include <glm/glm.hpp>
 #include <functional>
 
+#ifdef GSEURAT_DEV_MODE
+struct ImDrawList;
+#endif
+
 namespace gseurat {
+
+struct CollisionGrid;
 
 using DrawLineFn = std::function<void(float x1, float y1, float x2, float y2,
                                        float thickness, glm::vec4 color)>;
@@ -30,5 +36,15 @@ void draw_box_gizmo(const glm::vec3& center, const glm::vec3& half_extents,
 void draw_region_gizmo(const GsAnimRegion& region, const glm::vec3& offset,
                          const glm::mat4& vp, float sw, float sh,
                          glm::vec4 color, const DrawLineFn& draw_line);
+
+#ifdef GSEURAT_DEV_MODE
+// Draw a collision grid overlay on the ImGui foreground draw list.
+// grid_origin is the world XZ origin of the grid (grid cell 0,0).
+void draw_collision_grid_overlay(ImDrawList* dl,
+                                  const CollisionGrid& grid,
+                                  glm::vec2 grid_origin,
+                                  const glm::mat4& vp,
+                                  float screen_w, float screen_h);
+#endif
 
 }  // namespace gseurat

--- a/include/gseurat/engine/dev_overlay.hpp
+++ b/include/gseurat/engine/dev_overlay.hpp
@@ -46,6 +46,7 @@ public:
     bool show_gizmo_camera_zones = true;
     bool show_gizmo_portals = true;
     bool show_gizmo_world = true;
+    bool show_gizmo_collision = false;  // off by default — overlay is heavy
 
 private:
     struct PanelEntry {

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1937,56 +1937,7 @@ void IslandDemoState::draw_gizmos(AppBase& app) {
 
     // ── Collision grid overlay ──
     if (ov.show_gizmo_collision && collision_grid_.width > 0) {
-        const auto& grid = collision_grid_;
-
-        ImU32 solid_col    = IM_COL32(204, 0, 0, 77);    // red, alpha ~0.3
-        ImU32 walkable_col = IM_COL32(0, 204, 0, 38);    // green, alpha ~0.15
-        ImU32 grid_line_col = IM_COL32(255, 255, 255, 51); // white, alpha ~0.2
-
-        for (uint32_t gz = 0; gz < grid.height; gz++) {
-            for (uint32_t gx = 0; gx < grid.width; gx++) {
-                // Four corners of the cell in world space
-                float wx0 = grid_origin_.x + gx * grid.cell_size;
-                float wx1 = grid_origin_.x + (gx + 1) * grid.cell_size;
-                float wz0 = grid_origin_.y + gz * grid.cell_size;
-                float wz1 = grid_origin_.y + (gz + 1) * grid.cell_size;
-                float wy = grid.get_elevation(gx, gz);
-
-                glm::vec3 p00(wx0, wy, wz0);
-                glm::vec3 p10(wx1, wy, wz0);
-                glm::vec3 p01(wx0, wy, wz1);
-                glm::vec3 p11(wx1, wy, wz1);
-
-                // Project all 4 corners to screen
-                float sx00, sy00, sx10, sy10, sx01, sy01, sx11, sy11;
-                bool v00 = project_to_screen(p00, vp, sw, sh, sx00, sy00);
-                bool v10 = project_to_screen(p10, vp, sw, sh, sx10, sy10);
-                bool v01 = project_to_screen(p01, vp, sw, sh, sx01, sy01);
-                bool v11 = project_to_screen(p11, vp, sw, sh, sx11, sy11);
-
-                // Skip if all 4 corners are behind camera
-                if (!v00 && !v10 && !v01 && !v11) continue;
-
-                // Skip if all 4 corners are off-screen (simple AABB check)
-                float min_x = std::min({sx00, sx10, sx01, sx11});
-                float max_x = std::max({sx00, sx10, sx01, sx11});
-                float min_y = std::min({sy00, sy10, sy01, sy11});
-                float max_y = std::max({sy00, sy10, sy01, sy11});
-                if (max_x < 0 || min_x > sw || max_y < 0 || min_y > sh) continue;
-
-                bool is_solid = grid.is_solid(gx, gz);
-                ImU32 fill = is_solid ? solid_col : walkable_col;
-
-                // Filled quad
-                dl->AddQuadFilled(
-                    ImVec2(sx00, sy00), ImVec2(sx10, sy10),
-                    ImVec2(sx11, sy11), ImVec2(sx01, sy01), fill);
-
-                // Grid lines (only draw right and bottom edges to avoid double-drawing)
-                dl->AddLine(ImVec2(sx10, sy10), ImVec2(sx11, sy11), grid_line_col, 1.0f);
-                dl->AddLine(ImVec2(sx01, sy01), ImVec2(sx11, sy11), grid_line_col, 1.0f);
-            }
-        }
+        draw_collision_grid_overlay(dl, collision_grid_, grid_origin_, vp, sw, sh);
     }
 #else
     (void)app;

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1934,6 +1934,60 @@ void IslandDemoState::draw_gizmos(AppBase& app) {
                 imgui_sphere(dl, t.position.vec(), pt.radius, vp, sw, sh, col);
             });
     }
+
+    // ── Collision grid overlay ──
+    if (ov.show_gizmo_collision && collision_grid_.width > 0) {
+        const auto& grid = collision_grid_;
+
+        ImU32 solid_col    = IM_COL32(204, 0, 0, 77);    // red, alpha ~0.3
+        ImU32 walkable_col = IM_COL32(0, 204, 0, 38);    // green, alpha ~0.15
+        ImU32 grid_line_col = IM_COL32(255, 255, 255, 51); // white, alpha ~0.2
+
+        for (uint32_t gz = 0; gz < grid.height; gz++) {
+            for (uint32_t gx = 0; gx < grid.width; gx++) {
+                // Four corners of the cell in world space
+                float wx0 = grid_origin_.x + gx * grid.cell_size;
+                float wx1 = grid_origin_.x + (gx + 1) * grid.cell_size;
+                float wz0 = grid_origin_.y + gz * grid.cell_size;
+                float wz1 = grid_origin_.y + (gz + 1) * grid.cell_size;
+                float wy = grid.get_elevation(gx, gz);
+
+                glm::vec3 p00(wx0, wy, wz0);
+                glm::vec3 p10(wx1, wy, wz0);
+                glm::vec3 p01(wx0, wy, wz1);
+                glm::vec3 p11(wx1, wy, wz1);
+
+                // Project all 4 corners to screen
+                float sx00, sy00, sx10, sy10, sx01, sy01, sx11, sy11;
+                bool v00 = project_to_screen(p00, vp, sw, sh, sx00, sy00);
+                bool v10 = project_to_screen(p10, vp, sw, sh, sx10, sy10);
+                bool v01 = project_to_screen(p01, vp, sw, sh, sx01, sy01);
+                bool v11 = project_to_screen(p11, vp, sw, sh, sx11, sy11);
+
+                // Skip if all 4 corners are behind camera
+                if (!v00 && !v10 && !v01 && !v11) continue;
+
+                // Skip if all 4 corners are off-screen (simple AABB check)
+                float min_x = std::min({sx00, sx10, sx01, sx11});
+                float max_x = std::max({sx00, sx10, sx01, sx11});
+                float min_y = std::min({sy00, sy10, sy01, sy11});
+                float max_y = std::max({sy00, sy10, sy01, sy11});
+                if (max_x < 0 || min_x > sw || max_y < 0 || min_y > sh) continue;
+
+                bool is_solid = grid.is_solid(gx, gz);
+                ImU32 fill = is_solid ? solid_col : walkable_col;
+
+                // Filled quad
+                dl->AddQuadFilled(
+                    ImVec2(sx00, sy00), ImVec2(sx10, sy10),
+                    ImVec2(sx11, sy11), ImVec2(sx01, sy01), fill);
+
+                // Grid lines (only draw right and bottom edges to avoid double-drawing)
+                dl->AddLine(ImVec2(sx10, sy10), ImVec2(sx11, sy11), grid_line_col, 1.0f);
+                dl->AddLine(ImVec2(sx01, sy01), ImVec2(sx11, sy11), grid_line_col, 1.0f);
+            }
+        }
+    }
 #else
     (void)app;
 #endif

--- a/src/engine/debug_draw.cpp
+++ b/src/engine/debug_draw.cpp
@@ -86,3 +86,60 @@ void draw_region_gizmo(const GsAnimRegion& region, const glm::vec3& offset,
 }
 
 }  // namespace gseurat
+
+#ifdef GSEURAT_DEV_MODE
+#include "gseurat/engine/collision_gen.hpp"
+#include <imgui.h>
+
+namespace gseurat {
+
+void draw_collision_grid_overlay(ImDrawList* dl,
+                                  const CollisionGrid& grid,
+                                  glm::vec2 grid_origin,
+                                  const glm::mat4& vp,
+                                  float sw, float sh) {
+    ImU32 solid_col    = IM_COL32(204, 0, 0, 77);    // red, alpha ~0.3
+    ImU32 walkable_col = IM_COL32(0, 204, 0, 38);    // green, alpha ~0.15
+    ImU32 grid_line_col = IM_COL32(255, 255, 255, 51); // white, alpha ~0.2
+
+    for (uint32_t gz = 0; gz < grid.height; gz++) {
+        for (uint32_t gx = 0; gx < grid.width; gx++) {
+            float wx0 = grid_origin.x + gx * grid.cell_size;
+            float wx1 = grid_origin.x + (gx + 1) * grid.cell_size;
+            float wz0 = grid_origin.y + gz * grid.cell_size;
+            float wz1 = grid_origin.y + (gz + 1) * grid.cell_size;
+            float wy = grid.get_elevation(gx, gz);
+
+            glm::vec3 p00(wx0, wy, wz0);
+            glm::vec3 p10(wx1, wy, wz0);
+            glm::vec3 p01(wx0, wy, wz1);
+            glm::vec3 p11(wx1, wy, wz1);
+
+            float sx00, sy00, sx10, sy10, sx01, sy01, sx11, sy11;
+            bool v00 = project_to_screen(p00, vp, sw, sh, sx00, sy00);
+            bool v10 = project_to_screen(p10, vp, sw, sh, sx10, sy10);
+            bool v01 = project_to_screen(p01, vp, sw, sh, sx01, sy01);
+            bool v11 = project_to_screen(p11, vp, sw, sh, sx11, sy11);
+
+            if (!v00 && !v10 && !v01 && !v11) continue;
+
+            float min_x = std::min({sx00, sx10, sx01, sx11});
+            float max_x = std::max({sx00, sx10, sx01, sx11});
+            float min_y = std::min({sy00, sy10, sy01, sy11});
+            float max_y = std::max({sy00, sy10, sy01, sy11});
+            if (max_x < 0 || min_x > sw || max_y < 0 || min_y > sh) continue;
+
+            ImU32 fill = grid.is_solid(gx, gz) ? solid_col : walkable_col;
+
+            dl->AddQuadFilled(
+                ImVec2(sx00, sy00), ImVec2(sx10, sy10),
+                ImVec2(sx11, sy11), ImVec2(sx01, sy01), fill);
+
+            dl->AddLine(ImVec2(sx10, sy10), ImVec2(sx11, sy11), grid_line_col, 1.0f);
+            dl->AddLine(ImVec2(sx01, sy01), ImVec2(sx11, sy11), grid_line_col, 1.0f);
+        }
+    }
+}
+
+}  // namespace gseurat
+#endif

--- a/src/engine/dev_overlay.cpp
+++ b/src/engine/dev_overlay.cpp
@@ -153,18 +153,19 @@ void DevOverlay::draw_menu_bar() {
             ImGui::MenuItem("Gizmo: Camera Zones", nullptr, &show_gizmo_camera_zones);
             ImGui::MenuItem("Gizmo: Portals", nullptr, &show_gizmo_portals);
             ImGui::MenuItem("Gizmo: World", nullptr, &show_gizmo_world);
+            ImGui::MenuItem("Gizmo: Collision", nullptr, &show_gizmo_collision);
             ImGui::Separator();
             if (ImGui::MenuItem("Show All")) {
                 for (auto& p : panels_) p.visible = true;
                 show_gizmo_lights = show_gizmo_emitters = show_gizmo_vfx = true;
                 show_gizmo_game_objects = show_gizmo_triggers = true;
-                show_gizmo_camera_zones = show_gizmo_portals = show_gizmo_world = true;
+                show_gizmo_camera_zones = show_gizmo_portals = show_gizmo_world = show_gizmo_collision = true;
             }
             if (ImGui::MenuItem("Hide All")) {
                 for (auto& p : panels_) p.visible = false;
                 show_gizmo_lights = show_gizmo_emitters = show_gizmo_vfx = false;
                 show_gizmo_game_objects = show_gizmo_triggers = false;
-                show_gizmo_camera_zones = show_gizmo_portals = show_gizmo_world = false;
+                show_gizmo_camera_zones = show_gizmo_portals = show_gizmo_world = show_gizmo_collision = false;
             }
             ImGui::EndMenu();
         }

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -7,6 +7,8 @@
 #include "gseurat/engine/shutdown_auditor.hpp"
 #include "gseurat/engine/world_manifest.hpp"
 #include "gseurat/engine/project_root.hpp"
+#include "gseurat/engine/coordinate.hpp"
+#include "gseurat/engine/collision_gen.hpp"
 
 #ifdef GSEURAT_DEV_MODE
 #include <imgui.h>
@@ -1106,6 +1108,63 @@ void StagingState::draw_gizmos(AppBase& app) {
     // ── Camera Zone gizmos (visible in both orbit and review modes) ──
     if (ov.show_gizmo_camera_zones && camera_review_ && camera_review_->has_zone_data()) {
         camera_review_->draw_gizmos(vp, sw, sh, dl, project_wrapper, this);
+    }
+
+    // ── Collision grid overlay ──
+    if (ov.show_gizmo_collision && last_scene_data_ && last_scene_data_->collision.has_value()) {
+        const auto& grid = *last_scene_data_->collision;
+        auto terrain_aabb = app.gs_terrain().terrain_aabb;
+
+        ImU32 solid_col    = IM_COL32(204, 0, 0, 77);    // red, alpha ~0.3
+        ImU32 walkable_col = IM_COL32(0, 204, 0, 38);    // green, alpha ~0.15
+        ImU32 grid_line_col = IM_COL32(255, 255, 255, 51); // white, alpha ~0.2
+
+        for (uint32_t gz = 0; gz < grid.height; gz++) {
+            for (uint32_t gx = 0; gx < grid.width; gx++) {
+                // Four corners of the cell in world space
+                auto p00 = coord::to_world(
+                    coord::CellPos(static_cast<float>(gx), 0.0f, static_cast<float>(gz)),
+                    grid, terrain_aabb);
+                auto p10 = coord::to_world(
+                    coord::CellPos(static_cast<float>(gx + 1), 0.0f, static_cast<float>(gz)),
+                    grid, terrain_aabb);
+                auto p01 = coord::to_world(
+                    coord::CellPos(static_cast<float>(gx), 0.0f, static_cast<float>(gz + 1)),
+                    grid, terrain_aabb);
+                auto p11 = coord::to_world(
+                    coord::CellPos(static_cast<float>(gx + 1), 0.0f, static_cast<float>(gz + 1)),
+                    grid, terrain_aabb);
+
+                // Project all 4 corners to screen
+                float sx00, sy00, sx10, sy10, sx01, sy01, sx11, sy11;
+                bool v00 = project_to_screen(p00.vec(), vp, sw, sh, sx00, sy00);
+                bool v10 = project_to_screen(p10.vec(), vp, sw, sh, sx10, sy10);
+                bool v01 = project_to_screen(p01.vec(), vp, sw, sh, sx01, sy01);
+                bool v11 = project_to_screen(p11.vec(), vp, sw, sh, sx11, sy11);
+
+                // Skip if all 4 corners are behind camera
+                if (!v00 && !v10 && !v01 && !v11) continue;
+
+                // Skip if all 4 corners are off-screen (simple AABB check)
+                float min_x = std::min({sx00, sx10, sx01, sx11});
+                float max_x = std::max({sx00, sx10, sx01, sx11});
+                float min_y = std::min({sy00, sy10, sy01, sy11});
+                float max_y = std::max({sy00, sy10, sy01, sy11});
+                if (max_x < 0 || min_x > sw || max_y < 0 || min_y > sh) continue;
+
+                bool is_solid = grid.is_solid(gx, gz);
+                ImU32 fill = is_solid ? solid_col : walkable_col;
+
+                // Filled quad
+                dl->AddQuadFilled(
+                    ImVec2(sx00, sy00), ImVec2(sx10, sy10),
+                    ImVec2(sx11, sy11), ImVec2(sx01, sy01), fill);
+
+                // Grid lines (only draw right and bottom edges to avoid double-drawing)
+                dl->AddLine(ImVec2(sx10, sy10), ImVec2(sx11, sy11), grid_line_col, 1.0f);
+                dl->AddLine(ImVec2(sx01, sy01), ImVec2(sx11, sy11), grid_line_col, 1.0f);
+            }
+        }
     }
 
     // ── World manifest gizmos ──

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -9,6 +9,7 @@
 #include "gseurat/engine/project_root.hpp"
 #include "gseurat/engine/coordinate.hpp"
 #include "gseurat/engine/collision_gen.hpp"
+#include "gseurat/engine/debug_draw.hpp"
 
 #ifdef GSEURAT_DEV_MODE
 #include <imgui.h>
@@ -1112,59 +1113,9 @@ void StagingState::draw_gizmos(AppBase& app) {
 
     // ── Collision grid overlay ──
     if (ov.show_gizmo_collision && last_scene_data_ && last_scene_data_->collision.has_value()) {
-        const auto& grid = *last_scene_data_->collision;
         auto terrain_aabb = app.gs_terrain().terrain_aabb;
-
-        ImU32 solid_col    = IM_COL32(204, 0, 0, 77);    // red, alpha ~0.3
-        ImU32 walkable_col = IM_COL32(0, 204, 0, 38);    // green, alpha ~0.15
-        ImU32 grid_line_col = IM_COL32(255, 255, 255, 51); // white, alpha ~0.2
-
-        for (uint32_t gz = 0; gz < grid.height; gz++) {
-            for (uint32_t gx = 0; gx < grid.width; gx++) {
-                // Four corners of the cell in world space
-                auto p00 = coord::to_world(
-                    coord::CellPos(static_cast<float>(gx), 0.0f, static_cast<float>(gz)),
-                    grid, terrain_aabb);
-                auto p10 = coord::to_world(
-                    coord::CellPos(static_cast<float>(gx + 1), 0.0f, static_cast<float>(gz)),
-                    grid, terrain_aabb);
-                auto p01 = coord::to_world(
-                    coord::CellPos(static_cast<float>(gx), 0.0f, static_cast<float>(gz + 1)),
-                    grid, terrain_aabb);
-                auto p11 = coord::to_world(
-                    coord::CellPos(static_cast<float>(gx + 1), 0.0f, static_cast<float>(gz + 1)),
-                    grid, terrain_aabb);
-
-                // Project all 4 corners to screen
-                float sx00, sy00, sx10, sy10, sx01, sy01, sx11, sy11;
-                bool v00 = project_to_screen(p00.vec(), vp, sw, sh, sx00, sy00);
-                bool v10 = project_to_screen(p10.vec(), vp, sw, sh, sx10, sy10);
-                bool v01 = project_to_screen(p01.vec(), vp, sw, sh, sx01, sy01);
-                bool v11 = project_to_screen(p11.vec(), vp, sw, sh, sx11, sy11);
-
-                // Skip if all 4 corners are behind camera
-                if (!v00 && !v10 && !v01 && !v11) continue;
-
-                // Skip if all 4 corners are off-screen (simple AABB check)
-                float min_x = std::min({sx00, sx10, sx01, sx11});
-                float max_x = std::max({sx00, sx10, sx01, sx11});
-                float min_y = std::min({sy00, sy10, sy01, sy11});
-                float max_y = std::max({sy00, sy10, sy01, sy11});
-                if (max_x < 0 || min_x > sw || max_y < 0 || min_y > sh) continue;
-
-                bool is_solid = grid.is_solid(gx, gz);
-                ImU32 fill = is_solid ? solid_col : walkable_col;
-
-                // Filled quad
-                dl->AddQuadFilled(
-                    ImVec2(sx00, sy00), ImVec2(sx10, sy10),
-                    ImVec2(sx11, sy11), ImVec2(sx01, sy01), fill);
-
-                // Grid lines (only draw right and bottom edges to avoid double-drawing)
-                dl->AddLine(ImVec2(sx10, sy10), ImVec2(sx11, sy11), grid_line_col, 1.0f);
-                dl->AddLine(ImVec2(sx01, sy01), ImVec2(sx11, sy11), grid_line_col, 1.0f);
-            }
-        }
+        glm::vec2 origin(terrain_aabb.min.x, terrain_aabb.min.z);
+        draw_collision_grid_overlay(dl, *last_scene_data_->collision, origin, vp, sw, sh);
     }
 
     // ── World manifest gizmos ──


### PR DESCRIPTION
## Summary
- Add **Gizmo: Collision** toggle to the Developer Mode View menu for visualizing the CollisionGrid
- Solid (impassable) cells rendered as semi-transparent **red**, walkable cells as **green**, with white grid lines at cell boundaries
- Frustum-culled: cells behind the camera or off-screen are skipped
- Default **off** (36k quads for 192×192 grid); enable via View → Gizmo: Collision

## Test plan
- [ ] Build with `cmake --build --preset macos-debug`
- [ ] Launch Staging, load seurat_island scene
- [ ] Press F1, enable View → Gizmo: Collision — verify red/green overlay appears
- [ ] Verify Show All / Hide All toggles the collision overlay
- [ ] Enter Camera Review mode (WASD) — confirm solid cells match impassable areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)