### PR TITLE
fix: make terrain PLY opaque with depth write

### DIFF
--- a/docs/superpowers/specs/2026-04-18-ply-point-cloud-reference-design.md
+++ b/docs/superpowers/specs/2026-04-18-ply-point-cloud-reference-design.md
@@ -16,15 +16,26 @@
 - Keep wireframe cube as fallback when no PLY or toggle off
 
 ### TerrainPlyReference.tsx (new)
-- Path derived from `projectName`: `assets/maps/<slug>.ply`
-- Renders at world origin
+- Path from `terrainPlyFile` store value, sourced from `world.json` chunk/instance `ply_file`
+- Renders at world origin in PLY capture space (no coordinate transform)
+- Opaque with depth write enabled
 - Controlled by `showTerrainPly` toggle
 
 ## Store Changes (useSceneStore)
 - `showTerrainPly: boolean` (default `false`)
 - `showObjectPly: boolean` (default `true`)
-- `setShowTerrainPly`, `setShowObjectPly` setters
+- `terrainPlyFile: string` (set from world manifest when switching scenes)
+- `setShowTerrainPly`, `setShowObjectPly`, `setTerrainPlyFile` setters
+
+## Schema Changes (project-root)
+- `WorldInstance` gains optional `ply_file?: string`
+- `WorldChunk` already has `ply_file: string`
+- Terrain PLY path is owned by `world.json`, not derived from project name
 
 ## UI Changes
 - View menu: "Terrain PLY" and "Object PLY" toggles
+- Instance editor: "PLY File" text field in WorldPropertiesPanel
 - Viewport.tsx: add `<TerrainPlyReference />`
+
+## Coordinate Spaces
+PLY files are in capture space (from Echidna/3DGS training), game objects are in engine world space. These are independent coordinate systems — the PLY renders at its native coordinates as a visual reference.

--- a/tools/apps/bricklayer/src/viewport/PlyPointCloud.tsx
+++ b/tools/apps/bricklayer/src/viewport/PlyPointCloud.tsx
@@ -183,6 +183,9 @@ export function PlyPointCloud({
     const mat = pointCloudMaterial.clone();
     mat.uniforms.uPointSize = { value: pointSize };
     mat.uniforms.uOpacity = { value: opacity };
+    const isOpaque = opacity >= 1.0;
+    mat.transparent = !isOpaque;
+    mat.depthWrite = isOpaque;
     return mat;
   }, [pointSize, opacity]);
 

--- a/tools/apps/bricklayer/src/viewport/TerrainPlyReference.tsx
+++ b/tools/apps/bricklayer/src/viewport/TerrainPlyReference.tsx
@@ -15,7 +15,7 @@ export function TerrainPlyReference() {
       projectHandle={projectHandle}
       visible={visible}
       pointSize={2.5}
-      opacity={0.7}
+      opacity={1.0}
     />
   );
 }


### PR DESCRIPTION
## Summary

- Terrain PLY opacity set to 1.0 (was 0.7)
- PlyPointCloud material enables `depthWrite` and disables `transparent` when opacity >= 1.0

## Test plan
- [ ] Terrain PLY renders solid, not see-through
- [ ] Points occlude each other correctly (depth ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)