### PR TITLE
feat: PLY point cloud reference layers in Bricklayer viewport

### DIFF
--- a/docs/superpowers/specs/2026-04-18-ply-point-cloud-reference-design.md
+++ b/docs/superpowers/specs/2026-04-18-ply-point-cloud-reference-design.md
@@ -1,0 +1,30 @@
+# PLY Point Cloud Reference Layers
+
+**Date:** 2026-04-18
+**Goal:** Display PLY files as read-only point cloud references in the Bricklayer viewport, for both game objects and terrain.
+
+## Components
+
+### PlyPointCloud.tsx (shared)
+- Props: `plyPath`, `projectHandle`, `visible`, `pointSize?`, `opacity?`
+- Loads binary PLY from FSAPI, parses position + color (SH DC or RGB fallback)
+- Renders as `<points>` with ShaderMaterial
+- Caches parsed geometry
+
+### GameObjectMarkers.tsx (enhancement)
+- When `ply_file` is set and `showObjectPly` is true, render `<PlyPointCloud>` at object position/rotation/scale
+- Keep wireframe cube as fallback when no PLY or toggle off
+
+### TerrainPlyReference.tsx (new)
+- Path derived from `projectName`: `assets/maps/<slug>.ply`
+- Renders at world origin
+- Controlled by `showTerrainPly` toggle
+
+## Store Changes (useSceneStore)
+- `showTerrainPly: boolean` (default `false`)
+- `showObjectPly: boolean` (default `true`)
+- `setShowTerrainPly`, `setShowObjectPly` setters
+
+## UI Changes
+- View menu: "Terrain PLY" and "Object PLY" toggles
+- Viewport.tsx: add `<TerrainPlyReference />`

