### PR TITLE
demo: switch portals to Iris Wipe effect

### DIFF
--- a/examples/island_demo/assets/scenes/dungeon.json
+++ b/examples/island_demo/assets/scenes/dungeon.json
@@ -5123,7 +5123,7 @@
           "target_position": [192, 3, 197],
           "transition_color": [1, 1, 1],
           "transition_duration": 0.5,
-          "effect_type": 1
+          "effect_type": 2
         }
       }
     },

--- a/examples/island_demo/assets/scenes/dungeon.json
+++ b/examples/island_demo/assets/scenes/dungeon.json
@@ -5122,7 +5122,8 @@
           "target_scene": "assets/scenes/seurat_island.json",
           "target_position": [192, 3, 197],
           "transition_color": [1, 1, 1],
-          "transition_duration": 0.5
+          "transition_duration": 0.5,
+          "effect_type": 1
         }
       }
     },

--- a/examples/island_demo/assets/scenes/seurat_island.json
+++ b/examples/island_demo/assets/scenes/seurat_island.json
@@ -73822,7 +73822,8 @@
           "target_scene": "assets/scenes/dungeon.json",
           "target_position": [5, 0, 5],
           "transition_color": [1, 1, 1],
-          "transition_duration": 0.5
+          "transition_duration": 0.5,
+          "effect_type": 1
         }
       }
     },

--- a/examples/island_demo/assets/scenes/seurat_island.json
+++ b/examples/island_demo/assets/scenes/seurat_island.json
@@ -73823,7 +73823,7 @@
           "target_position": [5, 0, 5],
           "transition_color": [1, 1, 1],
           "transition_duration": 0.5,
-          "effect_type": 1
+          "effect_type": 2
         }
       }
     },


### PR DESCRIPTION
## Summary

Both demo portals now use `effect_type: 2` (Iris Wipe) introduced in #268 instead of the default solid color fade. The iris wipe gives a more classic, dramatic transition.

- `seurat_island.json` portal_dungeon → enters dungeon with iris wipe
- `dungeon.json` portal_dungeon_exit → returns to overworld with iris wipe

## Test plan

- [ ] Launch demo, walk into Portal to Dungeon — should see circular iris closing instead of solid white fade
- [ ] In dungeon, walk into Portal Back to Overworld — same iris effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)