### PR TITLE
feat(scene): optional morph-pair block on gaussian_splat

### DIFF
--- a/include/gseurat/engine/scene_loader.hpp
+++ b/include/gseurat/engine/scene_loader.hpp
@@ -85,8 +85,9 @@ struct GsParallaxConfig {
     float parallax_strength = 1.0f;    // mapping multiplier (0 = disabled)
 };
 
+/// Engine parses but does NOT load pair_ply; game-side SceneManager owns that policy.
 struct GsMorphPairData {
-    std::string pair_ply;            // asset path, validated like ply_file
+    std::string pair_ply;            // asset path, project-relative ("assets/...")
     float duration = 1.5f;
     float default_blend = 0.0f;
     std::string easing = "linear";   // "linear" | "ease_in_out"

--- a/include/gseurat/engine/scene_loader.hpp
+++ b/include/gseurat/engine/scene_loader.hpp
@@ -85,6 +85,13 @@ struct GsParallaxConfig {
     float parallax_strength = 1.0f;    // mapping multiplier (0 = disabled)
 };
 
+struct GsMorphPairData {
+    std::string pair_ply;            // asset path, validated like ply_file
+    float duration = 1.5f;
+    float default_blend = 0.0f;
+    std::string easing = "linear";   // "linear" | "ease_in_out"
+};
+
 struct GaussianSplatData {
     std::string ply_file;
     glm::vec3 camera_position{0.0f, 5.0f, 10.0f};
@@ -97,6 +104,7 @@ struct GaussianSplatData {
     std::string background_image;  // Optional background behind GS (sky, mountains, etc.)
     glm::vec3 ground_color{0.0f};  // Hybrid BG: solid ground beneath Gaussians (0 = disabled)
     glm::vec3 sky_color{0.0f};     // Hybrid BG: sky gradient above horizon (0 = disabled)
+    std::optional<GsMorphPairData> morph;
 };
 
 

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -223,6 +223,25 @@ SceneData SceneLoader::from_json(const nlohmann::json& j) {
             pcfg.parallax_strength = px.value("parallax_strength", 1.0f);
             gsd.parallax = pcfg;
         }
+        // Optional morph pair — engine parses but does not load pair_ply.
+        if (gs.contains("morph") && gs["morph"].is_object()) {
+            const auto& m = gs["morph"];
+            GsMorphPairData morph;
+            morph.pair_ply      = m.value("pair_ply",      std::string{});
+            morph.duration      = m.value("duration",      1.5f);
+            morph.default_blend = m.value("default_blend", 0.0f);
+            morph.easing        = m.value("easing",        std::string{"linear"});
+
+            // Unknown easing → fall back to linear with a warning.
+            if (morph.easing != "linear" && morph.easing != "ease_in_out") {
+                std::fprintf(stderr,
+                    "[SceneLoader] Warning: unknown morph.easing '%s', "
+                    "falling back to 'linear'\n", morph.easing.c_str());
+                morph.easing = "linear";
+            }
+
+            gsd.morph = std::move(morph);
+        }
         data.gaussian_splat = std::move(gsd);
     }
 
@@ -959,6 +978,15 @@ nlohmann::json SceneLoader::to_json(const SceneData& data) {
                 {"distance_range", px.distance_range},
                 {"parallax_strength", px.parallax_strength}
             };
+        }
+        if (gs.morph) {
+            const auto& morph = *gs.morph;
+            nlohmann::json m;
+            m["pair_ply"]      = morph.pair_ply;
+            m["duration"]      = morph.duration;
+            m["default_blend"] = morph.default_blend;
+            m["easing"]        = morph.easing;
+            gs_j["morph"] = m;
         }
         j["gaussian_splat"] = gs_j;
     }

--- a/tests/test_scene_loading.cpp
+++ b/tests/test_scene_loading.cpp
@@ -113,6 +113,69 @@ static void test_background_colors() {
           "default sky_color is black (disabled)");
 }
 
