### PR TITLE
feat(echidna): implement lasso selection

### DIFF
--- a/tools/apps/echidna/src/__tests__/pointInPolygon.test.ts
+++ b/tools/apps/echidna/src/__tests__/pointInPolygon.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { pointInPolygon } from '../lib/pointInPolygon.js';
+
+describe('pointInPolygon', () => {
+  const triangle: [number, number][] = [[0, 0], [10, 0], [5, 10]];
+  const square: [number, number][] = [[0, 0], [10, 0], [10, 10], [0, 10]];
+  // U-shape concave polygon
+  const concave: [number, number][] = [
+    [0, 0], [10, 0], [10, 10], [7, 10], [7, 3], [3, 3], [3, 10], [0, 10],
+  ];
+
+  it('point inside triangle returns true', () => {
+    expect(pointInPolygon(5, 3, triangle)).toBe(true);
+  });
+
+  it('point outside triangle returns false', () => {
+    expect(pointInPolygon(15, 5, triangle)).toBe(false);
+    expect(pointInPolygon(-1, 5, triangle)).toBe(false);
+    expect(pointInPolygon(5, 15, triangle)).toBe(false);
+  });
+
+  it('point at center of square returns true', () => {
+    expect(pointInPolygon(5, 5, square)).toBe(true);
+  });
+
+  it('point in concave region returns false', () => {
+    // Inside the "U" notch
+    expect(pointInPolygon(5, 8, concave)).toBe(false);
+  });
+
+  it('point in solid part of concave shape returns true', () => {
+    expect(pointInPolygon(5, 1, concave)).toBe(true);
+  });
+
+  it('empty or degenerate polygon returns false', () => {
+    expect(pointInPolygon(5, 5, [])).toBe(false);
+    expect(pointInPolygon(5, 5, [[0, 0]])).toBe(false);
+    expect(pointInPolygon(5, 5, [[0, 0], [10, 10]])).toBe(false);
+  });
+});

--- a/tools/apps/echidna/src/expected-components.json
+++ b/tools/apps/echidna/src/expected-components.json
@@ -9,6 +9,7 @@
     "ImportDialog": "when import dialog is open",
     "ImageImportDialog": "when image import dialog is open",
     "NewProjectDialog": "when new project dialog is open",
-    "ResizeGridDialog": "when resize grid dialog is open"
+    "ResizeGridDialog": "when resize grid dialog is open",
+    "LassoOverlay": "when lasso tool is active"
   }
 }

--- a/tools/apps/echidna/src/lib/pointInPolygon.ts
+++ b/tools/apps/echidna/src/lib/pointInPolygon.ts
@@ -1,0 +1,28 @@
+/**
+ * Ray-casting point-in-polygon test.
+ * Returns true if point (x, y) is inside the polygon defined by vertices.
+ *
+ * Uses the crossing number algorithm: cast a horizontal ray from the point
+ * to +infinity and count how many polygon edges it crosses. Odd = inside.
+ */
+export function pointInPolygon(
+  x: number,
+  y: number,
+  polygon: [number, number][],
+): boolean {
+  const n = polygon.length;
+  if (n < 3) return false;
+
+  let inside = false;
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const [xi, yi] = polygon[i];
+    const [xj, yj] = polygon[j];
+
+    const intersect =
+      ((yi > y) !== (yj > y)) &&
+      (x < ((xj - xi) * (y - yi)) / (yj - yi) + xi);
+    if (intersect) inside = !inside;
+  }
+
+  return inside;
+}

--- a/tools/apps/echidna/src/viewport/AssetViewport.tsx
+++ b/tools/apps/echidna/src/viewport/AssetViewport.tsx
@@ -8,6 +8,7 @@ import { GroundPlane } from './GroundPlane.js';
 import { GhostVoxel } from './GhostVoxel.js';
 import { JointGizmos } from './JointGizmos.js';
 import { MirrorPlane } from './MirrorPlane.js';
