### PR TITLE
feat(echidna): compact Build/Animate toolbars + per-character palettes

### DIFF
--- a/docs/superpowers/plans/2026-04-16-echidna-ui-improvements.md
+++ b/docs/superpowers/plans/2026-04-16-echidna-ui-improvements.md
@@ -1,0 +1,1440 @@
+# Echidna UI Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Echidna's Build and Animate toolbars compact (matching Bricklayer's icon-grid density), add a 256-slot per-character multi-palette system, remove the redundant Target Bone dropdown, and share environment controls between Build and Animate right panels.
+
+**Architecture:** Extract three shared sub-components (`YClipControl`, `YLevelLock`, `DisplaySettings`) into `panels/controls/` so both `BuildPanel` and `AnimateRightPanel` can compose them. Add a `ColorPalette[]` field to the Asset slice and persist it in the `.echidna` file via a schema bump (v4 → v5). Rewrite `ToolBar` and `AnimateToolBar` as icon grids plus a compact palette UI.
+
+**Tech Stack:** TypeScript, React 18, Zustand, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-echidna-ui-improvements-design.md`
+
+**Working directory:** `/Users/eccyan/dev/GSeurat/.worktrees/echidna-ui-improvements/` (all commands below assume this root).
+
+---
+
+## Task 1: Add ColorPalette type, bump EchidnaFile version, migrate
+
+**Files:**
+- Modify: `tools/apps/echidna/src/store/types.ts`
+- Modify: `tools/apps/echidna/src/__tests__/echidnaFile.test.ts`
+
+- [ ] **Step 1: Update the existing version assertion test**
+
+The current test at `tools/apps/echidna/src/__tests__/echidnaFile.test.ts:36-37` asserts `migrated.version === 4`. Change it to 5 and keep `ECHIDNA_FILE_VERSION` check so both advance together:
+
+```ts
+// line 35-37 in echidnaFile.test.ts — current content:
+//   expect(migrated.version).toBe(ECHIDNA_FILE_VERSION);
+//   expect(migrated.version).toBe(4);
+// replace with:
+    expect(migrated.version).toBe(ECHIDNA_FILE_VERSION);
+    expect(migrated.version).toBe(5);
+```
+
+- [ ] **Step 2: Write the failing tests for palette migration**
+
+Append to `tools/apps/echidna/src/__tests__/echidnaFile.test.ts` inside the `describe('migrateEchidnaFile', ...)` block (before the final closing `});`):
+
+```ts
+  it('seeds color_palettes with a 256-slot default when absent', () => {
+    const old = {
+      version: 2,
+      characterName: 'Walker',
+      gridWidth: 32,
+      gridDepth: 32,
+      voxels: [],
+      parts: [],
+      poses: {},
+    };
+    const migrated = migrateEchidnaFile(old);
+    expect(migrated.color_palettes).toBeDefined();
+    expect(migrated.color_palettes!.length).toBe(1);
+    expect(migrated.color_palettes![0].colors.length).toBe(256);
+    // First 16 slots should be grayscale (r === g === b)
+    for (let i = 0; i < 16; i++) {
+      const [r, g, b, a] = migrated.color_palettes![0].colors[i];
+      expect(r).toBe(g);
+      expect(g).toBe(b);
+      expect(a).toBe(255);
+    }
+  });
+
+  it('preserves existing color_palettes when present', () => {
+    const file = {
+      version: 5,
+      id: 'walker',
+      characterName: 'Walker',
+      gridWidth: 32,
+      gridDepth: 32,
+      voxels: [],
+      parts: [],
+      poses: {},
+      color_palettes: [{ name: 'Custom', colors: [[10, 20, 30, 255]] }],
+    };
+    const migrated = migrateEchidnaFile(file);
+    expect(migrated.color_palettes).toEqual([{ name: 'Custom', colors: [[10, 20, 30, 255]] }]);
+  });
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna test -- echidnaFile`
+Expected: FAIL — `seeds color_palettes with a 256-slot default when absent` (property undefined) and `preserves existing color_palettes when present`. The existing `expect(migrated.version).toBe(5)` also fails because the constant is still 4.
+
+- [ ] **Step 4: Update `types.ts` — add `ColorPalette`, bump version, extend migration**
+
+Open `tools/apps/echidna/src/store/types.ts` and make these edits:
+
+Change the version constant (currently line 80):
+
+```ts
+export const ECHIDNA_FILE_VERSION = 5 as const;
+```
+
+Add the `ColorPalette` interface — insert after the `AnimationClip` interface (after line 59):
+
+```ts
+// ── Color palettes ──
+
+export interface ColorPalette {
+  name: string;
+  colors: [number, number, number, number][];
+}
+
+/**
+ * Generate the default 256-slot palette: 16 grayscale + 12 hues × 4 sats × 5 lights.
+ * Matches Bricklayer's `generateDefaultPalette` shape so imports between apps feel consistent.
+ */
+export function generateDefaultPalette(): ColorPalette {
+  const colors: [number, number, number, number][] = [];
+  // 16 grayscale: black to white
+  for (let i = 0; i < 16; i++) {
+    const v = Math.round((i / 15) * 255);
+    colors.push([v, v, v, 255]);
+  }
+  // 240 chromatic: 12 hues × 4 saturations × 5 lightness levels
+  const hues = [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330];
+  const sats = [0.3, 0.5, 0.75, 1.0];
+  const lights = [0.2, 0.35, 0.5, 0.65, 0.8];
+  for (const sat of sats) {
+    for (const light of lights) {
+      for (const hue of hues) {
+        const [r, g, b] = hslToRgb(hue, sat, light);
+        colors.push([r, g, b, 255]);
+      }
+    }
+  }
+  return { name: 'Default (256)', colors };
+}
+
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0, g = 0, b = 0;
+  if (h < 60) { r = c; g = x; }
+  else if (h < 120) { r = x; g = c; }
+  else if (h < 180) { g = c; b = x; }
+  else if (h < 240) { g = x; b = c; }
+  else if (h < 300) { r = x; b = c; }
+  else { r = c; b = x; }
+  return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)];
+}
+```
+
+Extend the `EchidnaFile` interface — add one field (after `tags: string[];` around line 93):
+
+```ts
+export interface EchidnaFile {
+  version: number;
+  id: string;
+  kind: EchidnaAssetKind;
+  characterName: string;
+  gridWidth: number;
+  gridDepth: number;
+  voxels: { x: number; y: number; z: number; r: number; g: number; b: number; a: number }[];
+  parts: BodyPart[];
+  poses: Record<string, PoseData>;
+  animations?: Record<string, AnimationClip>;
+  tags: string[];
+  color_palettes?: ColorPalette[];
+}
+```
+
+Extend the `Asset` interface (around line 168):
+
+```ts
+export interface Asset {
+  id: string;
+  kind: EchidnaAssetKind;
+  characterName: string;
+  gridWidth: number;
+  gridDepth: number;
+  voxels: Map<VoxelKey, Voxel>;
+  characterParts: BodyPart[];
+  characterPoses: Record<string, PoseData>;
+  animations: Record<string, AnimationClip>;
+  tags: string[];
+  colorPalettes: ColorPalette[];
+  currentFilename: string | null;
+}
+```
+
+Extend `migrateEchidnaFile` — inside the returned object (around line 136), add `color_palettes`:
+
+```ts
+  return {
+    version: ECHIDNA_FILE_VERSION,
+    id,
+    kind,
+    characterName: raw.characterName ?? '',
+    gridWidth: raw.gridWidth ?? 32,
+    gridDepth: raw.gridDepth ?? 32,
+    voxels: Array.isArray(raw.voxels) ? raw.voxels : [],
+    parts: Array.isArray(raw.parts) ? raw.parts : [],
+    poses: raw.poses && typeof raw.poses === 'object' ? raw.poses : {},
+    animations: raw.animations && typeof raw.animations === 'object' && !Array.isArray(raw.animations)
+      ? raw.animations
+      : undefined,
+    tags: Array.isArray(raw.tags) ? raw.tags : [],
+    color_palettes: Array.isArray(raw.color_palettes) && raw.color_palettes.length > 0
+      ? raw.color_palettes
+      : [generateDefaultPalette()],
+  };
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna test -- echidnaFile`
+Expected: PASS — all `migrateEchidnaFile` tests including new palette tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/apps/echidna/src/store/types.ts tools/apps/echidna/src/__tests__/echidnaFile.test.ts
+git commit -m "feat(echidna): add ColorPalette type and bump file version to v5
+
+Adds color_palettes to EchidnaFile, colorPalettes to Asset, and a
+generateDefaultPalette helper (256 slots: 16 grayscale + 240 chromatic).
+Migration seeds the default palette on v4 → v5 upgrade."
+```
+
+---
+
+## Task 2: Port `colorExtract` utility from Bricklayer to Echidna
+
+**Files:**
+- Create: `tools/apps/echidna/src/lib/colorExtract.ts`
+- Create: `tools/apps/echidna/src/__tests__/colorExtract.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tools/apps/echidna/src/__tests__/colorExtract.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { extractColorsFromImage } from '../lib/colorExtract.js';
+
+function solidColorImageData(r: number, g: number, b: number, w = 8, h = 8): ImageData {
+  const data = new Uint8ClampedArray(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    data[i * 4] = r;
+    data[i * 4 + 1] = g;
+    data[i * 4 + 2] = b;
+    data[i * 4 + 3] = 255;
+  }
+  return { data, width: w, height: h, colorSpace: 'srgb' } as ImageData;
+}
+
+describe('extractColorsFromImage', () => {
+  it('returns a single color for a solid-fill image', () => {
+    const img = solidColorImageData(120, 200, 80);
+    const colors = extractColorsFromImage(img, 16);
+    expect(colors.length).toBeGreaterThanOrEqual(1);
+    // Bucketed, so the reported color is close but not necessarily exact
+    const [r, g, b, a] = colors[0];
+    expect(Math.abs(r - 120)).toBeLessThan(8);
+    expect(Math.abs(g - 200)).toBeLessThan(8);
+    expect(Math.abs(b - 80)).toBeLessThan(8);
+    expect(a).toBe(255);
+  });
+
+  it('skips transparent pixels', () => {
+    const data = new Uint8ClampedArray(4 * 4 * 4);
+    // First pixel opaque red, rest transparent
+    data[0] = 255; data[1] = 0; data[2] = 0; data[3] = 255;
+    const img = { data, width: 4, height: 4, colorSpace: 'srgb' } as ImageData;
+    const colors = extractColorsFromImage(img, 16);
+    expect(colors.length).toBe(1);
+    expect(colors[0][0]).toBeGreaterThan(240);
+    expect(colors[0][1]).toBeLessThan(16);
+    expect(colors[0][2]).toBeLessThan(16);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna test -- colorExtract`
+Expected: FAIL — `Cannot find module '../lib/colorExtract.js'`.
+
+- [ ] **Step 3: Create `colorExtract.ts` by copying from Bricklayer**
+
+Create `tools/apps/echidna/src/lib/colorExtract.ts` with the exact contents of `tools/apps/bricklayer/src/lib/colorExtract.ts` (verbatim — identical file). The file exports `extractColorsFromImage(imageData, maxColors)` and `extractColorsFromFile(file, maxColors)`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna test -- colorExtract`
+Expected: PASS — both tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/apps/echidna/src/lib/colorExtract.ts tools/apps/echidna/src/__tests__/colorExtract.test.ts
+git commit -m "feat(echidna): port colorExtract utility from Bricklayer
+
+Verbatim copy of extractColorsFromImage + extractColorsFromFile for use
+by the new palette system's From Image button. Future refactor: move to
+a shared package when a third consumer appears."
+```
+
+---
+
+## Task 3: Add palette state, actions, and serialization to `useCharacterStore`
+
+**Files:**
+- Modify: `tools/apps/echidna/src/store/useCharacterStore.ts`
+- Modify: `tools/apps/echidna/src/__tests__/characterStore.test.ts`
+
+- [ ] **Step 1: Write failing tests for palette actions and round-trip**
+
+Append to `tools/apps/echidna/src/__tests__/characterStore.test.ts`. (First inspect the top of that file to match its existing `beforeEach` and import style, then append this block at the end.)
+
+```ts
+describe('color palettes', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({
+      asset: null,
+      knownAssets: [],
+      activePaletteIndex: 0,
+    });
+  });
+
+  it('newAsset seeds asset.colorPalettes with a 256-slot default palette', () => {
+    useCharacterStore.getState().newAsset('character', 32, 'Test Bot');
+    const asset = useCharacterStore.getState().asset!;
+    expect(asset.colorPalettes.length).toBe(1);
+    expect(asset.colorPalettes[0].colors.length).toBe(256);
+  });
+
+  it('addPalette appends an empty 256-slot palette and activates it', () => {
+    const store = useCharacterStore.getState();
+    store.newAsset('character', 32, 'Test');
+    store.addPalette('MyPalette');
+    const s = useCharacterStore.getState();
+    expect(s.asset!.colorPalettes.length).toBe(2);
+    expect(s.asset!.colorPalettes[1].name).toBe('MyPalette');
+    expect(s.asset!.colorPalettes[1].colors.length).toBe(256);
+    expect(s.asset!.colorPalettes[1].colors[0]).toEqual([0, 0, 0, 0]); // empty slot
+    expect(s.activePaletteIndex).toBe(1);
+  });
+
+  it('addColorToPalette fills the first empty slot', () => {
+    const store = useCharacterStore.getState();
+    store.newAsset('character', 32, 'Test');
+    store.addPalette('MyPalette');
+    store.addColorToPalette(1, [200, 100, 50, 255]);
+    const s = useCharacterStore.getState();
+    expect(s.asset!.colorPalettes[1].colors[0]).toEqual([200, 100, 50, 255]);
+  });
+
+  it('removePalette drops by index and adjusts activePaletteIndex', () => {
+    const store = useCharacterStore.getState();
+    store.newAsset('character', 32, 'Test');
+    store.addPalette('A');
+    store.addPalette('B');
+    expect(useCharacterStore.getState().asset!.colorPalettes.length).toBe(3);
+    store.removePalette(0);
+    const s = useCharacterStore.getState();
+    expect(s.asset!.colorPalettes.length).toBe(2);
+    expect(s.asset!.colorPalettes.map((p) => p.name)).toEqual(['A', 'B']);
+  });
+
+  it('removePalette never leaves zero palettes', () => {
+    const store = useCharacterStore.getState();
+    store.newAsset('character', 32, 'Test');
+    // Asset already has 1 (default). Try to remove it.
+    store.removePalette(0);
+    const s = useCharacterStore.getState();
+    expect(s.asset!.colorPalettes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('saveProject / loadProject round-trips color_palettes', () => {
+    const store = useCharacterStore.getState();
+    store.newAsset('character', 32, 'Test');
+    store.addColorToPalette(0, [11, 22, 33, 255]);
+    const file = store.saveProject();
+    expect(file.color_palettes).toBeDefined();
+    expect(file.color_palettes!.length).toBe(1);
+    expect(file.color_palettes![0].colors[16]).toEqual([11, 22, 33, 255]); // first empty slot after 16 grayscale
+
+    // Clear and reload
+    useCharacterStore.setState({ asset: null });
+    store.loadProject(file);
+    const reloaded = useCharacterStore.getState().asset!;
+    expect(reloaded.colorPalettes[0].colors[16]).toEqual([11, 22, 33, 255]);
+  });
+
+  it('openAsset resets activePaletteIndex to 0', () => {
+    useCharacterStore.setState({ activePaletteIndex: 3 });
+    // Simulate state reset that openAsset performs.
+    useCharacterStore.setState({ activePaletteIndex: 0 });
+    expect(useCharacterStore.getState().activePaletteIndex).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna test -- characterStore`
+Expected: FAIL — `colorPalettes` / `activePaletteIndex` / `addPalette` not defined.
+
+- [ ] **Step 3: Add palette state + actions to the store**
+
+Open `tools/apps/echidna/src/store/useCharacterStore.ts`.
+
+Add imports (top of file, in the type import block):
+
+```ts
+import type {
+  Voxel,
+  VoxelKey,
+  BodyPart,
+  PoseData,
+  ToolType,
+  Snapshot,
+  EchidnaFile,
+  AppMode,
+  AnimationClip,
+  AnimationKeyframe,
+  ClipboardEntry,
+  PlaybackMode,
+  Asset,
+  AssetListEntry,
+  EchidnaAssetKind,
+  ColorPalette,
+} from './types.js';
+import { migrateEchidnaFile, slugifyAssetId, ECHIDNA_FILE_VERSION, generateDefaultPalette } from './types.js';
+```
+
+Add to the `CharacterStoreState` interface (find the section with UI-state fields, e.g. near `activeTool`) — top-level state (NOT on `Asset`):
+
+```ts
+  activePaletteIndex: number;
+```
+
+Add to the action interface section (near `setTool`, `setActiveColor`):
+
+```ts
+  addPalette: (name: string) => void;
+  removePalette: (index: number) => void;
+  setActivePalette: (index: number) => void;
+  addColorToPalette: (paletteIndex: number, color: [number, number, number, number]) => void;
+  addPaletteFromFile: (file: File) => Promise<void>;
+```
+
+Add to the store's initial state object (alongside other top-level defaults like `activeTool`, `activeColor`):
+
+```ts
+  activePaletteIndex: 0,
+```
+
+Add the action implementations anywhere in the actions block (e.g. near the end, before `save`). Every mutating action calls `markDirty()` so the file is saved; `setActivePalette` does not mutate the asset, so no dirty flag.
+
+```ts
+  addPalette: (name) => {
+    const s = get();
+    if (!s.asset) return;
+    const emptyColors: [number, number, number, number][] = Array.from({ length: 256 }, () => [0, 0, 0, 0]);
+    const palettes = [...s.asset.colorPalettes, { name, colors: emptyColors }];
+    set({
+      asset: { ...s.asset, colorPalettes: palettes },
+      activePaletteIndex: palettes.length - 1,
+      dirty: true,
+    });
+  },
+
+  removePalette: (index) => {
+    const s = get();
+    if (!s.asset) return;
+    let palettes = s.asset.colorPalettes.filter((_, i) => i !== index);
+    // Always keep at least one palette so the Build UI never has nothing to draw.
+    if (palettes.length === 0) palettes = [generateDefaultPalette()];
+    set({
+      asset: { ...s.asset, colorPalettes: palettes },
+      activePaletteIndex: Math.min(s.activePaletteIndex, palettes.length - 1),
+      dirty: true,
+    });
+  },
+
+  setActivePalette: (index) => set({ activePaletteIndex: index }),
+
+  addColorToPalette: (paletteIndex, color) => {
+    const s = get();
+    if (!s.asset) return;
+    const palettes = [...s.asset.colorPalettes];
+    if (!palettes[paletteIndex]) return;
+    const colors = [...palettes[paletteIndex].colors];
+    const emptyIdx = colors.findIndex((c) => c[3] === 0);
+    if (emptyIdx >= 0) {
+      colors[emptyIdx] = color;
+    } else if (colors.length < 256) {
+      colors.push(color);
+    } else {
+      return; // palette full, no-op
+    }
+    palettes[paletteIndex] = { ...palettes[paletteIndex], colors };
+    set({ asset: { ...s.asset, colorPalettes: palettes }, dirty: true });
+  },
+
+  addPaletteFromFile: async (file) => {
+    const { extractColorsFromFile } = await import('../lib/colorExtract.js');
+    const extracted = await extractColorsFromFile(file, 256);
+    const colors: [number, number, number, number][] = [...extracted];
+    while (colors.length < 256) colors.push([0, 0, 0, 0]);
+    const s = get();
+    if (!s.asset) return;
+    const palettes = [...s.asset.colorPalettes, { name: file.name, colors }];
+    set({
+      asset: { ...s.asset, colorPalettes: palettes },
+      activePaletteIndex: palettes.length - 1,
+      dirty: true,
+    });
+  },
+```
+
+Update `newAsset` (around line 1204) — add `colorPalettes: [generateDefaultPalette()]` to the new Asset object:
+
+```ts
+    set({
+      asset: {
+        id: newId,
+        kind,
+        voxels: new Map(),
+        gridWidth: size,
+        gridDepth: size,
+        characterName: charName,
+        characterParts: [],
+        characterPoses: {},
+        animations: {},
+        tags: [],
+        colorPalettes: [generateDefaultPalette()],
+        currentFilename: null,
+      },
+      // ... rest unchanged
+      activePaletteIndex: 0,
+      // ... rest unchanged
+    });
+```
+
+Note: add `activePaletteIndex: 0` to that `set()` call's state reset (alongside `selectedPart: null`, etc.).
+
+Update `openAsset` (around line 927) — the constructed `char: Asset` needs `colorPalettes`, and the `set()` call needs `activePaletteIndex: 0`:
+
+```ts
+      const char: Asset = {
+        id: data.id,
+        kind: data.kind ?? 'character',
+        characterName: data.characterName,
+        gridWidth: data.gridWidth,
+        gridDepth: data.gridDepth,
+        voxels: voxelArrayToMap(data.voxels),
+        characterParts: parts,
+        characterPoses: data.poses,
+        animations,
+        tags: data.tags ?? [],
+        colorPalettes: data.color_palettes ?? [generateDefaultPalette()],
+        currentFilename: null,
+      };
+      set({
+        asset: char,
+        // ... existing fields
+        activePaletteIndex: 0,
+        // ... existing fields
+      });
+```
+
+Update `saveProject` (around line 1289) — include `color_palettes` in the returned `EchidnaFile`:
+
+```ts
+    return {
+      version: ECHIDNA_FILE_VERSION,
+      id,
+      kind: char.kind ?? 'character',
+      characterName: char.characterName,
+      gridWidth: char.gridWidth,
+      gridDepth: char.gridDepth,
+      voxels: voxelArr,
+      parts: char.characterParts,
+      poses: char.characterPoses,
+      animations: Object.keys(char.animations).length > 0 ? char.animations : undefined,
+      tags: char.tags ?? [],
+      color_palettes: char.colorPalettes,
+    };
+```
+
+Update `loadProject` (around line 1316) — construct the Asset with `colorPalettes`:
+
+```ts
+    set({
+      asset: {
+        id: data.id,
+        kind: data.kind ?? 'character',
+        voxels,
+        gridWidth: data.gridWidth,
+        gridDepth: data.gridDepth,
+        characterName: data.characterName,
+        characterParts: parts,
+        characterPoses: data.poses,
+        animations,
+        tags: data.tags ?? [],
+        colorPalettes: data.color_palettes ?? [generateDefaultPalette()],
+        currentFilename: get().asset?.currentFilename ?? null,
+      },
+      // ...
+      activePaletteIndex: 0,
+      // ...
+    });
+```
+
+(`data.color_palettes` is populated by `migrateEchidnaFile`, so the fallback is defensive only.)
+
+Check every other place that constructs an `Asset` object inline (grep for `currentFilename: null,` within `useCharacterStore.ts`) and add `colorPalettes: [generateDefaultPalette()]` — expect at least `duplicateAsset` and any import-from-vox / import-from-image paths. If an import preserves the source palette, use that instead of the default.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna test -- characterStore`
+Expected: PASS — all palette tests plus all existing characterStore tests.
+
+- [ ] **Step 5: Run the full echidna test suite to catch Asset-shape breakages**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna test`
+Expected: PASS — all suites. If any suite constructs an Asset inline without `colorPalettes`, fix the fixture.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/apps/echidna/src/store/useCharacterStore.ts tools/apps/echidna/src/__tests__/characterStore.test.ts
+git commit -m "feat(echidna): persist color palettes per-character in the store
+
+Adds activePaletteIndex top-level state plus addPalette, removePalette,
+setActivePalette, addColorToPalette, and addPaletteFromFile actions.
+newAsset seeds the default 256-slot palette; openAsset/loadProject
+read color_palettes via migration; saveProject writes it back."
+```
+
+---
+
+## Task 4: Extract `YClipControl`, `YLevelLock`, and `DisplaySettings` to shared controls
+
+**Files:**
+- Create: `tools/apps/echidna/src/panels/controls/YClipControl.tsx`
+- Create: `tools/apps/echidna/src/panels/controls/YLevelLock.tsx`
+- Create: `tools/apps/echidna/src/panels/controls/DisplaySettings.tsx`
+- Modify: `tools/apps/echidna/src/panels/BuildPanel.tsx`
+
+This is a behavior-preserving refactor — no tests change. Smoke-check via the existing test suite plus `pnpm build`.
+
+- [ ] **Step 1: Create `YClipControl.tsx`**
+
+Create `tools/apps/echidna/src/panels/controls/YClipControl.tsx`:
+
+```tsx
+import React from 'react';
+import { useCharacterStore } from '../../store/useCharacterStore.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  section: { display: 'flex', flexDirection: 'column', gap: 8 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+};
+
+export function YClipControl() {
+  const yClip = useCharacterStore((s) => s.yClip);
+  const setYClip = useCharacterStore((s) => s.setYClip);
+  const voxels = useCharacterStore((s) => s.asset?.voxels ?? new Map());
+
+  let maxY = 0;
+  for (const [key] of voxels) {
+    const parts = key.split(',');
+    const y = Number(parts[1]);
+    if (y > maxY) maxY = y;
+  }
+
+  const enabled = yClip !== null;
+
+  return (
+    <div style={styles.section}>
+      <span style={styles.label}>Y-Clip</span>
+      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => setYClip(e.target.checked ? Math.floor(maxY / 2) : null)}
+        />
+        Enable
+      </label>
+      {enabled && (
+        <div style={styles.row}>
+          <input
+            type="range"
+            min={0}
+            max={maxY}
+            value={yClip}
+            onChange={(e) => setYClip(Number(e.target.value))}
+            style={{ flex: 1 }}
+          />
+          <span style={{ fontSize: 13, color: '#ddd', minWidth: 24 }}>Y:{yClip}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create `YLevelLock.tsx`**
+
+Create `tools/apps/echidna/src/panels/controls/YLevelLock.tsx`:
+
+```tsx
+import React from 'react';
+import { NumberInput } from '@gseurat/ui-kit';
+import { useCharacterStore } from '../../store/useCharacterStore.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  section: { display: 'flex', flexDirection: 'column', gap: 8 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+};
+
+export function YLevelLock() {
+  const yLevelLock = useCharacterStore((s) => s.yLevelLock);
+  const setYLevelLock = useCharacterStore((s) => s.setYLevelLock);
+
+  return (
+    <div style={styles.section}>
+      <span style={styles.label}>Y-Level Lock</span>
+      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
+        <input
+          type="checkbox"
+          checked={yLevelLock !== null}
+          onChange={(e) => setYLevelLock(e.target.checked ? 0 : null)}
+        />
+        Enable
+      </label>
+      {yLevelLock !== null && (
+        <NumberInput value={yLevelLock} onChange={setYLevelLock} min={0} step={1} label="Y" />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create `DisplaySettings.tsx`**
+
+Create `tools/apps/echidna/src/panels/controls/DisplaySettings.tsx`:
+
+```tsx
+import React from 'react';
+import { useCharacterStore } from '../../store/useCharacterStore.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  section: { display: 'flex', flexDirection: 'column', gap: 8 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+};
+
+export function DisplaySettings() {
+  const showGrid = useCharacterStore((s) => s.showGrid);
+  const showGizmos = useCharacterStore((s) => s.showGizmos);
+  const setShowGrid = useCharacterStore((s) => s.setShowGrid);
+  const setShowGizmos = useCharacterStore((s) => s.setShowGizmos);
+  const colorByPart = useCharacterStore((s) => s.colorByPart);
+  const setColorByPart = useCharacterStore((s) => s.setColorByPart);
+  const xrayMode = useCharacterStore((s) => s.xrayMode);
+  const setXrayMode = useCharacterStore((s) => s.setXrayMode);
+
+  return (
+    <div style={styles.section}>
+      <span style={styles.label}>Display</span>
+      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
+        <input type="checkbox" checked={showGrid} onChange={(e) => setShowGrid(e.target.checked)} />
+        Grid
+      </label>
+      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
+        <input type="checkbox" checked={showGizmos} onChange={(e) => setShowGizmos(e.target.checked)} />
+        Gizmos
+      </label>
+      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
+        <input type="checkbox" checked={colorByPart} onChange={(e) => setColorByPart(e.target.checked)} />
+        Color by Part
+      </label>
+      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
+        <input type="checkbox" checked={xrayMode} onChange={(e) => setXrayMode(e.target.checked)} />
+        X-Ray Mode (T)
+      </label>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Rewrite `BuildPanel.tsx` to compose the shared controls**
+
+Replace the full contents of `tools/apps/echidna/src/panels/BuildPanel.tsx`:
+
+```tsx
+import React from 'react';
+import { useComponentRegistry } from '@gseurat/ui-kit';
+import { useCharacterStore } from '../store/useCharacterStore.js';
+import { YClipControl } from './controls/YClipControl.js';
+import { YLevelLock } from './controls/YLevelLock.js';
+import { DisplaySettings } from './controls/DisplaySettings.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    flex: 1,
+    background: '#1e1e3a',
+    padding: 12,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 16,
+    overflowY: 'auto',
+  },
+  section: { display: 'flex', flexDirection: 'column', gap: 8 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+  select: {
+    flex: 1, padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 13,
+  },
+};
+
+function MirrorControl() {
+  const mirrorAxis = useCharacterStore((s) => s.mirrorAxis);
+  const setMirrorAxis = useCharacterStore((s) => s.setMirrorAxis);
+
+  return (
+    <div style={styles.section}>
+      <span style={styles.label}>Mirror</span>
+      <div style={styles.row}>
+        <select
+          style={styles.select}
+          value={mirrorAxis ?? 'none'}
+          onChange={(e) => {
+            const v = e.target.value;
+            setMirrorAxis(v === 'none' ? null : (v as 'x' | 'z'));
+          }}
+        >
+          <option value="none">Off</option>
+          <option value="x">Mirror X</option>
+          <option value="z">Mirror Z</option>
+        </select>
+      </div>
+    </div>
+  );
+}
+
+export function BuildPanel() {
+  useComponentRegistry('BuildPanel');
+  return (
+    <div style={styles.container}>
+      <YClipControl />
+      <YLevelLock />
+      <MirrorControl />
+      <DisplaySettings />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Build + run full test suite**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna build && pnpm --filter @gseurat/echidna test`
+Expected: PASS — no type errors, no test regressions. `BuildPanel` now composes three shared controls.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/apps/echidna/src/panels/controls/ tools/apps/echidna/src/panels/BuildPanel.tsx
+git commit -m "refactor(echidna): extract shared environment controls
+
+YClipControl, YLevelLock, DisplaySettings move to panels/controls/ so
+they can be composed by both BuildPanel and the upcoming AnimateRightPanel
+extension. BuildPanel behavior is unchanged."
+```
+
+---
+
+## Task 5: Rewrite the Build `ToolBar` as icon grids with the full palette UI
+
+**Files:**
+- Modify: `tools/apps/echidna/src/panels/ToolBar.tsx`
+
+- [ ] **Step 1: Rewrite the full file**
+
+Replace the full contents of `tools/apps/echidna/src/panels/ToolBar.tsx`:
+
+```tsx
+import React from 'react';
+import { useComponentRegistry } from '@gseurat/ui-kit';
+import { useCharacterStore } from '../store/useCharacterStore.js';
+import type { ToolType } from '../store/types.js';
+
+const drawTools: { id: ToolType; label: string; key: string; icon: string }[] = [
+  { id: 'place', label: 'Place', key: 'V', icon: '\u25A3' },    // ▣
+  { id: 'paint', label: 'Paint', key: 'B', icon: '\u270E' },    // ✎
+  { id: 'erase', label: 'Erase', key: 'E', icon: '\u25AB' },    // ▫
+  { id: 'fill', label: 'Fill', key: 'G', icon: '\u25A7' },      // ▧
+  { id: 'extrude', label: 'Extrude', key: 'X', icon: '\u2B06' },// ⬆
+];
+
+const utilTools: { id: ToolType; label: string; key: string; icon: string }[] = [
+  { id: 'orbit', label: 'Orbit', key: 'Q', icon: '\u27F2' },        // ⟲
+  { id: 'eyedropper', label: 'Eyedrop', key: 'I', icon: '\u25C9' }, // ◉
+  { id: 'box_select', label: 'Box Select', key: 'S', icon: '\u25AF' }, // ▯
+  { id: 'lasso_select', label: 'Lasso', key: 'L', icon: '\u2312' },   // ⌒
+];
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    width: 180,
+    background: '#1e1e3a',
+    borderRight: '1px solid #333',
+    padding: 12,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+    overflowY: 'auto',
+  },
+  section: { display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 4 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1, marginBottom: 2 },
+  toolGrid: { display: 'flex', flexWrap: 'wrap' as const, gap: 4 },
+  toolBtn: {
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    width: 32, height: 32,
+    border: '1px solid #444', borderRadius: 4,
+    background: '#2a2a4a', color: '#ddd',
+    cursor: 'pointer', fontSize: 16, padding: 0,
+  },
+  toolBtnActive: { background: '#4a4a8a', borderColor: '#77f' },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+  colorGrid: { display: 'grid', gridTemplateColumns: 'repeat(16, 1fr)', gap: 2 },
+  colorSwatch: {
+    width: '100%', aspectRatio: '1',
+    border: '2px solid transparent', borderRadius: 3,
+    cursor: 'pointer',
+  },
+  btn: {
+    padding: '4px 10px', border: '1px solid #555', borderRadius: 4,
+    background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 12,
+  },
+  select: {
+    flex: 1, minWidth: 0,
+    padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 12,
+    overflow: 'hidden', textOverflow: 'ellipsis',
+  },
+};
+
+export function ToolBar() {
+  useComponentRegistry('ToolBar');
+  const activeTool = useCharacterStore((s) => s.activeTool);
+  const activeColor = useCharacterStore((s) => s.activeColor);
+  const brushSize = useCharacterStore((s) => s.brushSize);
+  const setTool = useCharacterStore((s) => s.setTool);
+  const setActiveColor = useCharacterStore((s) => s.setActiveColor);
+  const setBrushSize = useCharacterStore((s) => s.setBrushSize);
+
+  const colorPalettes = useCharacterStore((s) => s.asset?.colorPalettes ?? []);
+  const activePaletteIndex = useCharacterStore((s) => s.activePaletteIndex);
+  const setActivePalette = useCharacterStore((s) => s.setActivePalette);
+  const addPalette = useCharacterStore((s) => s.addPalette);
+  const addColorToPalette = useCharacterStore((s) => s.addColorToPalette);
+  const addPaletteFromFile = useCharacterStore((s) => s.addPaletteFromFile);
+
+  const hexColor = `#${activeColor.slice(0, 3).map((c) => c.toString(16).padStart(2, '0')).join('')}`;
+  const activePalette = colorPalettes[activePaletteIndex] ?? colorPalettes[0];
+
+  return (
+    <div style={styles.container}>
+      {/* Draw */}
+      <div style={styles.section}>
+        <span style={styles.label}>Draw</span>
+        <div style={styles.toolGrid}>
+          {drawTools.map((t) => (
+            <button
+              key={t.id}
+              title={`${t.label} (${t.key})`}
+              style={{ ...styles.toolBtn, ...(activeTool === t.id ? styles.toolBtnActive : {}) }}
+              onClick={() => setTool(t.id)}
+            >
+              {t.icon}
+            </button>
+          ))}
+        </div>
+        <div style={{ ...styles.row, marginTop: 4 }}>
+          <input
+            type="range"
+            min={1}
+            max={8}
+            value={brushSize}
+            onChange={(e) => setBrushSize(Number(e.target.value))}
+            style={{ flex: 1 }}
+          />
+          <span style={{ fontSize: 11, color: '#888', minWidth: 14 }}>{brushSize}</span>
+        </div>
+      </div>
+
+      {/* Utility */}
+      <div style={styles.section}>
+        <span style={styles.label}>Utility</span>
+        <div style={styles.toolGrid}>
+          {utilTools.map((t) => (
+            <button
+              key={t.id}
+              title={`${t.label} (${t.key})`}
+              style={{ ...styles.toolBtn, ...(activeTool === t.id ? styles.toolBtnActive : {}) }}
+              onClick={() => setTool(t.id)}
+            >
+              {t.icon}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Color */}
+      <div style={styles.section}>
+        <span style={styles.label}>Color</span>
+        <div style={styles.row}>
+          <input
+            type="color"
+            value={hexColor}
+            onChange={(e) => {
+              const hex = e.target.value;
+              const r = parseInt(hex.slice(1, 3), 16);
+              const g = parseInt(hex.slice(3, 5), 16);
+              const b = parseInt(hex.slice(5, 7), 16);
+              setActiveColor([r, g, b, activeColor[3]]);
+            }}
+            style={{ width: 30, height: 24, border: 'none', cursor: 'pointer' }}
+          />
+          <div
+            style={{
+              width: 24, height: 24, borderRadius: 3,
+              background: `rgba(${activeColor.join(',')})`,
+              border: '1px solid #666',
+            }}
+          />
+          <button
+            style={{ ...styles.btn, fontSize: 11, padding: '2px 6px' }}
+            onClick={() => addColorToPalette(activePaletteIndex, [...activeColor] as [number, number, number, number])}
+          >
+            + Palette
+          </button>
+        </div>
+
+        <div style={styles.row}>
+          <select
+            value={activePaletteIndex}
+            onChange={(e) => setActivePalette(Number(e.target.value))}
+            style={styles.select}
+          >
+            {colorPalettes.map((p, i) => (
+              <option key={i} value={i}>{p.name}</option>
+            ))}
+          </select>
+          <button
+            style={{ ...styles.btn, fontSize: 11, padding: '2px 6px' }}
+            onClick={() => addPalette(`Palette ${colorPalettes.length + 1}`)}
+          >
+            New
+          </button>
+          <button
+            style={{ ...styles.btn, fontSize: 11, padding: '2px 6px' }}
+            onClick={() => {
+              const input = document.createElement('input');
+              input.type = 'file';
+              input.accept = 'image/*';
+              input.onchange = async () => {
+                const file = input.files?.[0];
+                if (!file) return;
+                await addPaletteFromFile(file);
+              };
+              input.click();
+            }}
+          >
+            From Image
+          </button>
+        </div>
+
+        <div style={styles.colorGrid}>
+          {(activePalette?.colors ?? []).map((c, i) => {
+            const isEmpty = c[3] === 0;
+            const isSelected = !isEmpty &&
+              c[0] === activeColor[0] && c[1] === activeColor[1] && c[2] === activeColor[2];
+            return (
+              <div
+                key={i}
+                style={{
+                  ...styles.colorSwatch,
+                  background: isEmpty ? '#1a1a2e' : `rgba(${c.join(',')})`,
+                  borderColor: isSelected ? '#fff' : 'transparent',
+                }}
+                onClick={() => { if (!isEmpty) setActiveColor(c); }}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build the app**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna build`
+Expected: PASS — no TypeScript errors.
+
+- [ ] **Step 3: Smoke-check via dev server + Chrome MCP**
+
+Start dev server if not running: `cd tools && pnpm --filter @gseurat/echidna dev`. Open `http://localhost:5179` in Chrome, open or create a character asset, verify:
+
+- Build ToolBar renders icon grid (Draw: 5 icons, Utility: 4 icons).
+- Brush size slider updates.
+- Color picker + `+ Palette` + palette dropdown + `New` + `From Image` work.
+- 16-column 256-slot grid renders with default palette.
+- Component registry health: in Chrome DevTools console run `JSON.stringify(window.__COMPONENT_REGISTRY__.health())`. Expected: no missing components.
+- Console has no React errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/echidna/src/panels/ToolBar.tsx
+git commit -m "feat(echidna): compact Build ToolBar with 256-slot palette UI
+
+Icon-grid Draw and Utility sections match Bricklayer's TerrainLeftPanel
+density. Color section adds a full 16-column palette grid, palette
+dropdown, New palette, and From Image extraction — all persisted
+per-character via the store's colorPalettes field."
+```
+
+---
+
+## Task 6: Add shared environment controls to `AnimateRightPanel`
+
+**Files:**
+- Modify: `tools/apps/echidna/src/panels/AnimateRightPanel.tsx`
+
+- [ ] **Step 1: Add a new environment section at the top**
+
+Modify `tools/apps/echidna/src/panels/AnimateRightPanel.tsx`. Add imports:
+
+```tsx
+import { YClipControl } from './controls/YClipControl.js';
+import { YLevelLock } from './controls/YLevelLock.js';
+import { DisplaySettings } from './controls/DisplaySettings.js';
+```
+
+Update the exported `AnimateRightPanel` component (around line 275):
+
+```tsx
+export function AnimateRightPanel() {
+  useComponentRegistry('AnimateRightPanel');
+  return (
+    <div style={styles.container}>
+      <YClipControl />
+      <YLevelLock />
+      <DisplaySettings />
+      <BoneProperties />
+      <KeyframeEditor />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build the app**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna build`
+Expected: PASS — no TypeScript errors.
+
+- [ ] **Step 3: Smoke-check via Chrome MCP**
+
+In a running dev server, switch to a character asset's Animate tab. Verify:
+
+- Right panel now shows Y-Clip, Y-Level Lock, and Display sections above Bone properties.
+- Toggling "Grid" in Animate mode affects the viewport identically to Build mode.
+- Toggling "X-Ray Mode" works in Animate mode (same state key `xrayMode`).
+- Component registry health check returns no missing components.
+- Console has no React errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/echidna/src/panels/AnimateRightPanel.tsx
+git commit -m "feat(echidna): add environment controls to Animate right panel
+
+Y-Clip, Y-Level Lock, Display (Grid/Gizmos/Color by Part/X-Ray) now
+appear above Bone properties in Animate mode, sharing implementation
+with BuildPanel via panels/controls/."
+```
+
+---
+
+## Task 7: Rewrite `AnimateToolBar` — icon grid Tools, remove Target Bone, compact Selection
+
+**Files:**
+- Modify: `tools/apps/echidna/src/panels/AnimateToolBar.tsx`
+- Modify: `tools/apps/echidna/src/__tests__/animateToolBar.test.ts`
+
+- [ ] **Step 1: Inspect the existing test file to understand test structure**
+
+Read `tools/apps/echidna/src/__tests__/animateToolBar.test.ts` to see how the component is currently tested. If there are assertions about the Target Bone `<select>`, they need updating or removing. If tests are store-level only, they probably still pass.
+
+- [ ] **Step 2: Update any tests that depend on the Target Bone dropdown**
+
+If a test queries for the target-bone `<select>`, replace or remove it. Any test that verifies `selectedPart` changes via the dropdown should be re-pointed to the `AnimateLeftPanel`'s `BoneTree` (or removed if redundant — the store-level action test already covers that).
+
+- [ ] **Step 3: Rewrite the full `AnimateToolBar.tsx`**
+
+Replace the full contents of `tools/apps/echidna/src/panels/AnimateToolBar.tsx`:
+
+```tsx
+import React, { useMemo } from 'react';
+import { useComponentRegistry } from '@gseurat/ui-kit';
+import { useCharacterStore } from '../store/useCharacterStore.js';
+import type { ToolType, VoxelKey } from '../store/types.js';
+
+const tools: { id: ToolType; label: string; key: string; icon: string }[] = [
+  { id: 'orbit',        label: 'Orbit',       key: 'Q', icon: '\u27F2' }, // ⟲
+  { id: 'assign_part',  label: 'Assign Part', key: 'A', icon: '\u2295' }, // ⊕
+  { id: 'box_select',   label: 'Box Select',  key: 'S', icon: '\u25AF' }, // ▯
+  { id: 'lasso_select', label: 'Lasso',       key: 'L', icon: '\u2312' }, // ⌒
+];
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    background: '#1e1e3a',
+    borderBottom: '1px solid #333',
+    padding: 12,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+  },
+  section: { display: 'flex', flexDirection: 'column', gap: 4 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1, marginBottom: 2 },
+  toolGrid: { display: 'flex', flexWrap: 'wrap' as const, gap: 4 },
+  toolBtn: {
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    width: 32, height: 32,
+    border: '1px solid #444', borderRadius: 4,
+    background: '#2a2a4a', color: '#ddd',
+    cursor: 'pointer', fontSize: 16, padding: 0,
+  },
+  toolBtnActive: { background: '#4a4a8a', borderColor: '#77f' },
+  count: { fontSize: 11, color: '#aaa', padding: '2px 0' },
+  selectionRow: { display: 'flex', gap: 4 },
+  actionBtn: {
+    flex: 1,
+    padding: '4px 8px',
+    borderWidth: 1, borderStyle: 'solid' as const, borderColor: '#555',
+    borderRadius: 4, background: '#3a3a6a', color: '#ddd',
+    cursor: 'pointer', fontSize: 11, textAlign: 'center' as const,
+  },
+  actionBtnPrimary: { background: '#4a4a8a', borderColor: '#77f', color: '#fff' },
+  actionBtnDisabled: { opacity: 0.4, cursor: 'not-allowed' },
+};
+
+export function AnimateToolBar() {
+  useComponentRegistry('AnimateToolBar');
+  const activeTool = useCharacterStore((s) => s.activeTool);
+  const setTool = useCharacterStore((s) => s.setTool);
+  const selectedPart = useCharacterStore((s) => s.selectedPart);
+  const boxSelection = useCharacterStore((s) => s.boxSelection);
+  const lassoSelection = useCharacterStore((s) => s.lassoSelection);
+  const assignVoxelsToPart = useCharacterStore((s) => s.assignVoxelsToPart);
+  const unassignVoxelsFromPart = useCharacterStore((s) => s.unassignVoxelsFromPart);
+  const setBoxSelection = useCharacterStore((s) => s.setBoxSelection);
+  const setLassoSelection = useCharacterStore((s) => s.setLassoSelection);
+  const pushUndo = useCharacterStore((s) => s.pushUndo);
+
+  const selection = useMemo<VoxelKey[]>(() => {
+    const s = new Set<VoxelKey>();
+    if (boxSelection) for (const k of boxSelection) s.add(k);
+    if (lassoSelection) for (const k of lassoSelection) s.add(k);
+    return Array.from(s);
+  }, [boxSelection, lassoSelection]);
+
+  const selectionCount = selection.length;
+  const canCommit = selectionCount > 0 && selectedPart !== null;
+  const canClear = selectionCount > 0;
+
+  const clearSelection = () => {
+    setBoxSelection(null);
+    setLassoSelection(null);
+  };
+
+  const handleAssign = () => {
+    if (!canCommit || !selectedPart) return;
+    pushUndo();
+    assignVoxelsToPart(selection, selectedPart);
+    clearSelection();
+  };
+
+  const handleUnassign = () => {
+    if (!canCommit || !selectedPart) return;
+    pushUndo();
+    unassignVoxelsFromPart(selection, selectedPart);
+    clearSelection();
+  };
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.section}>
+        <span style={styles.label}>Tools</span>
+        <div style={styles.toolGrid}>
+          {tools.map((t) => (
+            <button
+              key={t.id}
+              title={`${t.label} (${t.key})`}
+              style={{ ...styles.toolBtn, ...(activeTool === t.id ? styles.toolBtnActive : {}) }}
+              onClick={() => setTool(t.id)}
+            >
+              {t.icon}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div style={styles.section}>
+        <span style={styles.label}>Selection</span>
+        <div style={styles.count}>
+          {selectionCount === 0 ? 'No selection' : `${selectionCount} voxels`}
+        </div>
+        <div style={styles.selectionRow}>
+          <button
+            title="Assign selection to selected bone"
+            style={{
+              ...styles.actionBtn,
+              ...styles.actionBtnPrimary,
+              ...(!canCommit ? styles.actionBtnDisabled : {}),
+            }}
+            onClick={handleAssign}
+            disabled={!canCommit}
+          >
+            Assign
+          </button>
+          <button
+            title="Unassign selection from selected bone"
+            style={{
+              ...styles.actionBtn,
+              ...(!canCommit ? styles.actionBtnDisabled : {}),
+            }}
+            onClick={handleUnassign}
+            disabled={!canCommit}
+          >
+            Unassign
+          </button>
+          <button
+            title="Clear selection"
+            style={{
+              ...styles.actionBtn,
+              ...(!canClear ? styles.actionBtnDisabled : {}),
+            }}
+            onClick={clearSelection}
+            disabled={!canClear}
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+Note: `selectedPart`, `setSelectedPart`, and the `parts` list are no longer consumed by `AnimateToolBar` — bone selection happens via the `BoneTree` in `AnimateLeftPanel`. The `selectedPart` still drives `canCommit`, but the `<select>` UI is gone.
+
+- [ ] **Step 4: Run the echidna test suite**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna test`
+Expected: PASS — all suites.
+
+- [ ] **Step 5: Build**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna build`
+Expected: PASS — no type errors.
+
+- [ ] **Step 6: Smoke-check via Chrome MCP**
+
+In a running dev server on a character asset, switch to Animate mode. Verify:
+
+- Tools section is an icon grid (4 icons: Orbit, Assign Part, Box Select, Lasso).
+- No Target Bone dropdown appears.
+- Clicking a bone in the left tree sets the selected bone; Assign/Unassign buttons enable when both a bone is selected and a voxel selection exists.
+- Selection row: three short-labeled buttons (Assign / Unassign / Clear) + a count line above.
+- Component registry health check returns no missing components.
+- Console has no React errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/apps/echidna/src/panels/AnimateToolBar.tsx tools/apps/echidna/src/__tests__/animateToolBar.test.ts
+git commit -m "feat(echidna): compact Animate ToolBar, remove Target Bone dropdown
+
+Tools section is now an icon grid. Target Bone select is removed — bone
+selection comes from the AnimateLeftPanel tree. Selection actions
+(Assign/Unassign/Clear) sit in a compact labeled row below a count line."
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Run the full Echidna test suite**
+
+Run: `cd tools && pnpm --filter @gseurat/echidna test`
+Expected: PASS — all suites (store, file, color extraction, any updated component tests).
+
+- [ ] **Step 2: Full monorepo build**
+
+Run: `cd tools && pnpm build`
+Expected: PASS — no TypeScript errors in any workspace.
+
+- [ ] **Step 3: Chrome MCP final sweep**
+
+Start/resume dev server. In the Echidna UI:
+
+- Load an existing v4 `.echidna` project; verify it migrates cleanly (console shows the legacy-migration warning) and the default palette is present.
+- Save the project; close; reopen; verify v5 file round-trips including palettes.
+- In Build mode: place, paint, fill, extrude, eyedrop, box/lasso select, mirror, Y-clip, Y-level-lock, display toggles all still work.
+- In Animate mode: orbit, assign part, box/lasso select all still work. Clicking a bone in the tree selects it. Assign/Unassign/Clear behave identically to before. Y-Clip, Y-Level Lock, Display controls on the right panel affect the viewport.
+- Run `JSON.stringify(window.__COMPONENT_REGISTRY__.health())` — no missing components.
+- Browser console — no React errors.
+
+- [ ] **Step 4: Cross-reference with `CLAUDE.md` UI checklist**
+
+Tick the React (Echidna) UI checklist items from `CLAUDE.md`:
+1. New components (`YClipControl`, `YLevelLock`, `DisplaySettings`) are imported in their parents (`BuildPanel`, `AnimateRightPanel`). ✓
+2. They are rendered in JSX. ✓
+3. `expected-components.json` — unchanged (sub-controls follow the existing non-registered convention, matching old `YClipControl`/`YLevelLock`/`GridSettings` in `BuildPanel.tsx`).
+4. Build succeeds. ✓
+5. Component registry health check — no missing components.
+6. Browser console — no React errors.
+7. Scenario runner — no Echidna-only role registered; no-op unless one is added.
+
+- [ ] **Step 5: Done**
+
+No additional commit — each task committed as it completed. Offer a PR via `superpowers:finishing-a-development-branch`.

--- a/docs/superpowers/specs/2026-04-16-echidna-ui-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-16-echidna-ui-improvements-design.md
@@ -1,0 +1,160 @@
+# Echidna UI Improvements — Design
+
+Date: 2026-04-16
+Branch: `feat/echidna-ui-improvements`
+
+## Goals
+
+1. Make the **Build tab** tool layout compact — mirror Bricklayer's `TerrainLeftPanel` icon-grid density — and replace the 12-color hardcoded preset with a full 256-slot multi-palette system, persisted per character.
+2. Make the **Animate tab** tool layout compact with the same style.
+3. Remove the redundant **Target Bone** dropdown from the Animate toolbar; bone selection happens via the tree in `AnimateLeftPanel`.
+4. Add environment display controls (**Y-Clip**, **Y-Level Lock**, **Display** (Grid/Gizmos), **Color by Part**, **X-Ray Mode**) to the Animate right panel, matching what the Build right panel exposes.
+
+## Non-goals
+
+- Sharing `colorExtract` / `ColorPalette` type with Bricklayer via a shared package. Duplicate for now; extract later if a third consumer appears.
+- Palette editing beyond what Bricklayer offers today (no rename-in-place, no reorder, no per-slot delete).
+- Adding a Mirror control to the Animate mode. Mirror applies to voxel placement, which is a Build-mode action.
+
+## Architecture
+
+### Shared environment controls
+
+New folder: `tools/apps/echidna/src/panels/controls/`
+
+- `YClipControl.tsx` — Y-clip enable checkbox + slider (ported from `BuildPanel.tsx`).
+- `YLevelLock.tsx` — Y-level lock checkbox + numeric input (ported from `BuildPanel.tsx`).
+- `DisplaySettings.tsx` — single `DISPLAY` section containing Grid, Gizmos, Color by Part, X-Ray checkboxes (ported from `BuildPanel.tsx`'s `GridSettings`).
+
+`BuildPanel.tsx` composes: `YClipControl` + `YLevelLock` + inline `MirrorControl` + `DisplaySettings`.
+`AnimateRightPanel.tsx` composes: `YClipControl` + `YLevelLock` + `DisplaySettings` + existing `BoneProperties` + existing `KeyframeEditor`. Environment controls sit above the bone/keyframe sections.
+
+Mirror stays inline in `BuildPanel.tsx` — single consumer, no reuse benefit.
+
+The three new components use `useCharacterStore` directly (no prop drilling). They do not register themselves with `useComponentRegistry` — they are leaf subsections, matching the existing convention in `BuildPanel.tsx` where `YClipControl`, `YLevelLock`, `MirrorControl`, `GridSettings` are unregistered internal components.
+
+### Palette system — per-character, persisted
+
+**Type changes** (`tools/apps/echidna/src/store/types.ts`):
+
+```ts
+export interface ColorPalette {
+  name: string;
+  colors: [number, number, number, number][];
+}
+
+export interface Asset {
+  // ... existing fields
+  colorPalettes: ColorPalette[];
+}
+
+export const ECHIDNA_FILE_VERSION = 5 as const;
+
+export interface EchidnaFile {
+  // ... existing fields
+  color_palettes?: ColorPalette[];
+}
+```
+
+Migration (`migrateEchidnaFile`): when a pre-v5 file is loaded with no `color_palettes`, seed with `[generateDefaultPalette()]` where `generateDefaultPalette()` matches Bricklayer's implementation (16 grayscale + 12 hues × 4 saturations × 5 lightness = 256 slots).
+
+**Store changes** (`tools/apps/echidna/src/store/useCharacterStore.ts`):
+
+- `activePaletteIndex: number` — stored in the app-level store (not per-asset). Resets to 0 on asset switch via `openAsset` / `newAsset`.
+- New actions (all `pushUndo()` where they mutate):
+  - `addPalette(name: string)` — append empty 256-slot palette, set active.
+  - `removePalette(index: number)` — remove (never removes the last one).
+  - `setActivePalette(index: number)` — no undo (UI state).
+  - `addColorToPalette(paletteIndex: number, color: RGBA)` — fill first empty slot.
+  - `addPaletteFromImage(file: File)` — use `extractColorsFromFile` from lib, pad to 256 with `[0,0,0,0]`, append, set active.
+- Serialization: `save()` writes `color_palettes` from current asset; `openAsset()` reads it via migration.
+
+**Color extraction lib** — new `tools/apps/echidna/src/lib/colorExtract.ts`: copy verbatim from `tools/apps/bricklayer/src/lib/colorExtract.ts`.
+
+### Build ToolBar rewrite (`panels/ToolBar.tsx`)
+
+Layout mirroring Bricklayer's `TerrainLeftPanel`:
+
+- **DRAW** section: icon grid (32×32 buttons, `flexWrap`, 4px gap) — Place ▣, Paint ✎, Erase ▫, Fill ▧, Extrude ⬆. Brush-size range slider (`type="range"`) with inline count display directly below.
+- **UTILITY** section: icon grid — Orbit ⟲, Eyedrop ◉, Box Select ▯, Lasso ⌒.
+- **COLOR** section:
+  - Row: current color swatch (24×24) + native `<input type="color">` + `+ Palette` button (adds active color to active palette's first empty slot).
+  - Row: palette `<select>` dropdown + `New` button + `From Image` button.
+  - 16-column color grid (256 slots). Empty slots render `#1a1a2e` (background color); filled slots show the color with 2px selection border if active.
+
+Panel width stays `180` (fits 16-col × small swatches cleanly).
+
+Tool shortcut keys in `App.tsx` (`buildToolKeys`) stay identical; only the visual representation changes.
+
+### Animate ToolBar rewrite (`panels/AnimateToolBar.tsx`)
+
+- **TOOLS** section: icon grid — Orbit ⟲, Assign Part ⊕, Box Select ▯, Lasso ⌒.
+- ~~TARGET BONE dropdown~~: removed. `AnimateLeftPanel`'s `BoneTree` already calls `setSelectedPart(part.id)` on click, so the dropdown was redundant.
+- **SELECTION** section: compact one-line count (`3 voxels` or `No selection`, fontSize 11, muted) + single flex row with three short-labeled buttons — `Assign`, `Unassign`, `Clear`. Button style: 4px vertical / 8px horizontal padding, fontSize 11, `flex: 1` so they share width evenly. Disabled states (from `canCommit` / `canClear`) preserved.
+
+Existing `assignVoxelsToPart` / `unassignVoxelsFromPart` / `clearSelection` handlers keep their current behavior.
+
+### Animate RightPanel (`panels/AnimateRightPanel.tsx`)
+
+New top section before `BoneProperties`:
+
+```
+<YClipControl />
+<YLevelLock />
+<DisplaySettings />
+<BoneProperties />      // existing
+<KeyframeEditor />      // existing
+```
+
+No changes to `BoneProperties` or `KeyframeEditor`.
+
+## File-level change summary
+
+| File | Change |
+|------|--------|
+| `tools/apps/echidna/src/store/types.ts` | Add `ColorPalette`; add `colorPalettes` to `Asset`; add `color_palettes` to `EchidnaFile`; bump version to 5; extend migration |
+| `tools/apps/echidna/src/store/useCharacterStore.ts` | Add `activePaletteIndex`, palette actions, serialization wiring, `generateDefaultPalette` helper |
+| `tools/apps/echidna/src/lib/colorExtract.ts` | NEW (port from Bricklayer) |
+| `tools/apps/echidna/src/panels/controls/YClipControl.tsx` | NEW (extracted from `BuildPanel.tsx`) |
+| `tools/apps/echidna/src/panels/controls/YLevelLock.tsx` | NEW (extracted from `BuildPanel.tsx`) |
+| `tools/apps/echidna/src/panels/controls/DisplaySettings.tsx` | NEW (extracted from `BuildPanel.tsx`'s `GridSettings`) |
+| `tools/apps/echidna/src/panels/ToolBar.tsx` | Rewrite: icon grids + full palette UI |
+| `tools/apps/echidna/src/panels/BuildPanel.tsx` | Compose shared controls + inline `MirrorControl` |
+| `tools/apps/echidna/src/panels/AnimateToolBar.tsx` | Icon grid Tools + remove Target Bone + compact Selection row |
+| `tools/apps/echidna/src/panels/AnimateRightPanel.tsx` | Add shared controls section at top |
+| `tools/apps/echidna/src/expected-components.json` | Unchanged (new sub-controls follow existing non-registered convention) |
+
+## Testing
+
+Per `CLAUDE.md`'s React UI checklist:
+
+1. `pnpm build` in `tools/` succeeds.
+2. Chrome MCP component-registry health check — no missing components:
+   ```js
+   JSON.stringify(window.__COMPONENT_REGISTRY__.health())
+   ```
+3. Browser console shows no React errors.
+4. `python3 scripts/scenario_runner.py --list` — run whichever Echidna-relevant role scenarios exist (no Echidna-only role registered at design time, so this step is a no-op unless one is added).
+
+Functional checks:
+
+- Existing v4 `.echidna` file loads; `color_palettes` is seeded via migration; subsequent save writes v5 with the palette; reload round-trips the palette.
+- "From Image" in Build mode appends a palette named after the file and activates it.
+- Clicking a bone in `AnimateLeftPanel` selects it; Assign/Unassign buttons reflect the selected-part state identically to before (gated by `canCommit = selectionCount > 0 && selectedPart !== null`).
+- Y-Clip / Y-Level Lock / Display / Color by Part / X-Ray toggles in Animate mode affect the viewport identically to Build mode (they write the same store keys).
+- Build tab layout width remains ~180px; 16-column palette grid fits without horizontal scroll.
+
+## Migration detail
+
+`migrateEchidnaFile` change (pseudo):
+
+```ts
+const color_palettes =
+  Array.isArray(raw.color_palettes) && raw.color_palettes.length > 0
+    ? raw.color_palettes
+    : [generateDefaultPalette()];
+```
+
+`openAsset` seeds `asset.colorPalettes = file.color_palettes ?? [generateDefaultPalette()]`. `save()` writes `color_palettes: asset.colorPalettes`.
+
+On `newAsset`, start with `[generateDefaultPalette()]`.

--- a/tools/apps/echidna/src/__tests__/AssetsPanel.test.ts
+++ b/tools/apps/echidna/src/__tests__/AssetsPanel.test.ts
@@ -23,6 +23,7 @@ const makeAsset = (id: string, name: string) => ({
   animations: {},
   tags: [],
   currentFilename: null,
+  colorPalettes: [],
 });
 
 describe('AssetsPanel data contract', () => {

--- a/tools/apps/echidna/src/__tests__/characterStore.test.ts
+++ b/tools/apps/echidna/src/__tests__/characterStore.test.ts
@@ -1159,17 +1159,20 @@ describe('color palettes', () => {
   it('saveProject / loadProject round-trips color_palettes', () => {
     const store = useCharacterStore.getState();
     store.newAsset('character', 32, 'Test');
-    store.addColorToPalette(0, [11, 22, 33, 255]);
+    store.addPalette('Custom');
+    store.addColorToPalette(1, [11, 22, 33, 255]);
     const file = store.saveProject();
     expect(file.color_palettes).toBeDefined();
-    expect(file.color_palettes!.length).toBe(1);
-    expect(file.color_palettes![0].colors[16]).toEqual([11, 22, 33, 255]); // first empty slot after 16 grayscale
+    expect(file.color_palettes!.length).toBe(2);           // default + custom
+    expect(file.color_palettes![1].name).toBe('Custom');
+    expect(file.color_palettes![1].colors[0]).toEqual([11, 22, 33, 255]);
 
     // Clear and reload
     useCharacterStore.setState({ asset: null });
     store.loadProject(file);
     const reloaded = useCharacterStore.getState().asset!;
-    expect(reloaded.colorPalettes[0].colors[16]).toEqual([11, 22, 33, 255]);
+    expect(reloaded.colorPalettes.length).toBe(2);
+    expect(reloaded.colorPalettes[1].colors[0]).toEqual([11, 22, 33, 255]);
   });
 
   it('openAsset resets activePaletteIndex to 0', () => {

--- a/tools/apps/echidna/src/__tests__/characterStore.test.ts
+++ b/tools/apps/echidna/src/__tests__/characterStore.test.ts
@@ -3,14 +3,14 @@ import { useCharacterStore } from '../store/useCharacterStore';
 import { testing } from '@gseurat/project-root';
 import { AssetListEntry, migrateEchidnaFile, ECHIDNA_FILE_VERSION } from '../store/types';
 
-describe('migrateEchidnaFile v3 → v4', () => {
+describe('migrateEchidnaFile v3 → v5', () => {
   it('defaults kind to character for legacy v3 files', () => {
     const raw = {
       version: 3, id: 'walker', characterName: 'Walker',
       gridWidth: 32, gridDepth: 32, voxels: [], parts: [], poses: {},
     };
     const result = migrateEchidnaFile(raw);
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.kind).toBe('character');
   });
 
@@ -30,8 +30,8 @@ describe('migrateEchidnaFile v3 → v4', () => {
     expect(result.tags).toEqual([]);
   });
 
-  it('ECHIDNA_FILE_VERSION is 4', () => {
-    expect(ECHIDNA_FILE_VERSION).toBe(4);
+  it('ECHIDNA_FILE_VERSION is 5', () => {
+    expect(ECHIDNA_FILE_VERSION).toBe(5);
   });
 });
 
@@ -1095,5 +1095,87 @@ describe('useCharacterStore.save — object kind', () => {
     const assets = await root.getDirectoryHandle('assets');
     const objects = await assets.getDirectoryHandle('objects');
     await objects.getFileHandle('crystal.ply');
+  });
+});
+
+describe('color palettes', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({
+      asset: null,
+      knownAssets: [],
+      activePaletteIndex: 0,
+    });
+  });
+
+  it('newAsset seeds asset.colorPalettes with a 256-slot default palette', () => {
+    useCharacterStore.getState().newAsset('character', 32, 'Test Bot');
+    const asset = useCharacterStore.getState().asset!;
+    expect(asset.colorPalettes.length).toBe(1);
+    expect(asset.colorPalettes[0].colors.length).toBe(256);
+  });
+
+  it('addPalette appends an empty 256-slot palette and activates it', () => {
+    const store = useCharacterStore.getState();
+    store.newAsset('character', 32, 'Test');
+    store.addPalette('MyPalette');
+    const s = useCharacterStore.getState();
+    expect(s.asset!.colorPalettes.length).toBe(2);
+    expect(s.asset!.colorPalettes[1].name).toBe('MyPalette');
+    expect(s.asset!.colorPalettes[1].colors.length).toBe(256);
+    expect(s.asset!.colorPalettes[1].colors[0]).toEqual([0, 0, 0, 0]); // empty slot
+    expect(s.activePaletteIndex).toBe(1);
+  });
+
+  it('addColorToPalette fills the first empty slot', () => {
+    const store = useCharacterStore.getState();
+    store.newAsset('character', 32, 'Test');
+    store.addPalette('MyPalette');
+    store.addColorToPalette(1, [200, 100, 50, 255]);
+    const s = useCharacterStore.getState();
+    expect(s.asset!.colorPalettes[1].colors[0]).toEqual([200, 100, 50, 255]);
+  });
+
+  it('removePalette drops by index and adjusts activePaletteIndex', () => {
+    const store = useCharacterStore.getState();
+    store.newAsset('character', 32, 'Test');
+    store.addPalette('A');
+    store.addPalette('B');
+    expect(useCharacterStore.getState().asset!.colorPalettes.length).toBe(3);
+    store.removePalette(0);
+    const s = useCharacterStore.getState();
+    expect(s.asset!.colorPalettes.length).toBe(2);
+    expect(s.asset!.colorPalettes.map((p) => p.name)).toEqual(['A', 'B']);
+  });
+
+  it('removePalette never leaves zero palettes', () => {
+    const store = useCharacterStore.getState();
+    store.newAsset('character', 32, 'Test');
+    // Asset already has 1 (default). Try to remove it.
+    store.removePalette(0);
+    const s = useCharacterStore.getState();
+    expect(s.asset!.colorPalettes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('saveProject / loadProject round-trips color_palettes', () => {
+    const store = useCharacterStore.getState();
+    store.newAsset('character', 32, 'Test');
+    store.addColorToPalette(0, [11, 22, 33, 255]);
+    const file = store.saveProject();
+    expect(file.color_palettes).toBeDefined();
+    expect(file.color_palettes!.length).toBe(1);
+    expect(file.color_palettes![0].colors[16]).toEqual([11, 22, 33, 255]); // first empty slot after 16 grayscale
+
+    // Clear and reload
+    useCharacterStore.setState({ asset: null });
+    store.loadProject(file);
+    const reloaded = useCharacterStore.getState().asset!;
+    expect(reloaded.colorPalettes[0].colors[16]).toEqual([11, 22, 33, 255]);
+  });
+
+  it('openAsset resets activePaletteIndex to 0', () => {
+    useCharacterStore.setState({ activePaletteIndex: 3 });
+    // Simulate state reset that openAsset performs.
+    useCharacterStore.setState({ activePaletteIndex: 0 });
+    expect(useCharacterStore.getState().activePaletteIndex).toBe(0);
   });
 });

--- a/tools/apps/echidna/src/__tests__/characterStore.test.ts
+++ b/tools/apps/echidna/src/__tests__/characterStore.test.ts
@@ -51,6 +51,7 @@ describe('useCharacterStore — dirty tracking', () => {
         animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
     });
     useCharacterStore.getState().markClean();
@@ -320,6 +321,7 @@ describe('useCharacterStore.save', () => {
         animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       dirty: true,
     });
@@ -364,6 +366,7 @@ describe('useCharacterStore.save', () => {
         animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       dirty: true,
     });
@@ -396,6 +399,7 @@ describe('useCharacterStore.save', () => {
         animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       dirty: true,
     });
@@ -437,6 +441,7 @@ describe('useCharacterStore.save', () => {
         animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       dirty: true,
     });
@@ -486,6 +491,7 @@ describe('useCharacterStore.requestOpenAsset', () => {
         animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       dirty: false,
       undoStack: [],
@@ -549,6 +555,7 @@ describe('useCharacterStore.requestOpenAsset', () => {
         animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
     });
 
@@ -585,6 +592,7 @@ describe('useCharacterStore.requestOpenAsset', () => {
         animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
     });
 
@@ -624,6 +632,7 @@ describe('useCharacterStore.requestOpenAsset', () => {
         animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       undoStack: [{} as any],
     });
@@ -663,6 +672,7 @@ describe('useCharacterStore.renameAsset', () => {
         characterParts: [], characterPoses: {}, animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       knownAssets: [{ id: 'walker', kind: 'character', name: 'Walker Bot', lastModified: 0 }],
       dirty: false,
@@ -697,6 +707,7 @@ describe('useCharacterStore.renameAsset', () => {
         characterParts: [], characterPoses: {}, animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       knownAssets: [{ id: 'walker', kind: 'character', name: 'Walker Bot', lastModified: 0 }],
       dirty: false,
@@ -736,6 +747,7 @@ describe('useCharacterStore.renameAsset', () => {
         characterParts: [], characterPoses: {}, animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       knownAssets: [
         { id: 'walker', kind: 'character', name: 'Walker Bot', lastModified: 0 },
@@ -779,6 +791,7 @@ describe('useCharacterStore.deleteAsset', () => {
         characterParts: [], characterPoses: {}, animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
     });
 
@@ -809,6 +822,7 @@ describe('useCharacterStore.deleteAsset', () => {
         characterParts: [], characterPoses: {}, animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       knownAssets: [{ id: 'walker', kind: 'character', name: 'Walker', lastModified: 0 }],
       dirty: true,
@@ -937,6 +951,7 @@ describe('useCharacterStore.save — return value', () => {
         characterParts: [], characterPoses: {}, animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       dirty: true,
     });
@@ -955,6 +970,7 @@ describe('useCharacterStore.save — return value', () => {
         characterParts: [], characterPoses: {}, animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       dirty: true,
     });
@@ -989,6 +1005,7 @@ describe('useCharacterStore.save — return value', () => {
         characterParts: [], characterPoses: {}, animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       dirty: true,
     });
@@ -1043,6 +1060,7 @@ describe('useCharacterStore.save — map kind', () => {
         voxels: new Map([['0,0,0', { color: [100, 150, 100, 255] }]]),
         characterParts: [], characterPoses: {}, animations: {},
         tags: [], currentFilename: null,
+        colorPalettes: [],
       },
       dirty: true,
     });
@@ -1068,6 +1086,7 @@ describe('useCharacterStore.save — object kind', () => {
         voxels: new Map([['0,0,0', { color: [200, 200, 255, 255] }]]),
         characterParts: [], characterPoses: {}, animations: {},
         tags: ['prop'], currentFilename: null,
+        colorPalettes: [],
       },
       dirty: true,
     });

--- a/tools/apps/echidna/src/__tests__/characterStore.test.ts
+++ b/tools/apps/echidna/src/__tests__/characterStore.test.ts
@@ -1175,10 +1175,18 @@ describe('color palettes', () => {
     expect(reloaded.colorPalettes[1].colors[0]).toEqual([11, 22, 33, 255]);
   });
 
-  it('openAsset resets activePaletteIndex to 0', () => {
+  it('loadProject resets activePaletteIndex to 0', () => {
+    const store = useCharacterStore.getState();
+    store.newAsset('character', 32, 'Before');
+    store.addPalette('Custom');
+    expect(useCharacterStore.getState().activePaletteIndex).toBe(1);
+
+    // Simulate loading a different asset: build a raw v4 file with color_palettes
+    // set, then feed it through loadProject — this mirrors what openAsset does
+    // via migrateEchidnaFile + state reset.
+    const file = store.saveProject();
     useCharacterStore.setState({ activePaletteIndex: 3 });
-    // Simulate state reset that openAsset performs.
-    useCharacterStore.setState({ activePaletteIndex: 0 });
+    store.loadProject(file);
     expect(useCharacterStore.getState().activePaletteIndex).toBe(0);
   });
 });

--- a/tools/apps/echidna/src/__tests__/colorExtract.test.ts
+++ b/tools/apps/echidna/src/__tests__/colorExtract.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { extractColorsFromImage } from '../lib/colorExtract.js';
+
+function solidColorImageData(r: number, g: number, b: number, w = 8, h = 8): ImageData {
+  const data = new Uint8ClampedArray(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    data[i * 4] = r;
+    data[i * 4 + 1] = g;
+    data[i * 4 + 2] = b;
+    data[i * 4 + 3] = 255;
+  }
+  return { data, width: w, height: h, colorSpace: 'srgb' } as ImageData;
+}
+
+describe('extractColorsFromImage', () => {
+  it('returns a single color for a solid-fill image', () => {
+    const img = solidColorImageData(120, 200, 80);
+    const colors = extractColorsFromImage(img, 16);
+    expect(colors.length).toBeGreaterThanOrEqual(1);
+    // Bucketed, so the reported color is close but not necessarily exact
+    const [r, g, b, a] = colors[0];
+    expect(Math.abs(r - 120)).toBeLessThan(8);
+    expect(Math.abs(g - 200)).toBeLessThan(8);
+    expect(Math.abs(b - 80)).toBeLessThan(8);
+    expect(a).toBe(255);
+  });
+
+  it('skips transparent pixels', () => {
+    const data = new Uint8ClampedArray(4 * 4 * 4);
+    // First pixel opaque red, rest transparent
+    data[0] = 255; data[1] = 0; data[2] = 0; data[3] = 255;
+    const img = { data, width: 4, height: 4, colorSpace: 'srgb' } as ImageData;
+    const colors = extractColorsFromImage(img, 16);
+    expect(colors.length).toBe(1);
+    expect(colors[0][0]).toBeGreaterThan(240);
+    expect(colors[0][1]).toBeLessThan(16);
+    expect(colors[0][2]).toBeLessThan(16);
+  });
+});

--- a/tools/apps/echidna/src/__tests__/echidnaFile.test.ts
+++ b/tools/apps/echidna/src/__tests__/echidnaFile.test.ts
@@ -119,4 +119,22 @@ describe('migrateEchidnaFile', () => {
     const migrated = migrateEchidnaFile(file);
     expect(migrated.color_palettes).toEqual([{ name: 'Custom', colors: [[10, 20, 30, 255]] }]);
   });
+
+  it('seeds default when color_palettes is an empty array', () => {
+    const file = {
+      version: 5,
+      id: 'walker',
+      characterName: 'Walker',
+      gridWidth: 32,
+      gridDepth: 32,
+      voxels: [],
+      parts: [],
+      poses: {},
+      color_palettes: [],
+    };
+    const migrated = migrateEchidnaFile(file);
+    expect(migrated.color_palettes).toBeDefined();
+    expect(migrated.color_palettes!.length).toBe(1);
+    expect(migrated.color_palettes![0].colors.length).toBe(256);
+  });
 });

--- a/tools/apps/echidna/src/__tests__/echidnaFile.test.ts
+++ b/tools/apps/echidna/src/__tests__/echidnaFile.test.ts
@@ -33,7 +33,7 @@ describe('migrateEchidnaFile', () => {
     };
     const migrated = migrateEchidnaFile(old);
     expect(migrated.version).toBe(ECHIDNA_FILE_VERSION);
-    expect(migrated.version).toBe(4);
+    expect(migrated.version).toBe(5);
     expect(migrated.id).toBe('walker_bot');
   });
 
@@ -79,5 +79,44 @@ describe('migrateEchidnaFile', () => {
     expect(() => migrateEchidnaFile(undefined)).toThrow();
     expect(() => migrateEchidnaFile(42)).toThrow();
     expect(() => migrateEchidnaFile('string')).toThrow();
+  });
+
+  it('seeds color_palettes with a 256-slot default when absent', () => {
+    const old = {
+      version: 2,
+      characterName: 'Walker',
+      gridWidth: 32,
+      gridDepth: 32,
+      voxels: [],
+      parts: [],
+      poses: {},
+    };
+    const migrated = migrateEchidnaFile(old);
+    expect(migrated.color_palettes).toBeDefined();
+    expect(migrated.color_palettes!.length).toBe(1);
+    expect(migrated.color_palettes![0].colors.length).toBe(256);
+    // First 16 slots should be grayscale (r === g === b)
+    for (let i = 0; i < 16; i++) {
+      const [r, g, b, a] = migrated.color_palettes![0].colors[i];
+      expect(r).toBe(g);
+      expect(g).toBe(b);
+      expect(a).toBe(255);
+    }
+  });
+
+  it('preserves existing color_palettes when present', () => {
+    const file = {
+      version: 5,
+      id: 'walker',
+      characterName: 'Walker',
+      gridWidth: 32,
+      gridDepth: 32,
+      voxels: [],
+      parts: [],
+      poses: {},
+      color_palettes: [{ name: 'Custom', colors: [[10, 20, 30, 255]] }],
+    };
+    const migrated = migrateEchidnaFile(file);
+    expect(migrated.color_palettes).toEqual([{ name: 'Custom', colors: [[10, 20, 30, 255]] }]);
   });
 });

--- a/tools/apps/echidna/src/__tests__/unassignVoxelsFromPart.test.ts
+++ b/tools/apps/echidna/src/__tests__/unassignVoxelsFromPart.test.ts
@@ -23,6 +23,7 @@ function makeAsset(): Asset {
     animations: {},
     tags: [],
     currentFilename: null,
+    colorPalettes: [],
   };
 }
 

--- a/tools/apps/echidna/src/lib/colorExtract.ts
+++ b/tools/apps/echidna/src/lib/colorExtract.ts
@@ -1,0 +1,137 @@
+/**
+ * Extract dominant colors from an image using histogram-based sampling.
+ * Returns up to `maxColors` RGBA tuples.
+ */
+export function extractColorsFromImage(
+  imageData: ImageData,
+  maxColors: number = 128,
+): [number, number, number, number][] {
+  const { data, width, height } = imageData;
+  const bucketBits = 5; // group into 32 bins per channel (32768 total buckets)
+  const shift = 8 - bucketBits;
+  const bucketCount = (1 << bucketBits) ** 3;
+
+  // Count pixels per bucket
+  const counts = new Uint32Array(bucketCount);
+  const sumR = new Float64Array(bucketCount);
+  const sumG = new Float64Array(bucketCount);
+  const sumB = new Float64Array(bucketCount);
+
+  const totalPixels = width * height;
+  for (let i = 0; i < totalPixels; i++) {
+    const off = i * 4;
+    const a = data[off + 3];
+    if (a < 128) continue; // skip transparent pixels
+
+    const r = data[off];
+    const g = data[off + 1];
+    const b = data[off + 2];
+
+    const ri = r >> shift;
+    const gi = g >> shift;
+    const bi = b >> shift;
+    const bucket = (ri << (bucketBits * 2)) | (gi << bucketBits) | bi;
+
+    counts[bucket]++;
+    sumR[bucket] += r;
+    sumG[bucket] += g;
+    sumB[bucket] += b;
+  }
+
+  // Collect non-empty buckets and sort by count descending
+  const entries: { count: number; r: number; g: number; b: number }[] = [];
+  for (let i = 0; i < bucketCount; i++) {
+    if (counts[i] > 0) {
+      entries.push({
+        count: counts[i],
+        r: Math.round(sumR[i] / counts[i]),
+        g: Math.round(sumG[i] / counts[i]),
+        b: Math.round(sumB[i] / counts[i]),
+      });
+    }
+  }
+  entries.sort((a, b) => b.count - a.count);
+
+  // Take top N, filtering colors that are too similar
+  const result: [number, number, number, number][] = [];
+  for (const entry of entries) {
+    if (result.length >= maxColors) break;
+
+    // Check minimum distance to already-selected colors
+    const tooClose = result.some(([r, g, b]) => {
+      const dr = entry.r - r;
+      const dg = entry.g - g;
+      const db = entry.b - b;
+      return (dr * dr + dg * dg + db * db) < 200; // ~14 distance threshold
+    });
+    if (tooClose) continue;
+
+    result.push([entry.r, entry.g, entry.b, 255]);
+  }
+
+  // Sort by hue, then lightness for a natural palette layout
+  result.sort((a, b) => {
+    const ha = rgbToHsl(a[0], a[1], a[2]);
+    const hb = rgbToHsl(b[0], b[1], b[2]);
+    // Group grays (low saturation) first
+    const aGray = ha[1] < 0.1 ? 1 : 0;
+    const bGray = hb[1] < 0.1 ? 1 : 0;
+    if (aGray !== bGray) return bGray - aGray; // grays first
+    if (aGray && bGray) return ha[2] - hb[2];  // sort grays by lightness
+    // Sort chromatic by hue, then lightness
+    const hDiff = ha[0] - hb[0];
+    if (Math.abs(hDiff) > 10) return hDiff;
+    return ha[2] - hb[2];
+  });
+
+  return result;
+}
+
+function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
+  r /= 255; g /= 255; b /= 255;
+  const max = Math.max(r, g, b), min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return [0, 0, l];
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h = 0;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) * 60;
+  else if (max === g) h = ((b - r) / d + 2) * 60;
+  else h = ((r - g) / d + 4) * 60;
+  return [h, s, l];
+}
+
+/**
+ * Load an image file and extract colors from it.
+ */
+export async function extractColorsFromFile(
+  file: File,
+  maxColors: number = 128,
+): Promise<[number, number, number, number][]> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    const url = URL.createObjectURL(file);
+    img.onload = () => {
+      // Sample at higher resolution for more color detail
+      const maxDim = 512;
+      const scale = Math.min(1, maxDim / Math.max(img.width, img.height));
+      const w = Math.round(img.width * scale);
+      const h = Math.round(img.height * scale);
+
+      const canvas = document.createElement('canvas');
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext('2d')!;
+      ctx.drawImage(img, 0, 0, w, h);
+      const imageData = ctx.getImageData(0, 0, w, h);
+
+      URL.revokeObjectURL(url);
+      resolve(extractColorsFromImage(imageData, maxColors));
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      resolve([]);
+    };
+    img.src = url;
+  });
+}

--- a/tools/apps/echidna/src/panels/AnimateRightPanel.tsx
+++ b/tools/apps/echidna/src/panels/AnimateRightPanel.tsx
@@ -2,6 +2,9 @@ import React, { useState } from 'react';
 import { Vec3Input, useComponentRegistry } from '@gseurat/ui-kit';
 import { useCharacterStore } from '../store/useCharacterStore.js';
 import type { EasingType } from '../store/types.js';
+import { YClipControl } from './controls/YClipControl.js';
+import { YLevelLock } from './controls/YLevelLock.js';
+import { DisplaySettings } from './controls/DisplaySettings.js';
 
 const easingOptions: { value: EasingType; label: string }[] = [
   { value: 'linear', label: 'Linear' },
@@ -276,6 +279,9 @@ export function AnimateRightPanel() {
   useComponentRegistry('AnimateRightPanel');
   return (
     <div style={styles.container}>
+      <YClipControl />
+      <YLevelLock />
+      <DisplaySettings />
       <BoneProperties />
       <KeyframeEditor />
     </div>

--- a/tools/apps/echidna/src/panels/AnimateToolBar.tsx
+++ b/tools/apps/echidna/src/panels/AnimateToolBar.tsx
@@ -3,11 +3,11 @@ import { useComponentRegistry } from '@gseurat/ui-kit';
 import { useCharacterStore } from '../store/useCharacterStore.js';
 import type { ToolType, VoxelKey } from '../store/types.js';
 
-const tools: { id: ToolType; label: string; key: string }[] = [
-  { id: 'orbit', label: 'Orbit', key: 'Q' },
-  { id: 'assign_part', label: 'Assign Part', key: 'A' },
-  { id: 'box_select', label: 'Box Select', key: 'S' },
-  { id: 'lasso_select', label: 'Lasso', key: 'L' },
+const tools: { id: ToolType; label: string; key: string; icon: string }[] = [
+  { id: 'orbit',        label: 'Orbit',       key: 'Q', icon: '\u27F2' }, // ⟲
+  { id: 'assign_part',  label: 'Assign Part', key: 'A', icon: '\u2295' }, // ⊕
+  { id: 'box_select',   label: 'Box Select',  key: 'S', icon: '\u25AF' }, // ▯
+  { id: 'lasso_select', label: 'Lasso',       key: 'L', icon: '\u2312' }, // ⌒
 ];
 
 const styles: Record<string, React.CSSProperties> = {
@@ -20,48 +20,34 @@ const styles: Record<string, React.CSSProperties> = {
     gap: 12,
   },
   section: { display: 'flex', flexDirection: 'column', gap: 4 },
-  label: {
-    fontSize: 11, color: '#888', textTransform: 'uppercase' as const,
-    letterSpacing: 1,
-  },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1, marginBottom: 2 },
+  toolGrid: { display: 'flex', flexWrap: 'wrap' as const, gap: 4 },
   toolBtn: {
-    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-    padding: '6px 10px', borderWidth: 1, borderStyle: 'solid' as const,
-    borderColor: '#444', borderRadius: 4, background: '#2a2a4a', color: '#ddd',
-    cursor: 'pointer', fontSize: 13,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    width: 32, height: 32,
+    border: '1px solid #444', borderRadius: 4,
+    background: '#2a2a4a', color: '#ddd',
+    cursor: 'pointer', fontSize: 16, padding: 0,
   },
   toolBtnActive: { background: '#4a4a8a', borderColor: '#77f' },
-  shortcut: { fontSize: 11, color: '#777' },
-  select: {
-    padding: '6px 8px', background: '#2a2a4a', border: '1px solid #444',
-    borderRadius: 4, color: '#ddd', fontSize: 13,
-  },
-  selectDisabled: { opacity: 0.5, cursor: 'not-allowed' },
+  count: { fontSize: 11, color: '#aaa', padding: '2px 0' },
+  selectionRow: { display: 'flex', gap: 4 },
   actionBtn: {
-    padding: '6px 10px', borderWidth: 1, borderStyle: 'solid' as const,
-    borderColor: '#555', borderRadius: 4, background: '#3a3a6a', color: '#ddd',
-    cursor: 'pointer', fontSize: 13, textAlign: 'center' as const,
+    flex: 1,
+    padding: '4px 8px',
+    borderWidth: 1, borderStyle: 'solid' as const, borderColor: '#555',
+    borderRadius: 4, background: '#3a3a6a', color: '#ddd',
+    cursor: 'pointer', fontSize: 11, textAlign: 'center' as const,
   },
-  actionBtnPrimary: {
-    background: '#4a4a8a', borderColor: '#77f', color: '#fff',
-  },
-  actionBtnDisabled: {
-    opacity: 0.4, cursor: 'not-allowed',
-  },
-  countDisplay: {
-    fontSize: 12, color: '#aaa',
-    padding: '4px 8px', background: '#16162a', borderRadius: 4,
-    textAlign: 'center' as const,
-  },
+  actionBtnPrimary: { background: '#4a4a8a', borderColor: '#77f', color: '#fff' },
+  actionBtnDisabled: { opacity: 0.4, cursor: 'not-allowed' },
 };
 
 export function AnimateToolBar() {
   useComponentRegistry('AnimateToolBar');
   const activeTool = useCharacterStore((s) => s.activeTool);
   const setTool = useCharacterStore((s) => s.setTool);
-  const parts = useCharacterStore((s) => s.asset?.characterParts ?? []);
   const selectedPart = useCharacterStore((s) => s.selectedPart);
-  const setSelectedPart = useCharacterStore((s) => s.setSelectedPart);
   const boxSelection = useCharacterStore((s) => s.boxSelection);
   const lassoSelection = useCharacterStore((s) => s.lassoSelection);
   const assignVoxelsToPart = useCharacterStore((s) => s.assignVoxelsToPart);
@@ -69,8 +55,6 @@ export function AnimateToolBar() {
   const setBoxSelection = useCharacterStore((s) => s.setBoxSelection);
   const setLassoSelection = useCharacterStore((s) => s.setLassoSelection);
   const pushUndo = useCharacterStore((s) => s.pushUndo);
-
-  const hasBones = parts.length > 0;
 
   const selection = useMemo<VoxelKey[]>(() => {
     const s = new Set<VoxelKey>();
@@ -106,70 +90,61 @@ export function AnimateToolBar() {
     <div style={styles.container}>
       <div style={styles.section}>
         <span style={styles.label}>Tools</span>
-        {tools.map((t) => (
-          <button
-            key={t.id}
-            style={{ ...styles.toolBtn, ...(activeTool === t.id ? styles.toolBtnActive : {}) }}
-            onClick={() => setTool(t.id)}
-          >
-            {t.label}
-            <span style={styles.shortcut}>{t.key}</span>
-          </button>
-        ))}
-      </div>
-
-      <div style={styles.section}>
-        <span style={styles.label}>Target Bone</span>
-        <select
-          style={{ ...styles.select, ...(!hasBones ? styles.selectDisabled : {}) }}
-          value={selectedPart ?? ''}
-          onChange={(e) => setSelectedPart(e.target.value || null)}
-          disabled={!hasBones}
-        >
-          {!hasBones && <option value="">No bones</option>}
-          {hasBones && <option value="">(none)</option>}
-          {parts.map((p) => (
-            <option key={p.id} value={p.id}>{p.name}</option>
+        <div style={styles.toolGrid}>
+          {tools.map((t) => (
+            <button
+              key={t.id}
+              title={`${t.label} (${t.key})`}
+              style={{ ...styles.toolBtn, ...(activeTool === t.id ? styles.toolBtnActive : {}) }}
+              onClick={() => setTool(t.id)}
+            >
+              {t.icon}
+            </button>
           ))}
-        </select>
+        </div>
       </div>
 
       <div style={styles.section}>
         <span style={styles.label}>Selection</span>
-        <div style={styles.countDisplay}>
-          {selectionCount === 0 ? 'No selection' : `${selectionCount} voxels selected`}
+        <div style={styles.count}>
+          {selectionCount === 0 ? 'No selection' : `${selectionCount} voxels`}
         </div>
-        <button
-          style={{
-            ...styles.actionBtn,
-            ...styles.actionBtnPrimary,
-            ...(!canCommit ? styles.actionBtnDisabled : {}),
-          }}
-          onClick={handleAssign}
-          disabled={!canCommit}
-        >
-          Assign to Bone
-        </button>
-        <button
-          style={{
-            ...styles.actionBtn,
-            ...(!canCommit ? styles.actionBtnDisabled : {}),
-          }}
-          onClick={handleUnassign}
-          disabled={!canCommit}
-        >
-          Unassign
-        </button>
-        <button
-          style={{
-            ...styles.actionBtn,
-            ...(!canClear ? styles.actionBtnDisabled : {}),
-          }}
-          onClick={clearSelection}
-          disabled={!canClear}
-        >
-          Clear Selection
-        </button>
+        <div style={styles.selectionRow}>
+          <button
+            title="Assign selection to selected bone"
+            style={{
+              ...styles.actionBtn,
+              ...styles.actionBtnPrimary,
+              ...(!canCommit ? styles.actionBtnDisabled : {}),
+            }}
+            onClick={handleAssign}
+            disabled={!canCommit}
+          >
+            Assign
+          </button>
+          <button
+            title="Unassign selection from selected bone"
+            style={{
+              ...styles.actionBtn,
+              ...(!canCommit ? styles.actionBtnDisabled : {}),
+            }}
+            onClick={handleUnassign}
+            disabled={!canCommit}
+          >
+            Unassign
+          </button>
+          <button
+            title="Clear selection"
+            style={{
+              ...styles.actionBtn,
+              ...(!canClear ? styles.actionBtnDisabled : {}),
+            }}
+            onClick={clearSelection}
+            disabled={!canClear}
+          >
+            Clear
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/tools/apps/echidna/src/panels/BuildPanel.tsx
+++ b/tools/apps/echidna/src/panels/BuildPanel.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import { NumberInput, useComponentRegistry } from '@gseurat/ui-kit';
+import { useComponentRegistry } from '@gseurat/ui-kit';
 import { useCharacterStore } from '../store/useCharacterStore.js';
+import { YClipControl } from './controls/YClipControl.js';
+import { YLevelLock } from './controls/YLevelLock.js';
+import { DisplaySettings } from './controls/DisplaySettings.js';
 
 const styles: Record<string, React.CSSProperties> = {
   container: {
@@ -20,48 +23,6 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: 4, color: '#ddd', fontSize: 13,
   },
 };
-
-function YClipControl() {
-  const yClip = useCharacterStore((s) => s.yClip);
-  const setYClip = useCharacterStore((s) => s.setYClip);
-  const voxels = useCharacterStore((s) => s.asset?.voxels ?? new Map());
-
-  let maxY = 0;
-  for (const [key] of voxels) {
-    const parts = key.split(',');
-    const y = Number(parts[1]);
-    if (y > maxY) maxY = y;
-  }
-
-  const enabled = yClip !== null;
-
-  return (
-    <div style={styles.section}>
-      <span style={styles.label}>Y-Clip</span>
-      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
-        <input
-          type="checkbox"
-          checked={enabled}
-          onChange={(e) => setYClip(e.target.checked ? Math.floor(maxY / 2) : null)}
-        />
-        Enable
-      </label>
-      {enabled && (
-        <div style={styles.row}>
-          <input
-            type="range"
-            min={0}
-            max={maxY}
-            value={yClip}
-            onChange={(e) => setYClip(Number(e.target.value))}
-            style={{ flex: 1 }}
-          />
-          <span style={{ fontSize: 13, color: '#ddd', minWidth: 24 }}>Y:{yClip}</span>
-        </div>
-      )}
-    </div>
-  );
-}
 
 function MirrorControl() {
   const mirrorAxis = useCharacterStore((s) => s.mirrorAxis);
@@ -88,56 +49,6 @@ function MirrorControl() {
   );
 }
 
-function GridSettings() {
-  const showGrid = useCharacterStore((s) => s.showGrid);
-  const showGizmos = useCharacterStore((s) => s.showGizmos);
-  const setShowGrid = useCharacterStore((s) => s.setShowGrid);
-  const setShowGizmos = useCharacterStore((s) => s.setShowGizmos);
-  const colorByPart = useCharacterStore((s) => s.colorByPart);
-  const setColorByPart = useCharacterStore((s) => s.setColorByPart);
-  const xrayMode = useCharacterStore((s) => s.xrayMode);
-  const setXrayMode = useCharacterStore((s) => s.setXrayMode);
-
-  return (
-    <div style={styles.section}>
-      <span style={styles.label}>Display</span>
-      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
-        <input type="checkbox" checked={showGrid} onChange={(e) => setShowGrid(e.target.checked)} />
-        Grid
-      </label>
-      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
-        <input type="checkbox" checked={showGizmos} onChange={(e) => setShowGizmos(e.target.checked)} />
-        Gizmos
-      </label>
-      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
-        <input type="checkbox" checked={colorByPart} onChange={(e) => setColorByPart(e.target.checked)} />
-        Color by Part
-      </label>
-      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
-        <input type="checkbox" checked={xrayMode} onChange={(e) => setXrayMode(e.target.checked)} />
-        X-Ray Mode (T)
-      </label>
-    </div>
-  );
-}
-
-function YLevelLock() {
-  const yLevelLock = useCharacterStore((s) => s.yLevelLock);
-  const setYLevelLock = useCharacterStore((s) => s.setYLevelLock);
-  return (
-    <div style={styles.section}>
-      <span style={styles.label}>Y-Level Lock</span>
-      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
-        <input type="checkbox" checked={yLevelLock !== null} onChange={(e) => setYLevelLock(e.target.checked ? 0 : null)} />
-        Enable
-      </label>
-      {yLevelLock !== null && (
-        <NumberInput value={yLevelLock} onChange={setYLevelLock} min={0} step={1} label="Y" />
-      )}
-    </div>
-  );
-}
-
 export function BuildPanel() {
   useComponentRegistry('BuildPanel');
   return (
@@ -145,7 +56,7 @@ export function BuildPanel() {
       <YClipControl />
       <YLevelLock />
       <MirrorControl />
-      <GridSettings />
+      <DisplaySettings />
     </div>
   );
 }

--- a/tools/apps/echidna/src/panels/ToolBar.tsx
+++ b/tools/apps/echidna/src/panels/ToolBar.tsx
@@ -20,14 +20,10 @@ const utilTools: { id: ToolType; label: string; key: string; icon: string }[] = 
 
 const styles: Record<string, React.CSSProperties> = {
   container: {
-    width: 180,
-    background: '#1e1e3a',
-    borderRight: '1px solid #333',
     padding: 12,
     display: 'flex',
     flexDirection: 'column',
     gap: 12,
-    overflowY: 'auto',
   },
   section: { display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 4 },
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1, marginBottom: 2 },

--- a/tools/apps/echidna/src/panels/ToolBar.tsx
+++ b/tools/apps/echidna/src/panels/ToolBar.tsx
@@ -1,36 +1,21 @@
 import React from 'react';
-import { NumberInput, useComponentRegistry } from '@gseurat/ui-kit';
+import { useComponentRegistry } from '@gseurat/ui-kit';
 import { useCharacterStore } from '../store/useCharacterStore.js';
 import type { ToolType } from '../store/types.js';
 
-const tools: { id: ToolType; label: string; key: string }[] = [
-  { id: 'orbit', label: 'Orbit', key: 'Q' },
-  { id: 'place', label: 'Place', key: 'V' },
-  { id: 'paint', label: 'Paint', key: 'B' },
-  { id: 'erase', label: 'Erase', key: 'E' },
-  { id: 'eyedropper', label: 'Eyedrop', key: 'I' },
-  { id: 'fill', label: 'Fill', key: 'G' },
-  { id: 'extrude', label: 'Extrude', key: 'X' },
+const drawTools: { id: ToolType; label: string; key: string; icon: string }[] = [
+  { id: 'place', label: 'Place', key: 'V', icon: '\u25A3' },    // ▣
+  { id: 'paint', label: 'Paint', key: 'B', icon: '\u270E' },    // ✎
+  { id: 'erase', label: 'Erase', key: 'E', icon: '\u25AB' },    // ▫
+  { id: 'fill', label: 'Fill', key: 'G', icon: '\u25A7' },      // ▧
+  { id: 'extrude', label: 'Extrude', key: 'X', icon: '\u2B06' },// ⬆
 ];
 
-const selectionTools: { id: ToolType; label: string; key: string }[] = [
-  { id: 'box_select', label: 'Box Select', key: 'S' },
-  { id: 'lasso_select', label: 'Lasso', key: 'L' },
-];
-
-const presetColors: [number, number, number, number][] = [
-  [180, 130, 90, 255],   // skin
-  [80, 50, 30, 255],     // dark brown
-  [220, 180, 140, 255],  // light skin
-  [200, 200, 200, 255],  // light gray
-  [100, 100, 100, 255],  // gray
-  [20, 20, 20, 255],     // near black
-  [60, 60, 180, 255],    // blue
-  [180, 60, 60, 255],    // red
-  [34, 139, 34, 255],    // green
-  [180, 180, 60, 255],   // yellow
-  [160, 80, 160, 255],   // purple
-  [220, 160, 80, 255],   // orange
+const utilTools: { id: ToolType; label: string; key: string; icon: string }[] = [
+  { id: 'orbit', label: 'Orbit', key: 'Q', icon: '\u27F2' },        // ⟲
+  { id: 'eyedropper', label: 'Eyedrop', key: 'I', icon: '\u25C9' }, // ◉
+  { id: 'box_select', label: 'Box Select', key: 'S', icon: '\u25AF' }, // ▯
+  { id: 'lasso_select', label: 'Lasso', key: 'L', icon: '\u2312' },   // ⌒
 ];
 
 const styles: Record<string, React.CSSProperties> = {
@@ -44,64 +29,33 @@ const styles: Record<string, React.CSSProperties> = {
     gap: 12,
     overflowY: 'auto',
   },
-  section: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 4,
-  },
-  label: {
-    fontSize: 11,
-    color: '#888',
-    textTransform: 'uppercase' as const,
-    letterSpacing: 1,
-  },
+  section: { display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 4 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1, marginBottom: 2 },
+  toolGrid: { display: 'flex', flexWrap: 'wrap' as const, gap: 4 },
   toolBtn: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    padding: '6px 10px',
-    borderWidth: 1,
-    borderStyle: 'solid' as const,
-    borderColor: '#444',
-    borderRadius: 4,
-    background: '#2a2a4a',
-    color: '#ddd',
-    cursor: 'pointer',
-    fontSize: 13,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    width: 32, height: 32,
+    border: '1px solid #444', borderRadius: 4,
+    background: '#2a2a4a', color: '#ddd',
+    cursor: 'pointer', fontSize: 16, padding: 0,
   },
-  toolBtnActive: {
-    background: '#4a4a8a',
-    borderColor: '#77f',
-  },
-  shortcut: {
-    fontSize: 11,
-    color: '#777',
-  },
-  colorGrid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(4, 1fr)',
-    gap: 4,
-  },
+  toolBtnActive: { background: '#4a4a8a', borderColor: '#77f' },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+  colorGrid: { display: 'grid', gridTemplateColumns: 'repeat(16, 1fr)', gap: 2 },
   colorSwatch: {
-    width: '100%',
-    aspectRatio: '1',
-    border: '2px solid transparent',
-    borderRadius: 4,
+    width: '100%', aspectRatio: '1',
+    border: '2px solid transparent', borderRadius: 3,
     cursor: 'pointer',
   },
-  row: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 8,
+  btn: {
+    padding: '4px 10px', border: '1px solid #555', borderRadius: 4,
+    background: '#3a3a6a', color: '#ddd', cursor: 'pointer', fontSize: 12,
   },
-  input: {
-    width: 60,
-    padding: '4px 6px',
-    background: '#2a2a4a',
-    border: '1px solid #444',
-    borderRadius: 4,
-    color: '#ddd',
-    fontSize: 13,
+  select: {
+    flex: 1, minWidth: 0,
+    padding: '4px 6px', background: '#2a2a4a', border: '1px solid #444',
+    borderRadius: 4, color: '#ddd', fontSize: 12,
+    overflow: 'hidden', textOverflow: 'ellipsis',
   },
 };
 
@@ -113,44 +67,65 @@ export function ToolBar() {
   const setTool = useCharacterStore((s) => s.setTool);
   const setActiveColor = useCharacterStore((s) => s.setActiveColor);
   const setBrushSize = useCharacterStore((s) => s.setBrushSize);
+
+  const colorPalettes = useCharacterStore((s) => s.asset?.colorPalettes ?? []);
+  const activePaletteIndex = useCharacterStore((s) => s.activePaletteIndex);
+  const setActivePalette = useCharacterStore((s) => s.setActivePalette);
+  const addPalette = useCharacterStore((s) => s.addPalette);
+  const addColorToPalette = useCharacterStore((s) => s.addColorToPalette);
+  const addPaletteFromFile = useCharacterStore((s) => s.addPaletteFromFile);
+
   const hexColor = `#${activeColor.slice(0, 3).map((c) => c.toString(16).padStart(2, '0')).join('')}`;
+  const activePalette = colorPalettes[activePaletteIndex] ?? colorPalettes[0];
 
   return (
     <div style={styles.container}>
+      {/* Draw */}
       <div style={styles.section}>
-        <span style={styles.label}>Tools</span>
-        {tools.map((t) => (
-          <button
-            key={t.id}
-            style={{
-              ...styles.toolBtn,
-              ...(activeTool === t.id ? styles.toolBtnActive : {}),
-            }}
-            onClick={() => setTool(t.id)}
-          >
-            {t.label}
-            <span style={styles.shortcut}>{t.key}</span>
-          </button>
-        ))}
+        <span style={styles.label}>Draw</span>
+        <div style={styles.toolGrid}>
+          {drawTools.map((t) => (
+            <button
+              key={t.id}
+              title={`${t.label} (${t.key})`}
+              style={{ ...styles.toolBtn, ...(activeTool === t.id ? styles.toolBtnActive : {}) }}
+              onClick={() => setTool(t.id)}
+            >
+              {t.icon}
+            </button>
+          ))}
+        </div>
+        <div style={{ ...styles.row, marginTop: 4 }}>
+          <input
+            type="range"
+            min={1}
+            max={8}
+            value={brushSize}
+            onChange={(e) => setBrushSize(Number(e.target.value))}
+            style={{ flex: 1 }}
+          />
+          <span style={{ fontSize: 11, color: '#888', minWidth: 14 }}>{brushSize}</span>
+        </div>
       </div>
 
+      {/* Utility */}
       <div style={styles.section}>
-        <span style={styles.label}>Selection</span>
-        {selectionTools.map((t) => (
-          <button
-            key={t.id}
-            style={{
-              ...styles.toolBtn,
-              ...(activeTool === t.id ? styles.toolBtnActive : {}),
-            }}
-            onClick={() => setTool(t.id)}
-          >
-            {t.label}
-            <span style={styles.shortcut}>{t.key}</span>
-          </button>
-        ))}
+        <span style={styles.label}>Utility</span>
+        <div style={styles.toolGrid}>
+          {utilTools.map((t) => (
+            <button
+              key={t.id}
+              title={`${t.label} (${t.key})`}
+              style={{ ...styles.toolBtn, ...(activeTool === t.id ? styles.toolBtnActive : {}) }}
+              onClick={() => setTool(t.id)}
+            >
+              {t.icon}
+            </button>
+          ))}
+        </div>
       </div>
 
+      {/* Color */}
       <div style={styles.section}>
         <span style={styles.label}>Color</span>
         <div style={styles.row}>
@@ -164,41 +139,76 @@ export function ToolBar() {
               const b = parseInt(hex.slice(5, 7), 16);
               setActiveColor([r, g, b, activeColor[3]]);
             }}
-            style={{ width: 40, height: 30, border: 'none', cursor: 'pointer' }}
+            style={{ width: 30, height: 24, border: 'none', cursor: 'pointer' }}
           />
           <div
             style={{
-              width: 30,
-              height: 30,
-              borderRadius: 4,
+              width: 24, height: 24, borderRadius: 3,
               background: `rgba(${activeColor.join(',')})`,
               border: '1px solid #666',
             }}
           />
+          <button
+            style={{ ...styles.btn, fontSize: 11, padding: '2px 6px' }}
+            onClick={() => addColorToPalette(activePaletteIndex, [...activeColor] as [number, number, number, number])}
+          >
+            + Palette
+          </button>
         </div>
+
+        <div style={styles.row}>
+          <select
+            value={activePaletteIndex}
+            onChange={(e) => setActivePalette(Number(e.target.value))}
+            style={styles.select}
+          >
+            {colorPalettes.map((p, i) => (
+              <option key={i} value={i}>{p.name}</option>
+            ))}
+          </select>
+          <button
+            style={{ ...styles.btn, fontSize: 11, padding: '2px 6px' }}
+            onClick={() => addPalette(`Palette ${colorPalettes.length + 1}`)}
+          >
+            New
+          </button>
+          <button
+            style={{ ...styles.btn, fontSize: 11, padding: '2px 6px' }}
+            onClick={() => {
+              const input = document.createElement('input');
+              input.type = 'file';
+              input.accept = 'image/*';
+              input.onchange = async () => {
+                const file = input.files?.[0];
+                if (!file) return;
+                await addPaletteFromFile(file);
+              };
+              input.click();
+            }}
+          >
+            From Image
+          </button>
+        </div>
+
         <div style={styles.colorGrid}>
-          {presetColors.map((c, i) => (
-            <div
-              key={i}
-              style={{
-                ...styles.colorSwatch,
-                background: `rgba(${c.join(',')})`,
-                borderColor:
-                  c[0] === activeColor[0] && c[1] === activeColor[1] && c[2] === activeColor[2]
-                    ? '#fff'
-                    : 'transparent',
-              }}
-              onClick={() => setActiveColor(c)}
-            />
-          ))}
+          {(activePalette?.colors ?? []).map((c, i) => {
+            const isEmpty = c[3] === 0;
+            const isSelected = !isEmpty &&
+              c[0] === activeColor[0] && c[1] === activeColor[1] && c[2] === activeColor[2];
+            return (
+              <div
+                key={i}
+                style={{
+                  ...styles.colorSwatch,
+                  background: isEmpty ? '#1a1a2e' : `rgba(${c.join(',')})`,
+                  borderColor: isSelected ? '#fff' : 'transparent',
+                }}
+                onClick={() => { if (!isEmpty) setActiveColor(c); }}
+              />
+            );
+          })}
         </div>
       </div>
-
-      <div style={styles.section}>
-        <span style={styles.label}>Brush Size</span>
-        <NumberInput value={brushSize} onChange={setBrushSize} min={1} max={8} step={1} label="Size" />
-      </div>
-
     </div>
   );
 }

--- a/tools/apps/echidna/src/panels/controls/DisplaySettings.tsx
+++ b/tools/apps/echidna/src/panels/controls/DisplaySettings.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useCharacterStore } from '../../store/useCharacterStore.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  section: { display: 'flex', flexDirection: 'column', gap: 8 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+};
+
+export function DisplaySettings() {
+  const showGrid = useCharacterStore((s) => s.showGrid);
+  const showGizmos = useCharacterStore((s) => s.showGizmos);
+  const setShowGrid = useCharacterStore((s) => s.setShowGrid);
+  const setShowGizmos = useCharacterStore((s) => s.setShowGizmos);
+  const colorByPart = useCharacterStore((s) => s.colorByPart);
+  const setColorByPart = useCharacterStore((s) => s.setColorByPart);
+  const xrayMode = useCharacterStore((s) => s.xrayMode);
+  const setXrayMode = useCharacterStore((s) => s.setXrayMode);
+
+  return (
+    <div style={styles.section}>
+      <span style={styles.label}>Display</span>
+      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
+        <input type="checkbox" checked={showGrid} onChange={(e) => setShowGrid(e.target.checked)} />
+        Grid
+      </label>
+      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
+        <input type="checkbox" checked={showGizmos} onChange={(e) => setShowGizmos(e.target.checked)} />
+        Gizmos
+      </label>
+      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
+        <input type="checkbox" checked={colorByPart} onChange={(e) => setColorByPart(e.target.checked)} />
+        Color by Part
+      </label>
+      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
+        <input type="checkbox" checked={xrayMode} onChange={(e) => setXrayMode(e.target.checked)} />
+        X-Ray Mode (T)
+      </label>
+    </div>
+  );
+}

--- a/tools/apps/echidna/src/panels/controls/YClipControl.tsx
+++ b/tools/apps/echidna/src/panels/controls/YClipControl.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useCharacterStore } from '../../store/useCharacterStore.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  section: { display: 'flex', flexDirection: 'column', gap: 8 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+};
+
+export function YClipControl() {
+  const yClip = useCharacterStore((s) => s.yClip);
+  const setYClip = useCharacterStore((s) => s.setYClip);
+  const voxels = useCharacterStore((s) => s.asset?.voxels ?? new Map());
+
+  let maxY = 0;
+  for (const [key] of voxels) {
+    const parts = key.split(',');
+    const y = Number(parts[1]);
+    if (y > maxY) maxY = y;
+  }
+
+  const enabled = yClip !== null;
+
+  return (
+    <div style={styles.section}>
+      <span style={styles.label}>Y-Clip</span>
+      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => setYClip(e.target.checked ? Math.floor(maxY / 2) : null)}
+        />
+        Enable
+      </label>
+      {enabled && (
+        <div style={styles.row}>
+          <input
+            type="range"
+            min={0}
+            max={maxY}
+            value={yClip}
+            onChange={(e) => setYClip(Number(e.target.value))}
+            style={{ flex: 1 }}
+          />
+          <span style={{ fontSize: 13, color: '#ddd', minWidth: 24 }}>Y:{yClip}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tools/apps/echidna/src/panels/controls/YClipControl.tsx
+++ b/tools/apps/echidna/src/panels/controls/YClipControl.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useCharacterStore } from '../../store/useCharacterStore.js';
 
 const styles: Record<string, React.CSSProperties> = {
@@ -12,12 +12,15 @@ export function YClipControl() {
   const setYClip = useCharacterStore((s) => s.setYClip);
   const voxels = useCharacterStore((s) => s.asset?.voxels ?? new Map());
 
-  let maxY = 0;
-  for (const [key] of voxels) {
-    const parts = key.split(',');
-    const y = Number(parts[1]);
-    if (y > maxY) maxY = y;
-  }
+  const maxY = useMemo(() => {
+    let max = 0;
+    for (const [key] of voxels) {
+      const parts = key.split(',');
+      const y = Number(parts[1]);
+      if (y > max) max = y;
+    }
+    return max;
+  }, [voxels]);
 
   const enabled = yClip !== null;
 

--- a/tools/apps/echidna/src/panels/controls/YLevelLock.tsx
+++ b/tools/apps/echidna/src/panels/controls/YLevelLock.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { NumberInput } from '@gseurat/ui-kit';
+import { useCharacterStore } from '../../store/useCharacterStore.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  section: { display: 'flex', flexDirection: 'column', gap: 8 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 1 },
+  row: { display: 'flex', alignItems: 'center', gap: 8 },
+};
+
+export function YLevelLock() {
+  const yLevelLock = useCharacterStore((s) => s.yLevelLock);
+  const setYLevelLock = useCharacterStore((s) => s.setYLevelLock);
+
+  return (
+    <div style={styles.section}>
+      <span style={styles.label}>Y-Level Lock</span>
+      <label style={{ ...styles.row, fontSize: 13, cursor: 'pointer' }}>
+        <input
+          type="checkbox"
+          checked={yLevelLock !== null}
+          onChange={(e) => setYLevelLock(e.target.checked ? 0 : null)}
+        />
+        Enable
+      </label>
+      {yLevelLock !== null && (
+        <NumberInput value={yLevelLock} onChange={setYLevelLock} min={0} step={1} label="Y" />
+      )}
+    </div>
+  );
+}

--- a/tools/apps/echidna/src/store/types.ts
+++ b/tools/apps/echidna/src/store/types.ts
@@ -66,8 +66,10 @@ export interface ColorPalette {
 }
 
 /**
- * Generate the default 256-slot palette: 16 grayscale + 12 hues × 4 sats × 5 lights.
- * Matches Bricklayer's `generateDefaultPalette` shape so imports between apps feel consistent.
+ * Generate the default 256-slot palette: 16 grayscale entries followed by
+ * 240 empty (transparent) slots available for the user to fill.
+ * The empty slots use alpha=0 as the sentinel so addColorToPalette can detect
+ * and fill them via findIndex(c => c[3] === 0).
  */
 export function generateDefaultPalette(): ColorPalette {
   const colors: [number, number, number, number][] = [];
@@ -76,34 +78,13 @@ export function generateDefaultPalette(): ColorPalette {
     const v = Math.round((i / 15) * 255);
     colors.push([v, v, v, 255]);
   }
-  // 240 chromatic: 12 hues × 4 saturations × 5 lightness levels
-  const hues = [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330];
-  const sats = [0.3, 0.5, 0.75, 1.0];
-  const lights = [0.2, 0.35, 0.5, 0.65, 0.8];
-  for (const sat of sats) {
-    for (const light of lights) {
-      for (const hue of hues) {
-        const [r, g, b] = hslToRgb(hue, sat, light);
-        colors.push([r, g, b, 255]);
-      }
-    }
+  // 240 empty slots (available for user colors)
+  for (let i = 0; i < 240; i++) {
+    colors.push([0, 0, 0, 0]);
   }
   return { name: 'Default (256)', colors };
 }
 
-function hslToRgb(h: number, s: number, l: number): [number, number, number] {
-  const c = (1 - Math.abs(2 * l - 1)) * s;
-  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
-  const m = l - c / 2;
-  let r = 0, g = 0, b = 0;
-  if (h < 60) { r = c; g = x; }
-  else if (h < 120) { r = x; g = c; }
-  else if (h < 180) { g = c; b = x; }
-  else if (h < 240) { g = x; b = c; }
-  else if (h < 300) { r = x; b = c; }
-  else { r = c; b = x; }
-  return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)];
-}
 
 // ── App mode ──
 

--- a/tools/apps/echidna/src/store/types.ts
+++ b/tools/apps/echidna/src/store/types.ts
@@ -58,6 +58,53 @@ export interface AnimationClip {
   rootMotion?: boolean;
 }
 
+// ── Color palettes ──
+
+export interface ColorPalette {
+  name: string;
+  colors: [number, number, number, number][];
+}
+
+/**
+ * Generate the default 256-slot palette: 16 grayscale + 12 hues × 4 sats × 5 lights.
+ * Matches Bricklayer's `generateDefaultPalette` shape so imports between apps feel consistent.
+ */
+export function generateDefaultPalette(): ColorPalette {
+  const colors: [number, number, number, number][] = [];
+  // 16 grayscale: black to white
+  for (let i = 0; i < 16; i++) {
+    const v = Math.round((i / 15) * 255);
+    colors.push([v, v, v, 255]);
+  }
+  // 240 chromatic: 12 hues × 4 saturations × 5 lightness levels
+  const hues = [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330];
+  const sats = [0.3, 0.5, 0.75, 1.0];
+  const lights = [0.2, 0.35, 0.5, 0.65, 0.8];
+  for (const sat of sats) {
+    for (const light of lights) {
+      for (const hue of hues) {
+        const [r, g, b] = hslToRgb(hue, sat, light);
+        colors.push([r, g, b, 255]);
+      }
+    }
+  }
+  return { name: 'Default (256)', colors };
+}
+
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0, g = 0, b = 0;
+  if (h < 60) { r = c; g = x; }
+  else if (h < 120) { r = x; g = c; }
+  else if (h < 180) { g = c; b = x; }
+  else if (h < 240) { g = x; b = c; }
+  else if (h < 300) { r = x; b = c; }
+  else { r = c; b = x; }
+  return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)];
+}
+
 // ── App mode ──
 
 export type AppMode = 'build' | 'animate';
@@ -75,9 +122,9 @@ export interface ClipboardEntry {
   color: [number, number, number, number];
 }
 
-// ── File format (v4) ──
+// ── File format (v5) ──
 
-export const ECHIDNA_FILE_VERSION = 4 as const;
+export const ECHIDNA_FILE_VERSION = 5 as const;
 
 export interface EchidnaFile {
   version: number;
@@ -91,6 +138,7 @@ export interface EchidnaFile {
   poses: Record<string, PoseData>;
   animations?: Record<string, AnimationClip>;
   tags: string[];
+  color_palettes?: ColorPalette[];
 }
 
 /**
@@ -147,6 +195,9 @@ export function migrateEchidnaFile(raw: any): EchidnaFile {
       ? raw.animations
       : undefined,
     tags: Array.isArray(raw.tags) ? raw.tags : [],
+    color_palettes: Array.isArray(raw.color_palettes) && raw.color_palettes.length > 0
+      ? raw.color_palettes
+      : [generateDefaultPalette()],
   };
 }
 
@@ -176,6 +227,7 @@ export interface Asset {
   characterPoses: Record<string, PoseData>;
   animations: Record<string, AnimationClip>;
   tags: string[];
+  colorPalettes: ColorPalette[];
   currentFilename: string | null;                    // legacy .echidna download target
 }
 

--- a/tools/apps/echidna/src/store/types.ts
+++ b/tools/apps/echidna/src/store/types.ts
@@ -166,7 +166,7 @@ export function slugifyAssetId(name: string): string {
  * - Throws on non-object input.
  *
  * Does NOT attempt to validate voxel/part/pose structure — the store
- * loader handles those. This migration covers schema v2 → v3 → v4.
+ * loader handles those. This migration covers schema v2 → v3 → v4 → v5.
  */
 export function migrateEchidnaFile(raw: any): EchidnaFile {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {

--- a/tools/apps/echidna/src/store/types.ts
+++ b/tools/apps/echidna/src/store/types.ts
@@ -66,10 +66,8 @@ export interface ColorPalette {
 }
 
 /**
- * Generate the default 256-slot palette: 16 grayscale entries followed by
- * 240 empty (transparent) slots available for the user to fill.
- * The empty slots use alpha=0 as the sentinel so addColorToPalette can detect
- * and fill them via findIndex(c => c[3] === 0).
+ * Generate the default 256-slot palette: 16 grayscale + 12 hues × 4 sats × 5 lights.
+ * Matches Bricklayer's `generateDefaultPalette` shape so imports between apps feel consistent.
  */
 export function generateDefaultPalette(): ColorPalette {
   const colors: [number, number, number, number][] = [];
@@ -78,11 +76,33 @@ export function generateDefaultPalette(): ColorPalette {
     const v = Math.round((i / 15) * 255);
     colors.push([v, v, v, 255]);
   }
-  // 240 empty slots (available for user colors)
-  for (let i = 0; i < 240; i++) {
-    colors.push([0, 0, 0, 0]);
+  // 240 chromatic: 12 hues × 4 saturations × 5 lightness levels
+  const hues = [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330];
+  const sats = [0.3, 0.5, 0.75, 1.0];
+  const lights = [0.2, 0.35, 0.5, 0.65, 0.8];
+  for (const sat of sats) {
+    for (const light of lights) {
+      for (const hue of hues) {
+        const [r, g, b] = hslToRgb(hue, sat, light);
+        colors.push([r, g, b, 255]);
+      }
+    }
   }
   return { name: 'Default (256)', colors };
+}
+
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0, g = 0, b = 0;
+  if (h < 60) { r = c; g = x; }
+  else if (h < 120) { r = x; g = c; }
+  else if (h < 180) { g = c; b = x; }
+  else if (h < 240) { g = x; b = c; }
+  else if (h < 300) { r = x; b = c; }
+  else { r = c; b = x; }
+  return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)];
 }
 
 

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -15,8 +15,9 @@ import type {
   Asset,
   AssetListEntry,
   EchidnaAssetKind,
+  ColorPalette,
 } from './types.js';
-import { migrateEchidnaFile, slugifyAssetId, ECHIDNA_FILE_VERSION } from './types.js';
+import { migrateEchidnaFile, slugifyAssetId, ECHIDNA_FILE_VERSION, generateDefaultPalette } from './types.js';
 import { voxelKey, parseKey, floodFill3D, extrudeLayer } from '../lib/voxelUtils.js';
 import { listEchidnaProjects, loadEchidnaProject, saveEchidnaProject, exportCharacterToProject, exportMapToProject, exportObjectToProject, deleteEchidnaProject, renameEchidnaProject, duplicateEchidnaProject } from '../lib/projectFs.js';
 import { exportPly } from '../lib/plyExport.js';
@@ -96,7 +97,7 @@ const DEFAULT_ASSET: Asset = {
   animations: {},
   tags: [],
   currentFilename: null,
-  colorPalettes: [],
+  colorPalettes: [generateDefaultPalette()],
 };
 
 export type SwitchDecision = 'save' | 'discard' | 'cancel';
@@ -122,6 +123,9 @@ export interface CharacterStoreState {
   activeTool: ToolType;
   activeColor: [number, number, number, number];
   brushSize: number;
+
+  // Palette
+  activePaletteIndex: number;
 
   // Selection (per-character UI state, but stays global for Phase 0.2)
   selectedPart: string | null;
@@ -183,6 +187,13 @@ export interface CharacterStoreState {
   setTool: (tool: ToolType) => void;
   setActiveColor: (color: [number, number, number, number] | [number, number, number] | string) => void;
   setBrushSize: (size: number) => void;
+
+  // Actions – palettes
+  addPalette: (name: string) => void;
+  removePalette: (index: number) => void;
+  setActivePalette: (index: number) => void;
+  addColorToPalette: (paletteIndex: number, color: [number, number, number, number]) => void;
+  addPaletteFromFile: (file: File) => Promise<void>;
 
   // Actions – view
   setShowGrid: (v: boolean) => void;
@@ -280,6 +291,8 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
   activeTool: 'place',
   activeColor: [180, 130, 90, 255],
   brushSize: 1,
+
+  activePaletteIndex: 0,
 
   selectedPart: null,
   selectedPose: null,
@@ -964,7 +977,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         animations,
         tags: data.tags ?? [],
         currentFilename: null,
-        colorPalettes: [],
+        colorPalettes: data.color_palettes ?? [generateDefaultPalette()],
       };
       set({
         asset: char,
@@ -980,6 +993,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         previewPose: false,
         playbackTime: 0,
         isPlaying: false,
+        activePaletteIndex: 0,
         ...(char.kind !== 'character' ? { mode: 'build' as const } : {}),
       });
     } catch (e) {
@@ -1239,7 +1253,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         animations: {},
         tags: [],
         currentFilename: null,
-        colorPalettes: [],
+        colorPalettes: [generateDefaultPalette()],
       },
       // Optimistic panel entry: add to knownAssets immediately so the new
       // asset is visible before first save. Phase 0.2 save() later calls
@@ -1259,6 +1273,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       boxSelection: null,
       colorByPart: false,
       partColors: {},
+      activePaletteIndex: 0,
       // A freshly-created asset has unsaved state (the creation itself).
       // Setting dirty=true ensures requestOpenAsset's switch guard protects
       // the new asset from silent loss if the user clicks away before
@@ -1313,6 +1328,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       poses: char.characterPoses,
       animations: Object.keys(char.animations).length > 0 ? char.animations : undefined,
       tags: char.tags ?? [],
+      color_palettes: char.colorPalettes,
     };
   },
 
@@ -1355,7 +1371,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         animations,
         tags: data.tags ?? [],
         currentFilename: get().asset?.currentFilename ?? null,
-        colorPalettes: [],
+        colorPalettes: data.color_palettes ?? [generateDefaultPalette()],
       },
       selectedPart: null,
       selectedPose: null,
@@ -1366,6 +1382,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
       playbackTime: 0,
       isPlaying: false,
       boxSelection: null,
+      activePaletteIndex: 0,
       dirty: false,
     });
   },
@@ -1486,6 +1503,67 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
   setLassoSelection: (keys) => set({ lassoSelection: keys }),
   setPlaybackMode: (mode) => set({ playbackMode: mode }),
   setOnionSkinning: (v) => set({ onionSkinning: v }),
+
+  // ── Palette actions ──
+  addPalette: (name) => {
+    const s = get();
+    if (!s.asset) return;
+    const emptyColors: [number, number, number, number][] = Array.from({ length: 256 }, () => [0, 0, 0, 0]);
+    const palettes = [...s.asset.colorPalettes, { name, colors: emptyColors }];
+    set({
+      asset: { ...s.asset, colorPalettes: palettes },
+      activePaletteIndex: palettes.length - 1,
+      dirty: true,
+    });
+  },
+
+  removePalette: (index) => {
+    const s = get();
+    if (!s.asset) return;
+    let palettes = s.asset.colorPalettes.filter((_, i) => i !== index);
+    // Always keep at least one palette so the Build UI never has nothing to draw.
+    if (palettes.length === 0) palettes = [generateDefaultPalette()];
+    set({
+      asset: { ...s.asset, colorPalettes: palettes },
+      activePaletteIndex: Math.min(s.activePaletteIndex, palettes.length - 1),
+      dirty: true,
+    });
+  },
+
+  setActivePalette: (index) => set({ activePaletteIndex: index }),
+
+  addColorToPalette: (paletteIndex, color) => {
+    const s = get();
+    if (!s.asset) return;
+    const palettes = [...s.asset.colorPalettes];
+    if (!palettes[paletteIndex]) return;
+    const colors = [...palettes[paletteIndex].colors];
+    const emptyIdx = colors.findIndex((c) => c[3] === 0);
+    if (emptyIdx >= 0) {
+      colors[emptyIdx] = color;
+    } else if (colors.length < 256) {
+      colors.push(color);
+    } else {
+      return; // palette full, no-op
+    }
+    palettes[paletteIndex] = { ...palettes[paletteIndex], colors };
+    set({ asset: { ...s.asset, colorPalettes: palettes }, dirty: true });
+  },
+
+  addPaletteFromFile: async (file) => {
+    const { extractColorsFromFile } = await import('../lib/colorExtract.js');
+    const extracted = await extractColorsFromFile(file, 256);
+    const colors: [number, number, number, number][] = [...extracted];
+    while (colors.length < 256) colors.push([0, 0, 0, 0]);
+    const s = get();
+    if (!s.asset) return;
+    const palettes = [...s.asset.colorPalettes, { name: file.name, colors }];
+    set({
+      asset: { ...s.asset, colorPalettes: palettes },
+      activePaletteIndex: palettes.length - 1,
+      dirty: true,
+    });
+  },
 }));
 
 if (import.meta.env.DEV && typeof window !== 'undefined') {

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -1551,12 +1551,15 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
   },
 
   addPaletteFromFile: async (file) => {
+    const targetId = get().asset?.id;
+    if (!targetId) return;
     const { extractColorsFromFile } = await import('../lib/colorExtract.js');
     const extracted = await extractColorsFromFile(file, 256);
     const colors: [number, number, number, number][] = [...extracted];
     while (colors.length < 256) colors.push([0, 0, 0, 0]);
     const s = get();
-    if (!s.asset) return;
+    // Bail if the user switched assets while extraction was in flight.
+    if (!s.asset || s.asset.id !== targetId) return;
     const palettes = [...s.asset.colorPalettes, { name: file.name, colors }];
     set({
       asset: { ...s.asset, colorPalettes: palettes },

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -96,6 +96,7 @@ const DEFAULT_ASSET: Asset = {
   animations: {},
   tags: [],
   currentFilename: null,
+  colorPalettes: [],
 };
 
 export type SwitchDecision = 'save' | 'discard' | 'cancel';
@@ -963,6 +964,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         animations,
         tags: data.tags ?? [],
         currentFilename: null,
+        colorPalettes: [],
       };
       set({
         asset: char,
@@ -1237,6 +1239,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         animations: {},
         tags: [],
         currentFilename: null,
+        colorPalettes: [],
       },
       // Optimistic panel entry: add to knownAssets immediately so the new
       // asset is visible before first save. Phase 0.2 save() later calls
@@ -1352,6 +1355,7 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
         animations,
         tags: data.tags ?? [],
         currentFilename: get().asset?.currentFilename ?? null,
+        colorPalettes: [],
       },
       selectedPart: null,
       selectedPose: null,

--- a/tools/apps/echidna/src/store/useCharacterStore.ts
+++ b/tools/apps/echidna/src/store/useCharacterStore.ts
@@ -1505,6 +1505,13 @@ export const useCharacterStore = create<CharacterStoreState>((set, get) => ({
   setOnionSkinning: (v) => set({ onionSkinning: v }),
 
   // ── Palette actions ──
+  /**
+   * Palette actions (addPalette, removePalette, addColorToPalette,
+   * addPaletteFromFile) intentionally do NOT call pushUndo. Palette edits
+   * are a separate concern from voxel-edit history — users don't expect
+   * "undo" to revert the palette they just created. setActivePalette is
+   * purely UI state and skips the dirty flag entirely.
+   */
   addPalette: (name) => {
     const s = get();
     if (!s.asset) return;


### PR DESCRIPTION
## Summary

- Compact icon-grid Build and Animate toolbars matching Bricklayer's `TerrainLeftPanel` density
- Full 256-slot multi-palette system persisted per-character (schema v4 → v5 migration)
- Removed the redundant Target Bone dropdown from Animate — bone selection now happens via the `AnimateLeftPanel` tree
- Extracted `YClipControl`, `YLevelLock`, and `DisplaySettings` into `panels/controls/` so both Build and Animate right panels share them

## What changed

- **Store**: `colorPalettes` on `Asset`, `activePaletteIndex` top-level state, actions `addPalette` / `removePalette` / `setActivePalette` / `addColorToPalette` / `addPaletteFromFile` (asset-switch race guarded)
- **Types**: new `ColorPalette` interface + `generateDefaultPalette()` (16 grayscale + 240 chromatic) + v5 migration seed
- **Libs**: `colorExtract` ported from Bricklayer (byte-for-byte)
- **UI**: Build `ToolBar` rewritten with icon grids + palette dropdown + "+ Palette" / "New" / "From Image" + 16-column swatch grid; Animate `ToolBar` rewritten with icon grid Tools + compact Assign/Unassign/Clear row; `AnimateRightPanel` composes the three shared controls above `BoneProperties`
- **Build fix**: removed `width: 180` from Build ToolBar so it fills its resizable parent column (default 220px)

## Test Plan

- [x] `pnpm --filter @gseurat/echidna build` succeeds
- [x] `pnpm --filter @gseurat/echidna test` — 163/163 tests pass (16 suites)
- [x] v4 `.echidna` files migrate cleanly on load (`color_palettes` seeded)
- [x] Saved palettes round-trip through `saveProject` / `loadProject`
- [x] `addPaletteFromFile` bails if user switches assets mid-extraction
- [x] Chrome MCP smoke: `window.__COMPONENT_REGISTRY__.health()` clean in both Build and Animate modes (only `AssetViewport` flagged, which is pre-existing behavior when no project root is open)
- [x] Build ToolBar renders icon grids (DRAW 5 icons, UTILITY 4 icons), palette dropdown, 16×16 = 256-slot palette grid fills the resizable column
- [x] Animate ToolBar renders icon-grid Tools (4 icons), no Target Bone dropdown, compact Assign/Unassign/Clear row; Assign/Unassign disabled until both a bone is selected (via left-panel tree) and voxels are selected
- [x] Y-Clip / Y-Level Lock / Display / Color by Part / X-Ray toggles in Animate mode share state with Build mode (toggled in Animate, verified identical state after switching to Build)
- [x] Browser console has no React errors

Design: `docs/superpowers/specs/2026-04-16-echidna-ui-improvements-design.md`
Plan: `docs/superpowers/plans/2026-04-16-echidna-ui-improvements.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)