+static void test_gaussian_splat_morph_roundtrip() {
+    std::printf("\n== test_gaussian_splat_morph_roundtrip ==\n");
+
+    nlohmann::json j = {
+        {"version", 2},
+        {"gaussian_splat", {
+            {"ply_file", "assets/maps/library_present.ply"},
+            {"camera", {
+                {"position", {0.0, 5.0, 10.0}},
+                {"target",   {0.0, 0.0, 0.0}},
+                {"fov", 45.0}
+            }},
+            {"render_width",  1280},
+            {"render_height", 720},
+            {"morph", {
+                {"pair_ply",      "assets/maps/library_past.ply"},
+                {"duration",      1.5},
+                {"default_blend", 0.0},
+                {"easing",        "linear"}
+            }}
+        }}
+    };
+
+    auto data = gseurat::SceneLoader::from_json(j);
+    check(data.gaussian_splat.has_value(), "gaussian_splat present");
+    check(data.gaussian_splat->morph.has_value(), "morph present");
+    check(data.gaussian_splat->morph->pair_ply == "assets/maps/library_past.ply",
+          "morph.pair_ply parsed");
+    check(approx(data.gaussian_splat->morph->duration, 1.5f),
+          "morph.duration parsed");
+    check(approx(data.gaussian_splat->morph->default_blend, 0.0f),
+          "morph.default_blend parsed");
+    check(data.gaussian_splat->morph->easing == "linear",
+          "morph.easing parsed");
+
+    auto round = gseurat::SceneLoader::to_json(data);
+    check(round["gaussian_splat"].contains("morph"), "morph serialized");
+    check(round["gaussian_splat"]["morph"]["pair_ply"] ==
+              "assets/maps/library_past.ply",
+          "morph.pair_ply round-trip");
+
+    // Absence case: scenes without morph must not emit the key.
+    nlohmann::json j_no_morph = {
+        {"version", 2},
+        {"gaussian_splat", {
+            {"ply_file", "assets/maps/some.ply"},
+            {"camera", {
+                {"position", {0.0, 0.0, 0.0}},
+                {"target",   {0.0, 0.0, 0.0}},
+                {"fov", 45.0}
+            }},
+            {"render_width", 320},
+            {"render_height", 240}
+        }}
+    };
+    auto d2 = gseurat::SceneLoader::from_json(j_no_morph);
+    check(d2.gaussian_splat.has_value(), "gaussian_splat present (no morph)");
+    check(!d2.gaussian_splat->morph.has_value(), "morph absent when omitted");
+    auto r2 = gseurat::SceneLoader::to_json(d2);
+    check(!r2["gaussian_splat"].contains("morph"),
+          "morph absent in to_json when unset");
+}
+
 int main() {
     std::printf("\n=== Scene Loading Tests ===\n\n");
 
@@ -551,6 +614,8 @@ int main() {
         glm::vec3 terrain_center = (terrain_aabb.min + terrain_aabb.max) * 0.5f;
         check(world_pos.x() < terrain_center.x, "game object LEFT of terrain center");
     }
+
+    test_gaussian_splat_morph_roundtrip();
 
     // ── Summary ──
     std::printf("\n========================================\n");

--- a/tools/apps/bricklayer/src/lib/__tests__/sceneExport.test.ts
+++ b/tools/apps/bricklayer/src/lib/__tests__/sceneExport.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   validateScenePaths,
   assertScenePathsValid,
+  exportSceneJson,
   ScenePathValidationError,
   type ScenePathError,
 } from '../sceneExport';