+import { LassoOverlay } from './LassoOverlay.js';
 import { useCharacterStore } from '../store/useCharacterStore.js';
 import { parseKey } from '../lib/voxelUtils.js';
 
@@ -19,6 +20,15 @@ function InitialInvalidator() {
     // Dispatch resize to ensure the first frame renders immediately.
     requestAnimationFrame(() => window.dispatchEvent(new Event('resize')));
   }, []);
+  return null;
+}
+
+/** Exposes the R3F camera to a ref so overlay components can use it. */
+function CameraExposer({ cameraRef }: { cameraRef: React.MutableRefObject<THREE.Camera | null> }) {
+  const { camera } = useThree();
+  useEffect(() => {
+    cameraRef.current = camera;
+  }, [camera, cameraRef]);
   return null;
 }
 
@@ -69,55 +79,65 @@ export function AssetViewport() {
   const gridWidth = useCharacterStore((s) => s.asset?.gridWidth ?? 32);
   const gridDepth = useCharacterStore((s) => s.asset?.gridDepth ?? 32);
   const showGrid = useCharacterStore((s) => s.showGrid);
+  const activeTool = useCharacterStore((s) => s.activeTool);
+  const cameraRef = useRef<THREE.Camera | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const lassoActive = activeTool === 'lasso_select';
 
   return (
-    <Canvas
-      frameloop="always"
-      camera={{ position: [gridWidth / 2, 20, gridDepth + 15], fov: 50 }}
-      style={{ background: '#16162a' }}
-      onContextMenu={(e) => e.preventDefault()}
-    >
-      <ambientLight intensity={0.6} />
-      <directionalLight position={[20, 40, 30]} intensity={0.8} />
-      <directionalLight position={[-10, 20, -20]} intensity={0.3} />
+    <div ref={containerRef} style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <Canvas
+        frameloop="always"
+        camera={{ position: [gridWidth / 2, 20, gridDepth + 15], fov: 50 }}
+        style={{ background: '#16162a' }}
+        onContextMenu={(e) => e.preventDefault()}
+      >
+        <ambientLight intensity={0.6} />
+        <directionalLight position={[20, 40, 30]} intensity={0.8} />
+        <directionalLight position={[-10, 20, -20]} intensity={0.3} />
 
-      {showGrid && (
-        <Grid
-          args={[gridWidth, gridDepth]}
-          position={[gridWidth / 2 - 0.5, -0.5, gridDepth / 2 - 0.5]}
-          cellSize={1}
-          cellThickness={0.5}
-          cellColor="#334"
-          sectionSize={8}
-          sectionThickness={1}
-          sectionColor="#446"
-          fadeDistance={200}
-          infiniteGrid={false}
+        {showGrid && (
+          <Grid
+            args={[gridWidth, gridDepth]}
+            position={[gridWidth / 2 - 0.5, -0.5, gridDepth / 2 - 0.5]}
+            cellSize={1}
+            cellThickness={0.5}
+            cellColor="#334"
+            sectionSize={8}
+            sectionThickness={1}
+            sectionColor="#446"
+            fadeDistance={200}
+            infiniteGrid={false}
+          />
+        )}
+
+        <VoxelMesh />
+        <GroundPlane />
+        <GhostVoxel />
+        <JointGizmos />
+        <MirrorPlane />
+        <CameraFitter />
+        <InitialInvalidator />
+        <CameraExposer cameraRef={cameraRef} />
+
+        <OrbitControls
+          enabled={!lassoActive}
+          target={[gridWidth / 2, 0, gridDepth / 2]}
+          makeDefault
+          screenSpacePanning
+          mouseButtons={{
+            LEFT: 0,
+            MIDDLE: 1,
+            RIGHT: 2,
+          }}
+          touches={{
+            ONE: 0,
+            TWO: 1,
+          }}
         />
-      )}
-
-      <VoxelMesh />
-      <GroundPlane />
-      <GhostVoxel />
-      <JointGizmos />
-      <MirrorPlane />
-      <CameraFitter />
-      <InitialInvalidator />
-
-      <OrbitControls
-        target={[gridWidth / 2, 0, gridDepth / 2]}
-        makeDefault
-        screenSpacePanning
-        mouseButtons={{
-          LEFT: 0,
-          MIDDLE: 1,
-          RIGHT: 2,
-        }}
-        touches={{
-          ONE: 0,
-          TWO: 1,
-        }}
-      />
-    </Canvas>
+      </Canvas>
+      <LassoOverlay cameraRef={cameraRef} containerRef={containerRef} />
+    </div>
   );
 }

