### PR TITLE
feat: add CoordinateSystem option for PLY Y-flip

### DIFF
--- a/include/gseurat/engine/gaussian_cloud.hpp
+++ b/include/gseurat/engine/gaussian_cloud.hpp
@@ -9,6 +9,21 @@
 
 namespace gseurat {
 
+/// Coordinate system convention for PLY import/export.
+///
+/// GSeurat internally uses a **right-handed, Y-up** coordinate system and
+/// applies a Vulkan Y-flip in the projection matrix (`proj[1][1] *= -1`).
+///
+/// When loading PLY files into an engine that does NOT apply this projection
+/// flip (e.g. OpenGL-style renderers, or Vulkan renderers that handle Y
+/// differently), pass CoordinateSystem::kVulkanYDown to negate the Y axis
+/// on load so that the geometry appears right-side-up.
+enum class CoordinateSystem {
+    kYUp,         ///< Default. Y points up (matches GSeurat's internal convention).
+    kVulkanYDown, ///< Negate Y on load/write for consumers that expect Y-down NDC
+                  ///< without a projection-matrix flip.
+};
+
 struct Gaussian {
     glm::vec3 position;   // 12 bytes
     glm::vec3 scale;      // 12 bytes
@@ -63,14 +78,16 @@ struct GsvxPayload {
 
 class GaussianCloud {
 public:
-    static GaussianCloud load_ply(const std::string& path);
+    static GaussianCloud load_ply(const std::string& path,
+                                   CoordinateSystem coords = CoordinateSystem::kYUp);
     /// Load a pre-baked .gsvx binary file (zero-copy GPU format).
     static GsvxPayload load_gsvx(const std::string& path);
     static GaussianCloud from_gaussians(std::vector<Gaussian> gaussians);
 
     // Write Gaussians to a binary little-endian PLY file.
     // Data is stored in the same format load_ply() expects (log-scale, logit-opacity, SH DC color).
-    static void write_ply(const std::string& path, const std::vector<Gaussian>& gaussians);
+    static void write_ply(const std::string& path, const std::vector<Gaussian>& gaussians,
+                          CoordinateSystem coords = CoordinateSystem::kYUp);
 
     const std::vector<Gaussian>& gaussians() const { return gaussians_; }
     const AABB& bounds() const { return bounds_; }

--- a/src/engine/gaussian_cloud.cpp
+++ b/src/engine/gaussian_cloud.cpp
@@ -56,7 +56,8 @@ float read_float(const char* data, const PlyProperty& prop) {
 
 }  // namespace
 
-GaussianCloud GaussianCloud::load_ply(const std::string& path) {
+GaussianCloud GaussianCloud::load_ply(const std::string& path,
+                                      CoordinateSystem coords) {
     auto resolved = resolve_asset_path(path);
     std::ifstream file(resolved, std::ios::binary);
     if (!file.is_open()) {
@@ -189,6 +190,10 @@ GaussianCloud GaussianCloud::load_ply(const std::string& path) {
         g.position.y = read_float(row, *py);
         g.position.z = read_float(row, *pz);
 
+        if (coords == CoordinateSystem::kVulkanYDown) {
+            g.position.y = -g.position.y;
+        }
+
         // Scale: stored as log(scale) in standard 3DGS → apply exp()
         if (sx && sy && sz) {
             g.scale.x = std::exp(read_float(row, *sx));
@@ -208,6 +213,12 @@ GaussianCloud GaussianCloud::load_ply(const std::string& path) {
             ));
         } else {
             g.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+        }
+
+        // Y-flip: mirror the rotation around the XZ plane by negating qx and qz
+        if (coords == CoordinateSystem::kVulkanYDown) {
+            g.rotation.x = -g.rotation.x;
+            g.rotation.z = -g.rotation.z;
         }
 
         // Color
@@ -271,7 +282,8 @@ GaussianCloud GaussianCloud::from_gaussians(std::vector<Gaussian> gaussians) {
 }
 
 void GaussianCloud::write_ply(const std::string& path,
-                              const std::vector<Gaussian>& gaussians) {
+                              const std::vector<Gaussian>& gaussians,
+                              CoordinateSystem coords) {
     std::ofstream file(path, std::ios::binary);
     if (!file.is_open()) {
         throw std::runtime_error("Failed to open PLY file for writing: " + path);
@@ -304,8 +316,10 @@ void GaussianCloud::write_ply(const std::string& path,
     constexpr float kSH_C0 = 0.28209479177387814f;
 
     for (const auto& g : gaussians) {
-        // Position (stored directly)
-        float x = g.position.x, y = g.position.y, z = g.position.z;
+        // Position (negate Y when writing for Y-down consumers)
+        float x = g.position.x;
+        float y = (coords == CoordinateSystem::kVulkanYDown) ? -g.position.y : g.position.y;
+        float z = g.position.z;
         file.write(reinterpret_cast<const char*>(&x), 4);
         file.write(reinterpret_cast<const char*>(&y), 4);
         file.write(reinterpret_cast<const char*>(&z), 4);
@@ -319,8 +333,11 @@ void GaussianCloud::write_ply(const std::string& path,
         file.write(reinterpret_cast<const char*>(&s2), 4);
 
         // Rotation quaternion (stored directly, w first)
-        float rw = g.rotation.w, rx = g.rotation.x;
-        float ry = g.rotation.y, rz = g.rotation.z;
+        // Mirror around XZ plane for Y-down: negate qx and qz
+        float rw = g.rotation.w;
+        float rx = (coords == CoordinateSystem::kVulkanYDown) ? -g.rotation.x : g.rotation.x;
+        float ry = g.rotation.y;
+        float rz = (coords == CoordinateSystem::kVulkanYDown) ? -g.rotation.z : g.rotation.z;
         file.write(reinterpret_cast<const char*>(&rw), 4);
         file.write(reinterpret_cast<const char*>(&rx), 4);
         file.write(reinterpret_cast<const char*>(&ry), 4);

--- a/tests/test_gaussian_cloud.cpp
+++ b/tests/test_gaussian_cloud.cpp
@@ -607,6 +607,94 @@ int main() {
         printf("PASS: Test 18 - GSVX file size matches header count\n");
     }
 
+    // ====== Test 19: load_ply with kVulkanYDown flips Y position and rotation ======
+    {
+        const std::string ply_path = tmp_dir + "/test_standard.ply";
+        write_test_ply(ply_path, 10);
+
+        auto cloud_yup = GaussianCloud::load_ply(ply_path);
+        auto cloud_ydn = GaussianCloud::load_ply(ply_path, CoordinateSystem::kVulkanYDown);
+
+        assert(cloud_ydn.count() == 10 && "Y-down should load same count");
+
+        // Position Y should be negated
+        const auto& g5_up = cloud_yup.gaussians()[5];
+        const auto& g5_dn = cloud_ydn.gaussians()[5];
+        assert(approx(g5_dn.position.x, g5_up.position.x) && "X unchanged");
+        assert(approx(g5_dn.position.y, -g5_up.position.y) && "Y negated");
+        assert(approx(g5_dn.position.z, g5_up.position.z) && "Z unchanged");
+
+        // Rotation: qx and qz should be negated (mirror around XZ plane)
+        // For identity quaternion (w=1, x=0, y=0, z=0), negating 0 is still 0
+        // so verify the sign flip with a non-trivial quaternion via write_ply round-trip
+        assert(approx(g5_dn.rotation.w, g5_up.rotation.w) && "rot.w unchanged");
+
+        printf("PASS: Test 19 - load_ply with kVulkanYDown flips Y\n");
+    }
+
+    // ====== Test 20: write_ply + load_ply round-trip with kVulkanYDown ======
+    {
+        // Create a cloud with known non-trivial values
+        std::vector<Gaussian> src(1);
+        src[0].position = glm::vec3(1.0f, 2.0f, 3.0f);
+        src[0].scale = glm::vec3(0.5f, 0.5f, 0.5f);
+        src[0].rotation = glm::normalize(glm::quat(0.7f, 0.3f, 0.5f, 0.1f));
+        src[0].color = glm::vec3(0.8f, 0.2f, 0.4f);
+        src[0].opacity = 0.9f;
+        src[0].importance = 0.45f;
+        src[0].bone_index = 0;
+        src[0].emission = 0.0f;
+
+        // Write with Y-down, then read back with default (Y-up) — Y should be negated
+        const std::string ply_path = tmp_dir + "/test_ydown_roundtrip.ply";
+        GaussianCloud::write_ply(ply_path, src, CoordinateSystem::kVulkanYDown);
+        auto cloud = GaussianCloud::load_ply(ply_path);  // default Y-up load
+
+        const auto& g = cloud.gaussians()[0];
+        assert(approx(g.position.x, 1.0f) && "Written X unchanged");
+        assert(approx(g.position.y, -2.0f) && "Written Y negated by kVulkanYDown");
+        assert(approx(g.position.z, 3.0f) && "Written Z unchanged");
+
+        // Rotation: qx and qz negated during write
+        assert(approx(g.rotation.x, -src[0].rotation.x, 0.02f) && "Written rot.x negated");
+        assert(approx(g.rotation.y, src[0].rotation.y, 0.02f) && "Written rot.y unchanged");
+        assert(approx(g.rotation.z, -src[0].rotation.z, 0.02f) && "Written rot.z negated");
+        assert(approx(g.rotation.w, src[0].rotation.w, 0.02f) && "Written rot.w unchanged");
+
+        printf("PASS: Test 20 - write_ply + load_ply round-trip with kVulkanYDown\n");
+    }
+
+    // ====== Test 21: kVulkanYDown write then kVulkanYDown load recovers original ======
+    {
+        std::vector<Gaussian> src(1);
+        src[0].position = glm::vec3(5.0f, -3.0f, 7.0f);
+        src[0].scale = glm::vec3(0.1f, 0.2f, 0.3f);
+        src[0].rotation = glm::normalize(glm::quat(0.5f, 0.5f, 0.5f, 0.5f));
+        src[0].color = glm::vec3(1.0f, 0.0f, 0.5f);
+        src[0].opacity = 0.95f;
+        src[0].importance = 0.285f;
+        src[0].bone_index = 0;
+        src[0].emission = 0.0f;
+
+        const std::string ply_path = tmp_dir + "/test_ydown_identity.ply";
+        GaussianCloud::write_ply(ply_path, src, CoordinateSystem::kVulkanYDown);
+        auto cloud = GaussianCloud::load_ply(ply_path, CoordinateSystem::kVulkanYDown);
+
+        const auto& g = cloud.gaussians()[0];
+        // Double-negation should recover original position
+        assert(approx(g.position.x, 5.0f) && "Round-trip X preserved");
+        assert(approx(g.position.y, -3.0f) && "Round-trip Y preserved");
+        assert(approx(g.position.z, 7.0f) && "Round-trip Z preserved");
+
+        // Double-negation of qx, qz should recover original rotation
+        assert(approx(g.rotation.x, src[0].rotation.x, 0.02f) && "Round-trip rot.x preserved");
+        assert(approx(g.rotation.y, src[0].rotation.y, 0.02f) && "Round-trip rot.y preserved");
+        assert(approx(g.rotation.z, src[0].rotation.z, 0.02f) && "Round-trip rot.z preserved");
+        assert(approx(g.rotation.w, src[0].rotation.w, 0.02f) && "Round-trip rot.w preserved");
+
+        printf("PASS: Test 21 - kVulkanYDown write+load recovers original\n");
+    }
+
     // Cleanup temp files
     fs::remove_all(tmp_dir);
 


### PR DESCRIPTION
## Summary
- Adds `CoordinateSystem` enum (`kYUp`, `kVulkanYDown`) to `gaussian_cloud.hpp`
- `load_ply` and `write_ply` accept an optional `CoordinateSystem` parameter (defaults to `kYUp`, backward-compatible)
- When `kVulkanYDown` is used, position Y and rotation quaternion (qx, qz) are negated to match renderers that don't apply the Vulkan projection Y-flip
- 3 new tests verify the flip, write+load round-trip, and double-negation identity

## Test plan
- [x] All 21 gaussian cloud tests pass (`test_gaussian_cloud`)
- [x] `gseurat_core` builds cleanly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)