### PR TITLE
feat: camera system for all demo scenes + bricklayer sync CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,21 @@ jobs:
       - name: Test
         run: ctest --test-dir build/linux-release --output-on-failure --label-exclude gpu
 
+  validate-data:
+    runs-on: ubuntu-24.04
+    name: Validate (Demo Data)
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate bricklayer sync
+        run: python3 scripts/validate_bricklayer_sync.py
+
   test-tools:
     runs-on: ubuntu-24.04
     name: Test (TypeScript)

--- a/examples/island_demo/assets/scenes/dungeon.json
+++ b/examples/island_demo/assets/scenes/dungeon.json
@@ -6624,5 +6624,213 @@
       "trigger": "auto",
       "loop": true
     }
-  ]
+  ],
+  "camera_zones": {
+    "default_params": {
+      "mode": "orbit",
+      "blend_time": 1.0,
+      "allow_user_orbit": true,
+      "pitch_min": -70,
+      "pitch_max": -20,
+      "fov": 40,
+      "orbit_distance": 12,
+      "offset": [
+        0,
+        8,
+        -5
+      ]
+    },
+    "volumes": [
+      {
+        "id": "entry_room",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            7,
+            3,
+            7
+          ],
+          "half_extents": [
+            7,
+            5,
+            7
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 1,
+          "orbit_distance": 10,
+          "offset": [
+            0,
+            7,
+            -4
+          ],
+          "fov": 38
+        }
+      },
+      {
+        "id": "main_hall",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            25,
+            3,
+            9
+          ],
+          "half_extents": [
+            8,
+            5,
+            9
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 1,
+          "orbit_distance": 14,
+          "offset": [
+            0,
+            9,
+            -6
+          ],
+          "fov": 42
+        }
+      },
+      {
+        "id": "treasure_room",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            25,
+            3,
+            29
+          ],
+          "half_extents": [
+            8,
+            5,
+            7
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 2,
+          "orbit_distance": 11,
+          "offset": [
+            0,
+            6,
+            -4
+          ],
+          "pitch_min": -60,
+          "pitch_max": -15,
+          "fov": 36
+        }
+      },
+      {
+        "id": "boss_area",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            42,
+            4,
+            38
+          ],
+          "half_extents": [
+            8,
+            6,
+            10
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 3,
+          "orbit_distance": 16,
+          "offset": [
+            0,
+            10,
+            -7
+          ],
+          "fov": 44,
+          "pitch_min": -65,
+          "pitch_max": -10
+        }
+      },
+      {
+        "id": "exit_area",
+        "shape": {
+          "type": "sphere",
+          "center": [
+            45,
+            2,
+            42
+          ],
+          "radius": 6
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 4,
+          "orbit_distance": 8,
+          "offset": [
+            0,
+            4,
+            -3
+          ],
+          "fov": 35
+        }
+      }
+    ],
+    "triggers": [
+      {
+        "shape": {
+          "type": "aabb",
+          "center": [
+            15,
+            3,
+            7
+          ],
+          "half_extents": [
+            2,
+            5,
+            7
+          ]
+        },
+        "from_zone": "entry_room",
+        "to_zone": "main_hall",
+        "blend_override": 0.8
+      },
+      {
+        "shape": {
+          "type": "aabb",
+          "center": [
+            25,
+            3,
+            19
+          ],
+          "half_extents": [
+            8,
+            5,
+            2
+          ]
+        },
+        "from_zone": "main_hall",
+        "to_zone": "treasure_room",
+        "blend_override": 0.8
+      },
+      {
+        "shape": {
+          "type": "aabb",
+          "center": [
+            35,
+            3,
+            29
+          ],
+          "half_extents": [
+            2,
+            5,
+            5
+          ]
+        },
+        "to_zone": "boss_area",
+        "blend_override": 1.0
+      }
+    ]
+  }
 }

--- a/examples/island_demo/assets/scenes/northern_forest.json
+++ b/examples/island_demo/assets/scenes/northern_forest.json
@@ -74545,5 +74545,124 @@
       3.6009
     ],
     "nav_zone": []
