### PR TITLE
feat(weaver): stem drag-to-reorder and master volume control

### DIFF
--- a/tools/apps/weaver/src/components/TimelinePanel.tsx
+++ b/tools/apps/weaver/src/components/TimelinePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import { useWeaverStore } from '../store/useWeaverStore.js';
 import { pixelToFrame } from '../lib/frameUtils.js';
 import { Ruler } from './Ruler.js';
@@ -11,6 +11,8 @@ export function TimelinePanel() {
   const fileRef = useRef<HTMLInputElement>(null);
   const stems = useWeaverStore((s) => s.stems);
   const addStem = useWeaverStore((s) => s.addStem);
+  const moveStem = useWeaverStore((s) => s.moveStem);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   // Zoom (Ctrl/Cmd+scroll) and pan (plain scroll) — covers ruler + stem lanes
   useEffect(() => {
@@ -76,7 +78,23 @@ export function TimelinePanel() {
       <Ruler />
       <div style={{ flex: 1, overflowY: 'auto' }}>
         {stems.map((_, i) => (
-          <StemLane key={i} index={i} />
+          <div
+            key={i}
+            draggable
+            onDragStart={(e) => { e.dataTransfer.setData('text/plain', String(i)); e.dataTransfer.effectAllowed = 'move'; }}
+            onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; setDragOverIndex(i); }}
+            onDragLeave={() => setDragOverIndex(null)}
+            onDrop={(e) => {
+              e.preventDefault();
+              const from = parseInt(e.dataTransfer.getData('text/plain'), 10);
+              if (!isNaN(from) && from !== i) moveStem(from, i);
+              setDragOverIndex(null);
+            }}
+            onDragEnd={() => setDragOverIndex(null)}
+            style={{ borderTop: dragOverIndex === i ? '2px solid #77aaff' : '2px solid transparent' }}
+          >
+            <StemLane key={i} index={i} />
+          </div>
         ))}
         <input
           ref={fileRef}

--- a/tools/apps/weaver/src/components/TransportBar.tsx
+++ b/tools/apps/weaver/src/components/TransportBar.tsx
@@ -18,6 +18,8 @@ export function TransportBar() {
   const sampleRate = useWeaverStore((s) => s.sampleRate);
   const maxFrames = useWeaverStore((s) => s.maxFrames);
   const bpm = useWeaverStore((s) => s.bpm);
+  const masterVolume = useWeaverStore((s) => s.masterVolume);
+  const setMasterVolume = useWeaverStore((s) => s.setMasterVolume);
 
   const currentSec = framesToSeconds(playheadFrame, sampleRate);
   const totalSec = framesToSeconds(maxFrames(), sampleRate);
@@ -77,6 +79,22 @@ export function TransportBar() {
         <div style={{ fontSize: 11, color: '#666' }}>
           Frame {playheadFrame}
         </div>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginLeft: 'auto' }}>
+        <span style={{ fontSize: 10, color: '#888' }}>Master</span>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={masterVolume}
+          onChange={(e) => setMasterVolume(Number(e.target.value))}
+          style={{ width: 80 }}
+        />
+        <span style={{ fontSize: 10, color: '#888', minWidth: 30 }}>
+          {Math.round(masterVolume * 100)}%
+        </span>
       </div>
     </div>
   );

--- a/tools/apps/weaver/src/hooks/useAudioPlayer.ts
+++ b/tools/apps/weaver/src/hooks/useAudioPlayer.ts
@@ -14,6 +14,7 @@ function hasValidLoopRegion(loopStart: number, loopEnd: number): boolean {
 export function useAudioPlayer() {
   const sourcesRef = useRef<AudioBufferSourceNode[]>([]);
   const gainsRef = useRef<GainNode[]>([]);
+  const masterGainRef = useRef<GainNode | null>(null);
   const rafRef = useRef<number>(0);
   const startTimeRef = useRef<number>(0);
   const startFrameRef = useRef<number>(0);
@@ -21,6 +22,7 @@ export function useAudioPlayer() {
   const isPlaying = useWeaverStore((s) => s.isPlaying);
   const stems = useWeaverStore((s) => s.stems);
   const loopEnabled = useWeaverStore((s) => s.loopEnabled);
+  const masterVolume = useWeaverStore((s) => s.masterVolume);
 
   useEffect(() => {
     if (isPlaying) {
@@ -56,6 +58,13 @@ export function useAudioPlayer() {
     }
   }, [loopEnabled]);
 
+  // Update master volume live
+  useEffect(() => {
+    if (masterGainRef.current) {
+      masterGainRef.current.gain.value = masterVolume;
+    }
+  }, [masterVolume]);
+
   useEffect(() => {
     const gains = gainsRef.current;
     if (gains.length === 0) return;
@@ -90,6 +99,12 @@ export function useAudioPlayer() {
     const sources: AudioBufferSourceNode[] = [];
     const gains: GainNode[] = [];
 
+    // Master gain node — all stems route through this
+    const masterGain = ctx.createGain();
+    masterGain.gain.value = state.masterVolume ?? 1.0;
+    masterGain.connect(ctx.destination);
+    masterGainRef.current = masterGain;
+
     const offsetSec = framesToSeconds(playheadFrame, sampleRate);
 
     const anySoloed = stems.some(s => s.soloed);
@@ -105,7 +120,7 @@ export function useAudioPlayer() {
       if (stem.muted) effectiveVol = 0;
       if (anySoloed && !stem.soloed) effectiveVol = 0;
       gain.gain.value = effectiveVol;
-      source.connect(gain).connect(ctx.destination);
+      source.connect(gain).connect(masterGain);
 
       if (loopEnabled && hasValidLoopRegion(loopStart, loopEnd)) {
         source.loop = true;
@@ -171,6 +186,10 @@ export function useAudioPlayer() {
     }
     sourcesRef.current = [];
     gainsRef.current = [];
+    if (masterGainRef.current) {
+      masterGainRef.current.disconnect();
+      masterGainRef.current = null;
+    }
   }
 
   function stopPlayback() {

--- a/tools/apps/weaver/src/store/useWeaverStore.ts
+++ b/tools/apps/weaver/src/store/useWeaverStore.ts
@@ -74,8 +74,12 @@ interface WeaverStore {
   isPlaying: boolean;
   playheadFrame: number;
 
+  masterVolume: number;
+  setMasterVolume: (volume: number) => void;
+
   addStem: (file: File) => Promise<void>;
   removeStem: (index: number) => void;
+  moveStem: (fromIndex: number, toIndex: number) => void;
   setStemVolume: (index: number, volume: number) => void;
   toggleMute: (index: number) => void;
   toggleSolo: (index: number) => void;
@@ -333,6 +337,9 @@ export const useWeaverStore = create<WeaverStore>((set, get) => ({
     });
   },
 
+  masterVolume: 1.0,
+  setMasterVolume: (volume) => set({ masterVolume: Math.max(0, Math.min(1, volume)) }),
+
   stems: [],
   bpm: 120,
   loopStart: 0,
@@ -381,6 +388,16 @@ export const useWeaverStore = create<WeaverStore>((set, get) => ({
   removeStem: (index) => {
     get().pushUndo();
     set((s) => ({ stems: s.stems.filter((_, i) => i !== index), dirty: true }));
+  },
+
+  moveStem: (fromIndex, toIndex) => {
+    get().pushUndo();
+    set((s) => {
+      const stems = [...s.stems];
+      const [moved] = stems.splice(fromIndex, 1);
+      stems.splice(toIndex, 0, moved);
+      return { stems, dirty: true };
+    });
   },
 
   setStemVolume: (index, volume) =>


### PR DESCRIPTION
## Summary
- **#322**: Drag stems up/down to reorder in the timeline. Blue drop indicator shows target position. `moveStem()` store action is undoable.
- **#324**: Master volume slider in transport bar (right side). All stems route through a shared `GainNode` before `AudioContext.destination`. Updates live during playback.

Closes #322, closes #324

## Test plan
- [x] `pnpm build` passes
- [x] 14/14 vitest tests pass
- [ ] Drag a stem lane up/down — blue line shows, stems reorder on drop
- [ ] Cmd+Z after reorder — reverts to previous order
- [ ] Drag master volume slider — audio level changes in real time
- [ ] Master volume persists across play/stop cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)