### PR TITLE
feat(weaver): bridge integration, save/load fixes, clickable drop zone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,7 +458,8 @@ set(AUDIO_ENGINE_TEST_SOURCES
     src/engine/audio/state_variable_filter.cpp
     src/engine/audio/streaming_audio_source.cpp
     src/engine/audio/audio_stream_manager.cpp
-    src/engine/platform/memory_mapped_file.cpp)
+    src/engine/platform/memory_mapped_file.cpp
+    src/engine/project_root.cpp)
 add_gseurat_test(test_audio_streaming      ${AUDIO_ENGINE_TEST_SOURCES})
 target_include_directories(test_audio_streaming PRIVATE ${PROJECT_SOURCE_DIR}/src/engine/audio)
 add_gseurat_test(test_audio_mixer_basic        ${AUDIO_ENGINE_TEST_SOURCES})

--- a/docs/audio-engine.md
+++ b/docs/audio-engine.md
@@ -336,6 +336,30 @@ schemas/
   music_config.schema.json  — JSON schema for music_config.json
 ```
 
+## Weaver (Authoring Tool)
+
+Weaver is a web-based visual editor for composing `music_config.json` v2 files. It replaces the legacy Audio Composer.
+
+- **Project-based workflow** — `.weaver` project files separate editor state from runtime `music_config.json`
+- **Multi-track management** — multiple TrackGroups per project, one loaded in memory at a time
+- **Visual timeline** — canvas waveforms, draggable loop handles, markers, per-stem mute/solo
+- **Staging integration** — "Open in Staging" pushes music to the running engine via bridge
+
+See [Weaver documentation](docs/weaver.md) for details.
+
+```bash
+cd tools && pnpm --filter weaver dev  # http://localhost:5182
+```
+
+## Bridge Commands (audio)
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `reload_music_config` | `path` (relative) | Load a music_config.json and play the first group |
+| `set_feature` | `name: "music"`, `enabled` | Toggle music playback on/off |
+
+The `reload_music_config` command resolves stem paths via `resolve_asset_path()` (requires `set_project_root` to be called first).
+
 ## Design Specs
 
 - [Phase 1: Interactive Music](docs/superpowers/specs/2026-04-17-audio-engine-interactive-music-design.md)
@@ -343,3 +367,5 @@ schemas/
 - [Phase 2: DSP Effects](docs/superpowers/specs/2026-04-17-audio-phase2-dsp-effects-design.md)
 - [Phase 3: Mmap Asset Pipeline](docs/superpowers/specs/2026-04-17-audio-phase3-mmap-design.md)
 - [Phase 4: Ogg Vorbis Streaming](docs/superpowers/specs/2026-04-18-audio-phase4-streaming-design.md)
+- [Phase 5: Weaver](docs/superpowers/specs/2026-04-18-audio-phase5-weaver-design.md)
+- [Phase 6: Multi-Track Management](docs/superpowers/specs/2026-04-18-audio-phase6-multitrack-design.md)

--- a/docs/weaver.md
+++ b/docs/weaver.md
@@ -1,0 +1,205 @@
+# Weaver — Interactive Music Authoring Tool
+
+Weaver is a web-based visual editor for GSeurat's interactive music engine. It replaces the legacy Audio Composer with a purpose-built tool for authoring `music_config.json` v2 — the data format that drives the engine's TrackGroups, loop boundaries, markers, and stem volumes.
+
+Named "Weaver" because it weaves audio stems together into a cohesive musical tapestry.
+
+## Quick Start
+
+```bash
+cd tools
+pnpm install
+pnpm --filter weaver dev
+# Open http://localhost:5182
+```
+
+### First-time setup
+
+1. **Open Project Root** — select your game project directory (e.g., `examples/island_demo/`)
+2. **Create New Project** — give it a name (e.g., "island_demo")
+3. **+ Add** a track group (e.g., "Field Theme")
+4. **Import stems** — click the drop zone or use File > Import Stems
+5. **Set loop points** — drag the green/red handles on the ruler
+6. **Save** (Cmd+S) — saves to `tools_data/weaver/<name>.weaver`
+7. **Export v2 JSON** — produces `music_config.json` for the engine
+
+## Architecture
+
+### Authoring Data vs. Runtime Data
+
+Weaver separates editor state from engine runtime data, analogous to `.blend` -> `.gltf`:
+
+| File | Purpose | Contains |
+|------|---------|----------|
+| `.weaver` (project file) | Authoring source of truth | All groups, editor-only state (muted, soloed, loop_enabled), stem paths |
+| `music_config.json` v2 | Engine runtime asset | Clean track_groups array, no editor metadata |
+
+The `.weaver` file is saved in `tools_data/weaver/` via the File System Access API. The `music_config.json` is a derived export artifact.
+
+### Store Architecture
+
+The Zustand store splits into **project-level** and **active-group** state:
+
+- **Project-level** — `projectName`, `sampleRate`, `groups[]` (lightweight metadata for all groups), `dirty` flag
+- **Active group** — one group's `stems[]` (with decoded `AudioBuffer` + `waveformPeaks`), `bpm`, `loopStart/End`, `markers[]`, transport state
+
+Only one group is loaded in memory at a time. Switching groups calls `flushActiveGroup()` (writes live state back to `groups[]`), discards AudioBuffers, then decodes the new group's stems.
+
+### Key Operations
+
+| Operation | Flow |
+|-----------|------|
+| `switchGroup(id)` | flush current -> discard buffers -> decode new stems -> populate live state |
+| `saveProject()` | flush -> serialize `{ version, name, sample_rate, groups }` -> write via FSAPI |
+| `exportMusicConfig()` | flush -> map all groups -> strip editor fields -> download JSON |
+| `addStem(file)` | decode audio -> compute peaks -> copy file to project dir -> add to live state |
+
+## UI Layout
+
+```
++----------------------------------------------------------+
+|  Menu: [File] [Edit] [View]               Weaver project |
++----------------------------------------------------------+
+|  Transport: [<<] [>] [Stop] [Loop] | 0:05.4 / 4:15.0    |
++----------+---------------------------+------------------+
+|  Groups  |  Ruler (loop handles,     |  Group Metadata  |
+|  * field |   markers, playhead)      |  Name / ID / BPM |
+|  o dung. |---------------------------|  Sample Rate     |
+|  o battl |  Lane 0: [waveform][M][S] |------------------|
+|  [+][dup]|  Lane 1: [waveform][M][S] |  Markers         |
+|  [del]   |  ...                      |  (sorted list)   |
+|          |  [click to import stems]  |                  |
++----------+---------------------------+------------------+
+```
+
+### Menu Bar
+
+- **File** — Save Project (Cmd+S), Import Stems, Export v2 JSON, Open in Staging, Open Project Root, Connect Bridge to Project Root
+- **Edit** — Undo/Redo (planned)
+- **View** — Zoom to Fit
+
+### Transport Bar
+
+- Rewind, Play/Stop, Loop toggle
+- Time position display (MM:SS / total)
+- Bar:Beat counter (derived from BPM)
+- Frame number
+
+### Timeline
+
+- **Ruler** — beat-grid ticks, draggable loop handles (green start, red end), marker diamonds (Shift+click to add), playhead (click to seek)
+- **Stem Lanes** — canvas waveform from pre-computed peaks, volume slider, Mute (M) / Solo (S) buttons, remove button
+- **Drop Zone** — drag-and-drop or click to import audio files
+
+### Sidebar
+
+- **Group Metadata** — editable name, read-only ID, BPM input, read-only sample rate
+- **Markers** — sorted by frame, click to seek, editable names, delete button
+
+### Group Panel (left)
+
+- Track group list with active indicator
+- Add / Duplicate / Delete buttons
+- Dirty-state dialog on switch (Save & Switch / Discard / Cancel)
+
+## Staging Integration
+
+### Open in Staging
+
+Exports the music config and pushes it to the running staging app:
+
+1. Writes `music_config.json` v2 to project assets dir via FSAPI
+2. Sends `set_project_root` command to engine via bridge WebSocket
+3. Sends `reload_music_config` command — engine loads stems and plays the first group
+
+### Connect Bridge to Project Root
+
+Prompts for the absolute disk path to the project root and POSTs it to the bridge REST API at `http://localhost:9101/api/project/root`.
+
+## Playback
+
+Web Audio API preview via `useAudioPlayer` hook:
+
+- One `AudioBufferSourceNode` + `GainNode` per stem
+- Loop support with configurable `loopStart` / `loopEnd` (converted from frames to seconds)
+- Live mute/solo via gain node updates
+- Live loop toggle via `source.loop` property updates
+- Minimum loop region guard (4410 frames / ~100ms) to prevent Web Audio beep from tiny loops
+- `requestAnimationFrame` playhead tracking with frame-accurate position
+
+## File Format
+
+### `.weaver` Project File (v1)
+
+```json
+{
+  "version": 1,
+  "name": "island_demo",
+  "sample_rate": 44100,
+  "groups": [
+    {
+      "id": "field-theme",
+      "name": "Field Theme",
+      "bpm": 120,
+      "loop_start": 0,
+      "loop_end": 352800,
+      "loop_enabled": true,
+      "markers": [{ "frame": 176400, "name": "chorus" }],
+      "stems": [
+        { "source": "assets/audio/field/bass.wav", "initial_volume": 0.8, "muted": false, "soloed": false },
+        { "source": "assets/audio/field/melody.wav", "initial_volume": 1.0, "muted": false, "soloed": false }
+      ]
+    }
+  ]
+}
+```
+
+Editor-only fields (`loop_enabled`, `muted`, `soloed`) are stripped on export to `music_config.json`.
+
+## File Layout
+
+```
+tools/apps/weaver/
+  package.json               — @gseurat/weaver, port 5182
+  vite.config.ts
+  src/
+    main.tsx
+    App.tsx                  — project root restore, empty states, Cmd+S
+    App.css                  — layout styles
+    store/
+      useWeaverStore.ts      — project + active-group Zustand store
+    components/
+      MenuBar.tsx            — File/Edit/View dropdown menus
+      TransportBar.tsx       — playback controls + position display
+      GroupPanel.tsx          — left panel wrapper for GroupSelector
+      GroupSelector.tsx       — track group list + CRUD + dirty dialog
+      TimelinePanel.tsx       — ruler + stem lanes + drop zone + zoom/pan
+      Ruler.tsx              — beat ticks, loop handles, markers, playhead
+      StemLane.tsx            — waveform canvas, volume, mute/solo
+      Sidebar.tsx            — group metadata + marker list
+      EmptyProjectState.tsx  — no-project-root / no-project screens
+      DirtyDialog.tsx        — save/discard/cancel prompt
+    hooks/
+      useAudioPlayer.ts      — Web Audio playback with live updates
+    lib/
+      types.ts               — StemState, MarkerState
+      projectTypes.ts        — WeaverProjectFile, WeaverGroupConfig
+      projectFs.ts           — FSAPI: list/save/load projects, stem files
+      slugify.ts             — group ID slug generation
+      frameUtils.ts          — frame/pixel/time conversions
+      waveformPeaks.ts       — AudioBuffer -> peak array downsampling
+      exportConfig.ts        — multi-group music_config.json v2 export
+      importConfig.ts        — stem decode + legacy v2 migration
+```
+
+## Dependencies
+
+- `react` / `react-dom` ^18 — UI framework
+- `zustand` ^4 — state management
+- `@gseurat/project-root` — File System Access API helpers (shared with Echidna)
+- `@gseurat/engine-client` — bridge WebSocket client (shared with Bricklayer)
+
+## Design Specs
+
+- [Phase 5: Weaver Design](docs/superpowers/specs/2026-04-18-audio-phase5-weaver-design.md)
+- [Phase 6: Multi-Track Management](docs/superpowers/specs/2026-04-18-audio-phase6-multitrack-design.md)

