### PR TITLE
feat(echidna): add Animate ToolBar with Orbit tool

### DIFF
--- a/docs/superpowers/plans/2026-04-16-echidna-animate-toolbar.md
+++ b/docs/superpowers/plans/2026-04-16-echidna-animate-toolbar.md
@@ -1,0 +1,512 @@
+# Echidna Animate ToolBar — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated Animate mode toolbar with Orbit, Assign Part, Box Select, Lasso, and a Target Bone dropdown. Introduce a neutral Orbit tool as default on mode switch.
+
+**Architecture:** New `AnimateToolBar` component rendered above `AnimateLeftPanel` in Animate mode. New `'orbit'` tool type that does nothing in the viewport's click handler. `setMode()` resets `activeTool` to `'orbit'` to prevent edit bleed-through between modes.
+
+**Tech Stack:** TypeScript, React, Zustand, Vitest
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `tools/apps/echidna/src/store/types.ts` | Modify | Add `'orbit'` to ToolType |
+| `tools/apps/echidna/src/store/useCharacterStore.ts` | Modify | `setMode()` resets activeTool |
+| `tools/apps/echidna/src/App.tsx` | Modify | Add `q` key binding; render AnimateToolBar |
+| `tools/apps/echidna/src/panels/ToolBar.tsx` | Modify | Add Orbit button |
+| `tools/apps/echidna/src/panels/AnimateToolBar.tsx` | Create | New component |
+| `tools/apps/echidna/src/viewport/VoxelMesh.tsx` | Modify | No-op for `'orbit'` tool |
+| `tools/apps/echidna/src/__tests__/animateToolBar.test.ts` | Create | Mode switch + orbit tests |
+
+---
+
+### Task 1: Add `'orbit'` ToolType and `setMode` reset (TDD)
+
+**Files:**
+- Modify: `tools/apps/echidna/src/store/types.ts`
+- Modify: `tools/apps/echidna/src/store/useCharacterStore.ts`
+- Create: `tools/apps/echidna/src/__tests__/animateToolBar.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tools/apps/echidna/src/__tests__/animateToolBar.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCharacterStore } from '../store/useCharacterStore.js';
+
+describe('setMode resets activeTool to orbit', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({ mode: 'build', activeTool: 'place' });
+  });
+
+  it('resets activeTool to orbit when switching to animate', () => {
+    useCharacterStore.getState().setMode('animate');
+    expect(useCharacterStore.getState().activeTool).toBe('orbit');
+  });
+
+  it('resets activeTool to orbit when switching to build', () => {
+    useCharacterStore.setState({ mode: 'animate', activeTool: 'assign_part' });
+    useCharacterStore.getState().setMode('build');
+    expect(useCharacterStore.getState().activeTool).toBe('orbit');
+  });
+
+  it('orbit tool can be set in both modes', () => {
+    useCharacterStore.getState().setMode('build');
+    useCharacterStore.getState().setTool('orbit');
+    expect(useCharacterStore.getState().activeTool).toBe('orbit');
+
+    useCharacterStore.getState().setMode('animate');
+    useCharacterStore.getState().setTool('orbit');
+    expect(useCharacterStore.getState().activeTool).toBe('orbit');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/eccyan/dev/GSeurat/tools/apps/echidna && npx vitest run src/__tests__/animateToolBar.test.ts 2>&1 || true
+```
+
+Expected: FAIL — `'orbit'` not assignable to ToolType, or activeTool remains `'place'`.
+
+- [ ] **Step 3: Add `'orbit'` to ToolType**
+
+In `tools/apps/echidna/src/store/types.ts`, change:
+
+```ts
+export type ToolType =
+  | 'place'
+  | 'paint'
+  | 'erase'
+  | 'fill'
+  | 'extrude'
+  | 'eyedropper'
+  | 'assign_part'
+  | 'box_select'
+  | 'lasso_select';
+```
+
+to:
+
+```ts
+export type ToolType =
+  | 'orbit'
+  | 'place'
+  | 'paint'
+  | 'erase'
+  | 'fill'
+  | 'extrude'
+  | 'eyedropper'
+  | 'assign_part'
+  | 'box_select'
+  | 'lasso_select';
+```
+
+- [ ] **Step 4: Update `setMode` to reset activeTool**
+
+In `tools/apps/echidna/src/store/useCharacterStore.ts`, find:
+
+```ts
+  setMode: (mode) => set({ mode }),
+```
+
+Change to:
+
+```ts
+  setMode: (mode) => set({ mode, activeTool: 'orbit' }),
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd /Users/eccyan/dev/GSeurat/tools/apps/echidna && npx vitest run src/__tests__/animateToolBar.test.ts
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/eccyan/dev/GSeurat
+git add tools/apps/echidna/src/store/types.ts \
+  tools/apps/echidna/src/store/useCharacterStore.ts \
+  tools/apps/echidna/src/__tests__/animateToolBar.test.ts
+git commit -m "feat(echidna): add orbit tool, setMode resets activeTool"
+```
+
+---
+
+### Task 2: Handle `'orbit'` in viewport (no-op)
+
+**Files:**
+- Modify: `tools/apps/echidna/src/viewport/VoxelMesh.tsx`
+
+- [ ] **Step 1: Add orbit case to click handler switch**
+
+In `tools/apps/echidna/src/viewport/VoxelMesh.tsx`, find line 523:
+
+```ts
+    switch (store.activeTool) {
+      case 'place': {
+```
+
+Insert a new case before `'place'`:
+
+```ts
+    switch (store.activeTool) {
+      case 'orbit': {
+        // Orbit is camera-only — no voxel interactions
+        return;
+      }
+      case 'place': {
+```
+
+- [ ] **Step 2: Build to verify types**
+
+```bash
+cd /Users/eccyan/dev/GSeurat/tools && pnpm --filter echidna build
+```
+
+Expected: builds successfully.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/eccyan/dev/GSeurat
+git add tools/apps/echidna/src/viewport/VoxelMesh.tsx
+git commit -m "feat(echidna): orbit tool is no-op in viewport click handler"
+```
+
+---
+
+### Task 3: Add Orbit button to Build ToolBar + `q` keybinding
+
+**Files:**
+- Modify: `tools/apps/echidna/src/panels/ToolBar.tsx`
+- Modify: `tools/apps/echidna/src/App.tsx`
+
+- [ ] **Step 1: Add Orbit to Build ToolBar tools array**
+
+In `tools/apps/echidna/src/panels/ToolBar.tsx`, find:
+
+```ts
+const tools: { id: ToolType; label: string; key: string }[] = [
+  { id: 'place', label: 'Place', key: 'V' },
+```
+
+Add Orbit as the first item:
+
+```ts
+const tools: { id: ToolType; label: string; key: string }[] = [
+  { id: 'orbit', label: 'Orbit', key: 'Q' },
+  { id: 'place', label: 'Place', key: 'V' },
+```
+
+- [ ] **Step 2: Add `q` to Build tool keyboard shortcuts**
+
+In `tools/apps/echidna/src/App.tsx`, find:
+
+```ts
+const buildToolKeys: Record<string, ToolType> = {
+  v: 'place',
+```
+
+Change to:
+
+```ts
+const buildToolKeys: Record<string, ToolType> = {
+  q: 'orbit',
+  v: 'place',
+```
+
+- [ ] **Step 3: Add `q` to Animate tool keyboard shortcuts**
+
+In the same file, find:
+
+```ts
+const animateToolKeys: Record<string, ToolType> = {
+  a: 'assign_part',
+  s: 'box_select',
+};
+```
+
+Change to:
+
+```ts
+const animateToolKeys: Record<string, ToolType> = {
+  q: 'orbit',
+  a: 'assign_part',
+  s: 'box_select',
+  l: 'lasso_select',
+};
+```
+
+- [ ] **Step 4: Build to verify**
+
+```bash
+cd /Users/eccyan/dev/GSeurat/tools && pnpm --filter echidna build
+```
+
+Expected: builds successfully.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/eccyan/dev/GSeurat
+git add tools/apps/echidna/src/panels/ToolBar.tsx \
+  tools/apps/echidna/src/App.tsx
+git commit -m "feat(echidna): add orbit tool button and Q keybinding"
+```
+
+---
+
+### Task 4: Create AnimateToolBar component
+
+**Files:**
+- Create: `tools/apps/echidna/src/panels/AnimateToolBar.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `tools/apps/echidna/src/panels/AnimateToolBar.tsx`:
+
+```tsx
+import React from 'react';
+import { useComponentRegistry } from '@gseurat/ui-kit';
+import { useCharacterStore } from '../store/useCharacterStore.js';
+import type { ToolType } from '../store/types.js';
+
+const tools: { id: ToolType; label: string; key: string }[] = [
+  { id: 'orbit', label: 'Orbit', key: 'Q' },
+  { id: 'assign_part', label: 'Assign Part', key: 'A' },
+  { id: 'box_select', label: 'Box Select', key: 'S' },
+  { id: 'lasso_select', label: 'Lasso', key: 'L' },
+];
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    background: '#1e1e3a',
+    borderBottom: '1px solid #333',
+    padding: 12,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+  },
+  section: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+  },
+  label: {
+    fontSize: 11,
+    color: '#888',
+    textTransform: 'uppercase' as const,
+    letterSpacing: 1,
+  },
+  toolBtn: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '6px 10px',
+    borderWidth: 1,
+    borderStyle: 'solid' as const,
+    borderColor: '#444',
+    borderRadius: 4,
+    background: '#2a2a4a',
+    color: '#ddd',
+    cursor: 'pointer',
+    fontSize: 13,
+  },
+  toolBtnActive: {
+    background: '#4a4a8a',
+    borderColor: '#77f',
+  },
+  shortcut: {
+    fontSize: 11,
+    color: '#777',
+  },
+  select: {
+    padding: '6px 8px',
+    background: '#2a2a4a',
+    border: '1px solid #444',
+    borderRadius: 4,
+    color: '#ddd',
+    fontSize: 13,
+  },
+  selectDisabled: {
+    opacity: 0.5,
+    cursor: 'not-allowed',
+  },
+};
+
+export function AnimateToolBar() {
+  useComponentRegistry('AnimateToolBar');
+  const activeTool = useCharacterStore((s) => s.activeTool);
+  const setTool = useCharacterStore((s) => s.setTool);
+  const parts = useCharacterStore((s) => s.asset?.characterParts ?? []);
+  const selectedPart = useCharacterStore((s) => s.selectedPart);
+  const setSelectedPart = useCharacterStore((s) => s.setSelectedPart);
+
+  const hasBones = parts.length > 0;
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.section}>
+        <span style={styles.label}>Tools</span>
+        {tools.map((t) => (
+          <button
+            key={t.id}
+            style={{
+              ...styles.toolBtn,
+              ...(activeTool === t.id ? styles.toolBtnActive : {}),
+            }}
+            onClick={() => setTool(t.id)}
+          >
+            {t.label}
+            <span style={styles.shortcut}>{t.key}</span>
+          </button>
+        ))}
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Target Bone</span>
+        <select
+          style={{
+            ...styles.select,
+            ...(!hasBones ? styles.selectDisabled : {}),
+          }}
+          value={selectedPart ?? ''}
+          onChange={(e) => setSelectedPart(e.target.value || null)}
+          disabled={!hasBones}
+        >
+          {!hasBones && <option value="">No bones</option>}
+          {hasBones && <option value="">(none)</option>}
+          {parts.map((p) => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+```bash
+cd /Users/eccyan/dev/GSeurat/tools && pnpm --filter echidna build
+```
+
+Expected: builds successfully.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/eccyan/dev/GSeurat
+git add tools/apps/echidna/src/panels/AnimateToolBar.tsx
+git commit -m "feat(echidna): add AnimateToolBar component"
+```
+
+---
+
+### Task 5: Mount AnimateToolBar above AnimateLeftPanel
+
+**Files:**
+- Modify: `tools/apps/echidna/src/App.tsx`
+
+- [ ] **Step 1: Add import**
+
+In `tools/apps/echidna/src/App.tsx`, find:
+
+```ts
+import { ToolBar } from './panels/ToolBar.js';
+```
+
+Add after it:
+
+```ts
+import { AnimateToolBar } from './panels/AnimateToolBar.js';
+```
+
+- [ ] **Step 2: Render AnimateToolBar above AnimateLeftPanel**
+
+In the same file, find line 300:
+
+```tsx
+            {mode === 'build' || assetKind !== 'character' ? <ToolBar /> : <AnimateLeftPanel />}
+```
+
+Change to:
+
+```tsx
+            {mode === 'build' || assetKind !== 'character' ? (
+              <ToolBar />
+            ) : (
+              <>
+                <AnimateToolBar />
+                <AnimateLeftPanel />
+              </>
+            )}
+```
+
+- [ ] **Step 3: Build and verify**
+
+```bash
+cd /Users/eccyan/dev/GSeurat/tools && pnpm --filter echidna build
+```
+
+Expected: builds successfully.
+
+- [ ] **Step 4: Run store tests to verify nothing broke**
+
+```bash
+cd /Users/eccyan/dev/GSeurat/tools/apps/echidna && npx vitest run src/__tests__/animateToolBar.test.ts
+```
+
+Expected: all 3 tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/eccyan/dev/GSeurat
+git add tools/apps/echidna/src/App.tsx
+git commit -m "feat(echidna): mount AnimateToolBar above AnimateLeftPanel"
+```
+
+---
+
+### Task 6: Register AnimateToolBar in expected-components
+
+**Files:**
+- Modify: `tools/apps/echidna/src/expected-components.json`
+
+- [ ] **Step 1: Read current file**
+
+Read `tools/apps/echidna/src/expected-components.json` to understand its structure.
+
+- [ ] **Step 2: Add AnimateToolBar**
+
+Add `"AnimateToolBar"` to the appropriate section (likely under Animate mode components or always-present components). Follow the pattern for `AnimateLeftPanel` if it's listed — AnimateToolBar should be in the same scope since it renders alongside.
+
+If `AnimateLeftPanel` is listed under `animate` or similar conditional mode, add `AnimateToolBar` there.
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+cd /Users/eccyan/dev/GSeurat/tools && pnpm --filter echidna build
+```
+
+Expected: builds successfully.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/eccyan/dev/GSeurat
+git add tools/apps/echidna/src/expected-components.json
+git commit -m "chore(echidna): register AnimateToolBar in expected-components"
+```

--- a/docs/superpowers/plans/2026-04-16-gsvx-binary-format.md
+++ b/docs/superpowers/plans/2026-04-16-gsvx-binary-format.md
@@ -1,0 +1,701 @@
+# GSVX Binary Format Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace runtime PLY parsing with a pre-baked binary format (.gsvx) that loads via zero-copy bulk read directly into Vulkan SSBOs.
+
+**Architecture:** A Python offline cooker reads PLY files, applies all math transforms (exp, sigmoid, SH→RGB), and writes a flat binary matching the existing `GpuGaussian` struct (4×vec4 = 64 bytes). The C++ loader validates a 32-byte header and bulk-reads the payload into a `std::vector<GpuGaussian>`, skipping all per-element parsing.
+
+**Tech Stack:** Python 3 (numpy, plyfile), C++23, CMake, Vulkan (VMA)
+
+**Spec:** `docs/superpowers/specs/2026-04-16-gsvx-binary-format-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `include/gseurat/engine/gaussian_cloud.hpp` | Modify | Add `GpuGaussian`, `GsvxHeader`, `GsvxPayload`, `load_gsvx()` |
+| `src/engine/gaussian_cloud.cpp` | Modify | Implement `load_gsvx()` |
+| `src/engine/gs_renderer.cpp` | Modify | Remove local `GpuGaussian` definition, use shared header |
+| `tests/test_gaussian_cloud.cpp` | Modify | Add GSVX round-trip and validation tests |
+| `CMakeLists.txt` | No change | Test already links `gaussian_cloud.cpp` |
+| `scripts/ply_to_gseurat.py` | Create | Python PLY→GSVX cooker |
+
+---
+
+### Task 1: Promote `GpuGaussian` to the shared header
+
+**Files:**
+- Modify: `include/gseurat/engine/gaussian_cloud.hpp`
+- Modify: `src/engine/gs_renderer.cpp` (lines 14–19)
+
+The `GpuGaussian` struct is currently defined in an anonymous namespace inside `gs_renderer.cpp`. We need it in the header so both the loader and renderer can share it.
+
+- [ ] **Step 1: Add `GpuGaussian` and `GsvxHeader` to gaussian_cloud.hpp**
+
+Add after the `AABB` struct (line 33), before `class GaussianCloud`:
+
+```cpp
+/// GPU-side Gaussian struct (matches gs_preprocess.comp GpuGaussian).
+/// 4 × vec4 = 64 bytes, std430-compatible.
+struct alignas(16) GpuGaussian {
+    glm::vec4 pos_opacity;  // xyz = position, w = opacity
+    glm::vec4 scale_pad;    // xyz = scale, w = float_bits(bone_index)
+    glm::vec4 rot;          // xyzw = quaternion (x, y, z, w)
+    glm::vec4 color_pad;    // rgb = color, w = emission
+};
+static_assert(sizeof(GpuGaussian) == 64, "GpuGaussian must be 64 bytes for GPU std430");
+static_assert(alignof(GpuGaussian) == 16, "GpuGaussian must be 16-byte aligned");
+
+/// GSVX binary file header (32 bytes).
+struct GsvxHeader {
+    char     magic[4];     // "GSVX"
+    uint32_t version;      // Format version (currently 1)
+    uint32_t count;        // Number of Gaussians in payload
+    uint32_t flags;        // Reserved (must be 0)
+    uint8_t  reserved[16]; // Padding to 32 bytes
+};
+static_assert(sizeof(GsvxHeader) == 32, "GsvxHeader must be 32 bytes");
+```
+
+Also add `#include <cstdint>` to the includes at the top of the file.
+
+- [ ] **Step 2: Remove the local GpuGaussian from gs_renderer.cpp**
+
+In `src/engine/gs_renderer.cpp`, replace lines 13–19:
+
+```cpp
+// GPU-side Gaussian struct (matches gs_preprocess.comp input)
+struct GpuGaussian {
+    glm::vec4 pos_opacity;    // xyz = position, w = opacity
+    glm::vec4 scale_pad;      // xyz = scale, w = unused
+    glm::vec4 rot;            // xyzw = quaternion
+    glm::vec4 color_pad;      // rgb = color, w = emission intensity
+};  // 64 bytes, aligned
+```
+
+with a comment noting the struct is now in the shared header:
+
+```cpp
+// GpuGaussian is defined in gaussian_cloud.hpp (shared with GSVX loader).
+```
+
+Verify that `gs_renderer.cpp` already includes `gaussian_cloud.hpp` (it should, since it uses `GaussianCloud`).
+
+- [ ] **Step 3: Build to verify no regressions**
+
+Run: `cmake --build build/macos-debug --target test_gaussian_cloud 2>&1 | tail -5`
+Expected: Build succeeds.
+
+Run: `cmake --build build/macos-debug --target gseurat_core 2>&1 | tail -5`
+Expected: Build succeeds (renderer still compiles).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add include/gseurat/engine/gaussian_cloud.hpp src/engine/gs_renderer.cpp
+git commit -m "refactor: promote GpuGaussian to shared header for GSVX loader"
+```
+
+---
+
+### Task 2: Implement `load_gsvx()` in the C++ engine
+
+**Files:**
+- Modify: `include/gseurat/engine/gaussian_cloud.hpp`
+- Modify: `src/engine/gaussian_cloud.cpp`
+
+- [ ] **Step 1: Add `GsvxPayload` and `load_gsvx()` declaration to the header**
+
+Add after the `GsvxHeader` static_assert, before `class GaussianCloud`:
+
+```cpp
+/// Pre-baked GPU-ready Gaussian data loaded from a .gsvx file.
+struct GsvxPayload {
+    std::vector<GpuGaussian> gpu_gaussians;
+    AABB bounds;
+    uint32_t count = 0;
+};
+```
+
+Add to `class GaussianCloud` public section (after `load_ply`):
+
+```cpp
+    /// Load a pre-baked .gsvx binary file (zero-copy GPU format).
+    static GsvxPayload load_gsvx(const std::string& path);
+```
+
+- [ ] **Step 2: Implement `load_gsvx()` in gaussian_cloud.cpp**
+
+Add at the end of the file, before the closing `}  // namespace gseurat`:
+
+```cpp
+GsvxPayload GaussianCloud::load_gsvx(const std::string& path) {
+    auto resolved = resolve_asset_path(path);
+    std::ifstream file(resolved, std::ios::binary);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open GSVX file: " + resolved.string());
+    }
+
+    // Read and validate header
+    GsvxHeader header{};
+    file.read(reinterpret_cast<char*>(&header), sizeof(GsvxHeader));
+    if (!file) {
+        throw std::runtime_error("Failed to read GSVX header: " + resolved.string());
+    }
+
+    if (std::memcmp(header.magic, "GSVX", 4) != 0) {
+        throw std::runtime_error("Invalid GSVX magic number: " + resolved.string());
+    }
+    if (header.version != 1) {
+        throw std::runtime_error("Unsupported GSVX version " +
+                                 std::to_string(header.version) + ": " + resolved.string());
+    }
+
+    GsvxPayload payload;
+    payload.count = header.count;
+
+    if (payload.count == 0) {
+        return payload;
+    }
+
+    // Bulk-read payload directly into vector (zero per-element parsing)
+    payload.gpu_gaussians.resize(payload.count);
+    const auto payload_bytes = static_cast<std::streamsize>(
+        static_cast<size_t>(payload.count) * sizeof(GpuGaussian));
+    file.read(reinterpret_cast<char*>(payload.gpu_gaussians.data()), payload_bytes);
+    if (!file) {
+        throw std::runtime_error("Failed to read GSVX payload (" +
+                                 std::to_string(payload.count) + " gaussians): " +
+                                 resolved.string());
+    }
+
+    // Compute AABB from pre-baked positions (trivial scan, no math)
+    for (const auto& g : payload.gpu_gaussians) {
+        payload.bounds.expand(glm::vec3(g.pos_opacity));
+    }
+
+    return payload;
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `cmake --build build/macos-debug --target test_gaussian_cloud 2>&1 | tail -5`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add include/gseurat/engine/gaussian_cloud.hpp src/engine/gaussian_cloud.cpp
+git commit -m "feat: implement GSVX zero-copy loader in gaussian_cloud"
+```
+
+---
+
+### Task 3: Add C++ tests for GSVX loading
+
+**Files:**
+- Modify: `tests/test_gaussian_cloud.cpp`
+
+- [ ] **Step 1: Add a helper to write a GSVX file from known data**
+
+Add after the existing `write_test_scene_json` helper (around line 171), before the `approx` helper:
+
+```cpp
+// Helper: write a .gsvx file with known GpuGaussian data
+static void write_test_gsvx(const std::string& path,
+                             const std::vector<gseurat::GpuGaussian>& gaussians) {
+    std::ofstream out(path, std::ios::binary);
+
+    // Header
+    gseurat::GsvxHeader header{};
+    std::memcpy(header.magic, "GSVX", 4);
+    header.version = 1;
+    header.count = static_cast<uint32_t>(gaussians.size());
+    header.flags = 0;
+    std::memset(header.reserved, 0, sizeof(header.reserved));
+    out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+
+    // Payload
+    if (!gaussians.empty()) {
+        out.write(reinterpret_cast<const char*>(gaussians.data()),
+                  static_cast<std::streamsize>(gaussians.size() * sizeof(gseurat::GpuGaussian)));
+    }
+}
+```
+
+- [ ] **Step 2: Add Test — GSVX round-trip matches PLY→GpuGaussian conversion**
+
+Add after the last existing test (before the `fs::remove_all` cleanup):
+
+```cpp
+    // ====== Test 10: GSVX load matches PLY→GpuGaussian conversion ======
+    {
+        // Load PLY and manually convert to GpuGaussian (same as gs_renderer.cpp)
+        const std::string ply_path = tmp_dir + "/test_standard.ply";
+        write_test_ply(ply_path, 5);
+        auto cloud = GaussianCloud::load_ply(ply_path);
+
+        std::vector<GpuGaussian> expected(cloud.count());
+        for (uint32_t i = 0; i < cloud.count(); ++i) {
+            const auto& g = cloud.gaussians()[i];
+            float bone_as_float;
+            uint32_t bone_idx = g.bone_index;
+            std::memcpy(&bone_as_float, &bone_idx, sizeof(float));
+            expected[i].pos_opacity = glm::vec4(g.position, g.opacity);
+            expected[i].scale_pad = glm::vec4(g.scale, bone_as_float);
+            expected[i].rot = glm::vec4(g.rotation.x, g.rotation.y, g.rotation.z, g.rotation.w);
+            expected[i].color_pad = glm::vec4(g.color, g.emission);
+        }
+
+        // Write as GSVX and reload
+        const std::string gsvx_path = tmp_dir + "/test_roundtrip.gsvx";
+        write_test_gsvx(gsvx_path, expected);
+
+        auto payload = GaussianCloud::load_gsvx(gsvx_path);
+        assert(payload.count == 5 && "GSVX should load 5 Gaussians");
+
+        for (uint32_t i = 0; i < payload.count; ++i) {
+            const auto& got = payload.gpu_gaussians[i];
+            const auto& exp = expected[i];
+            assert(approx(got.pos_opacity.x, exp.pos_opacity.x) && "pos_opacity.x mismatch");
+            assert(approx(got.pos_opacity.y, exp.pos_opacity.y) && "pos_opacity.y mismatch");
+            assert(approx(got.pos_opacity.z, exp.pos_opacity.z) && "pos_opacity.z mismatch");
+            assert(approx(got.pos_opacity.w, exp.pos_opacity.w) && "pos_opacity.w mismatch");
+            assert(approx(got.scale_pad.x, exp.scale_pad.x) && "scale_pad.x mismatch");
+            assert(approx(got.rot.x, exp.rot.x) && "rot.x mismatch");
+            assert(approx(got.rot.w, exp.rot.w) && "rot.w mismatch");
+            assert(approx(got.color_pad.x, exp.color_pad.x) && "color_pad.x mismatch");
+            assert(approx(got.color_pad.w, exp.color_pad.w) && "color_pad.w (emission) mismatch");
+        }
+
+        // Verify AABB
+        assert(approx(payload.bounds.min.x, 0.0f) && "GSVX AABB min.x");
+        assert(approx(payload.bounds.max.x, 4.0f) && "GSVX AABB max.x");
+
+        printf("PASS: Test 10 - GSVX round-trip matches PLY→GpuGaussian\n");
+    }
+```
+
+- [ ] **Step 3: Add Test — GSVX header validation (bad magic)**
+
+```cpp
+    // ====== Test 11: GSVX bad magic number throws ======
+    {
+        const std::string bad_path = tmp_dir + "/test_bad_magic.gsvx";
+        {
+            std::ofstream out(bad_path, std::ios::binary);
+            GsvxHeader header{};
+            std::memcpy(header.magic, "NOPE", 4);
+            header.version = 1;
+            header.count = 0;
+            out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+        }
+
+        bool threw = false;
+        try {
+            GaussianCloud::load_gsvx(bad_path);
+        } catch (const std::runtime_error& e) {
+            threw = true;
+            assert(std::string(e.what()).find("magic") != std::string::npos &&
+                   "Error should mention magic");
+        }
+        assert(threw && "Should throw for bad GSVX magic");
+        printf("PASS: Test 11 - GSVX bad magic number throws\n");
+    }
+```
+
+- [ ] **Step 4: Add Test — GSVX bad version throws**
+
+```cpp
+    // ====== Test 12: GSVX unsupported version throws ======
+    {
+        const std::string bad_path = tmp_dir + "/test_bad_version.gsvx";
+        {
+            std::ofstream out(bad_path, std::ios::binary);
+            GsvxHeader header{};
+            std::memcpy(header.magic, "GSVX", 4);
+            header.version = 99;
+            header.count = 0;
+            out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+        }
+
+        bool threw = false;
+        try {
+            GaussianCloud::load_gsvx(bad_path);
+        } catch (const std::runtime_error& e) {
+            threw = true;
+            assert(std::string(e.what()).find("version") != std::string::npos &&
+                   "Error should mention version");
+        }
+        assert(threw && "Should throw for bad GSVX version");
+        printf("PASS: Test 12 - GSVX unsupported version throws\n");
+    }
+```
+
+- [ ] **Step 5: Add Test — GSVX empty file (0 Gaussians)**
+
+```cpp
+    // ====== Test 13: GSVX empty file (0 Gaussians) ======
+    {
+        const std::string empty_path = tmp_dir + "/test_empty.gsvx";
+        write_test_gsvx(empty_path, {});
+
+        auto payload = GaussianCloud::load_gsvx(empty_path);
+        assert(payload.count == 0 && "Empty GSVX should have 0 Gaussians");
+        assert(payload.gpu_gaussians.empty() && "Empty GSVX should have empty vector");
+        printf("PASS: Test 13 - GSVX empty file (0 Gaussians)\n");
+    }
+```
+
+- [ ] **Step 6: Add Test — GSVX missing file throws**
+
+```cpp
+    // ====== Test 14: GSVX missing file throws ======
+    {
+        bool threw = false;
+        try {
+            GaussianCloud::load_gsvx(tmp_dir + "/nonexistent.gsvx");
+        } catch (const std::runtime_error&) {
+            threw = true;
+        }
+        assert(threw && "Should throw for missing GSVX file");
+        printf("PASS: Test 14 - GSVX missing file throws\n");
+    }
+```
+
+- [ ] **Step 7: Build and run tests**
+
+Run: `cmake --build build/macos-debug --target test_gaussian_cloud 2>&1 | tail -5`
+Expected: Build succeeds.
+
+Run: `./build/macos-debug/test_gaussian_cloud`
+Expected: All 14 tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/test_gaussian_cloud.cpp
+git commit -m "test: add GSVX loader round-trip and validation tests"
+```
+
+---
+
+### Task 4: Create the Python PLY→GSVX cooker
+
+**Files:**
+- Create: `scripts/ply_to_gseurat.py`
+
+- [ ] **Step 1: Create the Python cooker script**
+
+Create `scripts/ply_to_gseurat.py`:
+
+```python
+#!/usr/bin/env python3
+"""Convert a binary little-endian PLY file to GSeurat's pre-baked .gsvx format.
+
+The output is a flat binary file whose payload is byte-identical to an array of
+GpuGaussian structs (4 × vec4 = 64 bytes each), ready for zero-copy upload to a
+Vulkan SSBO.
+
+Usage:
+    python3 scripts/ply_to_gseurat.py input.ply [-o output.gsvx]
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+from pathlib import Path
+
+import numpy as np
+
+try:
+    from plyfile import PlyData
+except ImportError:
+    sys.exit("Error: 'plyfile' package required.  Install with:  pip install plyfile")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GSVX_MAGIC = b"GSVX"
+GSVX_VERSION = 1
+HEADER_SIZE = 32          # bytes
+GAUSSIAN_SIZE = 64        # bytes (4 × vec4)
+SH_C0 = 0.28209479177387814  # 1 / (2 * sqrt(pi))
+
+# ---------------------------------------------------------------------------
+# PLY field resolution
+# ---------------------------------------------------------------------------
+
+def _resolve(vertex_data: np.ndarray, *candidates: str) -> np.ndarray | None:
+    """Return the first matching field from *candidates*, or None."""
+    for name in candidates:
+        if name in vertex_data.dtype.names:
+            return vertex_data[name].astype(np.float32)
+    return None
+
+
+def _require(vertex_data: np.ndarray, label: str, *candidates: str) -> np.ndarray:
+    arr = _resolve(vertex_data, *candidates)
+    if arr is None:
+        raise ValueError(f"PLY is missing required field '{label}' "
+                         f"(tried: {', '.join(candidates)})")
+    return arr
+
+# ---------------------------------------------------------------------------
+# Core conversion
+# ---------------------------------------------------------------------------
+
+def ply_to_gsvx(ply_path: Path) -> bytes:
+    """Read a PLY file and return the complete .gsvx binary (header + payload)."""
+
+    ply = PlyData.read(str(ply_path))
+    vertex = ply["vertex"].data
+    count = len(vertex)
+
+    # --- Position (stored directly) ---
+    px = _require(vertex, "x", "x").astype(np.float32)
+    py = _require(vertex, "y", "y").astype(np.float32)
+    pz = _require(vertex, "z", "z").astype(np.float32)
+
+    # --- Opacity: logit → sigmoid ---
+    raw_opacity = _resolve(vertex, "opacity")
+    if raw_opacity is not None:
+        opacity = (1.0 / (1.0 + np.exp(-raw_opacity))).astype(np.float32)
+    else:
+        opacity = np.ones(count, dtype=np.float32)
+
+    # --- Scale: log → exp ---
+    sx = _resolve(vertex, "scale_0", "scaling_0")
+    sy = _resolve(vertex, "scale_1", "scaling_1")
+    sz = _resolve(vertex, "scale_2", "scaling_2")
+    if sx is not None and sy is not None and sz is not None:
+        sx = np.exp(sx).astype(np.float32)
+        sy = np.exp(sy).astype(np.float32)
+        sz = np.exp(sz).astype(np.float32)
+    else:
+        sx = sy = sz = np.full(count, 0.01, dtype=np.float32)
+
+    # --- Bone index (uint32 stored as float bit-pattern) ---
+    bi_raw = _resolve(vertex, "bone_index")
+    if bi_raw is not None:
+        bone_idx = bi_raw.astype(np.uint32)
+    else:
+        bone_idx = np.zeros(count, dtype=np.uint32)
+    bone_as_float = bone_idx.view(np.float32)
+
+    # --- Rotation quaternion ---
+    # PLY stores (w, x, y, z) as rot_0..rot_3; shader expects (x, y, z, w)
+    rw = _resolve(vertex, "rot_0", "rotation_0")
+    rx = _resolve(vertex, "rot_1", "rotation_1")
+    ry = _resolve(vertex, "rot_2", "rotation_2")
+    rz = _resolve(vertex, "rot_3", "rotation_3")
+    if rw is not None and rx is not None and ry is not None and rz is not None:
+        # Normalize quaternion
+        length = np.sqrt(rw * rw + rx * rx + ry * ry + rz * rz)
+        length = np.where(length > 0, length, 1.0)
+        rw = (rw / length).astype(np.float32)
+        rx = (rx / length).astype(np.float32)
+        ry = (ry / length).astype(np.float32)
+        rz = (rz / length).astype(np.float32)
+    else:
+        rx = np.zeros(count, dtype=np.float32)
+        ry = np.zeros(count, dtype=np.float32)
+        rz = np.zeros(count, dtype=np.float32)
+        rw = np.ones(count, dtype=np.float32)
+
+    # --- Color ---
+    has_sh = "f_dc_0" in vertex.dtype.names
+    if has_sh:
+        cr = _resolve(vertex, "f_dc_0")
+        cg = _resolve(vertex, "f_dc_1")
+        cb = _resolve(vertex, "f_dc_2")
+        cr = np.clip(SH_C0 * cr + 0.5, 0.0, 1.0).astype(np.float32)
+        cg = np.clip(SH_C0 * cg + 0.5, 0.0, 1.0).astype(np.float32)
+        cb = np.clip(SH_C0 * cb + 0.5, 0.0, 1.0).astype(np.float32)
+    else:
+        cr = _resolve(vertex, "red")
+        cg = _resolve(vertex, "green")
+        cb = _resolve(vertex, "blue")
+        if cr is not None and cg is not None and cb is not None:
+            # uchar [0,255] → [0,1] (plyfile returns uint8 for uchar)
+            if vertex["red"].dtype == np.uint8:
+                cr = cr / 255.0
+                cg = cg / 255.0
+                cb = cb / 255.0
+            cr = cr.astype(np.float32)
+            cg = cg.astype(np.float32)
+            cb = cb.astype(np.float32)
+        else:
+            cr = cg = cb = np.ones(count, dtype=np.float32)
+
+    # --- Emission ---
+    emission = _resolve(vertex, "emission")
+    if emission is None:
+        emission = np.zeros(count, dtype=np.float32)
+
+    # --- Pack into structured array matching GpuGaussian ---
+    # GpuGaussian: vec4 pos_opacity, vec4 scale_pad, vec4 rot, vec4 color_pad
+    # = 16 floats per Gaussian
+    gpu_dtype = np.dtype([
+        ("pos_opacity", np.float32, 4),
+        ("scale_pad",   np.float32, 4),
+        ("rot",         np.float32, 4),
+        ("color_pad",   np.float32, 4),
+    ])
+    assert gpu_dtype.itemsize == GAUSSIAN_SIZE
+
+    out = np.zeros(count, dtype=gpu_dtype)
+    out["pos_opacity"][:, 0] = px
+    out["pos_opacity"][:, 1] = py
+    out["pos_opacity"][:, 2] = pz
+    out["pos_opacity"][:, 3] = opacity
+    out["scale_pad"][:, 0] = sx
+    out["scale_pad"][:, 1] = sy
+    out["scale_pad"][:, 2] = sz
+    out["scale_pad"][:, 3] = bone_as_float
+    out["rot"][:, 0] = rx   # shader order: x, y, z, w
+    out["rot"][:, 1] = ry
+    out["rot"][:, 2] = rz
+    out["rot"][:, 3] = rw
+    out["color_pad"][:, 0] = cr
+    out["color_pad"][:, 1] = cg
+    out["color_pad"][:, 2] = cb
+    out["color_pad"][:, 3] = emission
+
+    # --- Build binary ---
+    header = struct.pack("<4sIII16s",
+                         GSVX_MAGIC,
+                         GSVX_VERSION,
+                         count,
+                         0,           # flags (reserved)
+                         b"\x00" * 16)
+    assert len(header) == HEADER_SIZE
+
+    return header + out.tobytes()
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert a binary PLY file to GSeurat's .gsvx format.")
+    parser.add_argument("input", type=Path, help="Input .ply file")
+    parser.add_argument("-o", "--output", type=Path, default=None,
+                        help="Output .gsvx file (default: same name, .gsvx extension)")
+    args = parser.parse_args()
+
+    if not args.input.exists():
+        sys.exit(f"Error: input file not found: {args.input}")
+
+    output = args.output or args.input.with_suffix(".gsvx")
+    data = ply_to_gsvx(args.input)
+    output.write_bytes(data)
+
+    count = struct.unpack_from("<I", data, 8)[0]
+    print(f"Wrote {count} Gaussians ({len(data)} bytes) to {output}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Make the script executable**
+
+Run: `chmod +x scripts/ply_to_gseurat.py`
+
+- [ ] **Step 3: Verify the script runs (help output)**
+
+Run: `python3 scripts/ply_to_gseurat.py --help`
+Expected: Prints usage help without errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/ply_to_gseurat.py
+git commit -m "feat: add PLY to GSVX asset cooker script"
+```
+
+---
+
+### Task 5: End-to-end round-trip test (PLY → GSVX → C++ loader)
+
+**Files:**
+- Modify: `tests/test_gaussian_cloud.cpp`
+
+This test writes a PLY on disk, shells out to the Python cooker, then loads the resulting `.gsvx` via the C++ loader and compares against the PLY loader output. Since shelling out to Python from a C++ test adds a dependency, we instead write the GSVX directly using the same transforms the Python cooker applies, which we already tested in Task 3. The true end-to-end validation is a manual step.
+
+- [ ] **Step 1: Add a test that verifies file size matches header**
+
+Add to `tests/test_gaussian_cloud.cpp` before the cleanup:
+
+```cpp
+    // ====== Test 15: GSVX file size matches header count ======
+    {
+        const std::string gsvx_path = tmp_dir + "/test_size_check.gsvx";
+        std::vector<GpuGaussian> data(7);
+        for (uint32_t i = 0; i < 7; ++i) {
+            data[i].pos_opacity = glm::vec4(float(i), 0.0f, 0.0f, 1.0f);
+            data[i].scale_pad = glm::vec4(0.01f, 0.01f, 0.01f, 0.0f);
+            data[i].rot = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
+            data[i].color_pad = glm::vec4(1.0f, 1.0f, 1.0f, 0.0f);
+        }
+        write_test_gsvx(gsvx_path, data);
+
+        // Verify file size = 32 + 7 * 64 = 480
+        auto file_size = fs::file_size(gsvx_path);
+        assert(file_size == 32 + 7 * 64 && "GSVX file size = header + count * 64");
+
+        auto payload = GaussianCloud::load_gsvx(gsvx_path);
+        assert(payload.count == 7 && "Should load 7 Gaussians");
+        assert(approx(payload.gpu_gaussians[3].pos_opacity.x, 3.0f) && "Gaussian 3 pos.x=3");
+
+        printf("PASS: Test 15 - GSVX file size matches header count\n");
+    }
+```
+
+- [ ] **Step 2: Build and run all tests**
+
+Run: `cmake --build build/macos-debug --target test_gaussian_cloud 2>&1 | tail -5`
+Expected: Build succeeds.
+
+Run: `./build/macos-debug/test_gaussian_cloud`
+Expected: All 15 tests pass, ending with "All Gaussian splatting tests passed!"
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_gaussian_cloud.cpp
+git commit -m "test: add GSVX file size validation test"
+```
+
+---
+
+### Task 6: Manual end-to-end verification (Python cooker → C++ loader)
+
+This is a verification-only task — no code changes.
+
+- [ ] **Step 1: Find a test PLY file in the project**
+
+Run: `find examples/ -name "*.ply" -type f | head -3`
+
+- [ ] **Step 2: Cook it with the Python script**
+
+Run: `python3 scripts/ply_to_gseurat.py <path-to-ply> -o /tmp/test_cooked.gsvx`
+Expected: Prints "Wrote N Gaussians (M bytes) to /tmp/test_cooked.gsvx"
+
+- [ ] **Step 3: Verify file size**
+
+Run: `python3 -c "import struct, pathlib; d=pathlib.Path('/tmp/test_cooked.gsvx').read_bytes(); h=struct.unpack_from('<4sIII', d); print(f'magic={h[0]}, ver={h[1]}, count={h[2]}, flags={h[3]}, file_size={len(d)}, expected={32+h[2]*64}')"` 
+Expected: `file_size` equals `expected`.
+
+- [ ] **Step 4: Verify complete — all done**
+
+Print summary of what was built and tested.

--- a/docs/superpowers/specs/2026-04-16-echidna-animate-toolbar-design.md
+++ b/docs/superpowers/specs/2026-04-16-echidna-animate-toolbar-design.md
@@ -1,0 +1,86 @@
+# Echidna Animate ToolBar
+
+## Goal
+
+Add a dedicated toolbar for Animate mode so users can switch between Assign Part, Box Select, and Lasso Select without relying on keyboard shortcuts. Introduce a neutral Orbit tool that becomes the default when switching modes, preventing accidental edits from tools carried over from the other mode.
+
+This is sub-project 1 of a broader Animate panel improvement initiative. Future sub-projects (per-bone tracks, keyframe editing UX, pose management, playback controls, preview) will build on this foundation.
+
+## Architecture
+
+### Mode-specific toolbars
+
+Build mode keeps its existing `ToolBar`. Animate mode gets a new `AnimateToolBar` mounted above the existing `AnimateLeftPanel` in the left column:
+
+```
+Build mode                Animate mode
+┌──────────────┐          ┌──────────────────┐
+│  ToolBar     │          │ AnimateToolBar   │  <- NEW
+│  (existing)  │          ├──────────────────┤
+└──────────────┘          │ AnimateLeftPanel │
+                          │ (existing)       │
+                          └──────────────────┘
+```
+
+The two toolbars share no state beyond `activeTool` and `selectedPart`. Build tools and Animate tools are isolated — Build mode cannot activate Animate tools and vice versa.
+
+### Orbit tool
+
+Add a new neutral tool `'orbit'` to `ToolType`. In orbit mode, pointer interactions in the viewport only move the camera (using existing orbit controls) — no placement, painting, selection, or assignment.
+
+Orbit appears as the first tool button in both `ToolBar` and `AnimateToolBar`. Keyboard shortcut: **Q** (valid in both modes).
+
+### Mode switch behavior
+
+When `setMode()` is called, `activeTool` is always reset to `'orbit'`. This guarantees that switching from Build to Animate (or vice versa) never leaves the user with a tool that would modify the wrong thing on their next click. The user must explicitly pick the next tool.
+
+### AnimateToolBar contents
+
+1. **Tools section**
+   - Orbit (Q)
+   - Assign Part (A)
+   - Box Select (S)
+   - Lasso Select (L)
+
+2. **Target Bone dropdown**
+   - Lists all bones in `asset.characterParts`
+   - Bound to `selectedPart` — selecting a bone here updates the store, and the BoneTree below reflects the change (and vice versa)
+   - Shows "No bones" and is disabled when the asset has no parts
+
+## Data flow
+
+```
+User presses Q (or clicks Orbit button)
+  -> setTool('orbit')
+  -> activeTool = 'orbit'
+  -> viewport pointer events only drive camera
+
+User switches mode (Build <-> Animate)
+  -> setMode(newMode)
+  -> activeTool = 'orbit'  (always reset)
+  -> user picks next tool explicitly
+
+User selects bone in dropdown
+  -> setSelectedPart(boneId)
+  -> selectedPart updates
+  -> BoneTree highlights the same bone
+```
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `tools/apps/echidna/src/store/types.ts` | Add `'orbit'` to `ToolType` union |
+| `tools/apps/echidna/src/store/useCharacterStore.ts` | `setMode()` resets `activeTool` to `'orbit'` |
+| `tools/apps/echidna/src/App.tsx` | Add `q` key binding to `'orbit'` in both tool key maps; render `AnimateToolBar` above `AnimateLeftPanel` in animate mode |
+| `tools/apps/echidna/src/panels/ToolBar.tsx` | Add Orbit (Q) as first tool button |
+| `tools/apps/echidna/src/panels/AnimateToolBar.tsx` | New — Orbit + Assign Part + Box Select + Lasso + Target Bone dropdown |
+| `tools/apps/echidna/src/viewport/*` | Skip voxel/selection interactions when `activeTool === 'orbit'` |
+| `tools/apps/echidna/src/__tests__/animateToolBar.test.ts` | Mode switch → orbit; orbit tool available in both modes |
+
+## Testing
+
+- **Unit test:** `setMode('animate')` with `activeTool = 'place'` → `activeTool === 'orbit'`
+- **Unit test:** `setMode('build')` with `activeTool = 'assign_part'` → `activeTool === 'orbit'`
+- **Unit test:** `setTool('orbit')` works in both Build and Animate modes
+- **Manual test:** Open Echidna, switch Build → Animate, verify toolbar shows Orbit selected, verify clicking viewport moves camera only (no edits)

--- a/docs/superpowers/specs/2026-04-16-gsvx-binary-format-design.md
+++ b/docs/superpowers/specs/2026-04-16-gsvx-binary-format-design.md
@@ -1,0 +1,171 @@
+# GSVX Binary Asset Format and Zero-Copy Loader
+
+## Problem
+
+Runtime PLY loading is a CPU bottleneck:
+
+1. **Text header parsing**: Every PLY load parses ASCII property declarations, string-matching property names to offsets.
+2. **Per-element math**: `exp(scale)`, `sigmoid(opacity)`, `SH_C0 * f_dc + 0.5` computed for every Gaussian on every load.
+3. **Per-element repacking**: The CPU-side `Gaussian` (68 bytes) is converted element-by-element into `GpuGaussian` (64 bytes, 4×vec4) before upload — this loop is duplicated ~7 times in `gs_renderer.cpp`.
+
+For a 200K-splat scene, this means 200K iterations of float math + struct repacking on every cold load, plus string parsing overhead.
+
+## Solution
+
+A two-stage pipeline:
+
+1. **Offline cooker** (`scripts/ply_to_gseurat.py`): Reads PLY, pre-bakes all transforms, writes a `.gsvx` binary where the payload is byte-identical to an array of `GpuGaussian`.
+2. **Zero-copy loader** (C++23): Validates a 32-byte header, then bulk-reads the payload directly into a VMA-mapped SSBO — no per-element parsing, no math, no repacking.
+
+## Binary Format Specification
+
+### Header (32 bytes)
+
+```
+Offset  Size  Type      Field         Description
+─────── ───── ───────── ───────────── ────────────────────────────────────────
+0       4     char[4]   magic         "GSVX" (0x47 0x53 0x56 0x58)
+4       4     uint32_le version       Format version (1)
+8       4     uint32_le count         Number of Gaussians
+12      4     uint32_le flags         Reserved (must be 0)
+16      16    uint8[16] reserved      Zero-filled; ensures payload at offset 32
+```
+
+The header is exactly 32 bytes. Payload begins at offset 32, which is 16-byte aligned.
+
+### Per-Gaussian Payload (64 bytes, matches `GpuGaussian`)
+
+```
+Offset  Size  GLSL Type  C++ Field      Contents (pre-baked)
+─────── ───── ────────── ────────────── ─────────────────────────────────────
+0       16    vec4       pos_opacity    position.xyz, sigmoid(raw_opacity)
+16      16    vec4       scale_pad      exp(raw_scale).xyz, float_bits(bone_index)
+32      16    vec4       rot            quaternion (x, y, z, w)
+48      16    vec4       color_pad      (SH_C0 * f_dc + 0.5).rgb, emission
+```
+
+Total per-Gaussian: 64 bytes (4 × `vec4`).  
+Total file size: `32 + count × 64` bytes.
+
+This layout is byte-identical to the `GpuGaussian` struct in both `gs_preprocess.comp` (GLSL) and `gs_renderer.cpp` (C++).
+
+### Pre-baked Transforms (applied at cook time)
+
+| Field | Raw PLY Value | Baked Value |
+|-------|---------------|-------------|
+| scale | `log(scale)` | `exp(log_scale)` = linear scale |
+| opacity | `logit(opacity)` | `1 / (1 + exp(-logit))` = linear opacity |
+| color | SH DC coefficients `f_dc` | `0.28209479177387814 * f_dc + 0.5` = linear RGB |
+| bone_index | `uint8` | `uint32` stored as float bit-pattern via `struct.pack('I', idx)` |
+| quaternion | `(w, x, y, z)` in PLY | `(x, y, z, w)` in payload (matches shader convention) |
+
+### Byte Order
+
+All multi-byte values are **little-endian** (matches Vulkan on x86/ARM and Python's `<` struct prefix).
+
+## Component Design
+
+### 1. Python Cooker (`scripts/ply_to_gseurat.py`)
+
+```
+Input:  path/to/scene.ply
+Output: path/to/scene.gsvx
+
+Usage:  python3 scripts/ply_to_gseurat.py input.ply [-o output.gsvx]
+```
+
+- Uses `plyfile` to read the PLY binary data into numpy arrays.
+- Applies vectorized transforms (numpy `exp`, sigmoid, SH conversion) — no Python loops.
+- Packs header via `struct.pack`.
+- Writes payload as a single `ndarray.tobytes()` call from a structured numpy array with dtype matching `GpuGaussian`.
+- Recomputes quaternion order from PLY `(w,x,y,z)` to shader `(x,y,z,w)`.
+
+### 2. C++ Zero-Copy Loader
+
+**New struct** (in `gaussian_cloud.hpp`):
+
+```cpp
+struct GsvxHeader {
+    char     magic[4];    // "GSVX"
+    uint32_t version;     // 1
+    uint32_t count;       // Gaussian count
+    uint32_t flags;       // Reserved
+    uint8_t  reserved[16];
+};
+static_assert(sizeof(GsvxHeader) == 32);
+```
+
+**`GpuGaussian` promoted** from anonymous namespace in `gs_renderer.cpp` to `gaussian_cloud.hpp`:
+
+```cpp
+struct alignas(16) GpuGaussian {
+    glm::vec4 pos_opacity;  // xyz=position, w=opacity
+    glm::vec4 scale_pad;    // xyz=scale, w=float_bits(bone_index)
+    glm::vec4 rot;          // xyzw=quaternion (x,y,z,w)
+    glm::vec4 color_pad;    // rgb=color, w=emission
+};
+static_assert(sizeof(GpuGaussian) == 64);
+```
+
+**New method** on `GaussianCloud`:
+
+```cpp
+struct GsvxPayload {
+    std::vector<GpuGaussian> gpu_gaussians;
+    AABB bounds;
+    uint32_t count;
+};
+
+static GsvxPayload load_gsvx(const std::string& path);
+```
+
+Returns pre-baked GPU-ready data. The renderer calls this instead of `load_ply()` + per-element conversion loop.
+
+**Loading flow:**
+
+```
+open file → read 32-byte header → validate magic/version
+→ allocate vector<GpuGaussian>(count)
+→ single fread() of count×64 bytes into vector
+→ compute AABB from pos_opacity.xyz (single scan, no math)
+→ return GsvxPayload
+```
+
+### 3. Renderer Integration
+
+In `gs_renderer.cpp`, the upload path for `.gsvx` files becomes:
+
+```cpp
+// Old path (per-element conversion):
+for (uint32_t i = 0; i < count; ++i) {
+    staging[i].pos_opacity = vec4(g.position, g.opacity);  // ... etc
+}
+memcpy(ssbo.mapped(), staging.data(), count * sizeof(GpuGaussian));
+
+// New path (zero-copy):
+auto payload = GaussianCloud::load_gsvx(path);
+memcpy(ssbo.mapped(), payload.gpu_gaussians.data(), payload.count * sizeof(GpuGaussian));
+```
+
+The existing `load_ply()` path remains untouched for backward compatibility.
+
+## AABB and Importance
+
+The `.gsvx` format does not store `importance` (used for LOD decimation) since it equals `opacity * max(scale.xyz)` and can be recomputed from the baked values in a single pass if needed. The AABB is computed during the C++ load scan — this is a trivial vec3 min/max accumulation over `pos_opacity.xyz` and adds negligible overhead.
+
+## Testing
+
+1. **Round-trip test**: Load PLY → cook to GSVX → load GSVX → compare `GpuGaussian` arrays against the existing PLY→GpuGaussian conversion path. All values must match within float epsilon.
+2. **Header validation**: Corrupt magic/version/count → verify loader returns error.
+3. **File size check**: Verify `file_size == 32 + count * 64`.
+4. **Visual test**: Load same scene via PLY and GSVX paths in staging → screenshot diff via Game Director.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `scripts/ply_to_gseurat.py` | New — Python cooker |
+| `include/gseurat/engine/gaussian_cloud.hpp` | Add `GsvxHeader`, `GpuGaussian`, `GsvxPayload`, `load_gsvx()` |
+| `src/engine/gaussian_cloud.cpp` | Implement `load_gsvx()` |
+| `src/engine/gs_renderer.cpp` | Remove duplicate `GpuGaussian` definition, use shared header |
+| `tests/gsvx_loader_test.cpp` | Round-trip and validation tests |

--- a/tools/apps/echidna/src/App.tsx
+++ b/tools/apps/echidna/src/App.tsx
@@ -50,6 +50,7 @@ const styles: Record<string, React.CSSProperties> = {
 };
 
 const buildToolKeys: Record<string, ToolType> = {
+  q: 'orbit',
   v: 'place',
   b: 'paint',
   e: 'erase',
@@ -61,8 +62,10 @@ const buildToolKeys: Record<string, ToolType> = {
 };
 
 const animateToolKeys: Record<string, ToolType> = {
+  q: 'orbit',
   a: 'assign_part',
   s: 'box_select',
+  l: 'lasso_select',
 };
 
 const RESIZE_HANDLE_STYLE: React.CSSProperties = {

--- a/tools/apps/echidna/src/App.tsx
+++ b/tools/apps/echidna/src/App.tsx
@@ -4,6 +4,7 @@ import { MenuBar } from './panels/MenuBar.js';
 import { ToolBar } from './panels/ToolBar.js';
 import { BuildPanel } from './panels/BuildPanel.js';
 import { AnimateLeftPanel } from './panels/AnimateLeftPanel.js';
+import { AnimateToolBar } from './panels/AnimateToolBar.js';
 import { AnimateRightPanel } from './panels/AnimateRightPanel.js';
 import { Timeline } from './panels/Timeline.js';
 import { EmptyProjectState } from './panels/EmptyProjectState.js';
@@ -300,7 +301,14 @@ export function App() {
           <AssetsPanel onNewAsset={handleNewAsset} />
           <ModeTabs showAnimate={assetKind === 'character'} />
           <div style={{ flex: 1, overflow: 'auto' }}>
-            {mode === 'build' || assetKind !== 'character' ? <ToolBar /> : <AnimateLeftPanel />}
+            {mode === 'build' || assetKind !== 'character' ? (
+              <ToolBar />
+            ) : (
+              <>
+                <AnimateToolBar />
+                <AnimateLeftPanel />
+              </>
+            )}
           </div>
         </div>
         <ResizeHandle onDrag={handleLeftDrag} />

--- a/tools/apps/echidna/src/__tests__/animateToolBar.test.ts
+++ b/tools/apps/echidna/src/__tests__/animateToolBar.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCharacterStore } from '../store/useCharacterStore.js';
+
+describe('setMode resets activeTool to orbit', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({ mode: 'build', activeTool: 'place' });
+  });
+
+  it('resets activeTool to orbit when switching to animate', () => {
+    useCharacterStore.getState().setMode('animate');
+    expect(useCharacterStore.getState().activeTool).toBe('orbit');
+  });
+
+  it('resets activeTool to orbit when switching to build', () => {
+    useCharacterStore.setState({ mode: 'animate', activeTool: 'assign_part' });
+    useCharacterStore.getState().setMode('build');
+    expect(useCharacterStore.getState().activeTool).toBe('orbit');
+  });
+
+  it('orbit tool can be set in both modes', () => {
+    useCharacterStore.getState().setMode('build');
+    useCharacterStore.getState().setTool('orbit');
+    expect(useCharacterStore.getState().activeTool).toBe('orbit');
+
+    useCharacterStore.getState().setMode('animate');
+    useCharacterStore.getState().setTool('orbit');
+    expect(useCharacterStore.getState().activeTool).toBe('orbit');
+  });
+});

--- a/tools/apps/echidna/src/expected-components.json
+++ b/tools/apps/echidna/src/expected-components.json
@@ -2,7 +2,7 @@
   "always": ["MenuBar", "AssetViewport"],
   "modes": {
     "build": ["ToolBar", "BuildPanel"],
-    "animate": ["AnimateLeftPanel", "AnimateRightPanel", "Timeline"]
+    "animate": ["AnimateToolBar", "AnimateLeftPanel", "AnimateRightPanel", "Timeline"]
   },
   "conditional": {
     "ExportDialog": "when export dialog is open",

--- a/tools/apps/echidna/src/panels/AnimateToolBar.tsx
+++ b/tools/apps/echidna/src/panels/AnimateToolBar.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { useComponentRegistry } from '@gseurat/ui-kit';
+import { useCharacterStore } from '../store/useCharacterStore.js';
+import type { ToolType } from '../store/types.js';
+
+const tools: { id: ToolType; label: string; key: string }[] = [
+  { id: 'orbit', label: 'Orbit', key: 'Q' },
+  { id: 'assign_part', label: 'Assign Part', key: 'A' },
+  { id: 'box_select', label: 'Box Select', key: 'S' },
+  { id: 'lasso_select', label: 'Lasso', key: 'L' },
+];
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    background: '#1e1e3a',
+    borderBottom: '1px solid #333',
+    padding: 12,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+  },
+  section: { display: 'flex', flexDirection: 'column', gap: 4 },
+  label: {
+    fontSize: 11, color: '#888', textTransform: 'uppercase' as const,
+    letterSpacing: 1,
+  },
+  toolBtn: {
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+    padding: '6px 10px', borderWidth: 1, borderStyle: 'solid' as const,
+    borderColor: '#444', borderRadius: 4, background: '#2a2a4a', color: '#ddd',
+    cursor: 'pointer', fontSize: 13,
+  },
+  toolBtnActive: { background: '#4a4a8a', borderColor: '#77f' },
+  shortcut: { fontSize: 11, color: '#777' },
+  select: {
+    padding: '6px 8px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 13,
+  },
+  selectDisabled: { opacity: 0.5, cursor: 'not-allowed' },
+};
+
+export function AnimateToolBar() {
+  useComponentRegistry('AnimateToolBar');
+  const activeTool = useCharacterStore((s) => s.activeTool);
+  const setTool = useCharacterStore((s) => s.setTool);
+  const parts = useCharacterStore((s) => s.asset?.characterParts ?? []);
+  const selectedPart = useCharacterStore((s) => s.selectedPart);
+  const setSelectedPart = useCharacterStore((s) => s.setSelectedPart);
+  const hasBones = parts.length > 0;
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.section}>
+        <span style={styles.label}>Tools</span>
+        {tools.map((t) => (
+          <button
+            key={t.id}
+            style={{ ...styles.toolBtn, ...(activeTool === t.id ? styles.toolBtnActive : {}) }}
+            onClick={() => setTool(t.id)}
+          >
+            {t.label}
+            <span style={styles.shortcut}>{t.key}</span>
+          </button>
+        ))}
+      </div>
+      <div style={styles.section}>
+        <span style={styles.label}>Target Bone</span>
+        <select
+          style={{ ...styles.select, ...(!hasBones ? styles.selectDisabled : {}) }}
+          value={selectedPart ?? ''}
+          onChange={(e) => setSelectedPart(e.target.value || null)}
+          disabled={!hasBones}
+        >
+          {!hasBones && <option value="">No bones</option>}
+          {hasBones && <option value="">(none)</option>}
+          {parts.map((p) => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/tools/apps/echidna/src/panels/ToolBar.tsx
+++ b/tools/apps/echidna/src/panels/ToolBar.tsx
@@ -4,6 +4,7 @@ import { useCharacterStore } from '../store/useCharacterStore.js';
 import type { ToolType } from '../store/types.js';
 
 const tools: { id: ToolType; label: string; key: string }[] = [
+  { id: 'orbit', label: 'Orbit', key: 'Q' },
   { id: 'place', label: 'Place', key: 'V' },
   { id: 'paint', label: 'Paint', key: 'B' },
   { id: 'erase', label: 'Erase', key: 'E' },

--- a/tools/apps/echidna/src/store/types.ts
+++ b/tools/apps/echidna/src/store/types.ts
@@ -24,6 +24,7 @@ export interface PoseData {
 }
 
 export type ToolType =
+  | 'orbit'
   | 'place'
   | 'paint'
   | 'erase'

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -316,7 +316,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
   markClean: () => set({ dirty: false }),
 
   // ── Mode ──
-  setMode: (mode) => set({ mode }),
+  setMode: (mode) => set({ mode, activeTool: 'orbit' }),
 
   // ── Undo ──
   pushUndo: () => {

--- a/tools/apps/echidna/src/viewport/VoxelMesh.tsx
+++ b/tools/apps/echidna/src/viewport/VoxelMesh.tsx
@@ -521,6 +521,7 @@ export function VoxelMesh() {
     }
 
     switch (store.activeTool) {
+      case 'orbit': { return; }
       case 'place': {
         if (!normal) return;
         const nx = x + Math.round(normal.x);


### PR DESCRIPTION
## Summary
- New `AnimateToolBar` component with Orbit, Assign Part, Box Select, Lasso buttons + Target Bone dropdown
- New `'orbit'` neutral tool — camera-only, no edits in viewport
- `setMode()` resets `activeTool` to `'orbit'` to prevent edit bleed-through between Build/Animate modes
- Build and Animate mode state kept separate (per user request)

## Test Plan
- [x] Unit tests pass (3/3)
- [x] Echidna builds clean
- [ ] Open Echidna → Animate mode → verify AnimateToolBar appears above Bones panel
- [ ] Switch between Build/Animate → verify active tool resets to Orbit
- [ ] Press A → Assign Part active; select bone in dropdown → click voxels to assign

🤖 Generated with [Claude Code](https://claude.com/claude-code)