--- a/tools/apps/echidna/src/viewport/LassoOverlay.tsx
+++ b/tools/apps/echidna/src/viewport/LassoOverlay.tsx
@@ -1,0 +1,145 @@
+import React, { useRef, useState, useCallback } from 'react';
+import { useComponentRegistry } from '@gseurat/ui-kit';
+import * as THREE from 'three';
+import { useCharacterStore } from '../store/useCharacterStore.js';
+import { parseKey } from '../lib/voxelUtils.js';
+import { pointInPolygon } from '../lib/pointInPolygon.js';
+import type { VoxelKey } from '../store/types.js';
+
+const MIN_POINT_DISTANCE_PX = 5;
+
+interface Props {
+  cameraRef: React.MutableRefObject<THREE.Camera | null>;
+  containerRef: React.RefObject<HTMLDivElement>;
+}
+
+export function LassoOverlay({ cameraRef, containerRef }: Props) {
+  useComponentRegistry('LassoOverlay');
+  const activeTool = useCharacterStore((s) => s.activeTool);
+  const voxels = useCharacterStore((s) => s.asset?.voxels ?? new Map());
+  const setLassoSelection = useCharacterStore((s) => s.setLassoSelection);
+
+  const [points, setPoints] = useState<[number, number][]>([]);
+  const isDrawing = useRef(false);
+
+  const isActive = activeTool === 'lasso_select';
+
+  const projectVoxels = useCallback(
+    (polygon: [number, number][]): VoxelKey[] => {
+      const camera = cameraRef.current;
+      const container = containerRef.current;
+      if (!camera || !container) return [];
+
+      const rect = container.getBoundingClientRect();
+      const halfW = rect.width / 2;
+      const halfH = rect.height / 2;
+      const ndc = new THREE.Vector3();
+      const selected: VoxelKey[] = [];
+
+      for (const key of voxels.keys()) {
+        const [vx, vy, vz] = parseKey(key);
+        ndc.set(vx + 0.5, vy + 0.5, vz + 0.5);
+        ndc.project(camera);
+        // NDC (-1..1) to pixel (0..width, 0..height) — Y flipped
+        const px = (ndc.x + 1) * halfW;
+        const py = (1 - ndc.y) * halfH;
+        if (pointInPolygon(px, py, polygon)) {
+          selected.push(key);
+        }
+      }
+
+      return selected;
+    },
+    [voxels, cameraRef, containerRef],
+  );
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isActive) return;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      setPoints([[x, y]]);
+      isDrawing.current = true;
+    },
+    [isActive],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isDrawing.current) return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+
+      setPoints((prev) => {
+        const last = prev[prev.length - 1];
+        if (!last) return [[x, y]];
+        const dx = x - last[0];
+        const dy = y - last[1];
+        if (dx * dx + dy * dy < MIN_POINT_DISTANCE_PX * MIN_POINT_DISTANCE_PX) {
+          return prev;
+        }
+        const next: [number, number][] = [...prev, [x, y]];
+        // Live preview: update lasso selection as we drag
+        if (next.length >= 3) {
+          const selected = projectVoxels(next);
+          setLassoSelection(selected.length > 0 ? selected : null);
+        }
+        return next;
+      });
+    },
+    [projectVoxels, setLassoSelection],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isDrawing.current) return;
+      isDrawing.current = false;
+      e.currentTarget.releasePointerCapture(e.pointerId);
+
+      if (points.length >= 3) {
+        const selected = projectVoxels(points);
+        setLassoSelection(selected.length > 0 ? selected : null);
+      }
+      setPoints([]);
+    },
+    [points, projectVoxels, setLassoSelection],
+  );
+
+  if (!isActive) return null;
+
+  const pathD = points.length > 0
+    ? `M ${points[0][0]} ${points[0][1]} ` +
+      points.slice(1).map(([x, y]) => `L ${x} ${y}`).join(' ') +
+      (points.length > 2 ? ' Z' : '')
+    : '';
+
+  return (
+    <svg
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        cursor: 'crosshair',
+        pointerEvents: 'auto',
+        touchAction: 'none',
+      }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+    >
+      {pathD && (
+        <path
+          d={pathD}
+          fill="rgba(119, 119, 255, 0.15)"
+          stroke="#77f"
+          strokeWidth={2}
+          strokeDasharray="4 4"
+        />
+      )}
+    </svg>
+  );
+}