+import { useSceneStore } from '../../store/useSceneStore';
 import { createEmptyRegistry, registerCharacter } from '@gseurat/project-root';
 
 describe('validateScenePaths', () => {
@@ -131,6 +133,90 @@ describe('ScenePathValidationError', () => {
       { field: 'b', value: 'y', message: 'n' },
     ]);
     expect(err.message).toMatch(/2 path issues/i);
+  });
+});
+
+describe('exportSceneJson — gaussian_splat.morph', () => {
+  // Reset the store to its defaults before each test so state from a prior test
+  // cannot leak.
+  function resetStore() {
+    const s = useSceneStore.getState();
+    useSceneStore.setState({
+      gaussianSplat: {
+        ...s.gaussianSplat,
+        morphPairPly: '',
+        morphDuration: 1.5,
+        morphDefaultBlend: 0.0,
+        morphEasing: 'linear',
+      },
+    });
+  }
+
+  it('omits the morph key when pair_ply is empty (zero-regression invariant)', () => {
+    resetStore();
+    const scene = exportSceneJson(useSceneStore.getState()) as {
+      gaussian_splat: Record<string, unknown>;
+    };
+    expect(scene.gaussian_splat).toBeDefined();
+    expect('morph' in scene.gaussian_splat).toBe(false);
+  });
+
+  it('omits the morph key when pair_ply is whitespace-only', () => {
+    resetStore();
+    useSceneStore.setState({
+      gaussianSplat: {
+        ...useSceneStore.getState().gaussianSplat,
+        morphPairPly: '   \t  ',
+      },
+    });
+    const scene = exportSceneJson(useSceneStore.getState()) as {
+      gaussian_splat: Record<string, unknown>;
+    };
+    expect('morph' in scene.gaussian_splat).toBe(false);
+  });
+
+  it('emits morph with snake_case keys when pair_ply is set', () => {
+    resetStore();
+    useSceneStore.setState({
+      gaussianSplat: {
+        ...useSceneStore.getState().gaussianSplat,
+        morphPairPly: 'assets/maps/library_past.ply',
+        morphDuration: 2.25,
+        morphDefaultBlend: 0.3,
+        morphEasing: 'ease_in_out',
+      },
+    });
+    const scene = exportSceneJson(useSceneStore.getState()) as {
+      gaussian_splat: { morph?: Record<string, unknown> };
+    };
+    expect(scene.gaussian_splat.morph).toBeDefined();
+    const morph = scene.gaussian_splat.morph!;
+
+    // Exact key set — C++ parser rejects extras silently, but we also reject
+    // missing fields here to lock the contract.
+    expect(Object.keys(morph).sort()).toEqual(
+      ['default_blend', 'duration', 'easing', 'pair_ply'],
+    );
+    expect(morph.pair_ply).toBe('assets/maps/library_past.ply');
+    expect(morph.duration).toBe(2.25);
+    expect(morph.default_blend).toBe(0.3);
+    expect(morph.easing).toBe('ease_in_out');
+  });
+
+  it('trims leading/trailing whitespace on pair_ply', () => {
+    resetStore();
+    useSceneStore.setState({
+      gaussianSplat: {
+        ...useSceneStore.getState().gaussianSplat,
+        morphPairPly: '  assets/maps/library_past.ply  ',
+      },
+    });
+    const scene = exportSceneJson(useSceneStore.getState()) as {
+      gaussian_splat: { morph?: { pair_ply: string } };
+    };
+    expect(scene.gaussian_splat.morph?.pair_ply).toBe(
+      'assets/maps/library_past.ply',
+    );
   });
 });
 

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -295,15 +295,16 @@ export function exportSceneJson(
     parallax: gs.parallax,
   };
 