+  },
+  "camera_zones": {
+    "default_params": {
+      "mode": "orbit",
+      "blend_time": 2.0,
+      "allow_user_orbit": true,
+      "pitch_min": -50,
+      "pitch_max": 5,
+      "fov": 42,
+      "orbit_distance": 18,
+      "offset": [
+        0,
+        5,
+        -10
+      ]
+    },
+    "volumes": [
+      {
+        "id": "forest_entrance",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            192,
+            5,
+            -192
+          ],
+          "half_extents": [
+            30,
+            20,
+            20
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 1,
+          "orbit_distance": 20,
+          "offset": [
+            0,
+            6,
+            -12
+          ],
+          "fov": 45
+        }
+      },
+      {
+        "id": "mushroom_grove",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            190,
+            3,
+            -290
+          ],
+          "half_extents": [
+            50,
+            20,
+            40
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 2,
+          "orbit_distance": 14,
+          "offset": [
+            0,
+            3,
+            -8
+          ],
+          "pitch_min": -35,
+          "pitch_max": 0,
+          "fov": 38
+        }
+      },
+      {
+        "id": "deep_forest",
+        "shape": {
+          "type": "sphere",
+          "center": [
+            180,
+            3,
+            -322
+          ],
+          "radius": 25
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 2,
+          "orbit_distance": 12,
+          "offset": [
+            0,
+            3,
+            -7
+          ],
+          "pitch_min": -30,
+          "pitch_max": -5,
+          "fov": 36
+        }
+      }
+    ],
+    "triggers": [
+      {
+        "shape": {
+          "type": "aabb",
+          "center": [
+            192,
+            5,
+            -250
+          ],
+          "half_extents": [
+            40,
+            20,
+            5
+          ]
+        },
+        "from_zone": "forest_entrance",
+        "to_zone": "mushroom_grove",
+        "blend_override": 2.5
+      }
+    ]
   }
 }

--- a/examples/island_demo/assets/scenes/seurat_island.json
+++ b/examples/island_demo/assets/scenes/seurat_island.json
@@ -75341,5 +75341,196 @@
       "trigger": "proximity",
       "loop": true
     }
-  ]
+  ],
+  "camera_zones": {
+    "default_params": {
+      "mode": "orbit",
+      "blend_time": 1.5,
+      "allow_user_orbit": true,
+      "pitch_min": -60,
+      "pitch_max": 10,
+      "yaw_min": -180,
+      "yaw_max": 180,
+      "fov": 45,
+      "orbit_distance": 25,
+      "offset": [
+        0,
+        8,
+        -15
+      ]
+    },
+    "volumes": [
+      {
+        "id": "town_center",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            192,
+            5,
+            185
+          ],
+          "half_extents": [
+            25,
+            20,
+            25
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 1,
+          "orbit_distance": 20,
+          "offset": [
+            0,
+            6,
+            -12
+          ],
+          "pitch_min": -45,
+          "pitch_max": 5,
+          "fov": 42
+        }
+      },
+      {
+        "id": "cliff_overlook",
+        "shape": {
+          "type": "sphere",
+          "center": [
+            235,
+            6,
+            145
+          ],
+          "radius": 20
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 2,
+          "orbit_distance": 30,
+          "offset": [
+            0,
+            12,
+            -20
+          ],
+          "pitch_min": -70,
+          "pitch_max": -10,
+          "fov": 50
+        }
+      },
+      {
+        "id": "forest_edge",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            160,
+            5,
+            100
+          ],
+          "half_extents": [
+            40,
+            20,
+            30
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 1,
+          "orbit_distance": 22,
+          "offset": [
+            0,
+            7,
+            -14
+          ],
+          "fov": 48
+        }
+      },
+      {
+        "id": "dungeon_approach",
+        "shape": {
+          "type": "sphere",
+          "center": [
+            203,
+            3,
+            175
+          ],
+          "radius": 12
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 3,
+          "orbit_distance": 15,
+          "offset": [
+            0,
+            5,
+            -8
+          ],
+          "fov": 40,
+          "pitch_min": -30,
+          "pitch_max": 0
+        }
+      }
+    ],
+    "triggers": [
+      {
+        "shape": {
+          "type": "aabb",
+          "center": [
+            192,
+            5,
+            155
+          ],
+          "half_extents": [
+            50,
+            20,
+            5
+          ]
+        },
+        "from_zone": "forest_edge",
+        "to_zone": "town_center",
+        "blend_override": 2.0
+      },
+      {
+        "shape": {
+          "type": "sphere",
+          "center": [
+            203,
+            3,
+            180
+          ],
+          "radius": 5
+        },
+        "to_zone": "dungeon_approach",
+        "blend_override": 1.0
+      }
+    ],
+    "rails": [
+      {
+        "id": "main_path_rail",
+        "control_points": [
+          [
+            150,
+            8,
+            100
+          ],
+          [
+            170,
+            6,
+            140
+          ],
+          [
+            185,
+            5,
+            175
+          ],
+          [
+            195,
+            4,
+            190
+          ],
+          [
+            210,
+            5,
+            180
+          ]
+        ]
+      }
+    ]
+  }
 }

