### PR TITLE
fix(weaver): composer QA — playhead, shortcuts, mute/solo, volume input

### DIFF
--- a/tools/apps/weaver/src/App.tsx
+++ b/tools/apps/weaver/src/App.tsx
@@ -77,9 +77,11 @@ export function App() {
   // Keyboard shortcuts
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      // Don't intercept when typing in an input
+      // Don't intercept when typing in an input — but allow modifier shortcuts
       const tag = (e.target as HTMLElement).tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') {
+        if (!((e.metaKey || e.ctrlKey) && (e.key === 's' || e.key === 'z'))) return;
+      }
 
       if ((e.metaKey || e.ctrlKey) && e.key === 's') {
         e.preventDefault();

--- a/tools/apps/weaver/src/components/GroupSelector.tsx
+++ b/tools/apps/weaver/src/components/GroupSelector.tsx
@@ -11,9 +11,13 @@ export function GroupSelector() {
   const dirty = useWeaverStore((s) => s.dirty);
   const saveProject = useWeaverStore((s) => s.saveProject);
 
+  const renameGroup = useWeaverStore((s) => s.renameGroup);
+
   const [pendingSwitchId, setPendingSwitchId] = useState<string | null>(null);
   const [showNewInput, setShowNewInput] = useState(false);
   const [newName, setNewName] = useState('');
+  const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState('');
 
   // ESC key to dismiss dirty dialog
   useEffect(() => {
@@ -78,6 +82,7 @@ export function GroupSelector() {
           <div
             key={g.id}
             onClick={() => handleSwitchRequest(g.id)}
+            onDoubleClick={() => { setEditingGroupId(g.id); setEditingName(g.name); }}
             style={{
               padding: '4px 8px',
               cursor: 'pointer',
@@ -92,9 +97,28 @@ export function GroupSelector() {
             <span style={{ color: g.id === activeGroupId ? '#4488ff' : '#666' }}>
               {g.id === activeGroupId ? '\u25CF' : '\u25CB'}
             </span>
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {g.name}
-            </span>
+            {editingGroupId === g.id ? (
+              <input
+                type="text"
+                value={editingName}
+                onChange={(e) => setEditingName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') { renameGroup(g.id, editingName); setEditingGroupId(null); }
+                  if (e.key === 'Escape') setEditingGroupId(null);
+                }}
+                onBlur={() => { renameGroup(g.id, editingName); setEditingGroupId(null); }}
+                onClick={(e) => e.stopPropagation()}
+                autoFocus
+                style={{
+                  flex: 1, padding: '1px 4px', fontSize: 11,
+                  background: '#111', color: '#eee', border: '1px solid #555', borderRadius: 2,
+                }}
+              />
+            ) : (
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {g.name}
+              </span>
+            )}
           </div>
         ))}
       </div>

--- a/tools/apps/weaver/src/components/Ruler.tsx
+++ b/tools/apps/weaver/src/components/Ruler.tsx
@@ -17,6 +17,7 @@ export function Ruler() {
   const loopEnd = useWeaverStore((s) => s.loopEnd);
   const setLoopStart = useWeaverStore((s) => s.setLoopStart);
   const setLoopEnd = useWeaverStore((s) => s.setLoopEnd);
+  const resetLoop = useWeaverStore((s) => s.resetLoop);
   const markers = useWeaverStore((s) => s.markers);
   const addMarker = useWeaverStore((s) => s.addMarker);
   const moveMarker = useWeaverStore((s) => s.moveMarker);
@@ -169,16 +170,20 @@ export function Ruler() {
         </div>
       ))}
 
-      {/* Loop region highlight — red when too small to loop */}
+      {/* Loop region highlight — red when too small, double-click to reset */}
       {loopEnd > loopStart && (
-        <div style={{
-          position: 'absolute', left: loopStartPx, top: 0,
-          width: loopEndPx - loopStartPx, height: '100%',
-          background: loopTooSmall
-            ? 'rgba(255, 68, 68, 0.2)'
-            : loopEnabled ? 'rgba(68, 204, 102, 0.15)' : 'rgba(68, 204, 102, 0.05)',
-          pointerEvents: 'none',
-        }} />
+        <div
+          onDoubleClick={(e) => { e.stopPropagation(); resetLoop(); }}
+          title="Double-click to reset loop region"
+          style={{
+            position: 'absolute', left: loopStartPx, top: 0,
+            width: loopEndPx - loopStartPx, height: '100%',
+            background: loopTooSmall
+              ? 'rgba(255, 68, 68, 0.2)'
+              : loopEnabled ? 'rgba(68, 204, 102, 0.15)' : 'rgba(68, 204, 102, 0.05)',
+            pointerEvents: 'auto', cursor: 'pointer',
+          }}
+        />
       )}
 
       {/* Loop start handle (green triangle) */}

--- a/tools/apps/weaver/src/components/StemLane.tsx
+++ b/tools/apps/weaver/src/components/StemLane.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import { useWeaverStore } from '../store/useWeaverStore.js';
 import { frameToPixel } from '../lib/frameUtils.js';
 
@@ -8,6 +8,57 @@ const STEM_COLORS = ['#4488ff', '#44cc66', '#ff8844', '#cc44ff', '#44cccc', '#ff
 
 interface StemLaneProps {
   index: number;
+}
+
+function VolumeControl({ value, onChange }: { value: number; onChange: (v: number) => void }) {
+  const [editing, setEditing] = useState(false);
+  const [editText, setEditText] = useState('');
+
+  const commit = () => {
+    const n = parseInt(editText, 10);
+    if (!isNaN(n)) onChange(Math.max(0, Math.min(100, n)) / 100);
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 4 }}>
+        <input
+          type="number"
+          min={0}
+          max={100}
+          value={editText}
+          onChange={(e) => setEditText(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') commit(); if (e.key === 'Escape') setEditing(false); }}
+          onBlur={commit}
+          autoFocus
+          style={{ width: 40, fontSize: 10, padding: '1px 3px', background: '#111', color: '#eee', border: '1px solid #555', borderRadius: 2 }}
+        />
+        <span style={{ fontSize: 10, color: '#888' }}>%</span>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 4 }}>
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        style={{ width: 60 }}
+      />
+      <span
+        onClick={() => { setEditText(String(Math.round(value * 100))); setEditing(true); }}
+        style={{ fontSize: 10, color: '#888', cursor: 'pointer', userSelect: 'none' }}
+        title="Click to type exact value"
+      >
+        {Math.round(value * 100)}%
+      </span>
+    </div>
+  );
 }
 
 export function StemLane({ index }: StemLaneProps) {
@@ -23,6 +74,7 @@ export function StemLane({ index }: StemLaneProps) {
   const toggleMute = useWeaverStore((s) => s.toggleMute);
   const toggleSolo = useWeaverStore((s) => s.toggleSolo);
   const loopEnabled = useWeaverStore((s) => s.loopEnabled);
+  const anySoloed = useWeaverStore((s) => s.stems.some((st) => st.soloed));
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -63,12 +115,14 @@ export function StemLane({ index }: StemLaneProps) {
       );
     }
 
-    // Draw waveform
+    // Draw waveform (dimmed when muted or silenced by solo)
+    const isSilenced = stem.muted || (anySoloed && !stem.soloed);
     const peaks = stem.waveformPeaks;
     if (peaks && peaks.length > 0) {
       const totalFrames = stem.audioBuffer?.length ?? 0;
       const midY = h / 2;
       ctx.beginPath();
+      ctx.globalAlpha = isSilenced ? 0.25 : 1.0;
       ctx.strokeStyle = STEM_COLORS[index % STEM_COLORS.length];
       ctx.lineWidth = 1;
 
@@ -88,6 +142,7 @@ export function StemLane({ index }: StemLaneProps) {
         ctx.lineTo(x, midY + amp);
       }
       ctx.stroke();
+      ctx.globalAlpha = 1.0;
     }
 
     // Playhead line
@@ -108,7 +163,7 @@ export function StemLane({ index }: StemLaneProps) {
     ctx.moveTo(0, h - 0.5);
     ctx.lineTo(w, h - 0.5);
     ctx.stroke();
-  }, [stem, viewStart, viewEnd, loopStart, loopEnd, loopEnabled, playheadFrame]);
+  }, [stem, viewStart, viewEnd, loopStart, loopEnd, loopEnabled, playheadFrame, anySoloed]);
 
   if (!stem) return null;
 
