### PR TITLE
ui: rename Import Image dialog labels for clarity

### DIFF
--- a/tools/apps/bricklayer/src/panels/ImportDialog.tsx
+++ b/tools/apps/bricklayer/src/panels/ImportDialog.tsx
@@ -215,7 +215,7 @@ export function ImportDialog({ onClose }: { onClose: () => void }) {
         )}
 
         <div style={styles.row}>
-          <span style={styles.label}>Max Width</span>
+          <span style={styles.label}>Max Grid</span>
           <input
             type="range"
             min={32}
@@ -234,7 +234,7 @@ export function ImportDialog({ onClose }: { onClose: () => void }) {
 
         {showHeightSlider && (
           <div style={styles.row}>
-            <span style={styles.label}>Max Height</span>
+            <span style={styles.label}>Max Z</span>
             <input
               type="range"
               min={1}


### PR DESCRIPTION
## Summary
- Rename "Max Width" → **Max Grid** (controls grid X/Y resolution, not image width)
- Rename "Max Height" → **Max Z** (controls voxel column depth range)

## Test plan
- [ ] Open Bricklayer → Import Image dialog
- [ ] Verify labels show "Max Grid" and "Max Z"

🤖 Generated with [Claude Code](https://claude.com/claude-code)