### PR TITLE
feat(weaver): undo/redo, QA polish, and remaining bug fixes

### DIFF
--- a/tools/apps/weaver/src/App.tsx
+++ b/tools/apps/weaver/src/App.tsx
@@ -57,16 +57,38 @@ export function App() {
     })();
   }, [projectRootHandle]);
 
-  // Cmd+S keyboard shortcut
+  // Keyboard shortcuts
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      // Don't intercept when typing in an input
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+
       if ((e.metaKey || e.ctrlKey) && e.key === 's') {
         e.preventDefault();
         useWeaverStore.getState().saveProject();
+      } else if (e.key === ' ') {
+        e.preventDefault();
+        const s = useWeaverStore.getState();
+        s.setIsPlaying(!s.isPlaying);
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        useWeaverStore.getState().setPlayheadFrame(0);
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  // Warn on tab close with unsaved changes
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (useWeaverStore.getState().dirty) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
   }, []);
 
   const handleOpenProjectRoot = useCallback(async () => {

--- a/tools/apps/weaver/src/App.tsx
+++ b/tools/apps/weaver/src/App.tsx
@@ -67,6 +67,12 @@ export function App() {
       if ((e.metaKey || e.ctrlKey) && e.key === 's') {
         e.preventDefault();
         useWeaverStore.getState().saveProject();
+      } else if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'z') {
+        e.preventDefault();
+        useWeaverStore.getState().redo();
+      } else if ((e.metaKey || e.ctrlKey) && e.key === 'z') {
+        e.preventDefault();
+        useWeaverStore.getState().undo();
       } else if (e.key === ' ') {
         e.preventDefault();
         const s = useWeaverStore.getState();

--- a/tools/apps/weaver/src/components/MenuBar.tsx
+++ b/tools/apps/weaver/src/components/MenuBar.tsx
@@ -71,6 +71,10 @@ export function MenuBar() {
     const state = useWeaverStore.getState();
     state.flushActiveGroup();
     const flushed = useWeaverStore.getState();
+    if (flushed.groups.length === 0) {
+      alert('No track groups to export. Add at least one group first.');
+      return;
+    }
     const config = exportMultiGroupConfig(flushed.sampleRate, flushed.groups);
     downloadJson(config, `${flushed.projectName}.music.json`);
   };
@@ -222,7 +226,7 @@ export function MenuBar() {
           )}
         </div>
 
-        {/* Edit menu - placeholder for future */}
+        {/* Edit menu */}
         <div style={{ position: 'relative' }}>
           <button
             style={openMenu === 'edit' ? menuBtnActiveStyle : menuBtnStyle}
@@ -233,11 +237,19 @@ export function MenuBar() {
           </button>
           {openMenu === 'edit' && (
             <div style={dropdownStyle}>
-              <button style={{ ...itemStyle, color: '#666' }} disabled>
-                Undo (coming soon)
+              <button
+                style={{ ...itemStyle, opacity: useWeaverStore.getState().canUndo() ? 1 : 0.4 }}
+                disabled={!useWeaverStore.getState().canUndo()}
+                onClick={() => { close(); useWeaverStore.getState().undo(); }}
+              >
+                Undo <span style={{ float: 'right', color: '#888' }}>{'\u2318'}Z</span>
               </button>
-              <button style={{ ...itemStyle, color: '#666' }} disabled>
-                Redo (coming soon)
+              <button
+                style={{ ...itemStyle, opacity: useWeaverStore.getState().canRedo() ? 1 : 0.4 }}
+                disabled={!useWeaverStore.getState().canRedo()}
+                onClick={() => { close(); useWeaverStore.getState().redo(); }}
+              >
+                Redo <span style={{ float: 'right', color: '#888' }}>{'\u2318\u21E7'}Z</span>
               </button>
             </div>
           )}

--- a/tools/apps/weaver/src/components/Ruler.tsx
+++ b/tools/apps/weaver/src/components/Ruler.tsx
@@ -5,6 +5,7 @@ import { frameToPixel, pixelToFrame, frameToBarBeat } from '../lib/frameUtils.js
 const LABEL_WIDTH = 120;
 const RULER_HEIGHT = 32;
 const HANDLE_SIZE = 10;
+const MIN_LOOP_FRAMES = 4410; // Must match useAudioPlayer
 
 export function Ruler() {
   const rulerRef = useRef<HTMLDivElement>(null);
@@ -126,6 +127,7 @@ export function Ruler() {
   const loopStartPx = LABEL_WIDTH + frameToPixel(loopStart, viewStart, viewEnd, waveWidth);
   const loopEndPx = LABEL_WIDTH + frameToPixel(loopEnd, viewStart, viewEnd, waveWidth);
   const playheadPx = LABEL_WIDTH + frameToPixel(playheadFrame, viewStart, viewEnd, waveWidth);
+  const loopTooSmall = loopEnd > loopStart && (loopEnd - loopStart) < MIN_LOOP_FRAMES;
 
   return (
     <div
@@ -164,12 +166,15 @@ export function Ruler() {
         </div>
       ))}
 
-      {/* Loop region highlight */}
+      {/* Loop region highlight — red when too small to loop */}
       {loopEnd > loopStart && (
         <div style={{
           position: 'absolute', left: loopStartPx, top: 0,
           width: loopEndPx - loopStartPx, height: '100%',
-          background: loopEnabled ? 'rgba(68, 204, 102, 0.15)' : 'rgba(68, 204, 102, 0.05)', pointerEvents: 'none',
+          background: loopTooSmall
+            ? 'rgba(255, 68, 68, 0.2)'
+            : loopEnabled ? 'rgba(68, 204, 102, 0.15)' : 'rgba(68, 204, 102, 0.05)',
+          pointerEvents: 'none',
         }} />
       )}
 

--- a/tools/apps/weaver/src/components/StemLane.tsx
+++ b/tools/apps/weaver/src/components/StemLane.tsx
@@ -4,6 +4,7 @@ import { frameToPixel } from '../lib/frameUtils.js';
 
 const LABEL_WIDTH = 120;
 const LANE_HEIGHT = 80;
+const STEM_COLORS = ['#4488ff', '#44cc66', '#ff8844', '#cc44ff', '#44cccc', '#ff4488', '#88cc44', '#ff44cc'];
 
 interface StemLaneProps {
   index: number;
@@ -66,7 +67,7 @@ export function StemLane({ index }: StemLaneProps) {
       const totalFrames = stem.audioBuffer?.length ?? 0;
       const midY = h / 2;
       ctx.beginPath();
-      ctx.strokeStyle = '#4488ff';
+      ctx.strokeStyle = STEM_COLORS[index % STEM_COLORS.length];
       ctx.lineWidth = 1;
 
       for (let px = 0; px < waveWidth; px++) {

--- a/tools/apps/weaver/src/components/StemLane.tsx
+++ b/tools/apps/weaver/src/components/StemLane.tsx
@@ -164,7 +164,9 @@ export function StemLane({ index }: StemLaneProps) {
           </button>
         </div>
         <button
-          onClick={() => removeStem(index)}
+          onClick={() => {
+            if (confirm(`Remove ${stem.fileName}?`)) removeStem(index);
+          }}
           style={{ position: 'absolute', top: 2, right: 2, padding: '0 4px', fontSize: 10 }}
         >
           ✕

--- a/tools/apps/weaver/src/hooks/useAudioPlayer.ts
+++ b/tools/apps/weaver/src/hooks/useAudioPlayer.ts
@@ -125,6 +125,13 @@ export function useAudioPlayer() {
 
     sourcesRef.current = sources;
     gainsRef.current = gains;
+
+    // Don't start animation if no sources were created
+    if (sources.length === 0) {
+      useWeaverStore.getState().setIsPlaying(false);
+      return;
+    }
+
     startTimeRef.current = ctx.currentTime;
     startFrameRef.current = playheadFrame;
 

--- a/tools/apps/weaver/src/store/useWeaverStore.ts
+++ b/tools/apps/weaver/src/store/useWeaverStore.ts
@@ -367,7 +367,7 @@ export const useWeaverStore = create<WeaverStore>((set, get) => ({
   setLoopStart: (frame) => set({ loopStart: Math.max(0, frame), dirty: true }),
   setLoopEnd: (frame) => set({ loopEnd: Math.max(0, frame), dirty: true }),
   setLoopEnabled: (enabled) => set({ loopEnabled: enabled, dirty: true }),
-  setBpm: (bpm) => set({ bpm, dirty: true }),
+  setBpm: (bpm) => set({ bpm: Math.max(1, Math.min(999, bpm || 120)), dirty: true }),
   setGroupName: (name) => {
     const s = get();
     if (s.activeGroupId) s.renameGroup(s.activeGroupId, name);

--- a/tools/apps/weaver/src/store/useWeaverStore.ts
+++ b/tools/apps/weaver/src/store/useWeaverStore.ts
@@ -19,6 +19,33 @@ function getAudioContext(): AudioContext {
   return sharedCtx;
 }
 
+// ── Undo/Redo snapshot (lightweight — no AudioBuffers) ──
+
+interface UndoSnapshot {
+  stems: { sourcePath: string; initialVolume: number; muted: boolean; soloed: boolean }[];
+  bpm: number;
+  loopStart: number;
+  loopEnd: number;
+  loopEnabled: boolean;
+  markers: MarkerState[];
+}
+
+const MAX_UNDO = 50;
+
+function captureSnapshot(s: Pick<WeaverStore, 'stems' | 'bpm' | 'loopStart' | 'loopEnd' | 'loopEnabled' | 'markers'>): UndoSnapshot {
+  return {
+    stems: s.stems.map((st) => ({
+      sourcePath: st.sourcePath, initialVolume: st.initialVolume,
+      muted: st.muted, soloed: st.soloed,
+    })),
+    bpm: s.bpm,
+    loopStart: s.loopStart,
+    loopEnd: s.loopEnd,
+    loopEnabled: s.loopEnabled,
+    markers: s.markers.map((m) => ({ ...m })),
+  };
+}
+
 interface WeaverStore {
   // === Project-level ===
   projectName: string;
@@ -68,6 +95,15 @@ interface WeaverStore {
   moveMarker: (index: number, frame: number) => void;
   setIsPlaying: (playing: boolean) => void;
   setPlayheadFrame: (frame: number) => void;
+
+  // Undo/Redo
+  undoStack: UndoSnapshot[];
+  redoStack: UndoSnapshot[];
+  pushUndo: () => void;
+  undo: () => void;
+  redo: () => void;
+  canUndo: () => boolean;
+  canRedo: () => boolean;
 
   viewStartFrame: number;
   viewEndFrame: number;
@@ -296,6 +332,8 @@ export const useWeaverStore = create<WeaverStore>((set, get) => ({
       playheadFrame: 0,
       viewStartFrame: 0,
       viewEndFrame: maxLen > 0 ? maxLen : 44100,
+      undoStack: [],
+      redoStack: [],
     });
   },
 
@@ -309,6 +347,7 @@ export const useWeaverStore = create<WeaverStore>((set, get) => ({
   playheadFrame: 0,
 
   addStem: async (file: File) => {
+    get().pushUndo();
     const ctx = getAudioContext();
     const { audioBuffer, waveformPeaks } = await decodeStemFile(file, ctx);
     const s = get();
@@ -343,8 +382,10 @@ export const useWeaverStore = create<WeaverStore>((set, get) => ({
     });
   },
 
-  removeStem: (index) =>
-    set((s) => ({ stems: s.stems.filter((_, i) => i !== index), dirty: true })),
+  removeStem: (index) => {
+    get().pushUndo();
+    set((s) => ({ stems: s.stems.filter((_, i) => i !== index), dirty: true }));
+  },
 
   setStemVolume: (index, volume) =>
     set((s) => ({
@@ -352,47 +393,130 @@ export const useWeaverStore = create<WeaverStore>((set, get) => ({
       dirty: true,
     })),
 
-  toggleMute: (index) =>
+  toggleMute: (index) => {
+    get().pushUndo();
     set((s) => ({
       stems: s.stems.map((st, i) => i === index ? { ...st, muted: !st.muted } : st),
       dirty: true,
-    })),
+    }));
+  },
 
-  toggleSolo: (index) =>
+  toggleSolo: (index) => {
+    get().pushUndo();
     set((s) => ({
       stems: s.stems.map((st, i) => i === index ? { ...st, soloed: !st.soloed } : st),
       dirty: true,
-    })),
+    }));
+  },
 
-  setLoopStart: (frame) => set({ loopStart: Math.max(0, frame), dirty: true }),
-  setLoopEnd: (frame) => set({ loopEnd: Math.max(0, frame), dirty: true }),
+  setLoopStart: (frame) => { get().pushUndo(); set({ loopStart: Math.max(0, frame), dirty: true }); },
+  setLoopEnd: (frame) => { get().pushUndo(); set({ loopEnd: Math.max(0, frame), dirty: true }); },
   setLoopEnabled: (enabled) => set({ loopEnabled: enabled, dirty: true }),
-  setBpm: (bpm) => set({ bpm: Math.max(1, Math.min(999, bpm || 120)), dirty: true }),
+  setBpm: (bpm) => { get().pushUndo(); set({ bpm: Math.max(1, Math.min(999, bpm || 120)), dirty: true }); },
   setGroupName: (name) => {
     const s = get();
     if (s.activeGroupId) s.renameGroup(s.activeGroupId, name);
   },
 
-  addMarker: (frame, name) =>
+  addMarker: (frame, name) => {
+    get().pushUndo();
     set((s) => ({
       markers: [...s.markers, { frame, name: name ?? `Marker ${s.markers.length + 1}` }],
       dirty: true,
-    })),
-  removeMarker: (index) =>
-    set((s) => ({ markers: s.markers.filter((_, i) => i !== index), dirty: true })),
+    }));
+  },
+  removeMarker: (index) => {
+    get().pushUndo();
+    set((s) => ({ markers: s.markers.filter((_, i) => i !== index), dirty: true }));
+  },
   updateMarker: (index, patch) =>
     set((s) => ({
       markers: s.markers.map((m, i) => i === index ? { ...m, ...patch } : m),
       dirty: true,
     })),
-  moveMarker: (index, frame) =>
+  moveMarker: (index, frame) => {
+    get().pushUndo();
     set((s) => ({
       markers: s.markers.map((m, i) => i === index ? { ...m, frame } : m),
       dirty: true,
-    })),
+    }));
+  },
 
   setIsPlaying: (playing) => set({ isPlaying: playing }),
   setPlayheadFrame: (frame) => set({ playheadFrame: frame }),
+
+  // Undo/Redo
+  undoStack: [],
+  redoStack: [],
+  pushUndo: () => {
+    const s = get();
+    const snapshot = captureSnapshot(s);
+    set((prev) => ({
+      undoStack: [...prev.undoStack.slice(-(MAX_UNDO - 1)), snapshot],
+      redoStack: [],
+    }));
+  },
+  undo: () => {
+    const s = get();
+    if (s.undoStack.length === 0) return;
+    const current = captureSnapshot(s);
+    const prev = s.undoStack[s.undoStack.length - 1];
+    // Restore stems: match by sourcePath to preserve AudioBuffers
+    const restoredStems = prev.stems.map((ps) => {
+      const existing = s.stems.find((st) => st.sourcePath === ps.sourcePath);
+      return {
+        fileName: existing?.fileName ?? ps.sourcePath.split('/').pop() ?? '',
+        sourcePath: ps.sourcePath,
+        initialVolume: ps.initialVolume,
+        audioBuffer: existing?.audioBuffer ?? null,
+        waveformPeaks: existing?.waveformPeaks ?? null,
+        muted: ps.muted,
+        soloed: ps.soloed,
+      };
+    });
+    set({
+      undoStack: s.undoStack.slice(0, -1),
+      redoStack: [...s.redoStack, current],
+      stems: restoredStems,
+      bpm: prev.bpm,
+      loopStart: prev.loopStart,
+      loopEnd: prev.loopEnd,
+      loopEnabled: prev.loopEnabled,
+      markers: prev.markers.map((m) => ({ ...m })),
+      dirty: true,
+    });
+  },
+  redo: () => {
+    const s = get();
+    if (s.redoStack.length === 0) return;
+    const current = captureSnapshot(s);
+    const next = s.redoStack[s.redoStack.length - 1];
+    const restoredStems = next.stems.map((ns) => {
+      const existing = s.stems.find((st) => st.sourcePath === ns.sourcePath);
+      return {
+        fileName: existing?.fileName ?? ns.sourcePath.split('/').pop() ?? '',
+        sourcePath: ns.sourcePath,
+        initialVolume: ns.initialVolume,
+        audioBuffer: existing?.audioBuffer ?? null,
+        waveformPeaks: existing?.waveformPeaks ?? null,
+        muted: ns.muted,
+        soloed: ns.soloed,
+      };
+    });
+    set({
+      redoStack: s.redoStack.slice(0, -1),
+      undoStack: [...s.undoStack, current],
+      stems: restoredStems,
+      bpm: next.bpm,
+      loopStart: next.loopStart,
+      loopEnd: next.loopEnd,
+      loopEnabled: next.loopEnabled,
+      markers: next.markers.map((m) => ({ ...m })),
+      dirty: true,
+    });
+  },
+  canUndo: () => get().undoStack.length > 0,
+  canRedo: () => get().redoStack.length > 0,
 
   viewStartFrame: 0,
   viewEndFrame: 0,


### PR DESCRIPTION
## Summary

Complete QA polish pass for Weaver with undo/redo and all reported issues fixed.

### Undo/Redo (#288)
- Snapshot-based undo stack (max 50 entries)
- Captures stems metadata, BPM, loop points, markers (NOT AudioBuffers — matched by sourcePath on restore)
- Cmd+Z / Cmd+Shift+Z keyboard shortcuts
- Edit menu wired with disabled state when stack is empty
- Stack cleared on group switch (per-group context)

### Bug Fixes
- **#286** beforeunload warning for unsaved changes
- **#287** BPM validation: clamp to [1, 999]
- **#291** Loop region turns red when too small (<100ms)
- **#292** Stem delete shows confirmation dialog
- **#293** Export with 0 groups shows warning
- **#294** Play with no stems auto-stops

### Enhancements
- **#289** Keyboard shortcuts: Space=play/stop, Home=rewind
- **#290** Unique waveform color per stem (8-color palette)

## Test plan
- [ ] Cmd+Z undoes last action (add marker, change BPM, etc.)
- [ ] Cmd+Shift+Z redoes
- [ ] Edit menu shows Undo/Redo with enabled/disabled state
- [ ] Close tab with unsaved changes — browser warns
- [ ] Set BPM to 0 — clamps to 1
- [ ] Space toggles play/stop
- [ ] Small loop region (<100ms) shows red highlight
- [ ] Stem delete shows "Remove filename?" confirmation
- [ ] Export with 0 groups shows alert
- [ ] Play with no stems doesn't run animation
- [ ] 4+ stems each have unique waveform color
- [ ] `pnpm --filter weaver build` passes
- [ ] `pnpm --filter weaver test -- --run` — 14 tests pass

Closes #286, #287, #288, #289, #290, #291, #292, #293, #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)