### PR TITLE
fix(gs): preserve bone-animated Gaussians during distance culling

### DIFF
--- a/src/engine/gs_chunk_grid.cpp
+++ b/src/engine/gs_chunk_grid.cpp
@@ -294,7 +294,25 @@ uint32_t GsChunkGrid::gather_lod(const std::vector<uint32_t>& chunk_indices,
     }
 
     out.resize(offset);
-    return offset;
+
+    // Re-inject bone-animated Gaussians from culled chunks.
+    // Character Gaussians (bone_index > 0) are embedded in the static PLY
+    // and must always be present for skeletal animation to work.
+    std::vector<bool> chunk_included(chunks_.size(), false);
+    for (const auto& lod : lods) {
+        chunk_included[lod.idx] = true;
+    }
+    for (uint32_t ci = 0; ci < chunks_.size(); ++ci) {
+        if (chunk_included[ci]) continue;  // already gathered
+        const auto& chunk = chunks_[ci];
+        for (uint32_t i = chunk.start_index; i < chunk.start_index + chunk.count; ++i) {
+            if (sorted_gaussians_[i].bone_index > 0) {
+                out.push_back(sorted_gaussians_[i]);
+            }
+        }
+    }
+
+    return static_cast<uint32_t>(out.size());
 }
 
 }  // namespace gseurat


### PR DESCRIPTION
## Summary
- Re-inject bone-animated Gaussians (`bone_index > 0`) from distance-culled chunks in `gather_lod()`
- Fixes player character disappearing when walking to NorthForest

## Root Cause
Character Gaussians are embedded in the island PLY and assigned to chunks by position. When distant chunks are culled, character Gaussians in those chunks were removed from the static buffer, making the skeletal character invisible.

## Test plan
- [x] Build succeeds (macos-release)
- [x] Player character visible in NorthForest with distance culling active
- [x] Distant house still culled properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)