@@ -129,18 +184,7 @@ export function StemLane({ index }: StemLaneProps) {
         <div style={{ fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
           {stem.fileName}
         </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 4 }}>
-          <input
-            type="range"
-            min={0}
-            max={1}
-            step={0.01}
-            value={stem.initialVolume}
-            onChange={(e) => setStemVolume(index, Number(e.target.value))}
-            style={{ width: 60 }}
-          />
-          <span style={{ fontSize: 10, color: '#888' }}>{Math.round(stem.initialVolume * 100)}%</span>
-        </div>
+        <VolumeControl value={stem.initialVolume} onChange={(v) => setStemVolume(index, v)} />
         <div style={{ display: 'flex', gap: 2, marginTop: 2 }}>
           <button
             onClick={() => toggleMute(index)}

--- a/tools/apps/weaver/src/hooks/useAudioPlayer.ts
+++ b/tools/apps/weaver/src/hooks/useAudioPlayer.ts
@@ -72,10 +72,10 @@ export function useAudioPlayer() {
     }
   }, [stems]);
 
-  function startPlayback() {
+  async function startPlayback() {
     const state = useWeaverStore.getState();
     const ctx = getAudioContext();
-    if (ctx.state === 'suspended') ctx.resume();
+    if (ctx.state === 'suspended') await ctx.resume();
 
     const stems = state.stems;
     const sampleRate = state.sampleRate;

--- a/tools/apps/weaver/src/store/useWeaverStore.ts
+++ b/tools/apps/weaver/src/store/useWeaverStore.ts
@@ -81,6 +81,7 @@ interface WeaverStore {
   toggleSolo: (index: number) => void;
   setLoopStart: (frame: number) => void;
   setLoopEnd: (frame: number) => void;
+  resetLoop: () => void;
   setLoopEnabled: (enabled: boolean) => void;
   setBpm: (bpm: number) => void;
   setGroupName: (name: string) => void;
@@ -389,23 +390,20 @@ export const useWeaverStore = create<WeaverStore>((set, get) => ({
     })),
 
   toggleMute: (index) => {
-    get().pushUndo();
     set((s) => ({
       stems: s.stems.map((st, i) => i === index ? { ...st, muted: !st.muted } : st),
-      dirty: true,
     }));
   },
 
   toggleSolo: (index) => {
-    get().pushUndo();
     set((s) => ({
       stems: s.stems.map((st, i) => i === index ? { ...st, soloed: !st.soloed } : st),
-      dirty: true,
     }));
   },
 
   setLoopStart: (frame) => { get().pushUndo(); set({ loopStart: Math.max(0, frame), dirty: true }); },
   setLoopEnd: (frame) => { get().pushUndo(); set({ loopEnd: Math.max(0, frame), dirty: true }); },
+  resetLoop: () => { get().pushUndo(); set({ loopStart: 0, loopEnd: 0, dirty: true }); },
   setLoopEnabled: (enabled) => set({ loopEnabled: enabled, dirty: true }),
   setBpm: (bpm) => { get().pushUndo(); set({ bpm: Math.max(1, Math.min(999, bpm || 120)), dirty: true }); },
   setGroupName: (name) => {


### PR DESCRIPTION
## Summary
Fixes 7 issues from composer QA testing session:

- **#316** Playhead tracking freeze: `await ctx.resume()` before capturing `startTimeRef`
- **#318** Cmd+S/Z in focused inputs: allow modifier shortcuts to pass through input check
- **#319** Exact volume input: click % label to type a precise value
- **#320** Solo/mute dirty flag: these are monitoring controls, no longer mark project dirty
- **#321** Waveform dimming: muted/silenced stems render at 25% opacity
- **#323** Loop region reset: double-click loop overlay to clear, `resetLoop()` store action
- **#325** Inline group rename: double-click group name in left panel

Closes #316, closes #317, closes #318, closes #319, closes #320, closes #321, closes #323, closes #325

## Test plan
- [x] `pnpm build` passes
- [x] 14/14 vitest tests pass
- [ ] Play audio — playhead advances in real time
- [ ] Press Cmd+S while BPM input is focused — saves
- [ ] Click volume % label — input appears, type value, Enter commits
- [ ] Toggle solo — no dirty flag appears
- [ ] Solo a stem — other stems' waveforms dim
- [ ] Double-click loop region in ruler — loop resets
- [ ] Double-click group name — inline edit appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)