### PR TITLE
chore: add imgui.ini, perf.log, __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ out/
 .DS_Store
 Thumbs.db
 
+# Runtime / generated
+imgui.ini
+perf.log
+__pycache__/
+
 # Compiled objects
 *.o
 *.obj


### PR DESCRIPTION
## Summary
- Add `imgui.ini` (ImGui layout state, auto-generated by DevOverlay)
- Add `perf.log` (performance log file)
- Add `__pycache__/` (Python bytecode cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)