--- a/examples/island_demo/tools_data/bricklayer/dungeon.bricklayer
+++ b/examples/island_demo/tools_data/bricklayer/dungeon.bricklayer
@@ -1860,7 +1860,248 @@
         "trigger": "auto",
         "loop": true
       }
-    ]
+    ],
+    "cameraVolumes": [
+      {
+        "id": "entry_room",
+        "name": "entry_room",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            7,
+            3,
+            7
+          ],
+          "half_extents": [
+            7,
+            5,
+            7
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 1,
+          "blend_time": 1.0,
+          "allow_user_orbit": true,
+          "pitch_min": -70,
+          "pitch_max": -20,
+          "yaw_min": -180,
+          "yaw_max": 180,
+          "fov": 38,
+          "orbit_distance": 10,
+          "offset": [
+            0,
+            7,
+            -4
+          ]
+        }
+      },
+      {
+        "id": "main_hall",
+        "name": "main_hall",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            25,
+            3,
+            9
+          ],
+          "half_extents": [
+            8,
+            5,
+            9
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 1,
+          "blend_time": 1.0,
+          "allow_user_orbit": true,
+          "pitch_min": -70,
+          "pitch_max": -20,
+          "yaw_min": -180,
+          "yaw_max": 180,
+          "fov": 42,
+          "orbit_distance": 14,
+          "offset": [
+            0,
+            9,
+            -6
+          ]
+        }
+      },
+      {
+        "id": "treasure_room",
+        "name": "treasure_room",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            25,
+            3,
+            29
+          ],
+          "half_extents": [
+            8,
+            5,
+            7
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 2,
+          "blend_time": 1.0,
+          "allow_user_orbit": true,
+          "pitch_min": -60,
+          "pitch_max": -15,
+          "yaw_min": -180,
+          "yaw_max": 180,
+          "fov": 36,
+          "orbit_distance": 11,
+          "offset": [
+            0,
+            6,
+            -4
+          ]
+        }
+      },
+      {
+        "id": "boss_area",
+        "name": "boss_area",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            42,
+            4,
+            38
+          ],
+          "half_extents": [
+            8,
+            6,
+            10
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 3,
+          "blend_time": 1.0,
+          "allow_user_orbit": true,
+          "pitch_min": -65,
+          "pitch_max": -10,
+          "yaw_min": -180,
+          "yaw_max": 180,
+          "fov": 44,
+          "orbit_distance": 16,
+          "offset": [
+            0,
+            10,
+            -7
+          ]
+        }
+      },
+      {
+        "id": "exit_area",
+        "name": "exit_area",
+        "shape": {
+          "type": "sphere",
+          "center": [
+            45,
+            2,
+            42
+          ],
+          "radius": 6
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 4,
+          "blend_time": 1.0,
+          "allow_user_orbit": true,
+          "pitch_min": -70,
+          "pitch_max": -20,
+          "yaw_min": -180,
+          "yaw_max": 180,
+          "fov": 35,
+          "orbit_distance": 8,
+          "offset": [
+            0,
+            4,
+            -3
+          ]
+        }
+      }
+    ],
+    "cameraTriggers": [
+      {
+        "id": "trigger_0",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            15,
+            3,
+            7
+          ],
+          "half_extents": [
+            2,
+            5,
+            7
+          ]
+        },
+        "from_zone": "entry_room",
+        "to_zone": "main_hall",
+        "blend_override": 0.8
+      },
+      {
+        "id": "trigger_1",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            25,
+            3,
+            19
+          ],
+          "half_extents": [
+            8,
+            5,
+            2
+          ]
+        },
+        "from_zone": "main_hall",
+        "to_zone": "treasure_room",
+        "blend_override": 0.8
+      },
+      {
+        "id": "trigger_2",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            35,
+            3,
+            29
+          ],
+          "half_extents": [
+            2,
+            5,
+            5
+          ]
+        },
+        "from_zone": "",
+        "to_zone": "boss_area",
+        "blend_override": 1.0
+      }
+    ],
+    "cameraDefaultParams": {
+      "mode": "orbit",
+      "blend_time": 1.0,
+      "allow_user_orbit": true,
+      "pitch_min": -70,
+      "pitch_max": -20,
+      "fov": 40,
+      "orbit_distance": 12,
+      "offset": [
+        0,
+        8,
+        -5
+      ]
+    }
   },
   "collisionGridData": {
     "width": 50,

--- a/examples/island_demo/tools_data/bricklayer/northern_forest.bricklayer
+++ b/examples/island_demo/tools_data/bricklayer/northern_forest.bricklayer
@@ -935,6 +935,141 @@
       "morphDuration": 2,
       "morphDefaultBlend": 0,
       "morphEasing": "linear"
+    },
+    "cameraVolumes": [
+      {
+        "id": "forest_entrance",
+        "name": "forest_entrance",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            192,
+            5,
+            -192
+          ],
+          "half_extents": [
+            30,
+            20,
+            20
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 1,
+          "blend_time": 2.0,
+          "allow_user_orbit": true,
+          "pitch_min": -50,
+          "pitch_max": 5,
+          "yaw_min": -180,
+          "yaw_max": 180,
+          "fov": 45,
+          "orbit_distance": 20,
+          "offset": [
+            0,
+            6,
+            -12
+          ]
+        }
+      },
+      {
+        "id": "mushroom_grove",
+        "name": "mushroom_grove",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            190,
+            3,
+            -290
+          ],
+          "half_extents": [
+            50,
+            20,
+            40
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 2,
+          "blend_time": 2.0,
+          "allow_user_orbit": true,
+          "pitch_min": -35,
+          "pitch_max": 0,
+          "yaw_min": -180,
+          "yaw_max": 180,
+          "fov": 38,
+          "orbit_distance": 14,
+          "offset": [
+            0,
+            3,
+            -8
+          ]
+        }
+      },
+      {
+        "id": "deep_forest",
+        "name": "deep_forest",
+        "shape": {
+          "type": "sphere",
+          "center": [
+            180,
+            3,
+            -322
+          ],
+          "radius": 25
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 2,
+          "blend_time": 2.0,
+          "allow_user_orbit": true,
+          "pitch_min": -30,
+          "pitch_max": -5,
+          "yaw_min": -180,
+          "yaw_max": 180,
+          "fov": 36,
+          "orbit_distance": 12,
+          "offset": [
+            0,
+            3,
+            -7
+          ]
+        }
+      }
+    ],
+    "cameraTriggers": [
+      {
+        "id": "trigger_0",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            192,
+            5,
+            -250
+          ],
+          "half_extents": [
+            40,
+            20,
+            5
+          ]
+        },
+        "from_zone": "forest_entrance",
+        "to_zone": "mushroom_grove",
+        "blend_override": 2.5
+      }
+    ],
+    "cameraDefaultParams": {
+      "mode": "orbit",
+      "blend_time": 2.0,
+      "allow_user_orbit": true,
+      "pitch_min": -50,
+      "pitch_max": 5,
+      "fov": 42,
+      "orbit_distance": 18,
+      "offset": [
+        0,
+        5,
+        -10
+      ]
     }
   },
   "collisionGridData": {

--- a/examples/island_demo/tools_data/bricklayer/seurat_island.bricklayer
+++ b/examples/island_demo/tools_data/bricklayer/seurat_island.bricklayer
@@ -2002,7 +2002,223 @@
         "trigger": "proximity",
         "loop": true
       }