-  // Morph pair (optional) — emitted only when pair_ply is set.
-  // Engine parses this block but does NOT load the pair PLY; the game's
-  // SceneManager consumes it. See docs/superpowers/specs/2026-04-17-sprint1-walking-skeleton-design.md §A.2.
-  if (gs.morphPairPly && gs.morphPairPly.trim().length > 0) {
+  // Morph pair (optional) — emitted only when pair_ply is set (after trim).
+  // Contract: snake_case keys `pair_ply`, `duration`, `default_blend`, `easing`
+  // consumed by GSeurat's SceneLoader into GsMorphPairData. Engine parses but
+  // does NOT load the pair PLY — the game's SceneManager owns that policy.
+  if (gs.morphPairPly.trim().length > 0) {
     gaussianSplatOut.morph = {
       pair_ply: gs.morphPairPly.trim(),
-      duration: gs.morphDuration ?? 1.5,
-      default_blend: gs.morphDefaultBlend ?? 0.0,
-      easing: gs.morphEasing ?? 'linear',
+      duration: gs.morphDuration,
+      default_blend: gs.morphDefaultBlend,
+      easing: gs.morphEasing,
     };
   }
 

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -284,15 +284,30 @@ export function exportSceneJson(
     fov: cam.fov,
   } : cam;
 
-  scene.gaussian_splat = {
+  const gs = state.gaussianSplat;
+  const gaussianSplatOut: Record<string, unknown> = {
     ply_file: terrainPly,
     camera: autoCamera,
-    render_width: state.gaussianSplat.render_width,
-    render_height: state.gaussianSplat.render_height,
-    scale_multiplier: state.gaussianSplat.scale_multiplier,
-    background_image: state.gaussianSplat.background_image,
-    parallax: state.gaussianSplat.parallax,
+    render_width: gs.render_width,
+    render_height: gs.render_height,
+    scale_multiplier: gs.scale_multiplier,
+    background_image: gs.background_image,
+    parallax: gs.parallax,
   };
+
+  // Morph pair (optional) — emitted only when pair_ply is set.
+  // Engine parses this block but does NOT load the pair PLY; the game's
+  // SceneManager consumes it. See docs/superpowers/specs/2026-04-17-sprint1-walking-skeleton-design.md §A.2.
+  if (gs.morphPairPly && gs.morphPairPly.trim().length > 0) {
+    gaussianSplatOut.morph = {
+      pair_ply: gs.morphPairPly.trim(),
+      duration: gs.morphDuration ?? 1.5,
+      default_blend: gs.morphDefaultBlend ?? 0.0,
+      easing: gs.morphEasing ?? 'linear',
+    };
+  }
+
+  scene.gaussian_splat = gaussianSplatOut;
 
   const activeEmitters = state.gsParticleEmitters.filter((e) => !e.muted);
   if (activeEmitters.length > 0) {

--- a/tools/apps/bricklayer/src/panels/GaussianTab.tsx
+++ b/tools/apps/bricklayer/src/panels/GaussianTab.tsx
@@ -153,6 +153,59 @@ export function GaussianTab() {
         </div>
       </div>
 
+      {/* ── Morph Pair (optional) ── */}
+      <div style={styles.section}>
+        <span style={styles.label}>Morph Pair (optional)</span>
+        <span style={styles.info}>
+          Second PLY blended with the active cloud at runtime by the
+          game&apos;s SceneManager. Engine parses but does not load the pair PLY.
+        </span>
+        <div style={styles.row}>
+          <span style={{ fontSize: 12, minWidth: 80 }}>Pair PLY</span>
+          <input
+            type="text"
+            value={gs.morphPairPly}
+            placeholder="assets/maps/library_past.ply"
+            onChange={(e) => setGs({ morphPairPly: e.target.value })}
+            style={styles.input}
+          />
+        </div>
+        <div style={styles.row}>
+          <span style={{ fontSize: 12, minWidth: 80 }}>Duration (s)</span>
+          <NumberInput
+            value={gs.morphDuration}
+            onChange={(v) => setGs({ morphDuration: v })}
+            min={0.01}
+            step={0.05}
+            style={styles.input}
+          />
+        </div>
+        <div style={styles.row}>
+          <span style={{ fontSize: 12, minWidth: 80 }}>Default blend</span>
+          <NumberInput
+            value={gs.morphDefaultBlend}
+            onChange={(v) => setGs({ morphDefaultBlend: v })}
+            min={0}
+            max={1}
+            step={0.05}
+            style={styles.input}
+          />
+        </div>
+        <div style={styles.row}>
+          <span style={{ fontSize: 12, minWidth: 80 }}>Easing</span>
+          <select
+            value={gs.morphEasing}
+            onChange={(e) =>
+              setGs({ morphEasing: e.target.value as 'linear' | 'ease_in_out' })
+            }
+            style={styles.select}
+          >
+            <option value="linear">linear</option>
+            <option value="ease_in_out">ease_in_out</option>
+          </select>
+        </div>
+      </div>
+
       {/* ── Collision Grid ── */}
       <div style={styles.section}>
         <span style={styles.label}>Collision Grid</span>

--- a/tools/apps/bricklayer/src/panels/GaussianTab.tsx
+++ b/tools/apps/bricklayer/src/panels/GaussianTab.tsx
@@ -1,7 +1,12 @@
 import React, { useState } from 'react';
 import { NumberInput } from '../components/NumberInput.js';
 import { useSceneStore } from '../store/useSceneStore.js';
+import type { MorphEasing } from '../store/types.js';
 import { panelStyles } from '../styles/panel.js';
+
+/// Adding a new easing: extend MorphEasing in store/types.ts, then add an
+/// option here. The type coupling keeps the two in lockstep.
+const MORPH_EASINGS: readonly MorphEasing[] = ['linear', 'ease_in_out'];
 
 const styles: Record<string, React.CSSProperties> = { ...panelStyles, info: { fontSize: 11, color: '#aaa' } };
 
@@ -196,12 +201,13 @@ export function GaussianTab() {
           <select
             value={gs.morphEasing}
             onChange={(e) =>
-              setGs({ morphEasing: e.target.value as 'linear' | 'ease_in_out' })
+              setGs({ morphEasing: e.target.value as MorphEasing })
             }
             style={styles.select}
           >
-            <option value="linear">linear</option>
-            <option value="ease_in_out">ease_in_out</option>
+            {MORPH_EASINGS.map((e) => (
+              <option key={e} value={e}>{e}</option>
+            ))}
           </select>
         </div>
       </div>

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -131,6 +131,8 @@ export interface DayNightData {
   }[];
 }
 
+export type MorphEasing = 'linear' | 'ease_in_out';
+
 export interface GaussianSplatConfig {
   camera: {
     position: [number, number, number];
@@ -148,6 +150,13 @@ export interface GaussianSplatConfig {
     distance_range: number;
     parallax_strength: number;
   };
+  // Morph Pair (optional) — empty `morphPairPly` means no pair is set and the
+  // exporter skips the `morph` block entirely. Fields exist on the config so
+  // the Zustand `setGaussianSplat` partial-update pattern continues to apply.
+  morphPairPly: string;
+  morphDuration: number;
+  morphDefaultBlend: number;
+  morphEasing: MorphEasing;
 }
 
 export interface PlayerData {

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -190,6 +190,10 @@ function defaultGaussianSplat(): GaussianSplatConfig {
       distance_range: 2,
       parallax_strength: 1,
     },
+    morphPairPly: '',
+    morphDuration: 1.5,
+    morphDefaultBlend: 0.0,
+    morphEasing: 'linear',
   };
 }
 
@@ -1500,7 +1504,9 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       npcAuraEmitter: data.scene.npcAuraEmitter,
       weather: data.scene.weather,
       dayNight: data.scene.dayNight,
-      gaussianSplat: data.scene.gaussianSplat,
+      // Merge with defaults so older v2 files (saved before the Morph Pair
+      // fields were added) still produce a fully-populated config.
+      gaussianSplat: { ...defaultGaussianSplat(), ...data.scene.gaussianSplat },
       undoStack: [],
       redoStack: [],
     });


### PR DESCRIPTION
## Summary

Strictly-additive schema extension: `GaussianSplatData` grows an optional `morph` block (`pair_ply`, `duration`, `default_blend`, `easing`). Engine parses and serializes but does **NOT** load the pair PLY — that is the game's `SceneManager` policy. Unblocks Akashic Sprint 1's walking-skeleton migration.

## Changes

### Engine (C++)
- `include/gseurat/engine/scene_loader.hpp` — `GsMorphPairData` struct + `std::optional<GsMorphPairData> morph` field on `GaussianSplatData`.
- `src/engine/scene_loader.cpp` — symmetric parse/serialize. Unknown `easing` falls back to `"linear"` with a stderr warning.
- `tests/test_scene_loading.cpp` — round-trip coverage: present + absent cases (`morph` emitted only when set).

### Bricklayer (web authoring)
- `tools/apps/bricklayer/src/store/types.ts` — `MorphEasing` type + 4 fields on `GaussianSplatConfig`.
- `tools/apps/bricklayer/src/store/useSceneStore.ts` — defaults + load-path merge (handles legacy v2/v1 files missing the fields).
- `tools/apps/bricklayer/src/lib/sceneExport.ts` — emits `morph` block only when pair PLY is non-empty after trim. Trimmed `pair_ply` on output.
- `tools/apps/bricklayer/src/panels/GaussianTab.tsx` — new "Morph Pair (optional)" section: pair-PLY input, duration/default-blend `NumberInput`s, easing `<select>` driven by shared `MorphEasing` type.
- `tools/apps/bricklayer/src/lib/__tests__/sceneExport.test.ts` — 4 tests locking the morph-export contract (zero-regression for empty pair, snake_case key set, whitespace-only pair omitted, pair trimmed on output).

## Design invariants enforced

- **Engine parses, does not load.** `load_gs_scene` unchanged; pair PLY is the game's responsibility.
- **Strictly additive.** Existing scenes without `morph` export byte-identically.
- **Snake_case on the wire.** C++ parser contract: `pair_ply`, `duration`, `default_blend`, `easing`.
- **Optional field, optional emit.** `to_json` omits `morph` when `has_value()` is false.

## Test plan

- [x] `ctest -R test_scene_loading` — 118/118 pass (11 new morph assertions).
- [x] `pnpm exec vitest run` in `tools/apps/bricklayer` — 30/30 pass (26 previous + 4 new).
- [x] `pnpm exec tsc --noEmit` — clean for Bricklayer code (only pre-existing `@gseurat/simulation-wasm` baseline error, unrelated to this PR).
- [x] `pnpm exec vite build` — succeeds.
- [ ] Browser component-registry health check (human, before merge).
- [ ] Manual: open Bricklayer, set a pair PLY, export, verify `gaussian_splat.morph` shape on disk.

## Non-goals

- Engine does **not** load `pair_ply`. Memory policy stays game-side.
- No change to existing scenes — `morph` is optional.
- No new dependencies.

## Consumer

Blocks Akashic parent repo PR ([eccyan/game#12](https://github.com/eccyan/game/pull/12)'s follow-up), which will bump the GSeurat submodule pointer and wire `SceneManager` through the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)