### PR TITLE
feat: spline VFX authoring in Bricklayer viewport

### DIFF
--- a/docs/superpowers/plans/2026-04-19-spline-vfx-authoring.md
+++ b/docs/superpowers/plans/2026-04-19-spline-vfx-authoring.md
@@ -1,0 +1,705 @@
+# Spline VFX Authoring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let level designers draw spline paths for VFX instances in the Bricklayer 3D viewport, with per-instance control point overrides stored in scene JSON.
+
+**Architecture:** Add optional `splinePoints` field to VfxInstanceData. A new SplineEditor viewport component handles click-to-place and drag interaction. The C++ engine reads `spline_points` from scene JSON and overrides the preset's default control points. Shared spline math stays in `@gseurat/vfx-utils`; display components are per-app (~25 lines each).
+
+**Tech Stack:** TypeScript/React (Bricklayer), React Three Fiber, Three.js, Zustand, C++23/nlohmann::json (engine)
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `tools/apps/bricklayer/src/store/types.ts:277-288` | Add `splinePoints` to VfxInstanceData |
+| Modify | `tools/apps/bricklayer/src/store/useSceneStore.ts:253,302-305` | Add `editingSpline` state + setter |
+| Create | `tools/apps/bricklayer/src/viewport/SplineEditor.tsx` | Interactive spline editing overlay |
+| Modify | `tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx:15-33` | Use shared display, show override points |
+| Modify | `tools/apps/bricklayer/src/viewport/Viewport.tsx:307` | Add `<SplineEditor />` to SceneContent |
+| Modify | `tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx:1383-1450` | Add Edit Spline button + point count |
+| Modify | `tools/apps/bricklayer/src/lib/sceneExport.ts:366-379` | Export `spline_points` field |
+| Modify | `tools/apps/bricklayer/src/lib/projectIO.ts:518-658` | Import `spline_points` field |
+| Modify | `schemas/scene.schema.json:147-179` | Add `spline_points` to VFX instance schema |
+| Modify | `include/gseurat/engine/scene_loader.hpp:166-173` | Add `spline_points` to VfxInstanceRef |
+| Modify | `src/engine/scene_loader.cpp:541-550` | Parse `spline_points` from JSON |
+| Modify | `src/engine/gs_scene_loader.cpp:410-418` | Override preset spline with instance points |
+
+---
+
+### Task 1: Add splinePoints to VfxInstanceData type
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/store/types.ts:277-288`
+
+- [ ] **Step 1: Add the optional field to VfxInstanceData**
+
+In `tools/apps/bricklayer/src/store/types.ts`, find the `VfxInstanceData` interface and add:
+
+```typescript
+export interface VfxInstanceData {
+  id: string;
+  muted?: boolean;
+  name: string;
+  vfx_file: string;
+  vfx_preset: VfxPresetData;
+  position: [number, number, number];
+  rotation_y: number;
+  radius: number;
+  trigger: 'auto' | 'event';
+  loop: boolean;
+  splinePoints?: [number, number, number][];  // per-instance spline override (instance-relative)
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd tools && pnpm --filter bricklayer build`
+Expected: Build succeeds (optional field is backward compatible)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/store/types.ts
+git commit -m "feat(bricklayer): add splinePoints field to VfxInstanceData"
+```
+
+---
+
+### Task 2: Add editingSpline state to store
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/store/useSceneStore.ts`
+
+- [ ] **Step 1: Add state and action type declarations**
+
+Find the state interface section (around line 253) and add:
+
+```typescript
+editingSpline: string | null;
+```
+
+Find the actions section (around line 302-305) and add:
+
+```typescript
+setEditingSpline: (id: string | null) => void;
+```
+
+- [ ] **Step 2: Add initial state and implementation**
+
+In the store creation (the `create` call), add initial state:
+
+```typescript
+editingSpline: null,
+```
+
+Add the action implementation:
+
+```typescript
+setEditingSpline: (id) => {
+  if (id) {
+    // Lock orbit while editing spline
+    set({ editingSpline: id, orbitLocked: true });
+  } else {
+    set({ editingSpline: null, orbitLocked: false });
+  }
+},
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd tools && pnpm --filter bricklayer build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/store/useSceneStore.ts
+git commit -m "feat(bricklayer): add editingSpline state and setter"
+```
+
+---
+
+### Task 3: Export and import spline_points
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/lib/sceneExport.ts:366-379`
+- Modify: `tools/apps/bricklayer/src/lib/projectIO.ts:518-658`
+
+- [ ] **Step 1: Add spline_points to scene export**
+
+In `tools/apps/bricklayer/src/lib/sceneExport.ts`, find the VFX instance export (around line 366). After the `if (!v.loop) out.loop = false;` line, add:
+
+```typescript
+    if (v.splinePoints && v.splinePoints.length > 0) {
+      out.spline_points = v.splinePoints;
+    }
+```
+
+- [ ] **Step 2: Add spline_points to engine scene import**
+
+In `tools/apps/bricklayer/src/lib/projectIO.ts`, find the `importEngineScene` function. In the section where VFX instances are converted (around line 644, inside the BricklayerFile construction), ensure `vfxInstances` mapping includes:
+
+```typescript
+vfxInstances: engine.vfx_instances?.map((v: any) => ({
+  ...v,
+  splinePoints: v.spline_points ?? undefined,
+})) ?? undefined,
+```
+
+If VFX instances are passed through directly (`engine.vfx_instances`), change to map and add the camelCase conversion.
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd tools && pnpm --filter bricklayer build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/lib/sceneExport.ts tools/apps/bricklayer/src/lib/projectIO.ts
+git commit -m "feat(bricklayer): export/import spline_points for VFX instances"
+```
+
+---
+
+### Task 4: Update scene schema
+
+**Files:**
+- Modify: `schemas/scene.schema.json`
+
+- [ ] **Step 1: Add spline_points to VFX instance schema**
+
+In `schemas/scene.schema.json`, find the VFX instance items definition (around line 147-179). Add `spline_points` as an optional property:
+
+```json
+"spline_points": {
+  "type": "array",
+  "description": "Per-instance spline control points (instance-relative). Overrides preset spline.",
+  "items": {
+    "type": "array",
+    "items": { "type": "number" },
+    "minItems": 3,
+    "maxItems": 3
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add schemas/scene.schema.json
+git commit -m "feat(schema): add spline_points to VFX instance definition"
+```
+
+---
+
+### Task 5: C++ engine — parse and apply spline_points override
+
+**Files:**
+- Modify: `include/gseurat/engine/scene_loader.hpp:166-173`
+- Modify: `src/engine/scene_loader.cpp:541-550`
+- Modify: `src/engine/gs_scene_loader.cpp:410-418`
+
+- [ ] **Step 1: Add spline_points field to VfxInstanceRef**
+
+In `include/gseurat/engine/scene_loader.hpp`, find `VfxInstanceRef` (line 166) and add:
+
+```cpp
+struct VfxInstanceRef {
+    std::string vfx_file;
+    coord::GridPos position;
+    float rotation_y = 0.0f;
+    float radius = 5.0f;
+    std::string trigger = "auto";
+    bool loop = true;
+    std::vector<glm::vec3> spline_points;  // per-instance override (empty = use preset)
+};
+```
+
+- [ ] **Step 2: Parse spline_points from scene JSON**
+
+In `src/engine/scene_loader.cpp`, find the VFX instance parsing loop (line 541). After `inst.loop = ...;`, add:
+
+```cpp
+            if (vi.contains("spline_points")) {
+                for (const auto& pt : vi["spline_points"]) {
+                    inst.spline_points.emplace_back(
+                        pt[0].get<float>(), pt[1].get<float>(), pt[2].get<float>());
+                }
+            }
+```
+
+- [ ] **Step 3: Override preset spline control points when loading VFX**
+
+In `src/engine/gs_scene_loader.cpp`, find the VFX instance init loop (line 410). Change:
+
+```cpp
+        for (const auto& vi : scene_data.vfx_instances) {
+            if (vi.trigger != "auto") continue;
+            auto preset = load_vfx_preset(vi.vfx_file);
+            if (preset.elements.empty()) continue;
+
+            // Override preset spline control points with per-instance points
+            if (!vi.spline_points.empty()) {
+                for (auto& el : preset.elements) {
+                    if (el.spline_config.mode != SplineMode::None) {
+                        el.spline_config.path.control_points = vi.spline_points;
+                    }
+                }
+            }
+
+            VfxInstance inst;
+            auto world_pos = coord::to_world(vi.position, ctx.terrain.terrain_aabb);
+            inst.init(preset, world_pos.vec(), vi.loop, vi.rotation_y);
+            ctx.renderer.add_vfx_instance(std::move(inst));
+        }
+```
+
+- [ ] **Step 4: Verify C++ build**
+
+Run: `cmake --build --preset macos-debug`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add include/gseurat/engine/scene_loader.hpp src/engine/scene_loader.cpp src/engine/gs_scene_loader.cpp
+git commit -m "feat(engine): parse and apply per-instance spline_points override"
+```
+
+---
+
+### Task 6: SplineEditor viewport component
+
+**Files:**
+- Create: `tools/apps/bricklayer/src/viewport/SplineEditor.tsx`
+- Modify: `tools/apps/bricklayer/src/viewport/Viewport.tsx`
+
+- [ ] **Step 1: Create SplineEditor component**
+
+Create `tools/apps/bricklayer/src/viewport/SplineEditor.tsx`:
+
+```typescript
+import React, { useCallback, useMemo, useRef } from 'react';
+import { Line } from '@react-three/drei';
+import { useThree, ThreeEvent } from '@react-three/fiber';
+import * as THREE from 'three';
+import { sampleCatmullRom } from '@gseurat/vfx-utils';
+import { useSceneStore } from '../store/useSceneStore.js';
+
+const POINT_COLOR = '#f59e0b';
+const CURVE_COLOR = '#fbbf24';
+const HANDLE_RADIUS = 0.6;
+
+export function SplineEditor() {
+  const editingSpline = useSceneStore((s) => s.editingSpline);
+  const vfxInstances = useSceneStore((s) => s.vfxInstances);
+  const updateVfxInstance = useSceneStore((s) => s.updateVfxInstance);
+  const setEditingSpline = useSceneStore((s) => s.setEditingSpline);
+  const { camera } = useThree();
+
+  const dragging = useRef<number | null>(null);
+  const planeRef = useRef<THREE.Mesh>(null);
+
+  const instance = useMemo(
+    () => vfxInstances.find((v) => v.id === editingSpline),
+    [vfxInstances, editingSpline],
+  );
+
+  const points = instance?.splinePoints ?? [];
+  const instancePos = instance?.position ?? [0, 0, 0];
+
+  const curvePoints = useMemo(
+    () => (points.length >= 2 ? sampleCatmullRom(points, 64) : []),
+    [points],
+  );
+
+  // Escape to exit
+  React.useEffect(() => {
+    if (!editingSpline) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setEditingSpline(null);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [editingSpline, setEditingSpline]);
+
+  const updatePoints = useCallback(
+    (newPoints: [number, number, number][]) => {
+      if (!editingSpline) return;
+      updateVfxInstance(editingSpline, { splinePoints: newPoints });
+    },
+    [editingSpline, updateVfxInstance],
+  );
+
+  // Click on ground plane → add point
+  const handlePlaneClick = useCallback(
+    (e: ThreeEvent<MouseEvent>) => {
+      if (dragging.current !== null) return;
+      if (e.button !== 0) return;  // left click only
+      e.stopPropagation();
+
+      // Convert hit to instance-relative coordinates
+      const hit = e.point;
+      const rel: [number, number, number] = [
+        Math.round((hit.x - instancePos[0]) * 10) / 10,
+        Math.round((hit.y - instancePos[1]) * 10) / 10,
+        Math.round((hit.z - instancePos[2]) * 10) / 10,
+      ];
+      updatePoints([...points, rel]);
+    },
+    [points, instancePos, updatePoints],
+  );
+
+  // Right-click on control point → remove
+  const handlePointRightClick = useCallback(
+    (idx: number, e: ThreeEvent<MouseEvent>) => {
+      e.stopPropagation();
+      e.nativeEvent.preventDefault();
+      const newPts = points.filter((_, i) => i !== idx);
+      updatePoints(newPts);
+    },
+    [points, updatePoints],
+  );
+
+  // Drag control point
+  const handlePointPointerDown = useCallback(
+    (idx: number, e: ThreeEvent<PointerEvent>) => {
+      if (e.button !== 0) return;
+      e.stopPropagation();
+      (e.target as HTMLElement)?.setPointerCapture?.(e.pointerId);
+      dragging.current = idx;
+    },
+    [],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: ThreeEvent<PointerEvent>) => {
+      if (dragging.current === null || !planeRef.current) return;
+      e.stopPropagation();
+
+      // Raycast against drag plane
+      const raycaster = new THREE.Raycaster();
+      const rect = (e.nativeEvent.target as HTMLElement)?.getBoundingClientRect?.();
+      if (!rect) return;
+      const pointer = new THREE.Vector2(
+        ((e.nativeEvent.clientX - rect.left) / rect.width) * 2 - 1,
+        -((e.nativeEvent.clientY - rect.top) / rect.height) * 2 + 1,
+      );
+      raycaster.setFromCamera(pointer, camera);
+
+      const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -instancePos[1]);
+      const intersection = new THREE.Vector3();
+      if (raycaster.ray.intersectPlane(plane, intersection)) {
+        const rel: [number, number, number] = [
+          Math.round((intersection.x - instancePos[0]) * 10) / 10,
+          Math.round((intersection.y - instancePos[1]) * 10) / 10,
+          Math.round((intersection.z - instancePos[2]) * 10) / 10,
+        ];
+        const newPts = [...points];
+        newPts[dragging.current] = rel;
+        updatePoints(newPts);
+      }
+    },
+    [points, instancePos, camera, updatePoints],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    dragging.current = null;
+  }, []);
+
+  if (!editingSpline || !instance) return null;
+
+  return (
+    <group position={instancePos}>
+      {/* Interpolated curve */}
+      {curvePoints.length >= 2 && (
+        <Line points={curvePoints} color={CURVE_COLOR} lineWidth={3} />
+      )}
+
+      {/* Control point handles */}
+      {points.map((pt, i) => (
+        <mesh
+          key={i}
+          position={pt}
+          onPointerDown={(e) => handlePointPointerDown(i, e)}
+          onContextMenu={(e) => handlePointRightClick(i, e)}
+        >
+          <sphereGeometry args={[HANDLE_RADIUS, 12, 12]} />
+          <meshBasicMaterial color={POINT_COLOR} />
+        </mesh>
+      ))}
+
+      {/* Invisible ground plane for click-to-place and drag */}
+      <mesh
+        ref={planeRef}
+        position={[0, 0, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        onClick={handlePlaneClick}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        visible={false}
+      >
+        <planeGeometry args={[2000, 2000]} />
+        <meshBasicMaterial transparent opacity={0} side={THREE.DoubleSide} />
+      </mesh>
+    </group>
+  );
+}
+```
+
+- [ ] **Step 2: Add SplineEditor to Viewport**
+
+In `tools/apps/bricklayer/src/viewport/Viewport.tsx`, add the import at the top:
+
+```typescript
+import { SplineEditor } from './SplineEditor.js';
+```
+
+In the `SceneContent` component, add `<SplineEditor />` after `<GrabPlane />` (around line 321):
+
+```typescript
+      <GrabPlane />
+      <SplineEditor />
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd tools && pnpm --filter bricklayer build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/viewport/SplineEditor.tsx tools/apps/bricklayer/src/viewport/Viewport.tsx
+git commit -m "feat(bricklayer): add SplineEditor viewport component"
+```
+
+---
+
+### Task 7: Update VfxInstanceMarkers to show override spline
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx:15-33`
+
+- [ ] **Step 1: Show instance spline override when present**
+
+In `tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx`, find where `EmitterSplineGizmo` is rendered (around line 68-69). Change the logic to prefer instance `splinePoints` over preset spline:
+
+```typescript
+            {(() => {
+              // Prefer per-instance spline override, fall back to preset spline
+              const overridePoints = (inst as any).splinePoints as [number, number, number][] | undefined;
+              if (overridePoints && overridePoints.length >= 2) {
+                return <EmitterSplineGizmo points={overridePoints} mode={spline?.mode ?? 'emitter_path'} />;
+              }
+              if (spline?.control_points && spline.control_points.length >= 2) {
+                return <EmitterSplineGizmo points={spline.control_points} mode={spline.mode ?? 'emitter_path'} />;
+              }
+              return null;
+            })()}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd tools && pnpm --filter bricklayer build`
+Expected: Build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
+git commit -m "feat(bricklayer): show per-instance spline override in VFX markers"
+```
+
+---
+
+### Task 8: Add Edit Spline button to properties panel
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx:1383-1450`
+
+- [ ] **Step 1: Add Edit Spline UI to VfxInstanceProperties**
+
+In `tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx`, find the `VfxInstanceProperties` component (around line 1383). Add the spline editing controls after the existing fields (loop checkbox area):
+
+```typescript
+      {/* Spline editing — show if preset has spline elements */}
+      {(() => {
+        const hasSpline = vfx.vfx_preset?.elements?.some(
+          (el: any) => el.emitter?.spline?.mode && el.emitter.spline.mode !== 'none'
+        );
+        if (!hasSpline) return null;
+
+        const isEditing = useSceneStore.getState().editingSpline === vfx.id;
+        const pointCount = vfx.splinePoints?.length ?? 0;
+
+        return (
+          <div style={{ marginTop: 8, borderTop: '1px solid #333', paddingTop: 8 }}>
+            <div style={{ fontSize: 11, color: '#aaa', marginBottom: 4 }}>Spline Path</div>
+            <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+              <button
+                style={{
+                  padding: '4px 8px', fontSize: 11,
+                  background: isEditing ? '#f59e0b' : '#334',
+                  color: isEditing ? '#000' : '#ccc',
+                  border: 'none', borderRadius: 3, cursor: 'pointer',
+                }}
+                onClick={() => {
+                  const store = useSceneStore.getState();
+                  if (isEditing) {
+                    store.setEditingSpline(null);
+                  } else {
+                    // Initialize from preset if no override yet
+                    if (!vfx.splinePoints || vfx.splinePoints.length === 0) {
+                      const presetPoints = vfx.vfx_preset?.elements
+                        ?.find((el: any) => el.emitter?.spline?.control_points)
+                        ?.emitter?.spline?.control_points;
+                      if (presetPoints) {
+                        store.updateVfxInstance(vfx.id, { splinePoints: [...presetPoints] });
+                      }
+                    }
+                    store.setEditingSpline(vfx.id);
+                  }
+                }}
+              >
+                {isEditing ? 'Done Editing' : 'Edit Spline'}
+              </button>
+              {pointCount > 0 && (
+                <>
+                  <span style={{ fontSize: 10, color: '#888' }}>{pointCount} pts</span>
+                  <button
+                    style={{
+                      padding: '2px 6px', fontSize: 10,
+                      background: '#433', color: '#c88',
+                      border: 'none', borderRadius: 3, cursor: 'pointer',
+                    }}
+                    onClick={() => {
+                      useSceneStore.getState().updateVfxInstance(vfx.id, { splinePoints: undefined });
+                      useSceneStore.getState().setEditingSpline(null);
+                    }}
+                  >
+                    Reset
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        );
+      })()}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd tools && pnpm --filter bricklayer build`
+Expected: Build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+git commit -m "feat(bricklayer): add Edit Spline button to VFX instance properties"
+```
+
+---
+
+### Task 9: Place spline VFX in demo scene
+
+**Files:**
+- Modify: `examples/island_demo/assets/scenes/seurat_island.json`
+- Modify: `examples/island_demo/tools_data/bricklayer/seurat_island.bricklayer`
+
+- [ ] **Step 1: Add spline_dragon_flame VFX instance to seurat_island**
+
+Using Python, add the two spline VFX instances:
+
+```python
+import json
+
+si_path = "examples/island_demo/assets/scenes/seurat_island.json"
+si = json.load(open(si_path))
+
+# Dragon flame arc over cliff overlook
+si["vfx_instances"].append({
+    "vfx_file": "assets/vfx/spline_dragon_flame.vfx.json",
+    "position": [230, 4, 145],
+    "spline_points": [[0,0,0], [10,5,15], [20,10,10], [30,5,25]],
+    "rotation_y": 0,
+    "radius": 10,
+    "trigger": "auto",
+    "loop": True
+})
+
+# Smoke trail near house chimney
+si["vfx_instances"].append({
+    "vfx_file": "assets/vfx/spline_smoke_trail.vfx.json",
+    "position": [192, 6, 175],
+    "spline_points": [[0,0,0], [0,3,1], [1,8,0]],
+    "rotation_y": 0,
+    "radius": 8,
+    "trigger": "auto",
+    "loop": True
+})
+
+with open(si_path, 'w') as f:
+    json.dump(si, f, indent=2)
+```
+
+- [ ] **Step 2: Re-sync .bricklayer file**
+
+Run the bricklayer sync script (or manually ensure the .bricklayer file matches):
+
+```bash
+python3 scripts/validate_bricklayer_sync.py
+```
+
+If out of sync, run the sync process to regenerate the `.bricklayer` file from engine JSON.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/island_demo/assets/scenes/seurat_island.json examples/island_demo/tools_data/bricklayer/seurat_island.bricklayer
+git commit -m "feat(demo): place spline_dragon_flame and spline_smoke_trail in seurat_island"
+```
+
+---
+
+### Task 10: Verify end-to-end and final cleanup
+
+- [ ] **Step 1: Run full TS build**
+
+Run: `cd tools && pnpm --filter bricklayer build`
+Expected: Build succeeds with no errors
+
+- [ ] **Step 2: Run C++ build**
+
+Run: `cmake --build --preset macos-debug`
+Expected: Build succeeds
+
+- [ ] **Step 3: Run bricklayer sync validation**
+
+Run: `python3 scripts/validate_bricklayer_sync.py`
+Expected: All scenes in sync
+
+- [ ] **Step 4: Visual verification in Bricklayer**
+
+1. Start Bricklayer: `cd tools && pnpm --filter bricklayer dev`
+2. Open the island_demo project
+3. Expand seurat_island chunk
+4. Select the spline_dragon_flame VFX instance
+5. Verify the spline curve renders in the viewport
+6. Click "Edit Spline" — verify click-to-place works
+7. Drag a control point — verify it moves
+8. Right-click a point — verify it's removed
+9. Press Escape — verify edit mode exits
+
+- [ ] **Step 5: Final commit and PR**
+
+```bash
+git push -u origin feature/spline-vfx-authoring
+gh pr create --title "feat: spline VFX authoring in Bricklayer" \
+  --body "Closes #312. Per-instance spline point overrides for VFX instances."
+```

--- a/docs/superpowers/specs/2026-04-19-spline-vfx-authoring-design.md
+++ b/docs/superpowers/specs/2026-04-19-spline-vfx-authoring-design.md
@@ -1,0 +1,147 @@
+# Spline VFX Authoring in Bricklayer
+
+**Date:** 2026-04-19
+**Issue:** #312
+**Goal:** Let level designers draw spline paths for VFX instances directly in the Bricklayer viewport, using per-instance control point overrides.
+
+## Design Decisions
+
+- **Per-instance override**: VFX presets define a default spline; each scene instance can override `control_points` only. Mode/speed/spread stay with the preset.
+- **Click-to-place interaction**: Enter edit mode from the properties panel, click in viewport to place points sequentially, drag to reposition, right-click to remove. Escape/Done exits.
+- **Instance-relative coordinates**: Spline points are offsets from the VFX instance position, matching the preset's coordinate space.
+- **Shared display, separate editing**: Extract read-only spline rendering into a shared component; interactive editing is Bricklayer-only.
+
+## Data Model
+
+### VfxInstanceData (Bricklayer store)
+
+Add one optional field:
+
+```typescript
+splinePoints?: [number, number, number][]  // instance-relative control points
+```
+
+### Engine JSON (scene file)
+
+```json
+{
+  "vfx_file": "assets/vfx/spline_dragon_flame.vfx.json",
+  "position": [165, 2, 120],
+  "spline_points": [[0,0,0], [5,3,10], [10,8,20], [15,5,30]],
+  "rotation_y": 0,
+  "radius": 5,
+  "trigger": "auto",
+  "loop": true
+}
+```
+
+Field is `spline_points` (snake_case) in engine JSON, `splinePoints` (camelCase) in `.bricklayer`.
+
+### C++ Engine
+
+When loading a VFX instance from scene JSON:
+1. Check for `spline_points` array
+2. If present and non-empty, construct `SplinePath` from these points instead of the preset's `spline.control_points`
+3. All other spline params (`mode`, `emitter_speed`, `path_spread`, `align_to_tangent`) come from the preset unchanged
+
+## Components
+
+### SplineCurveDisplay (shared — `@gseurat/vfx-utils`)
+
+Read-only React Three Fiber component. Renders a Catmull-Rom curve and control point spheres.
+
+```typescript
+interface SplineCurveDisplayProps {
+  points: [number, number, number][];
+  color?: string;
+  lineWidth?: number;
+  opacity?: number;
+  pointRadius?: number;
+  samples?: number;  // default 64
+}
+```
+
+- Uses `sampleCatmullRom()` (already in `@gseurat/vfx-utils`) for interpolation
+- Renders `<Line>` for the curve, `<mesh><sphereGeometry>` for each control point
+- Replaces the duplicated rendering in Melies `SplineGizmo` and Bricklayer `EmitterSplineGizmo`
+
+### SplineEditor (Bricklayer — `src/viewport/SplineEditor.tsx`)
+
+Interactive overlay inside `<Canvas>`. Active when `editingSpline` is set.
+
+**Renders:**
+- `<SplineCurveDisplay>` for the current points (yellow/orange)
+- Larger interactive spheres at control points for drag interaction
+- A transparent raycast plane for click-to-place
+
+**Interaction:**
+- **Click on ground**: Raycasts against scene, appends new point at intersection
+- **Pointer down on control point sphere**: Enters drag mode, updates point position on pointer move
+- **Right-click on control point**: Removes it from the array
+- **Escape**: Exits spline edit mode
+
+**Store integration:**
+- Reads `editingSpline` (VFX instance ID) from store
+- Calls `updateVfxInstance(id, { splinePoints: [...] })` on changes
+- Sets `orbitLocked: true` while editing (same pattern as grab mode)
+
+### Properties Panel Changes (ScenePropertiesPanel)
+
+In the VFX instance inspector section:
+- Detect if the preset has a `spline` config (check loaded `.vfx.json` or the VfxElementData)
+- If yes, show **"Edit Spline"** / **"Done Editing"** toggle button
+- Show point count label: "4 control points"
+- Show **"Reset to Preset"** button to clear the override
+
+### sceneExport.ts Changes
+
+Include `spline_points` in VFX instance export when present:
+
+```typescript
+if (vfx.splinePoints && vfx.splinePoints.length > 0) {
+  out.spline_points = vfx.splinePoints;
+}
+```
+
+### importEngineScene (projectIO.ts) Changes
+
+Read `spline_points` from engine JSON when importing:
+
+```typescript
+splinePoints: vfx.spline_points ?? undefined,
+```
+
+## Store Changes (useSceneStore)
+
+```typescript
+editingSpline: string | null;           // VFX instance ID being edited, or null
+setEditingSpline: (id: string | null) => void;
+```
+
+When `setEditingSpline(id)` is called:
+- Set `orbitLocked: true`
+- If the VFX instance has no `splinePoints` yet, initialize from the preset's default control points
+
+When `setEditingSpline(null)` is called:
+- Set `orbitLocked: false`
+
+## Demo Scene Placement
+
+After the feature is built, place the two existing presets:
+
+- **spline_dragon_flame** on seurat_island: Arc sweeping over the cliff overlook area. ~4 control points: `[[0,0,0], [10,5,15], [20,10,10], [30,5,25]]` relative to instance position near `[230, 4, 145]`.
+- **spline_smoke_trail** on seurat_island: Gentle vertical drift near the house chimney. ~3 control points: `[[0,0,0], [0,3,1], [1,8,0]]` relative to instance position near `[192, 6, 175]`.
+
+Both added to engine JSON and synced to `.bricklayer`.
+
+## Schema Changes
+
+Update `schemas/scene.schema.json` to include `spline_points` as an optional array of vec3 in the VFX instance definition.
+
+## Testing
+
+- Bricklayer store test: `updateVfxInstance` with `splinePoints` field
+- Export test: verify `spline_points` appears in engine JSON output
+- Import test: verify `spline_points` round-trips through import/export
+- Visual: open in Bricklayer, edit spline, verify points render
+- Engine: verify spline_points override is used instead of preset default

--- a/examples/island_demo/assets/scenes/seurat_island.json
+++ b/examples/island_demo/assets/scenes/seurat_island.json
@@ -75340,6 +75340,69 @@
       "radius": 3,
       "trigger": "proximity",
       "loop": true
+    },
+    {
+      "vfx_file": "assets/vfx/spline_dragon_flame.vfx.json",
+      "position": [
+        230,
+        4,
+        145
+      ],
+      "spline_points": [
+        [
+          0,
+          0,
+          0
+        ],
+        [
+          10,
+          5,
+          15
+        ],
+        [
+          20,
+          10,
+          10
+        ],
+        [
+          30,
+          5,
+          25
+        ]
+      ],
+      "rotation_y": 0,
+      "radius": 10,
+      "trigger": "auto",
+      "loop": true
+    },
+    {
+      "vfx_file": "assets/vfx/spline_smoke_trail.vfx.json",
+      "position": [
+        192,
+        6,
+        175
+      ],
+      "spline_points": [
+        [
+          0,
+          0,
+          0
+        ],
+        [
+          0,
+          3,
+          1
+        ],
+        [
+          1,
+          8,
+          0
+        ]
+      ],
+      "rotation_y": 0,
+      "radius": 8,
+      "trigger": "auto",
+      "loop": true
     }
   ],
   "camera_zones": {

--- a/examples/island_demo/tools_data/bricklayer/seurat_island.bricklayer
+++ b/examples/island_demo/tools_data/bricklayer/seurat_island.bricklayer
@@ -2001,6 +2001,69 @@
         "radius": 3,
         "trigger": "proximity",
         "loop": true
+      },
+      {
+        "vfx_file": "assets/vfx/spline_dragon_flame.vfx.json",
+        "position": [
+          230,
+          4,
+          145
+        ],
+        "splinePoints": [
+          [
+            0,
+            0,
+            0
+          ],
+          [
+            10,
+            5,
+            15
+          ],
+          [
+            20,
+            10,
+            10
+          ],
+          [
+            30,
+            5,
+            25
+          ]
+        ],
+        "rotation_y": 0,
+        "radius": 10,
+        "trigger": "auto",
+        "loop": true
+      },
+      {
+        "vfx_file": "assets/vfx/spline_smoke_trail.vfx.json",
+        "position": [
+          192,
+          6,
+          175
+        ],
+        "splinePoints": [
+          [
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            3,
+            1
+          ],
+          [
+            1,
+            8,
+            0
+          ]
+        ],
+        "rotation_y": 0,
+        "radius": 8,
+        "trigger": "auto",
+        "loop": true
       }
     ],
     "cameraVolumes": [

--- a/include/gseurat/engine/scene_loader.hpp
+++ b/include/gseurat/engine/scene_loader.hpp
@@ -170,6 +170,7 @@ struct SceneData {
         float radius = 5.0f;
         std::string trigger = "auto";
         bool loop = true;
+        std::vector<glm::vec3> spline_points;  // per-instance override (empty = use preset)
     };
     std::vector<VfxInstanceRef> vfx_instances;
 

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -173,6 +173,16 @@
         "rotation_y": {
           "type": "number",
           "description": "Y-axis rotation in degrees (turntable orientation)"
+        },
+        "spline_points": {
+          "type": "array",
+          "description": "Per-instance spline control points (instance-relative). Overrides preset spline.",
+          "items": {
+            "type": "array",
+            "items": { "type": "number" },
+            "minItems": 3,
+            "maxItems": 3
+          }
         }
       },
       "additionalProperties": false

--- a/src/engine/gs_scene_loader.cpp
+++ b/src/engine/gs_scene_loader.cpp
@@ -411,6 +411,15 @@ void GsSceneLoader::load(SceneLoadContext& ctx, const SceneData& scene_data,
             if (vi.trigger != "auto") continue;
             auto preset = load_vfx_preset(vi.vfx_file);
             if (preset.elements.empty()) continue;
+            // Override preset spline control points with per-instance points
+            if (!vi.spline_points.empty()) {
+                for (auto& el : preset.elements) {
+                    if (el.emitter_config.spline &&
+                        el.emitter_config.spline->mode != SplineMode::None) {
+                        el.emitter_config.spline->path.control_points = vi.spline_points;
+                    }
+                }
+            }
             VfxInstance inst;
             auto world_pos = coord::to_world(vi.position, ctx.terrain.terrain_aabb);
             inst.init(preset, world_pos.vec(), vi.loop, vi.rotation_y);

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -547,6 +547,12 @@ SceneData SceneLoader::from_json(const nlohmann::json& j) {
             inst.radius = vi.value("radius", 5.0f);
             inst.trigger = vi.value("trigger", "auto");
             inst.loop = vi.value("loop", true);
+            if (vi.contains("spline_points")) {
+                for (const auto& pt : vi["spline_points"]) {
+                    inst.spline_points.emplace_back(
+                        pt[0].get<float>(), pt[1].get<float>(), pt[2].get<float>());
+                }
+            }
             data.vfx_instances.push_back(std::move(inst));
         }
     }

--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -641,7 +641,10 @@ export async function importEngineScene(
         dayNight: { enabled: false, cycle_speed: 1, initial_time: 0, keyframes: [] },
         gaussianSplat,
         gsParticleEmitters: gsParticleEmitters.length > 0 ? gsParticleEmitters : undefined,
-        vfxInstances: engine.vfx_instances ?? undefined,
+        vfxInstances: engine.vfx_instances?.map((v: any) => ({
+          ...v,
+          splinePoints: v.spline_points ?? undefined,
+        })) ?? undefined,
         audioZones: engine.audio_zones ?? undefined,
       },
     };

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -374,6 +374,9 @@ export function exportSceneJson(
       if (v.radius !== 5) out.radius = v.radius;
       if (v.trigger !== 'auto') out.trigger = v.trigger;
       if (!v.loop) out.loop = false;
+      if (v.splinePoints && v.splinePoints.length > 0) {
+        out.spline_points = v.splinePoints;
+      }
       return out;
     });
   }

--- a/tools/apps/bricklayer/src/panels/MasterTree.tsx
+++ b/tools/apps/bricklayer/src/panels/MasterTree.tsx
@@ -439,7 +439,7 @@ function SceneChildren({
               <TreeNode
                 key={v.id}
                 icon={icons.vfx}
-                label={v.name}
+                label={v.name || v.vfx_file?.replace(/^.*\//, '').replace(/\.vfx\.json$/, '') || v.id}
                 isActive={isActive({ kind: 'scene_item', entityType: 'vfx_instance', entityId: v.id })}
                 onClick={() => click({ kind: 'scene_item', entityType: 'vfx_instance', entityId: v.id })}
                 dimmed={v.muted}

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -1383,6 +1383,8 @@ function AudioZoneProperties({ zone }: { zone: AudioZoneData }) {
 function VfxInstanceProperties({ vfx }: { vfx: VfxInstanceData }) {
   const update = useSceneStore((s) => s.updateVfxInstance);
   const remove = useSceneStore((s) => s.removeVfxInstance);
+  const editingSpline = useSceneStore((s) => s.editingSpline);
+  const isEditingThis = editingSpline === vfx.id;
 
   return (
     <div>
@@ -1445,6 +1447,66 @@ function VfxInstanceProperties({ vfx }: { vfx: VfxInstanceData }) {
           {vfx.vfx_preset.name} ({(vfx.vfx_preset.elements ?? []).length} elements{vfx.vfx_preset.duration ? `, ${vfx.vfx_preset.duration}s` : ''})
         </div>
       </div>
+
+      {(vfx.vfx_preset?.elements ?? []).some((el: any) => el.emitter?.spline?.mode && el.emitter.spline.mode !== 'none') && (
+        <div style={styles.section}>
+          <span style={styles.label}>Spline Path</span>
+          <div style={{ display: 'flex', gap: 4, marginTop: 4, flexWrap: 'wrap', alignItems: 'center' }}>
+            <button
+              style={{
+                fontSize: 11,
+                padding: '2px 8px',
+                background: isEditingThis ? '#f59e0b' : '#334',
+                color: isEditingThis ? '#000' : '#ccc',
+                border: `1px solid ${isEditingThis ? '#f59e0b' : '#333'}`,
+                borderRadius: 3,
+                cursor: 'pointer',
+              }}
+              onClick={() => {
+                if (isEditingThis) {
+                  useSceneStore.getState().setEditingSpline(null);
+                } else {
+                  if (!vfx.splinePoints || vfx.splinePoints.length === 0) {
+                    const firstEl = (vfx.vfx_preset?.elements ?? []).find(
+                      (el: any) => el.emitter?.spline?.control_points?.length > 0
+                    ) as any;
+                    if (firstEl) {
+                      useSceneStore.getState().updateVfxInstance(vfx.id, {
+                        splinePoints: firstEl.emitter?.spline?.control_points,
+                      });
+                    }
+                  }
+                  useSceneStore.getState().setEditingSpline(vfx.id);
+                }
+              }}
+            >
+              {isEditingThis ? 'Done Editing' : 'Edit Spline'}
+            </button>
+            {vfx.splinePoints && vfx.splinePoints.length > 0 && (
+              <>
+                <span style={{ fontSize: 10, color: '#aaa' }}>{vfx.splinePoints.length} pts</span>
+                <button
+                  style={{
+                    fontSize: 11,
+                    padding: '2px 8px',
+                    background: '#334',
+                    color: '#ccc',
+                    border: '1px solid #333',
+                    borderRadius: 3,
+                    cursor: 'pointer',
+                  }}
+                  onClick={() => {
+                    useSceneStore.getState().updateVfxInstance(vfx.id, { splinePoints: undefined });
+                    useSceneStore.getState().setEditingSpline(null);
+                  }}
+                >
+                  Reset
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -1444,7 +1444,7 @@ function VfxInstanceProperties({ vfx }: { vfx: VfxInstanceData }) {
       <div style={styles.section}>
         <span style={styles.label}>Preset</span>
         <div style={{ fontSize: 10, color: '#888', marginTop: 2 }}>
-          {vfx.vfx_preset.name} ({(vfx.vfx_preset.elements ?? []).length} elements{vfx.vfx_preset.duration ? `, ${vfx.vfx_preset.duration}s` : ''})
+          {vfx.vfx_preset?.name ?? '(not loaded)'} ({(vfx.vfx_preset?.elements ?? []).length} elements{vfx.vfx_preset?.duration ? `, ${vfx.vfx_preset.duration}s` : ''})
         </div>
       </div>
 

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -1448,7 +1448,7 @@ function VfxInstanceProperties({ vfx }: { vfx: VfxInstanceData }) {
         </div>
       </div>
 
-      {(vfx.vfx_preset?.elements ?? []).some((el: any) => el.emitter?.spline?.mode && el.emitter.spline.mode !== 'none') && (
+      {((vfx.splinePoints && vfx.splinePoints.length > 0) || (vfx.vfx_preset?.elements ?? []).some((el: any) => el.emitter?.spline?.mode && el.emitter.spline.mode !== 'none')) && (
         <div style={styles.section}>
           <span style={styles.label}>Spline Path</span>
           <div style={{ display: 'flex', gap: 4, marginTop: 4, flexWrap: 'wrap', alignItems: 'center' }}>

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -285,6 +285,7 @@ export interface VfxInstanceData {
   radius: number;
   trigger: 'auto' | 'event';
   loop: boolean;
+  splinePoints?: [number, number, number][];  // per-instance spline override (instance-relative)
 }
 
 

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -242,6 +242,9 @@ export interface SceneStoreState {
   // Orbit lock
   orbitLocked: boolean;
 
+  // Spline editing
+  editingSpline: string | null;
+
   // Scene elements
   ambientColor: [number, number, number, number];
   godRaysIntensity: number;
@@ -349,6 +352,7 @@ export interface SceneStoreState {
   setGrabOriginalPosition: (pos: [number, number, number] | null) => void;
   setGrabAxisLock: (axis: 'free' | 'x' | 'y' | 'z') => void;
   setOrbitLocked: (v: boolean) => void;
+  setEditingSpline: (id: string | null) => void;
 
   // Actions – editor
   setSelectedEntity: (e: SelectedEntity | null) => void;
@@ -387,6 +391,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   grabOriginalPosition: null,
   grabAxisLock: 'free' as const,
   orbitLocked: false,
+  editingSpline: null,
 
   ambientColor: [0.25, 0.28, 0.45, 1],
   godRaysIntensity: 0,
@@ -752,6 +757,13 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   setGrabOriginalPosition: (pos) => set({ grabOriginalPosition: pos }),
   setGrabAxisLock: (axis) => set({ grabAxisLock: axis }),
   setOrbitLocked: (v) => set({ orbitLocked: v }),
+  setEditingSpline: (id) => {
+    if (id) {
+      set({ editingSpline: id, orbitLocked: true });
+    } else {
+      set({ editingSpline: null, orbitLocked: false });
+    }
+  },
 
   // ── Editor actions ──
   setSelectedEntity: (e) => set({ selectedEntity: e }),

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -900,7 +900,11 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
       })(),
       gsParticleEmitters: data.scene.gsParticleEmitters ?? [],
       gsAnimations: data.scene.gsAnimations ?? [],
-      vfxInstances: data.scene.vfxInstances ?? [],
+      vfxInstances: (data.scene.vfxInstances ?? []).map((v: any, i: number) => ({
+        ...v,
+        id: v.id || `vfx_${i}_${Date.now().toString(36)}`,
+        name: v.name || v.vfx_file?.replace(/^.*\//, '').replace(/\.vfx\.json$/, '') || `VFX ${i}`,
+      })),
       cameraVolumes: data.scene.cameraVolumes ?? [],
       cameraTriggers: data.scene.cameraTriggers ?? [],
       cameraRails: data.scene.cameraRails ?? [],

--- a/tools/apps/bricklayer/src/viewport/SplineEditor.tsx
+++ b/tools/apps/bricklayer/src/viewport/SplineEditor.tsx
@@ -1,0 +1,180 @@
+import React, { useRef, useEffect, useCallback } from 'react';
+import { useThree, ThreeEvent } from '@react-three/fiber';
+import { Line } from '@react-three/drei';
+import * as THREE from 'three';
+import { sampleCatmullRom } from '@gseurat/vfx-utils';
+import { useSceneStore } from '../store/useSceneStore.js';
+
+function snap(val: number): number {
+  return Math.round(val * 10) / 10;
+}
+
+/**
+ * Interactive spline editor rendered inside the R3F Canvas.
+ * Active when `editingSpline` is set in the scene store.
+ */
+export function SplineEditor() {
+  const editingSpline = useSceneStore((s) => s.editingSpline);
+  const setEditingSpline = useSceneStore((s) => s.setEditingSpline);
+  const vfxInstances = useSceneStore((s) => s.vfxInstances);
+  const updateVfxInstance = useSceneStore((s) => s.updateVfxInstance);
+
+  const { camera, gl } = useThree();
+  const dragIndexRef = useRef<number | null>(null);
+
+  const instance = editingSpline
+    ? vfxInstances.find((v) => v.id === editingSpline) ?? null
+    : null;
+
+  // Escape key exits edit mode
+  useEffect(() => {
+    if (!editingSpline) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setEditingSpline(null);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [editingSpline, setEditingSpline]);
+
+  const points = instance?.splinePoints ?? [];
+  const instancePos = instance?.position ?? [0, 0, 0];
+
+  // Compute Catmull-Rom curve samples
+  const curvePoints = points.length >= 2 ? sampleCatmullRom(points, 64) : [];
+
+  // Convert curve points (relative) to world-space for Line
+  const linePoints = curvePoints.map(
+    (p: [number, number, number]) =>
+      new THREE.Vector3(
+        p[0] + instancePos[0],
+        p[1] + instancePos[1],
+        p[2] + instancePos[2],
+      ),
+  );
+
+  // Raycast against the horizontal plane at the instance's Y
+  const raycastGroundPlane = useCallback(
+    (clientX: number, clientY: number): THREE.Vector3 | null => {
+      const rect = gl.domElement.getBoundingClientRect();
+      const pointer = new THREE.Vector2(
+        ((clientX - rect.left) / rect.width) * 2 - 1,
+        -((clientY - rect.top) / rect.height) * 2 + 1,
+      );
+      const raycaster = new THREE.Raycaster();
+      raycaster.setFromCamera(pointer, camera);
+      const plane = new THREE.Plane(
+        new THREE.Vector3(0, 1, 0),
+        -instancePos[1],
+      );
+      const hit = new THREE.Vector3();
+      const ok = raycaster.ray.intersectPlane(plane, hit);
+      return ok ? hit : null;
+    },
+    [camera, gl, instancePos],
+  );
+
+  // Ground plane: click-to-place and drag tracking
+  const handleGroundPointerMove = useCallback(
+    (e: ThreeEvent<PointerEvent>) => {
+      if (dragIndexRef.current === null) return;
+      if (!editingSpline || !instance) return;
+
+      const hit = raycastGroundPlane(e.nativeEvent.clientX, e.nativeEvent.clientY);
+      if (!hit) return;
+
+      const rx = snap(hit.x - instancePos[0]);
+      const ry = snap(hit.y - instancePos[1]);
+      const rz = snap(hit.z - instancePos[2]);
+
+      const newPoints = [...(instance.splinePoints ?? [])];
+      newPoints[dragIndexRef.current] = [rx, ry, rz];
+      updateVfxInstance(editingSpline, { splinePoints: newPoints });
+    },
+    [editingSpline, instance, instancePos, raycastGroundPlane, updateVfxInstance],
+  );
+
+  const handleGroundPointerUp = useCallback(() => {
+    dragIndexRef.current = null;
+  }, []);
+
+  const handleGroundClick = useCallback(
+    (e: ThreeEvent<MouseEvent>) => {
+      if (e.button !== 0) return;
+      if (dragIndexRef.current !== null) return;
+      if (!editingSpline || !instance) return;
+
+      const hit = raycastGroundPlane(e.nativeEvent.clientX, e.nativeEvent.clientY);
+      if (!hit) return;
+
+      const rx = snap(hit.x - instancePos[0]);
+      const ry = snap(hit.y - instancePos[1]);
+      const rz = snap(hit.z - instancePos[2]);
+
+      const newPoints = [...(instance.splinePoints ?? []), [rx, ry, rz] as [number, number, number]];
+      updateVfxInstance(editingSpline, { splinePoints: newPoints });
+    },
+    [editingSpline, instance, instancePos, raycastGroundPlane, updateVfxInstance],
+  );
+
+  // Control point handlers
+  const handleSpherePointerDown = useCallback(
+    (index: number) => (e: ThreeEvent<PointerEvent>) => {
+      e.stopPropagation();
+      dragIndexRef.current = index;
+    },
+    [],
+  );
+
+  const handleSphereContextMenu = useCallback(
+    (index: number) => (e: ThreeEvent<MouseEvent>) => {
+      e.stopPropagation();
+      if (!editingSpline || !instance) return;
+      const newPoints = (instance.splinePoints ?? []).filter((_, i) => i !== index);
+      updateVfxInstance(editingSpline, { splinePoints: newPoints });
+    },
+    [editingSpline, instance, updateVfxInstance],
+  );
+
+  if (!editingSpline || !instance) return null;
+
+  return (
+    <group position={[instancePos[0], instancePos[1], instancePos[2]]}>
+      {/* Interpolated curve */}
+      {linePoints.length >= 2 && (
+        <Line
+          points={linePoints.map((p) => p.toArray() as [number, number, number])}
+          color="#fbbf24"
+          lineWidth={3}
+        />
+      )}
+
+      {/* Control point spheres */}
+      {points.map((pt, i) => (
+        <mesh
+          key={i}
+          position={[pt[0], pt[1], pt[2]]}
+          onPointerDown={handleSpherePointerDown(i)}
+          onContextMenu={handleSphereContextMenu(i)}
+        >
+          <sphereGeometry args={[0.6, 16, 16]} />
+          <meshStandardMaterial color="#f59e0b" />
+        </mesh>
+      ))}
+
+      {/* Invisible ground plane for click-to-place and drag tracking */}
+      <mesh
+        position={[0, 0, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        visible={false}
+        onPointerMove={handleGroundPointerMove}
+        onPointerUp={handleGroundPointerUp}
+        onClick={handleGroundClick}
+      >
+        <planeGeometry args={[2000, 2000]} />
+        <meshBasicMaterial transparent opacity={0} side={THREE.DoubleSide} />
+      </mesh>
+    </group>
+  );
+}

--- a/tools/apps/bricklayer/src/viewport/SplineEditor.tsx
+++ b/tools/apps/bricklayer/src/viewport/SplineEditor.tsx
@@ -99,7 +99,7 @@ export function SplineEditor() {
   const handleGroundPointerUp = useCallback(() => {
     if (dragIndexRef.current !== null) {
       wasDraggingRef.current = true;
-      console.debug('[SplineEditor] pointerUp: drag ended, suppressing next click');
+      console.info('[SplineEditor] pointerUp: drag ended, suppressing next click');
     }
     dragIndexRef.current = null;
   }, []);
@@ -110,7 +110,7 @@ export function SplineEditor() {
       // Suppress click that follows a drag release
       if (wasDraggingRef.current) {
         wasDraggingRef.current = false;
-        console.debug('[SplineEditor] click suppressed (was dragging)');
+        console.info('[SplineEditor] click suppressed (was dragging)');
         return;
       }
       if (dragIndexRef.current !== null) return;
@@ -124,7 +124,7 @@ export function SplineEditor() {
       const rz = snap(hit.z - instancePos[2]);
 
       const newPoints = [...(instance.splinePoints ?? []), [rx, ry, rz] as [number, number, number]];
-      console.debug(`[SplineEditor] click: add point [${rx}, ${ry}, ${rz}] (total: ${newPoints.length})`);
+      console.info(`[SplineEditor] click: add point [${rx}, ${ry}, ${rz}] (total: ${newPoints.length})`);
       updateVfxInstance(editingSpline, { splinePoints: newPoints });
     },
     [editingSpline, instance, instancePos, raycastGroundPlane, updateVfxInstance],
@@ -135,7 +135,7 @@ export function SplineEditor() {
     (index: number) => (e: ThreeEvent<PointerEvent>) => {
       e.stopPropagation();
       dragIndexRef.current = index;
-      console.debug(`[SplineEditor] pointerDown: start drag point ${index}`);
+      console.info(`[SplineEditor] pointerDown: start drag point ${index}`);
     },
     [],
   );
@@ -145,7 +145,7 @@ export function SplineEditor() {
       e.stopPropagation();
       if (!editingSpline || !instance) return;
       const newPoints = (instance.splinePoints ?? []).filter((_, i) => i !== index);
-      console.debug(`[SplineEditor] contextMenu: remove point ${index} (total: ${newPoints.length})`);
+      console.info(`[SplineEditor] contextMenu: remove point ${index} (total: ${newPoints.length})`);
       updateVfxInstance(editingSpline, { splinePoints: newPoints });
     },
     [editingSpline, instance, updateVfxInstance],

--- a/tools/apps/bricklayer/src/viewport/SplineEditor.tsx
+++ b/tools/apps/bricklayer/src/viewport/SplineEditor.tsx
@@ -21,6 +21,7 @@ export function SplineEditor() {
 
   const { camera, gl } = useThree();
   const dragIndexRef = useRef<number | null>(null);
+  const wasDraggingRef = useRef(false);
 
   const instance = editingSpline
     ? vfxInstances.find((v) => v.id === editingSpline) ?? null
@@ -96,12 +97,22 @@ export function SplineEditor() {
   );
 
   const handleGroundPointerUp = useCallback(() => {
+    if (dragIndexRef.current !== null) {
+      wasDraggingRef.current = true;
+      console.debug('[SplineEditor] pointerUp: drag ended, suppressing next click');
+    }
     dragIndexRef.current = null;
   }, []);
 
   const handleGroundClick = useCallback(
     (e: ThreeEvent<MouseEvent>) => {
       if (e.button !== 0) return;
+      // Suppress click that follows a drag release
+      if (wasDraggingRef.current) {
+        wasDraggingRef.current = false;
+        console.debug('[SplineEditor] click suppressed (was dragging)');
+        return;
+      }
       if (dragIndexRef.current !== null) return;
       if (!editingSpline || !instance) return;
 
@@ -113,6 +124,7 @@ export function SplineEditor() {
       const rz = snap(hit.z - instancePos[2]);
 
       const newPoints = [...(instance.splinePoints ?? []), [rx, ry, rz] as [number, number, number]];
+      console.debug(`[SplineEditor] click: add point [${rx}, ${ry}, ${rz}] (total: ${newPoints.length})`);
       updateVfxInstance(editingSpline, { splinePoints: newPoints });
     },
     [editingSpline, instance, instancePos, raycastGroundPlane, updateVfxInstance],
@@ -123,6 +135,7 @@ export function SplineEditor() {
     (index: number) => (e: ThreeEvent<PointerEvent>) => {
       e.stopPropagation();
       dragIndexRef.current = index;
+      console.debug(`[SplineEditor] pointerDown: start drag point ${index}`);
     },
     [],
   );
@@ -132,6 +145,7 @@ export function SplineEditor() {
       e.stopPropagation();
       if (!editingSpline || !instance) return;
       const newPoints = (instance.splinePoints ?? []).filter((_, i) => i !== index);
+      console.debug(`[SplineEditor] contextMenu: remove point ${index} (total: ${newPoints.length})`);
       updateVfxInstance(editingSpline, { splinePoints: newPoints });
     },
     [editingSpline, instance, updateVfxInstance],

--- a/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
@@ -32,7 +32,7 @@ function EmitterSplineGizmo({ points, mode }: {
   );
 }
 
-function ElementGizmo({ element }: { element: VfxElementData }) {
+function ElementGizmo({ element, instanceSplinePoints }: { element: VfxElementData; instanceSplinePoints?: [number, number, number][] }) {
   const pos = element.position ?? [0, 0, 0];
   const color = ELEMENT_COLORS[element.type] ?? '#888';
 
@@ -65,9 +65,16 @@ function ElementGizmo({ element }: { element: VfxElementData }) {
                 <meshBasicMaterial color={color} transparent opacity={0.15} />
               </mesh>
             )}
-            {spline?.control_points && spline.control_points.length >= 2 && (
-              <EmitterSplineGizmo points={spline.control_points} mode={spline.mode ?? 'emitter_path'} />
-            )}
+            {(() => {
+              const overridePoints = instanceSplinePoints;
+              if (overridePoints && overridePoints.length >= 2) {
+                return <EmitterSplineGizmo points={overridePoints} mode={spline?.mode ?? 'emitter_path'} />;
+              }
+              if (spline?.control_points && spline.control_points.length >= 2) {
+                return <EmitterSplineGizmo points={spline.control_points} mode={spline.mode ?? 'emitter_path'} />;
+              }
+              return null;
+            })()}
           </>
         );
       })()}
@@ -155,7 +162,7 @@ function VfxMarker({ instance, isSelected, onSelect }: {
       )}
       {/* Element gizmos (shown when selected) */}
       {isSelected && (instance.vfx_preset.elements ?? []).map((el, i) => (
-        <ElementGizmo key={`${instance.id}_el_${i}`} element={el} />
+        <ElementGizmo key={`${instance.id}_el_${i}`} element={el} instanceSplinePoints={instance.splinePoints} />
       ))}
     </group>
   );

--- a/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
@@ -164,6 +164,10 @@ function VfxMarker({ instance, isSelected, onSelect }: {
       {isSelected && (instance.vfx_preset?.elements ?? []).map((el, i) => (
         <ElementGizmo key={`${instance.id}_el_${i}`} element={el} instanceSplinePoints={instance.splinePoints} />
       ))}
+      {/* Fallback: show spline from splinePoints when preset isn't loaded */}
+      {isSelected && !(instance.vfx_preset?.elements?.length) && instance.splinePoints && instance.splinePoints.length >= 2 && (
+        <EmitterSplineGizmo points={instance.splinePoints} mode="emitter_path" />
+      )}
     </group>
   );
 }

--- a/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxInstanceMarkers.tsx
@@ -161,7 +161,7 @@ function VfxMarker({ instance, isSelected, onSelect }: {
         </Html>
       )}
       {/* Element gizmos (shown when selected) */}
-      {isSelected && (instance.vfx_preset.elements ?? []).map((el, i) => (
+      {isSelected && (instance.vfx_preset?.elements ?? []).map((el, i) => (
         <ElementGizmo key={`${instance.id}_el_${i}`} element={el} instanceSplinePoints={instance.splinePoints} />
       ))}
     </group>

--- a/tools/apps/bricklayer/src/viewport/VfxRenderer.tsx
+++ b/tools/apps/bricklayer/src/viewport/VfxRenderer.tsx
@@ -282,8 +282,8 @@ function ObjectLayerRenderer({ layer, instancePos }: {
 // ── Per-instance renderer ──
 
 function InstanceRenderer({ instance, wasm }: { instance: VfxInstanceData; wasm: any }) {
-  const emitterLayers = (instance.vfx_preset.elements ?? []).filter((l) => l.type === 'emitter');
-  const objectLayers = (instance.vfx_preset.elements ?? []).filter((l) => l.type === 'object');
+  const emitterLayers = (instance.vfx_preset?.elements ?? []).filter((l) => l.type === 'emitter');
+  const objectLayers = (instance.vfx_preset?.elements ?? []).filter((l) => l.type === 'object');
   const rotY = ((instance.rotation_y ?? 0) * Math.PI) / 180;
 
   return (

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -17,6 +17,7 @@ import { CameraRailMarkers } from './CameraRailMarkers.js';
 import { CameraFrustumGizmo } from './CameraFrustumGizmo.js';
 import { ChunkWireframes } from './ChunkWireframes.js';
 import { TerrainPlyReference } from './TerrainPlyReference.js';
+import { SplineEditor } from './SplineEditor.js';
 import { useSceneStore } from '../store/useSceneStore.js';
 
 // Module-level ref so App.tsx can access the orbit controls for F/Home keys
@@ -319,6 +320,7 @@ function SceneContent() {
       <ChunkWireframes />
       <TeleportPlane />
       <GrabPlane />
+      <SplineEditor />
 
       <OrbitControls
         ref={(r: OrbitControlsRef | null) => {


### PR DESCRIPTION
## Summary
Per-instance spline point overrides for VFX instances in Bricklayer, with click-to-place editing in the 3D viewport.

- Add optional `splinePoints` field to VfxInstanceData
- SplineEditor viewport component: click to place points, drag to move, right-click to delete, Escape to exit
- VfxInstanceMarkers shows per-instance spline override when present
- "Edit Spline" button in properties panel with point count and Reset
- C++ engine reads `spline_points` from scene JSON and overrides preset spline
- Scene schema updated
- Export/import round-trips spline_points correctly
- Dragon flame + smoke trail placed in seurat_island demo

Closes #312

## Test plan
- [ ] Build TS: `pnpm --filter bricklayer build`
- [ ] Build C++: `cmake --build --preset macos-debug`
- [ ] Open seurat_island in Bricklayer — verify spline curves render on dragon flame and smoke trail VFX
- [ ] Select a spline VFX instance — verify "Edit Spline" button appears
- [ ] Click "Edit Spline" — click in viewport to place points — verify curve updates
- [ ] Drag a control point — verify it moves
- [ ] Right-click a point — verify it's removed
- [ ] Press Escape — verify edit mode exits
- [ ] Click "Reset" — verify points cleared back to preset default
- [ ] Run in Staging — verify spline override used by engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)