### PR TITLE
fix: polish debug dump panel annotations and audio state

### DIFF
--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -93,15 +93,16 @@ void AppBase::main_loop() {
     std::optional<AudioEngineDumper> audio_dumper;
     if (audio_engine_) {
         audio_dumper.emplace([this]() -> AudioEngineDumper::Snapshot {
-            // Minimal snapshot — actual Mixer internals will be exposed
-            // once the friend accessor API is added in a future phase.
+            // Read what we can from the public AudioEngine API.
+            // Full Mixer state (stems, voices, groups) requires a friend
+            // accessor that will be added in a future phase.
             return AudioEngineDumper::Snapshot{
                 .master_volume      = 1.0f,
                 .sample_rate        = 44100,
                 .max_polyphony      = 64,
                 .active_voice_count = 0,
                 .active_group_count = 0,
-                .dropped_commands   = 0,
+                .dropped_commands   = audio_engine_->dropped_command_count(),
             };
         });
         debug_dump_registry_.register_module(&*audio_dumper);

--- a/tools/apps/bricklayer/src/panels/MasterTree.tsx
+++ b/tools/apps/bricklayer/src/panels/MasterTree.tsx
@@ -658,7 +658,7 @@ export function MasterTree() {
     editingContext?.type === 'instance' && editingContext.id === id;
 
   return (
-    <div style={s.tree}>
+    <div data-panel-id="master-tree" style={s.tree}>
       <div style={s.heading}>{projectName} / WORLD</div>
 
       {/* ── Chunks ── */}

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -496,7 +496,7 @@ export function MenuBar() {
   ];
 
   return (
-    <div style={styles.bar}>
+    <div data-panel-id="menu-bar" style={styles.bar}>
       <DropdownMenu
         label="File"
         items={fileItems}

--- a/tools/apps/echidna/src/panels/MenuBar.tsx
+++ b/tools/apps/echidna/src/panels/MenuBar.tsx
@@ -641,7 +641,7 @@ export function MenuBar() {
   ];
 
   return (
-    <div style={styles.bar}>
+    <div data-panel-id="menu-bar" style={styles.bar}>
       <DropdownMenu
         label="File"
         items={fileItems}

--- a/tools/apps/melies/src/App.tsx
+++ b/tools/apps/melies/src/App.tsx
@@ -259,7 +259,7 @@ function MenuBar({ onImportScene }: { onImportScene?: () => void }) {
   }, [fileOpen]);
 
   return (
-    <div style={{
+    <div data-panel-id="menu-bar" style={{
       height: 32, background: T.panel, borderBottom: `1px solid ${T.border}`,
       display: 'flex', alignItems: 'center', padding: '0 8px', gap: 16,
       fontSize: 12, color: T.textDim, userSelect: 'none',
@@ -396,7 +396,7 @@ function VfxTree() {
   };
 
   return (
-    <div style={{
+    <div data-panel-id="left-panel" style={{
       width: 200, background: T.panel, borderRight: `1px solid ${T.border}`,
       display: 'flex', flexDirection: 'column', overflow: 'hidden',
     }}>
@@ -831,8 +831,11 @@ function Timeline() {
 function RightPanel() {
   useComponentRegistry('RightPanel');
   const selectedView = useVfxStore((s) => s.selectedView);
-  if (selectedView === 'preset-settings') return <PresetSettings />;
-  return <LayerProperties />;
+  return (
+    <div data-panel-id="right-panel">
+      {selectedView === 'preset-settings' ? <PresetSettings /> : <LayerProperties />}
+    </div>
+  );
 }
 
 export function App() {


### PR DESCRIPTION
## Summary
- Add `data-panel-id` attributes to key panels (MenuBar, MasterTree, VfxTree, RightPanel) across Bricklayer, Echidna, and Melies so the Eyes debug dumper can discover and report their layout
- Wire up `AudioEngine::dropped_command_count()` in the C++ AudioEngineDumper instead of hardcoded 0

## Test plan
- [ ] Build all three TS apps (`pnpm --filter bricklayer build`, echidna, melies)
- [ ] Build C++ engine (`cmake --build --preset macos-debug`)
- [ ] Open Bricklayer, press Ctrl+Shift+D — verify dump includes `menu-bar`, `master-tree`, `left-panel`, `viewport`, `right-panel`
- [ ] Open Melies — verify dump includes `menu-bar`, `left-panel`, `viewport`, `right-panel`
- [ ] Run Staging, press F12 — verify `dropped_commands` reflects real engine state

🤖 Generated with [Claude Code](https://claude.com/claude-code)