--- a/tools/apps/echidna/src/viewport/VoxelMesh.tsx
+++ b/tools/apps/echidna/src/viewport/VoxelMesh.tsx
@@ -215,6 +215,7 @@ export function VoxelMesh() {
   const colorByPart = useCharacterStore((s) => s.colorByPart);
   const partColors = useCharacterStore((s) => s.partColors);
   const boxSelection = useCharacterStore((s) => s.boxSelection);
+  const lassoSelection = useCharacterStore((s) => s.lassoSelection);
   const isPlaying = useCharacterStore((s) => s.isPlaying);
   const selectedAnimation = useCharacterStore((s) => s.selectedAnimation);
   const animations = useCharacterStore((s) => s.asset?.animations ?? {});
@@ -395,6 +396,11 @@ export function VoxelMesh() {
     return boxSelection ? new Set(boxSelection) : null;
   }, [boxSelection]);
 
+  const lassoSelectionSet = useMemo(() => {
+    if (!lassoSelection) return null;
+    return new Set(lassoSelection);
+  }, [lassoSelection]);
+
   // FK transforms: animation pose takes priority over preview pose
   const fkTransforms = useMemo(() => {
     if (animationPose) {
@@ -458,8 +464,8 @@ export function VoxelMesh() {
         }
       }
 
-      // Box selection highlight (green tint)
-      if (boxSelectionSet?.has(key)) {
+      // Box/lasso selection highlight (green tint)
+      if (boxSelectionSet?.has(key) || lassoSelectionSet?.has(key)) {
         g = Math.min(1, g + 0.2);
       }
 
@@ -469,7 +475,7 @@ export function VoxelMesh() {
     }
 
     return { matrices: mat, colors: col };
-  }, [surfaceEntries, count, characterParts, selectedPart, selectedKeys, otherPartKeys, fkTransforms, voxelToPartId, colorByPart, partColors, boxSelectionSet]);
+  }, [surfaceEntries, count, characterParts, selectedPart, selectedKeys, otherPartKeys, fkTransforms, voxelToPartId, colorByPart, partColors, boxSelectionSet, lassoSelectionSet]);
 
   useEffect(() => {
     const mesh = meshRef.current;


### PR DESCRIPTION
## Summary
- Implement lasso selection — draw a polygon on the viewport, all voxels with projected center inside are selected
- Live preview via green tint as user drags
- OrbitControls disabled while lasso tool is active
- Ray-casting point-in-polygon test (6 unit tests)

## Test Plan
- [x] Unit tests pass (6/6 for pointInPolygon, 146/146 total)
- [x] Echidna builds clean
- [ ] Switch to Animate mode → press L → drag a polygon → verify voxels highlight green
- [ ] Release pointer → verify selection persists
- [ ] Select a bone → verify assignment uses the lasso selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)