--- a/include/gseurat/engine/command_context.hpp
+++ b/include/gseurat/engine/command_context.hpp
@@ -15,7 +15,6 @@ namespace ecs { class World; }
 class ComponentRegistry;
 class InputManager;
 struct FeatureFlags;
-
 struct CommandContext {
     const GsTerrainState& terrain;
     SceneObjectState& scene_objects;
@@ -26,6 +25,8 @@ struct CommandContext {
     InputManager& input;
     FeatureFlags& feature_flags;
     GLFWwindow*& window;
+
+    std::function<void(const std::string&)> reload_music;  // optional: reload music_config.json
 
     std::function<void(const std::string&)> init_scene;
     std::function<void()> clear_scene;

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -454,6 +454,16 @@ CommandContext AppBase::build_command_context() {
         .input = input_,
         .feature_flags = feature_flags_,
         .window = window_,
+        .reload_music = [this](const std::string& path) {
+            if (audio_engine_) {
+                auto r = audio_engine_->load_track_group(path);
+                if (r) {
+                    std::fprintf(stderr, "[audio] Reloaded music config: %s (first group id=%u)\n", path.c_str(), r.value());
+                } else {
+                    std::fprintf(stderr, "[audio] Failed to reload music config: %s\n", path.c_str());
+                }
+            }
+        },
         .init_scene = [this](const std::string& path) { init_scene(path); },
         .clear_scene = [this]() { clear_scene(); },
         .load_character = [this](const std::string& path) { pending_character_path = path; },

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -456,9 +456,12 @@ CommandContext AppBase::build_command_context() {
         .window = window_,
         .reload_music = [this](const std::string& path) {
             if (audio_engine_) {
+                // Stop any currently playing groups before reload
                 auto r = audio_engine_->load_track_group(path);
                 if (r) {
-                    std::fprintf(stderr, "[audio] Reloaded music config: %s (first group id=%u)\n", path.c_str(), r.value());
+                    const uint32_t first_id = r.value();
+                    std::fprintf(stderr, "[audio] Reloaded music config: %s (first group id=%u) — playing\n", path.c_str(), first_id);
+                    audio_engine_->play_group(first_id);
                 } else {
                     std::fprintf(stderr, "[audio] Failed to reload music config: %s\n", path.c_str());
                 }

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -1,4 +1,5 @@
 #include "gseurat/engine/app_base.hpp"
+#include "gseurat/engine/project_root.hpp"
 #include "gseurat/engine/gs_scene_loader.hpp"
 #include "gseurat/engine/scene_load_context.hpp"
 #include "gseurat/engine/trigger_components.hpp"
@@ -456,14 +457,16 @@ CommandContext AppBase::build_command_context() {
         .window = window_,
         .reload_music = [this](const std::string& path) {
             if (audio_engine_) {
-                // Stop any currently playing groups before reload
-                auto r = audio_engine_->load_track_group(path);
+                // Resolve path relative to project root (not cwd)
+                auto resolved = resolve_asset_path(path).string();
+                std::fprintf(stderr, "[audio] Loading music config: %s\n", resolved.c_str());
+                auto r = audio_engine_->load_track_group(resolved);
                 if (r) {
                     const uint32_t first_id = r.value();
-                    std::fprintf(stderr, "[audio] Reloaded music config: %s (first group id=%u) — playing\n", path.c_str(), first_id);
+                    std::fprintf(stderr, "[audio] Reloaded music config (first group id=%u) — playing\n", first_id);
                     audio_engine_->play_group(first_id);
                 } else {
-                    std::fprintf(stderr, "[audio] Failed to reload music config: %s\n", path.c_str());
+                    std::fprintf(stderr, "[audio] Failed to reload music config: %s\n", resolved.c_str());
                 }
             }
         },

--- a/src/engine/audio/audio_engine.cpp
+++ b/src/engine/audio/audio_engine.cpp
@@ -1,4 +1,5 @@
 #include "gseurat/engine/audio/audio_engine.hpp"
+#include "gseurat/engine/project_root.hpp"
 #include "backend/miniaudio_device.hpp"
 #include "mixer.hpp"
 #include "metadata_loader.hpp"
@@ -71,9 +72,14 @@ public:
             std::vector<std::unique_ptr<IAudioSource>> stems;
             stems.reserve(tg.stems.size());
             for (const auto& s : tg.stems) {
-                auto src_r = load_audio_source(s.source_path, cfg.sample_rate,
+                // Resolve relative stem paths using project root
+                auto stem_path = resolve_asset_path(s.source_path).string();
+                auto src_r = load_audio_source(stem_path, cfg.sample_rate,
                                                 &stream_manager_, tg.loop_start, tg.loop_end);
-                if (!src_r) return std::unexpected(LoadTrackGroupError::StemLoadFailed);
+                if (!src_r) {
+                    std::fprintf(stderr, "[audio] Failed to load stem: %s\n", stem_path.c_str());
+                    return std::unexpected(LoadTrackGroupError::StemLoadFailed);
+                }
                 stems.push_back(std::move(src_r.value()));
             }
             const uint32_t id = tg.id;

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -526,6 +526,18 @@ void CommandDispatcher::register_default_commands() {
         }
     });
 
+    register_command("reload_music_config", [this](const json& cmd) -> CommandResult {
+        if (!ctx_.reload_music) {
+            return std::unexpected(std::string("Audio engine not available"));
+        }
+        const std::string path = cmd.value("path", "");
+        if (path.empty()) {
+            return std::unexpected(std::string("Missing 'path' parameter"));
+        }
+        ctx_.reload_music(path);
+        return json{{"type", "ok"}, {"message", "Music config reloaded: " + path}};
+    });
+
     register_command("quit", [this](const json&) -> CommandResult {
         glfwSetWindowShouldClose(ctx_.window, GLFW_TRUE);
         return json{{"type", "ok"}, {"message", "Shutting down"}};

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -1,5 +1,6 @@
 #include "gseurat/staging/staging_app.hpp"
 #include "gseurat/staging/staging_state.hpp"
+#include "gseurat/engine/audio/audio_engine.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/gs_parallax_camera.hpp"
 #include "gseurat/engine/project_root.hpp"
@@ -32,6 +33,17 @@ void StagingApp::parse_args(int argc, char* argv[]) {
 void StagingApp::run() {
     command_dispatcher_.register_default_commands();
     init_game_object_system();
+
+    // Create audio engine so Weaver's "Open in Staging" can play music.
+    auto engine_r = audio::AudioEngine::create(
+        {.sample_rate = 44100, .buffer_frames = 1024, .max_active_groups = 8,
+         .max_oneshot_voices = 32},
+        audio::AudioEngine::Mode::Realtime);
+    if (engine_r) {
+        audio_engine_ = std::move(engine_r.value());
+        std::fprintf(stderr, "[Staging] Audio engine initialized\n");
+    }
+
     init_game_content();
     scene_objects_.current_scene_path = scene_path_;
     state_stack_.push(std::make_unique<StagingState>(), *this);

--- a/tools/apps/weaver/package.json
+++ b/tools/apps/weaver/package.json
@@ -10,6 +10,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@gseurat/engine-client": "workspace:*",
     "@gseurat/project-root": "workspace:*",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/tools/apps/weaver/src/components/MenuBar.tsx
+++ b/tools/apps/weaver/src/components/MenuBar.tsx
@@ -1,6 +1,33 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useWeaverStore } from '../store/useWeaverStore.js';
 import { exportMultiGroupConfig, downloadJson } from '../lib/exportConfig.js';
+import { writeFileAtPath } from '@gseurat/project-root';
+import { sendBridgeCommand } from '@gseurat/engine-client';
+
+const BRIDGE_REST_URL = 'http://localhost:9101';
+
+type ConnectBridgeResult =
+  | { ok: true; activeProjectDir: string }
+  | { ok: false; error: string };
+
+async function connectBridgeToPath(absolutePath: string): Promise<ConnectBridgeResult> {
+  if (!absolutePath) return { ok: false, error: 'absolutePath is empty' };
+  try {
+    const res = await fetch(`${BRIDGE_REST_URL}/api/project/root`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ path: absolutePath }),
+    });
+    if (res.ok) {
+      const body = (await res.json()) as { activeProjectDir?: string };
+      return { ok: true, activeProjectDir: body.activeProjectDir ?? absolutePath };
+    }
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { ok: false, error: body.error ?? res.statusText };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
 
 type MenuId = 'file' | 'edit' | 'view' | null;
 
@@ -82,6 +109,49 @@ export function MenuBar() {
     zoomToFit();
   };
 
+  const handleConnectBridge = async () => {
+    close();
+    const absolutePath = prompt(
+      'Enter absolute path to your project root:\n(e.g., /Users/you/MyGame)',
+    );
+    if (!absolutePath?.trim()) return;
+    const result = await connectBridgeToPath(absolutePath.trim());
+    if (result.ok) {
+      console.info(`[weaver] Bridge connected: ${result.activeProjectDir}`);
+    } else {
+      console.error(`[weaver] Bridge connection failed: ${result.error}`);
+      alert(`Bridge connection failed: ${result.error}`);
+    }
+  };
+
+  const handleOpenInStaging = async () => {
+    close();
+    const state = useWeaverStore.getState();
+    state.flushActiveGroup();
+    const flushed = useWeaverStore.getState();
+    const config = exportMultiGroupConfig(flushed.sampleRate, flushed.groups);
+    const json = JSON.stringify(config, null, 2);
+
+    // Write music_config.json to project root via FSAPI
+    if (flushed.projectRootHandle) {
+      try {
+        const path = `assets/audio/${flushed.projectName}.music.json`;
+        await writeFileAtPath(flushed.projectRootHandle, path, json);
+        console.info(`[weaver] Exported to project: ${path}`);
+      } catch (e) {
+        console.warn('[weaver] Failed to write to project root:', e);
+      }
+    }
+
+    // Also push to staging via bridge WebSocket
+    try {
+      await sendBridgeCommand({ cmd: 'write_temp_file', path: `${flushed.projectName}.music.json`, content: json });
+      console.info('[weaver] Pushed music config to staging via bridge');
+    } catch (e) {
+      console.warn('[weaver] Bridge not available:', e);
+    }
+  };
+
   const menuBtnStyle: React.CSSProperties = {
     background: 'transparent', border: 'none', color: '#ccc',
     padding: '4px 10px', cursor: 'pointer', fontSize: 12, borderRadius: 3,
@@ -132,8 +202,15 @@ export function MenuBar() {
                 Export v2 JSON...
               </button>
               <div style={separatorStyle} />
+              <button style={itemStyle} onClick={handleOpenInStaging}>
+                Open in Staging
+              </button>
+              <div style={separatorStyle} />
               <button style={itemStyle} onClick={handleOpenProjectRoot}>
                 Open Project Root...
+              </button>
+              <button style={itemStyle} onClick={handleConnectBridge}>
+                Connect Bridge to Project Root...
               </button>
             </div>
           )}

--- a/tools/apps/weaver/src/components/MenuBar.tsx
+++ b/tools/apps/weaver/src/components/MenuBar.tsx
@@ -109,6 +109,8 @@ export function MenuBar() {
     zoomToFit();
   };
 
+  const [bridgePath, setBridgePath] = useState<string | null>(null);
+
   const handleConnectBridge = async () => {
     close();
     const absolutePath = prompt(
@@ -117,6 +119,7 @@ export function MenuBar() {
     if (!absolutePath?.trim()) return;
     const result = await connectBridgeToPath(absolutePath.trim());
     if (result.ok) {
+      setBridgePath(absolutePath.trim());
       console.info(`[weaver] Bridge connected: ${result.activeProjectDir}`);
     } else {
       console.error(`[weaver] Bridge connection failed: ${result.error}`);
@@ -143,9 +146,11 @@ export function MenuBar() {
       }
     }
 
-    // Push to staging: write file then reload music config
+    // Push to staging: set project root then reload music config
     try {
-      await sendBridgeCommand({ cmd: 'write_temp_file', path: assetPath, content: json });
+      if (bridgePath) {
+        await sendBridgeCommand({ cmd: 'set_project_root', path: bridgePath });
+      }
       await sendBridgeCommand({ cmd: 'reload_music_config', path: assetPath });
       console.info('[weaver] Pushed music config to staging and triggered reload');
     } catch (e) {

--- a/tools/apps/weaver/src/components/MenuBar.tsx
+++ b/tools/apps/weaver/src/components/MenuBar.tsx
@@ -131,22 +131,23 @@ export function MenuBar() {
     const flushed = useWeaverStore.getState();
     const config = exportMultiGroupConfig(flushed.sampleRate, flushed.groups);
     const json = JSON.stringify(config, null, 2);
+    const assetPath = `assets/audio/${flushed.projectName}.music.json`;
 
     // Write music_config.json to project root via FSAPI
     if (flushed.projectRootHandle) {
       try {
-        const path = `assets/audio/${flushed.projectName}.music.json`;
-        await writeFileAtPath(flushed.projectRootHandle, path, json);
-        console.info(`[weaver] Exported to project: ${path}`);
+        await writeFileAtPath(flushed.projectRootHandle, assetPath, json);
+        console.info(`[weaver] Exported to project: ${assetPath}`);
       } catch (e) {
         console.warn('[weaver] Failed to write to project root:', e);
       }
     }
 
-    // Also push to staging via bridge WebSocket
+    // Push to staging: write file then reload music config
     try {
-      await sendBridgeCommand({ cmd: 'write_temp_file', path: `${flushed.projectName}.music.json`, content: json });
-      console.info('[weaver] Pushed music config to staging via bridge');
+      await sendBridgeCommand({ cmd: 'write_temp_file', path: assetPath, content: json });
+      await sendBridgeCommand({ cmd: 'reload_music_config', path: assetPath });
+      console.info('[weaver] Pushed music config to staging and triggered reload');
     } catch (e) {
       console.warn('[weaver] Bridge not available:', e);
     }

--- a/tools/pnpm-lock.yaml
+++ b/tools/pnpm-lock.yaml
@@ -359,6 +359,9 @@ importers:
 
   apps/weaver:
     dependencies:
+      '@gseurat/engine-client':
+        specifier: workspace:*
+        version: link:../../packages/engine-client
       '@gseurat/project-root':
         specifier: workspace:*
         version: link:../../packages/project-root


### PR DESCRIPTION
## Summary

- **Open in Staging** — exports `music_config.json` v2 to project assets dir + pushes via bridge WebSocket
- **Connect Bridge to Project Root** — prompts for absolute path, POSTs to bridge REST API (same pattern as Bricklayer/Echidna)
- **Save/load fix** — imported audio files are now copied into the project directory; project name matches filename for consistent save/load
- **Clickable drop zone** — "Drop .wav / .ogg files here or click to browse" opens native file picker

## Test plan
- [ ] File → Open in Staging: exports music config to project assets
- [ ] File → Connect Bridge to Project Root: connects to bridge at localhost:9101
- [ ] Import stems, save project, refresh — stems and groups persist
- [ ] Click drop zone — native file picker opens
- [ ] `pnpm --filter weaver build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)