### PR TITLE
fix(weaver): restrict stem reorder drag to handle icon only

### DIFF
--- a/tools/apps/weaver/src/components/StemLane.tsx
+++ b/tools/apps/weaver/src/components/StemLane.tsx
@@ -8,6 +8,7 @@ const STEM_COLORS = ['#4488ff', '#44cc66', '#ff8844', '#cc44ff', '#44cccc', '#ff
 
 interface StemLaneProps {
   index: number;
+  onDragHandleStart?: (e: React.DragEvent) => void;
 }
 
 function VolumeControl({ value, onChange }: { value: number; onChange: (v: number) => void }) {
@@ -61,7 +62,7 @@ function VolumeControl({ value, onChange }: { value: number; onChange: (v: numbe
   );
 }
 
-export function StemLane({ index }: StemLaneProps) {
+export function StemLane({ index, onDragHandleStart }: StemLaneProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const stem = useWeaverStore((s) => s.stems[index]);
   const viewStart = useWeaverStore((s) => s.viewStartFrame);
@@ -181,8 +182,18 @@ export function StemLane({ index }: StemLaneProps) {
           padding: '4px 8px', zIndex: 1, pointerEvents: 'auto',
         }}
       >
-        <div style={{ fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-          {stem.fileName}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <span
+            draggable
+            onDragStart={onDragHandleStart}
+            style={{ cursor: 'grab', color: '#555', fontSize: 10, userSelect: 'none', flexShrink: 0 }}
+            title="Drag to reorder"
+          >
+            ⠿
+          </span>
+          <span style={{ fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {stem.fileName}
+          </span>
         </div>
         <VolumeControl value={stem.initialVolume} onChange={(v) => setStemVolume(index, v)} />
         <div style={{ display: 'flex', gap: 2, marginTop: 2 }}>

--- a/tools/apps/weaver/src/components/TimelinePanel.tsx
+++ b/tools/apps/weaver/src/components/TimelinePanel.tsx
@@ -80,8 +80,6 @@ export function TimelinePanel() {
         {stems.map((_, i) => (
           <div
             key={i}
-            draggable
-            onDragStart={(e) => { e.dataTransfer.setData('text/plain', String(i)); e.dataTransfer.effectAllowed = 'move'; }}
             onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; setDragOverIndex(i); }}
             onDragLeave={() => setDragOverIndex(null)}
             onDrop={(e) => {
@@ -93,7 +91,10 @@ export function TimelinePanel() {
             onDragEnd={() => setDragOverIndex(null)}
             style={{ borderTop: dragOverIndex === i ? '2px solid #77aaff' : '2px solid transparent' }}
           >
-            <StemLane key={i} index={i} />
+            <StemLane
+              index={i}
+              onDragHandleStart={(e) => { e.dataTransfer.setData('text/plain', String(i)); e.dataTransfer.effectAllowed = 'move'; }}
+            />
           </div>
         ))}
         <input


### PR DESCRIPTION
## Summary
The draggable wrapper covered the entire stem lane, so dragging the volume slider accidentally triggered reorder mode. Now only the ⠿ drag handle icon (left of filename) initiates reorder. The drop zone still covers the full lane for easy targeting.

## Changes
- `StemLane.tsx`: Added ⠿ drag handle span with `draggable` + `onDragStart` prop
- `TimelinePanel.tsx`: Removed `draggable` from wrapper div, pass `onDragHandleStart` prop to StemLane

## Test plan
- [x] Build passes, 14/14 tests pass
- [ ] Drag volume slider — adjusts volume (no reorder triggered)
- [ ] Drag ⠿ handle — initiates reorder with blue drop indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)