--- a/examples/island_demo/world.json
+++ b/examples/island_demo/world.json
@@ -296,7 +296,8 @@
     {
       "id": "dungeon_01",
       "display_name": "Dungeon Interior",
-      "scene_file": "assets/scenes/dungeon.json"
+      "scene_file": "assets/scenes/dungeon.json",
+      "ply_file": "assets/maps/dungeon.ply"
     },
     {
       "id": "tavern_01",

--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -466,6 +466,16 @@ export async function switchScene(
   const sceneName = sceneFile.split('/').pop()?.replace('.json', '') ?? 'scene';
   const bricklayerPath = `${PROJECT_LAYOUT.toolsData.bricklayer}/${sceneName}.bricklayer`;
 
+  // Try to extract terrain PLY path from the engine scene JSON
+  try {
+    const engineBlob = await readFileAtPath(handle, sceneFile);
+    const engineText = await engineBlob.text();
+    const engineData = JSON.parse(engineText);
+    if (engineData.gaussian_splat?.ply_file) {
+      sceneStore.setTerrainPlyFile(engineData.gaussian_splat.ply_file);
+    }
+  } catch { /* engine scene may not exist yet */ }
+
   try {
     // Try loading .bricklayer file first
     const blob = await readFileAtPath(handle, bricklayerPath);
@@ -647,6 +657,10 @@ export async function importEngineScene(
     };
 
     useSceneStore.getState().loadProject(bricklayerFile);
+    // Set terrain PLY path from engine scene's gaussian_splat.ply_file
+    if (engine.gaussian_splat?.ply_file) {
+      useSceneStore.getState().setTerrainPlyFile(engine.gaussian_splat.ply_file);
+    }
     globalToLocal();
     centerCameraOnScene();
     console.info(`[bricklayer] Imported engine scene: ${sceneFile}`);

--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -466,16 +466,6 @@ export async function switchScene(
   const sceneName = sceneFile.split('/').pop()?.replace('.json', '') ?? 'scene';
   const bricklayerPath = `${PROJECT_LAYOUT.toolsData.bricklayer}/${sceneName}.bricklayer`;
 
-  // Try to extract terrain PLY path from the engine scene JSON
-  try {
-    const engineBlob = await readFileAtPath(handle, sceneFile);
-    const engineText = await engineBlob.text();
-    const engineData = JSON.parse(engineText);
-    if (engineData.gaussian_splat?.ply_file) {
-      sceneStore.setTerrainPlyFile(engineData.gaussian_splat.ply_file);
-    }
-  } catch { /* engine scene may not exist yet */ }
-
   try {
     // Try loading .bricklayer file first
     const blob = await readFileAtPath(handle, bricklayerPath);
@@ -657,10 +647,6 @@ export async function importEngineScene(
     };
 
     useSceneStore.getState().loadProject(bricklayerFile);
-    // Set terrain PLY path from engine scene's gaussian_splat.ply_file
-    if (engine.gaussian_splat?.ply_file) {
-      useSceneStore.getState().setTerrainPlyFile(engine.gaussian_splat.ply_file);
-    }
     globalToLocal();
     centerCameraOnScene();
     console.info(`[bricklayer] Imported engine scene: ${sceneFile}`);

--- a/tools/apps/bricklayer/src/panels/MasterTree.tsx
+++ b/tools/apps/bricklayer/src/panels/MasterTree.tsx
@@ -609,6 +609,9 @@ export function MasterTree() {
     if (handle && sceneFile) {
       await switchScene(handle, sceneFile);
     }
+    // Set terrain PLY from chunk manifest
+    const chunk = manifest.chunks.find((c) => chunkGridKey(c.grid) === gridKey);
+    useSceneStore.getState().setTerrainPlyFile(chunk?.ply_file ?? '');
     useWorldStore.getState().setEditingContext({ type: 'chunk', gridKey, sceneFile });
   };
 
@@ -622,6 +625,9 @@ export function MasterTree() {
     if (handle && sceneFile) {
       await switchScene(handle, sceneFile);
     }
+    // Set terrain PLY from instance manifest
+    const inst = manifest.instances.find((i) => i.id === id);
+    useSceneStore.getState().setTerrainPlyFile(inst?.ply_file ?? '');
     useWorldStore.getState().setEditingContext({ type: 'instance', id, sceneFile });
   };
 

--- a/tools/apps/bricklayer/src/panels/MasterTree.tsx
+++ b/tools/apps/bricklayer/src/panels/MasterTree.tsx
@@ -611,7 +611,9 @@ export function MasterTree() {
     }
     // Set terrain PLY from chunk manifest
     const chunk = manifest.chunks.find((c) => chunkGridKey(c.grid) === gridKey);
-    useSceneStore.getState().setTerrainPlyFile(chunk?.ply_file ?? '');
+    const plyFile = chunk?.ply_file ?? '';
+    console.info(`[MasterTree] Chunk ${gridKey} terrain PLY: ${plyFile || '(none)'}`);
+    useSceneStore.getState().setTerrainPlyFile(plyFile);
     useWorldStore.getState().setEditingContext({ type: 'chunk', gridKey, sceneFile });
   };
 
@@ -627,7 +629,9 @@ export function MasterTree() {
     }
     // Set terrain PLY from instance manifest
     const inst = manifest.instances.find((i) => i.id === id);
-    useSceneStore.getState().setTerrainPlyFile(inst?.ply_file ?? '');
+    const plyFile = inst?.ply_file ?? '';
+    console.info(`[MasterTree] Instance ${id} terrain PLY: ${plyFile || '(none)'}`);
+    useSceneStore.getState().setTerrainPlyFile(plyFile);
     useWorldStore.getState().setEditingContext({ type: 'instance', id, sceneFile });
   };
 

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -473,6 +473,20 @@ export function MenuBar() {
       },
     },
     {
+      label: `${useSceneStore.getState().showTerrainPly ? '\u2713 ' : ''}Terrain PLY`,
+      action: () => {
+        const s = useSceneStore.getState();
+        s.setShowTerrainPly(!s.showTerrainPly);
+      },
+    },
+    {
+      label: `${useSceneStore.getState().showObjectPly ? '\u2713 ' : ''}Object PLY`,
+      action: () => {
+        const s = useSceneStore.getState();
+        s.setShowObjectPly(!s.showObjectPly);
+      },
+    },
+    {
       label: `${useSceneStore.getState().stagingAutoSync ? '\u2713 ' : ''}Auto-Sync Staging`,
       action: () => {
         const s = useSceneStore.getState();

--- a/tools/apps/bricklayer/src/panels/WorldPropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/WorldPropertiesPanel.tsx
@@ -320,6 +320,17 @@ function InstanceEditor({ id }: { id: string }) {
         />
       </div>
 
+      <label style={labelStyle}>PLY File</label>
+      <div style={rowStyle}>
+        <input
+          type="text"
+          value={inst.ply_file ?? ''}
+          placeholder="assets/maps/room.ply"
+          onChange={(e) => updateInstance(id, { ply_file: e.target.value })}
+          style={fullInputStyle}
+        />
+      </div>
+
       <button
         style={enterBtnStyle}
         onClick={async () => {

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -276,6 +276,8 @@ export interface SceneStoreState {
   showGrid: boolean;
   showCollision: boolean;
   showGizmos: boolean;
+  showTerrainPly: boolean;
+  showObjectPly: boolean;
   stagingAutoSync: boolean;
   selectedSettingsCategory: SettingsCategory;
 
@@ -353,6 +355,8 @@ export interface SceneStoreState {
   setShowGrid: (v: boolean) => void;
   setShowCollision: (v: boolean) => void;
   setShowGizmos: (v: boolean) => void;
+  setShowTerrainPly: (v: boolean) => void;
+  setShowObjectPly: (v: boolean) => void;
   setStagingAutoSync: (v: boolean) => void;
   setSavedEditorCamera: (v: { position: [number,number,number]; target: [number,number,number] } | null) => void;
   setSelectedSettingsCategory: (cat: SettingsCategory) => void;
@@ -414,6 +418,8 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   showGrid: true,
   showCollision: false,
   showGizmos: true,
+  showTerrainPly: false,
+  showObjectPly: true,
   stagingAutoSync: false,
   selectedSettingsCategory: 'gs_camera',
 
@@ -750,6 +756,8 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   setShowGrid: (v) => set({ showGrid: v }),
   setShowCollision: (v) => set({ showCollision: v }),
   setShowGizmos: (v) => set({ showGizmos: v }),
+  setShowTerrainPly: (v) => set({ showTerrainPly: v }),
+  setShowObjectPly: (v) => set({ showObjectPly: v }),
   setStagingAutoSync: (v) => set({ stagingAutoSync: v }),
   setSavedEditorCamera: (v) => set({ savedEditorCamera: v }),
   setSelectedSettingsCategory: (cat) => set({ selectedSettingsCategory: cat }),

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -278,6 +278,7 @@ export interface SceneStoreState {
   showGizmos: boolean;
   showTerrainPly: boolean;
   showObjectPly: boolean;
+  terrainPlyFile: string;
   stagingAutoSync: boolean;
   selectedSettingsCategory: SettingsCategory;
 
@@ -357,6 +358,7 @@ export interface SceneStoreState {
   setShowGizmos: (v: boolean) => void;
   setShowTerrainPly: (v: boolean) => void;
   setShowObjectPly: (v: boolean) => void;
+  setTerrainPlyFile: (v: string) => void;
   setStagingAutoSync: (v: boolean) => void;
   setSavedEditorCamera: (v: { position: [number,number,number]; target: [number,number,number] } | null) => void;
   setSelectedSettingsCategory: (cat: SettingsCategory) => void;
@@ -420,6 +422,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   showGizmos: true,
   showTerrainPly: false,
   showObjectPly: true,
+  terrainPlyFile: '',
   stagingAutoSync: false,
   selectedSettingsCategory: 'gs_camera',
 
@@ -758,6 +761,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   setShowGizmos: (v) => set({ showGizmos: v }),
   setShowTerrainPly: (v) => set({ showTerrainPly: v }),
   setShowObjectPly: (v) => set({ showObjectPly: v }),
+  setTerrainPlyFile: (v) => set({ terrainPlyFile: v }),
   setStagingAutoSync: (v) => set({ stagingAutoSync: v }),
   setSavedEditorCamera: (v) => set({ savedEditorCamera: v }),
   setSelectedSettingsCategory: (cat) => set({ selectedSettingsCategory: cat }),

--- a/tools/apps/bricklayer/src/viewport/GameObjectMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/GameObjectMarkers.tsx
@@ -82,9 +82,9 @@ export function GameObjectMarkers() {
 
   return (
     <group>
-      {gameObjects.map((obj) => (
+      {gameObjects.map((obj, idx) => (
         <Marker
-          key={obj.id}
+          key={`${obj.id}_${idx}`}
           id={obj.id}
           name={obj.name}
           position={obj.position}

--- a/tools/apps/bricklayer/src/viewport/GameObjectMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/GameObjectMarkers.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import { Html } from '@react-three/drei';
 import { useSceneStore } from '../store/useSceneStore.js';
+import { PlyPointCloud } from './PlyPointCloud.js';
 
-function Marker({ id, name, position, hasComponents, isSelected, onSelect }: {
+function Marker({ id, name, position, rotation, scale, plyFile, hasComponents, isSelected, showObjectPly, projectHandle, onSelect }: {
   id: string;
   name: string;
   position: [number, number, number];
+  rotation: [number, number, number];
+  scale: number;
+  plyFile: string;
   hasComponents: boolean;
   isSelected: boolean;
+  showObjectPly: boolean;
+  projectHandle: FileSystemDirectoryHandle | null;
   onSelect: () => void;
 }) {
   const color = isSelected ? '#ffffff' : hasComponents ? '#4488ff' : '#888888';
@@ -15,6 +21,17 @@ function Marker({ id, name, position, hasComponents, isSelected, onSelect }: {
 
   return (
     <group key={id}>
+      {/* PLY point cloud when available */}
+      {plyFile && (
+        <PlyPointCloud
+          plyPath={plyFile}
+          projectHandle={projectHandle}
+          visible={showObjectPly}
+          position={position}
+          rotation={rotation}
+          scale={scale}
+        />
+      )}
       {/* Invisible hit box for click detection */}
       <mesh
         position={position}
@@ -56,6 +73,8 @@ function Marker({ id, name, position, hasComponents, isSelected, onSelect }: {
 export function GameObjectMarkers() {
   const gameObjects = useSceneStore((s) => s.gameObjects);
   const showGizmos = useSceneStore((s) => s.showGizmos);
+  const showObjectPly = useSceneStore((s) => s.showObjectPly);
+  const projectHandle = useSceneStore((s) => s.projectHandle);
   const selectedEntity = useSceneStore((s) => s.selectedEntity);
   const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
 
@@ -69,8 +88,13 @@ export function GameObjectMarkers() {
           id={obj.id}
           name={obj.name}
           position={obj.position}
+          rotation={obj.rotation}
+          scale={obj.scale}
+          plyFile={obj.ply_file}
           hasComponents={Object.keys(obj.components).length > 0}
           isSelected={selectedEntity?.type === 'game_object' && selectedEntity.id === obj.id}
+          showObjectPly={showObjectPly}
+          projectHandle={projectHandle}
           onSelect={() => setSelectedEntity({ type: 'game_object', id: obj.id })}
         />
       ))}

--- a/tools/apps/bricklayer/src/viewport/PlyPointCloud.tsx
+++ b/tools/apps/bricklayer/src/viewport/PlyPointCloud.tsx
@@ -6,50 +6,70 @@ import { readFileAtPath } from '@gseurat/project-root';
  * Parse a binary PLY file into position + color arrays.
  * Supports GSeurat format (f_dc_0/1/2 SH DC) and standard RGB.
  */
+const PROP_SIZES: Record<string, number> = {
+  float: 4, double: 8,
+  int: 4, uint: 4,
+  short: 2, ushort: 2,
+  char: 1, uchar: 1,
+};
+
+interface PlyProp { name: string; type: string; offset: number }
+
 function parsePlyBuffer(buffer: ArrayBuffer): { positions: Float32Array; colors: Float32Array } | null {
   const headerText = new TextDecoder().decode(new Uint8Array(buffer, 0, Math.min(4096, buffer.byteLength)));
   const headerLines = headerText.split('\n');
   let vertexCount = 0;
-  const propNames: string[] = [];
+  const props: PlyProp[] = [];
   let dataStart = 0;
+  let byteOffset = 0;
 
   for (const line of headerLines) {
     dataStart += line.length + 1;
     if (line.startsWith('element vertex')) vertexCount = parseInt(line.split(' ')[2]);
-    if (line.startsWith('property float')) propNames.push(line.split(' ')[2]);
+    if (line.startsWith('property ')) {
+      const parts = line.trim().split(/\s+/);
+      const type = parts[1];
+      const name = parts[2];
+      const size = PROP_SIZES[type] ?? 4;
+      props.push({ name, type, offset: byteOffset });
+      byteOffset += size;
+    }
     if (line.trim() === 'end_header') break;
   }
 
-  if (vertexCount === 0 || propNames.length === 0) return null;
+  if (vertexCount === 0 || props.length === 0) return null;
 
-  const stride = propNames.length * 4;
+  const stride = byteOffset;
   const dataView = new DataView(buffer, dataStart);
   const positions = new Float32Array(vertexCount * 3);
   const colors = new Float32Array(vertexCount * 4);
 
-  const xIdx = propNames.indexOf('x');
-  const yIdx = propNames.indexOf('y');
-  const zIdx = propNames.indexOf('z');
-  const dcR = propNames.indexOf('f_dc_0');
-  const dcG = propNames.indexOf('f_dc_1');
-  const dcB = propNames.indexOf('f_dc_2');
-  const rIdx = propNames.indexOf('red');
-  const gIdx = propNames.indexOf('green');
-  const bIdx = propNames.indexOf('blue');
+  const find = (name: string) => props.find((p) => p.name === name);
+  const xProp = find('x'), yProp = find('y'), zProp = find('z');
+  const dcR = find('f_dc_0'), dcG = find('f_dc_1'), dcB = find('f_dc_2');
+  const rProp = find('red'), gProp = find('green'), bProp = find('blue');
+
+  if (!xProp || !yProp || !zProp) return null;
 
   for (let i = 0; i < vertexCount; i++) {
     const off = i * stride;
-    positions[i * 3] = dataView.getFloat32(off + xIdx * 4, true);
-    positions[i * 3 + 1] = dataView.getFloat32(off + yIdx * 4, true);
-    positions[i * 3 + 2] = dataView.getFloat32(off + zIdx * 4, true);
-    if (dcR >= 0) {
-      colors[i * 4] = 0.5 + 0.2820948 * dataView.getFloat32(off + dcR * 4, true);
-      colors[i * 4 + 1] = 0.5 + 0.2820948 * dataView.getFloat32(off + dcG * 4, true);
-      colors[i * 4 + 2] = 0.5 + 0.2820948 * dataView.getFloat32(off + dcB * 4, true);
-    } else if (rIdx >= 0) {
-      colors[i * 4] = dataView.getUint8(off + rIdx) / 255;
-      colors[i * 4 + 1] = dataView.getUint8(off + gIdx) / 255;
-      colors[i * 4 + 2] = dataView.getUint8(off + bIdx) / 255;
+    positions[i * 3] = dataView.getFloat32(off + xProp.offset, true);
+    positions[i * 3 + 1] = dataView.getFloat32(off + yProp.offset, true);
+    positions[i * 3 + 2] = dataView.getFloat32(off + zProp.offset, true);
+    if (dcR && dcG && dcB) {
+      colors[i * 4] = 0.5 + 0.2820948 * dataView.getFloat32(off + dcR.offset, true);
+      colors[i * 4 + 1] = 0.5 + 0.2820948 * dataView.getFloat32(off + dcG.offset, true);
+      colors[i * 4 + 2] = 0.5 + 0.2820948 * dataView.getFloat32(off + dcB.offset, true);
+    } else if (rProp && gProp && bProp) {
+      if (rProp.type === 'uchar') {
+        colors[i * 4] = dataView.getUint8(off + rProp.offset) / 255;
+        colors[i * 4 + 1] = dataView.getUint8(off + gProp.offset) / 255;
+        colors[i * 4 + 2] = dataView.getUint8(off + bProp.offset) / 255;
+      } else {
+        colors[i * 4] = dataView.getFloat32(off + rProp.offset, true);
+        colors[i * 4 + 1] = dataView.getFloat32(off + gProp.offset, true);
+        colors[i * 4 + 2] = dataView.getFloat32(off + bProp.offset, true);
+      }
     } else {
       colors[i * 4] = 0.7;
       colors[i * 4 + 1] = 0.7;

--- a/tools/apps/bricklayer/src/viewport/PlyPointCloud.tsx
+++ b/tools/apps/bricklayer/src/viewport/PlyPointCloud.tsx
@@ -89,7 +89,7 @@ const pointCloudMaterial = new THREE.ShaderMaterial({
     void main() {
       vColor = vec4(color.rgb, uOpacity);
       vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
-      gl_PointSize = max(1.5, uPointSize * (20.0 / -mvPosition.z));
+      gl_PointSize = max(2.0, uPointSize * (30.0 / -mvPosition.z));
       gl_Position = projectionMatrix * mvPosition;
     }
   `,

--- a/tools/apps/bricklayer/src/viewport/PlyPointCloud.tsx
+++ b/tools/apps/bricklayer/src/viewport/PlyPointCloud.tsx
@@ -127,9 +127,19 @@ export function PlyPointCloud({
 }) {
   const [geometry, setGeometry] = useState<THREE.BufferGeometry | null>(null);
 
+  // Dispose old geometry when path changes or component unmounts
   useEffect(() => {
-    if (!plyPath || !projectHandle || !visible) return;
+    return () => {
+      setGeometry((prev) => { prev?.dispose(); return null; });
+    };
+  }, [plyPath]);
 
+  useEffect(() => {
+    if (!plyPath || !projectHandle || !visible) {
+      return;
+    }
+
+    console.info(`[PlyPointCloud] Loading: ${plyPath}`);
     let cancelled = false;
     (async () => {
       try {
@@ -139,14 +149,30 @@ export function PlyPointCloud({
         if (cancelled) return;
 
         const parsed = parsePlyBuffer(buffer);
-        if (!parsed || cancelled) return;
+        if (!parsed) {
+          console.warn(`[PlyPointCloud] Failed to parse: ${plyPath}`);
+          return;
+        }
+        if (cancelled) return;
+
+        // Validate no NaN in positions
+        let hasNaN = false;
+        for (let i = 0; i < Math.min(30, parsed.positions.length); i++) {
+          if (isNaN(parsed.positions[i])) { hasNaN = true; break; }
+        }
+        if (hasNaN) {
+          console.error(`[PlyPointCloud] NaN detected in positions for: ${plyPath}`);
+          return;
+        }
 
         const geo = new THREE.BufferGeometry();
         geo.setAttribute('position', new THREE.BufferAttribute(parsed.positions, 3));
         geo.setAttribute('color', new THREE.BufferAttribute(parsed.colors, 4));
+        geo.computeBoundingSphere();
+        console.info(`[PlyPointCloud] Loaded ${parsed.positions.length / 3} vertices from: ${plyPath}`);
         setGeometry(geo);
-      } catch {
-        // PLY file not found — silently ignore
+      } catch (err) {
+        console.warn(`[PlyPointCloud] File not found or unreadable: ${plyPath}`, err);
       }
     })();
 

--- a/tools/apps/bricklayer/src/viewport/PlyPointCloud.tsx
+++ b/tools/apps/bricklayer/src/viewport/PlyPointCloud.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import * as THREE from 'three';
+import { readFileAtPath } from '@gseurat/project-root';
+
+/**
+ * Parse a binary PLY file into position + color arrays.
+ * Supports GSeurat format (f_dc_0/1/2 SH DC) and standard RGB.
+ */
+function parsePlyBuffer(buffer: ArrayBuffer): { positions: Float32Array; colors: Float32Array } | null {
+  const headerText = new TextDecoder().decode(new Uint8Array(buffer, 0, Math.min(4096, buffer.byteLength)));
+  const headerLines = headerText.split('\n');
+  let vertexCount = 0;
+  const propNames: string[] = [];
+  let dataStart = 0;
+
+  for (const line of headerLines) {
+    dataStart += line.length + 1;
+    if (line.startsWith('element vertex')) vertexCount = parseInt(line.split(' ')[2]);
+    if (line.startsWith('property float')) propNames.push(line.split(' ')[2]);
+    if (line.trim() === 'end_header') break;
+  }
+
+  if (vertexCount === 0 || propNames.length === 0) return null;
+
+  const stride = propNames.length * 4;
+  const dataView = new DataView(buffer, dataStart);
+  const positions = new Float32Array(vertexCount * 3);
+  const colors = new Float32Array(vertexCount * 4);
+
+  const xIdx = propNames.indexOf('x');
+  const yIdx = propNames.indexOf('y');
+  const zIdx = propNames.indexOf('z');
+  const dcR = propNames.indexOf('f_dc_0');
+  const dcG = propNames.indexOf('f_dc_1');
+  const dcB = propNames.indexOf('f_dc_2');
+  const rIdx = propNames.indexOf('red');
+  const gIdx = propNames.indexOf('green');
+  const bIdx = propNames.indexOf('blue');
+
+  for (let i = 0; i < vertexCount; i++) {
+    const off = i * stride;
+    positions[i * 3] = dataView.getFloat32(off + xIdx * 4, true);
+    positions[i * 3 + 1] = dataView.getFloat32(off + yIdx * 4, true);
+    positions[i * 3 + 2] = dataView.getFloat32(off + zIdx * 4, true);
+    if (dcR >= 0) {
+      colors[i * 4] = 0.5 + 0.2820948 * dataView.getFloat32(off + dcR * 4, true);
+      colors[i * 4 + 1] = 0.5 + 0.2820948 * dataView.getFloat32(off + dcG * 4, true);
+      colors[i * 4 + 2] = 0.5 + 0.2820948 * dataView.getFloat32(off + dcB * 4, true);
+    } else if (rIdx >= 0) {
+      colors[i * 4] = dataView.getUint8(off + rIdx) / 255;
+      colors[i * 4 + 1] = dataView.getUint8(off + gIdx) / 255;
+      colors[i * 4 + 2] = dataView.getUint8(off + bIdx) / 255;
+    } else {
+      colors[i * 4] = 0.7;
+      colors[i * 4 + 1] = 0.7;
+      colors[i * 4 + 2] = 0.7;
+    }
+    colors[i * 4 + 3] = 1.0;
+  }
+
+  return { positions, colors };
+}
+
+const pointCloudMaterial = new THREE.ShaderMaterial({
+  vertexShader: `
+    uniform float uPointSize;
+    uniform float uOpacity;
+    varying vec4 vColor;
+    void main() {
+      vColor = vec4(color.rgb, uOpacity);
+      vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+      gl_PointSize = uPointSize * (20.0 / -mvPosition.z);
+      gl_Position = projectionMatrix * mvPosition;
+    }
+  `,
+  fragmentShader: `
+    varying vec4 vColor;
+    void main() {
+      float d = length(gl_PointCoord - vec2(0.5));
+      if (d > 0.5) discard;
+      gl_FragColor = vColor;
+    }
+  `,
+  vertexColors: true,
+  transparent: true,
+  depthWrite: false,
+});
+
+export function PlyPointCloud({
+  plyPath,
+  projectHandle,
+  visible,
+  position,
+  rotation,
+  scale,
+  pointSize = 1.0,
+  opacity = 1.0,
+}: {
+  plyPath: string;
+  projectHandle: FileSystemDirectoryHandle | null;
+  visible: boolean;
+  position?: [number, number, number];
+  rotation?: [number, number, number];
+  scale?: number;
+  pointSize?: number;
+  opacity?: number;
+}) {
+  const [geometry, setGeometry] = useState<THREE.BufferGeometry | null>(null);
+
+  useEffect(() => {
+    if (!plyPath || !projectHandle || !visible) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const blob = await readFileAtPath(projectHandle, plyPath);
+        if (cancelled) return;
+        const buffer = await blob.arrayBuffer();
+        if (cancelled) return;
+
+        const parsed = parsePlyBuffer(buffer);
+        if (!parsed || cancelled) return;
+
+        const geo = new THREE.BufferGeometry();
+        geo.setAttribute('position', new THREE.BufferAttribute(parsed.positions, 3));
+        geo.setAttribute('color', new THREE.BufferAttribute(parsed.colors, 4));
+        setGeometry(geo);
+      } catch {
+        // PLY file not found — silently ignore
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [plyPath, projectHandle, visible]);
+
+  const material = useMemo(() => {
+    const mat = pointCloudMaterial.clone();
+    mat.uniforms.uPointSize = { value: pointSize };
+    mat.uniforms.uOpacity = { value: opacity };
+    return mat;
+  }, [pointSize, opacity]);
+
+  if (!visible || !geometry) return null;
+
+  const rot = rotation
+    ? [rotation[0] * Math.PI / 180, rotation[1] * Math.PI / 180, rotation[2] * Math.PI / 180] as [number, number, number]
+    : undefined;
+
+  return (
+    <points
+      geometry={geometry}
+      material={material}
+      position={position}
+      rotation={rot}
+      scale={scale !== undefined ? [scale, scale, scale] : undefined}
+    />
+  );
+}

--- a/tools/apps/bricklayer/src/viewport/PlyPointCloud.tsx
+++ b/tools/apps/bricklayer/src/viewport/PlyPointCloud.tsx
@@ -89,7 +89,7 @@ const pointCloudMaterial = new THREE.ShaderMaterial({
     void main() {
       vColor = vec4(color.rgb, uOpacity);
       vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
-      gl_PointSize = uPointSize * (20.0 / -mvPosition.z);
+      gl_PointSize = max(1.5, uPointSize * (20.0 / -mvPosition.z));
       gl_Position = projectionMatrix * mvPosition;
     }
   `,

--- a/tools/apps/bricklayer/src/viewport/TerrainPlyReference.tsx
+++ b/tools/apps/bricklayer/src/viewport/TerrainPlyReference.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useSceneStore } from '../store/useSceneStore.js';
+import { PlyPointCloud } from './PlyPointCloud.js';
+
+function slugify(name: string): string {
+  const cleaned = name.toLowerCase().trim().replace(/\s+/g, '_').replace(/[^a-z0-9_-]/g, '');
+  return cleaned.length > 0 ? cleaned : 'map';
+}
+
+export function TerrainPlyReference() {
+  const projectName = useSceneStore((s) => s.projectName);
+  const projectHandle = useSceneStore((s) => s.projectHandle);
+  const visible = useSceneStore((s) => s.showTerrainPly);
+
+  const plyPath = `assets/maps/${slugify(projectName)}.ply`;
+
+  return (
+    <PlyPointCloud
+      plyPath={plyPath}
+      projectHandle={projectHandle}
+      visible={visible}
+      pointSize={0.8}
+      opacity={0.7}
+    />
+  );
+}

--- a/tools/apps/bricklayer/src/viewport/TerrainPlyReference.tsx
+++ b/tools/apps/bricklayer/src/viewport/TerrainPlyReference.tsx
@@ -2,21 +2,16 @@ import React from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
 import { PlyPointCloud } from './PlyPointCloud.js';
 
-function slugify(name: string): string {
-  const cleaned = name.toLowerCase().trim().replace(/\s+/g, '_').replace(/[^a-z0-9_-]/g, '');
-  return cleaned.length > 0 ? cleaned : 'map';
-}
-
 export function TerrainPlyReference() {
-  const projectName = useSceneStore((s) => s.projectName);
+  const terrainPlyFile = useSceneStore((s) => s.terrainPlyFile);
   const projectHandle = useSceneStore((s) => s.projectHandle);
   const visible = useSceneStore((s) => s.showTerrainPly);
 
-  const plyPath = `assets/maps/${slugify(projectName)}.ply`;
+  if (!terrainPlyFile) return null;
 
   return (
     <PlyPointCloud
-      plyPath={plyPath}
+      plyPath={terrainPlyFile}
       projectHandle={projectHandle}
       visible={visible}
       pointSize={0.8}

--- a/tools/apps/bricklayer/src/viewport/TerrainPlyReference.tsx
+++ b/tools/apps/bricklayer/src/viewport/TerrainPlyReference.tsx
@@ -1,34 +1,19 @@
 import React from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
-import { useWorldStore } from '../store/useWorldStore.js';
 import { PlyPointCloud } from './PlyPointCloud.js';
-import { chunkAabbMin, chunkGridKey } from '@gseurat/project-root';
 
 export function TerrainPlyReference() {
   const terrainPlyFile = useSceneStore((s) => s.terrainPlyFile);
   const projectHandle = useSceneStore((s) => s.projectHandle);
   const visible = useSceneStore((s) => s.showTerrainPly);
-  const editingContext = useWorldStore((s) => s.editingContext);
-  const manifest = useWorldStore((s) => s.manifest);
 
   if (!terrainPlyFile) return null;
-
-  // Compute chunk offset so terrain PLY aligns with local-space game objects
-  let offset: [number, number, number] = [0, 0, 0];
-  if (editingContext?.type === 'chunk') {
-    const chunk = manifest.chunks.find((c) => chunkGridKey(c.grid) === editingContext.gridKey);
-    if (chunk) {
-      const worldMin = chunkAabbMin(chunk.grid, manifest.grid_cell_size);
-      offset = [-worldMin[0], -worldMin[1], -worldMin[2]];
-    }
-  }
 
   return (
     <PlyPointCloud
       plyPath={terrainPlyFile}
       projectHandle={projectHandle}
       visible={visible}
-      position={offset}
       pointSize={2.5}
       opacity={0.7}
     />

--- a/tools/apps/bricklayer/src/viewport/TerrainPlyReference.tsx
+++ b/tools/apps/bricklayer/src/viewport/TerrainPlyReference.tsx
@@ -1,20 +1,35 @@
 import React from 'react';
 import { useSceneStore } from '../store/useSceneStore.js';
+import { useWorldStore } from '../store/useWorldStore.js';
 import { PlyPointCloud } from './PlyPointCloud.js';
+import { chunkAabbMin, chunkGridKey } from '@gseurat/project-root';
 
 export function TerrainPlyReference() {
   const terrainPlyFile = useSceneStore((s) => s.terrainPlyFile);
   const projectHandle = useSceneStore((s) => s.projectHandle);
   const visible = useSceneStore((s) => s.showTerrainPly);
+  const editingContext = useWorldStore((s) => s.editingContext);
+  const manifest = useWorldStore((s) => s.manifest);
 
   if (!terrainPlyFile) return null;
+
+  // Compute chunk offset so terrain PLY aligns with local-space game objects
+  let offset: [number, number, number] = [0, 0, 0];
+  if (editingContext?.type === 'chunk') {
+    const chunk = manifest.chunks.find((c) => chunkGridKey(c.grid) === editingContext.gridKey);
+    if (chunk) {
+      const worldMin = chunkAabbMin(chunk.grid, manifest.grid_cell_size);
+      offset = [-worldMin[0], -worldMin[1], -worldMin[2]];
+    }
+  }
 
   return (
     <PlyPointCloud
       plyPath={terrainPlyFile}
       projectHandle={projectHandle}
       visible={visible}
-      pointSize={0.8}
+      position={offset}
+      pointSize={2.5}
       opacity={0.7}
     />
   );

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -16,6 +16,7 @@ import { CameraZoneMarkers } from './CameraZoneMarkers.js';
 import { CameraRailMarkers } from './CameraRailMarkers.js';
 import { CameraFrustumGizmo } from './CameraFrustumGizmo.js';
 import { ChunkWireframes } from './ChunkWireframes.js';
+import { TerrainPlyReference } from './TerrainPlyReference.js';
 import { useSceneStore } from '../store/useSceneStore.js';
 
 // Module-level ref so App.tsx can access the orbit controls for F/Home keys
@@ -303,6 +304,7 @@ function SceneContent() {
       )}
 
       <GroundPlane />
+      <TerrainPlyReference />
       <LightGizmos />
       <GameObjectMarkers />
       <GsEmitterMarkers />

--- a/tools/packages/project-root/src/world.ts
+++ b/tools/packages/project-root/src/world.ts
@@ -22,6 +22,7 @@ export interface WorldInstance {
   id: string;
   display_name: string;
   scene_file: string;
+  ply_file?: string;
 }
 
 export interface WorldPortal {


### PR DESCRIPTION
## Summary

- Add `PlyPointCloud` shared component — loads binary PLY files and renders as point clouds (SH DC + RGB color support)
- Add `TerrainPlyReference` — renders terrain PLY (`assets/maps/<project>.ply`) at world origin as read-only background reference
- Enhance `GameObjectMarkers` — renders PLY point clouds for objects with `ply_file` set, with position/rotation/scale transforms
- Add View menu toggles: "Terrain PLY" (off by default) and "Object PLY" (on by default)

## Test plan
- [ ] Build passes (`pnpm --filter bricklayer build`)
- [ ] Open Bricklayer, load a project with PLY files
- [ ] View > Object PLY toggle shows/hides game object point clouds
- [ ] View > Terrain PLY toggle shows/hides terrain reference layer
- [ ] Point clouds render at correct positions with correct colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)