-    ]
+    ],
+    "cameraVolumes": [
+      {
+        "id": "town_center",
+        "name": "town_center",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            192,
+            5,
+            185
+          ],
+          "half_extents": [
+            25,
+            20,
+            25
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 1,
+          "blend_time": 1.5,
+          "allow_user_orbit": true,
+          "pitch_min": -45,
+          "pitch_max": 5,
+          "yaw_min": -180,
+          "yaw_max": 180,
+          "fov": 42,
+          "orbit_distance": 20,
+          "offset": [
+            0,
+            6,
+            -12
+          ]
+        }
+      },
+      {
+        "id": "cliff_overlook",
+        "name": "cliff_overlook",
+        "shape": {
+          "type": "sphere",
+          "center": [
+            235,
+            6,
+            145
+          ],
+          "radius": 20
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 2,
+          "blend_time": 1.5,
+          "allow_user_orbit": true,
+          "pitch_min": -70,
+          "pitch_max": -10,
+          "yaw_min": -180,
+          "yaw_max": 180,
+          "fov": 50,
+          "orbit_distance": 30,
+          "offset": [
+            0,
+            12,
+            -20
+          ]
+        }
+      },
+      {
+        "id": "forest_edge",
+        "name": "forest_edge",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            160,
+            5,
+            100
+          ],
+          "half_extents": [
+            40,
+            20,
+            30
+          ]
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 1,
+          "blend_time": 1.5,
+          "allow_user_orbit": true,
+          "pitch_min": -60,
+          "pitch_max": 10,
+          "yaw_min": -180,
+          "yaw_max": 180,
+          "fov": 48,
+          "orbit_distance": 22,
+          "offset": [
+            0,
+            7,
+            -14
+          ]
+        }
+      },
+      {
+        "id": "dungeon_approach",
+        "name": "dungeon_approach",
+        "shape": {
+          "type": "sphere",
+          "center": [
+            203,
+            3,
+            175
+          ],
+          "radius": 12
+        },
+        "params": {
+          "mode": "orbit",
+          "priority": 3,
+          "blend_time": 1.5,
+          "allow_user_orbit": true,
+          "pitch_min": -30,
+          "pitch_max": 0,
+          "yaw_min": -180,
+          "yaw_max": 180,
+          "fov": 40,
+          "orbit_distance": 15,
+          "offset": [
+            0,
+            5,
+            -8
+          ]
+        }
+      }
+    ],
+    "cameraTriggers": [
+      {
+        "id": "trigger_0",
+        "shape": {
+          "type": "aabb",
+          "center": [
+            192,
+            5,
+            155
+          ],
+          "half_extents": [
+            50,
+            20,
+            5
+          ]
+        },
+        "from_zone": "forest_edge",
+        "to_zone": "town_center",
+        "blend_override": 2.0
+      },
+      {
+        "id": "trigger_1",
+        "shape": {
+          "type": "sphere",
+          "center": [
+            203,
+            3,
+            180
+          ],
+          "radius": 5
+        },
+        "from_zone": "",
+        "to_zone": "dungeon_approach",
+        "blend_override": 1.0
+      }
+    ],
+    "cameraRails": [
+      {
+        "id": "main_path_rail",
+        "name": "main_path_rail",
+        "control_points": [
+          [
+            150,
+            8,
+            100
+          ],
+          [
+            170,
+            6,
+            140
+          ],
+          [
+            185,
+            5,
+            175
+          ],
+          [
+            195,
+            4,
+            190
+          ],
+          [
+            210,
+            5,
+            180
+          ]
+        ],
+        "target_points": []
+      }
+    ],
+    "cameraDefaultParams": {
+      "mode": "orbit",
+      "blend_time": 1.5,
+      "allow_user_orbit": true,
+      "pitch_min": -60,
+      "pitch_max": 10,
+      "yaw_min": -180,
+      "yaw_max": 180,
+      "fov": 45,
+      "orbit_distance": 25,
+      "offset": [
+        0,
+        8,
+        -15
+      ]
+    }
   },
   "collisionGridData": {
     "width": 192,

--- a/scripts/validate_bricklayer_sync.py
+++ b/scripts/validate_bricklayer_sync.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Validate .bricklayer files are in sync with engine scene JSON.
+
+Compares entity counts and key fields between the two formats.
+Returns exit code 1 if any scene is out of sync.
+
+Usage:
+    python3 scripts/validate_bricklayer_sync.py [--fix]
+"""
+
+import json
+import os
+import sys
+
+BASE = "examples/island_demo"
+
+# Map: scene name -> (engine JSON path, bricklayer path)
+SCENES = {
+    "seurat_island": (
+        f"{BASE}/assets/scenes/seurat_island.json",
+        f"{BASE}/tools_data/bricklayer/seurat_island.bricklayer",
+    ),
+    "northern_forest": (
+        f"{BASE}/assets/scenes/northern_forest.json",
+        f"{BASE}/tools_data/bricklayer/northern_forest.bricklayer",
+    ),
+    "dungeon": (
+        f"{BASE}/assets/scenes/dungeon.json",
+        f"{BASE}/tools_data/bricklayer/dungeon.bricklayer",
+    ),
+}
+
+
+def count_entities(engine: dict, bricklayer: dict) -> list[str]:
+    """Compare entity counts. Returns list of mismatch descriptions."""
+    errors = []
+    scene = bricklayer.get("scene", {})
+
+    checks = [
+        ("game_objects", "gameObjects"),
+        ("lights", "staticLights"),
+        ("vfx_instances", "vfxInstances"),
+    ]
+
+    for engine_key, brick_key in checks:
+        e_count = len(engine.get(engine_key, []))
+        b_count = len(scene.get(brick_key, []))
+        if e_count != b_count:
+            errors.append(
+                f"  {engine_key}: engine={e_count}, bricklayer={b_count}"
+            )
+
+    # Camera zones
+    cz = engine.get("camera_zones", {})
+    e_vols = len(cz.get("volumes", []))
+    b_vols = len(scene.get("cameraVolumes", []))
+    if e_vols != b_vols:
+        errors.append(f"  camera_volumes: engine={e_vols}, bricklayer={b_vols}")
+
+    e_trigs = len(cz.get("triggers", []))
+    b_trigs = len(scene.get("cameraTriggers", []))
+    if e_trigs != b_trigs:
+        errors.append(f"  camera_triggers: engine={e_trigs}, bricklayer={b_trigs}")
+
+    e_rails = len(cz.get("rails", []))
+    b_rails = len(scene.get("cameraRails", []))
+    if e_rails != b_rails:
+        errors.append(f"  camera_rails: engine={e_rails}, bricklayer={b_rails}")
+
+    return errors
+
+
+def main():
+    all_ok = True
+
+    for name, (engine_path, brick_path) in SCENES.items():
+        if not os.path.exists(engine_path):
+            print(f"SKIP {name}: engine file not found ({engine_path})")
+            continue
+        if not os.path.exists(brick_path):
+            print(f"FAIL {name}: bricklayer file not found ({brick_path})")
+            all_ok = False
+            continue
+
+        engine = json.load(open(engine_path))
+        brick = json.load(open(brick_path))
+
+        errors = count_entities(engine, brick)
+        if errors:
+            print(f"FAIL {name}:")
+            for e in errors:
+                print(e)
+            all_ok = False
+        else:
+            print(f"OK   {name}")
+
+    if not all_ok:
+        print("\nBricklayer files are out of sync with engine JSON!")
+        print("Run the sync script to fix: python3 scripts/sync_bricklayer.py")
+        sys.exit(1)
+    else:
+        print("\nAll bricklayer files in sync.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add camera volumes, triggers, and rails to all 3 demo scenes
- Add CI validation for bricklayer file sync (prevents empty .bricklayer files)

### Camera Design
- **Seurat Island**: 4 volumes (town_center, cliff_overlook, forest_edge, dungeon_approach), 2 triggers, 1 rail
- **Northern Forest**: 3 volumes (forest_entrance, mushroom_grove, deep_forest), 1 trigger
- **Dungeon**: 5 volumes (entry_room, main_hall, treasure_room, boss_area, exit_area), 3 triggers

### CI
- New `validate-data` job runs `scripts/validate_bricklayer_sync.py` to catch entity count mismatches between engine JSON and .bricklayer files

Closes #310, #313

## Test plan
- [ ] Open each scene in Bricklayer — verify camera volumes appear in scene tree
- [ ] Run in Staging — verify camera transitions work at triggers
- [ ] CI validate-data job passes
- [ ] Intentionally break sync — verify CI catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)