### PR TITLE
fix(demo): portal, camera, audio crossfade, asset sync

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ add_executable(gseurat_demo
 )
 target_compile_definitions(gseurat_demo PRIVATE VG_BUILD_PROFILE=1)
 target_link_libraries(gseurat_demo PRIVATE gseurat_core)
-add_dependencies(gseurat_demo shaders)
+add_dependencies(gseurat_demo shaders sync_assets)
 
 add_executable(gseurat_staging
     src/staging_main.cpp
@@ -325,7 +325,7 @@ add_executable(gseurat_staging
     src/staging/camera_review_state.cpp
 )
 target_link_libraries(gseurat_staging PRIVATE gseurat_core)
-add_dependencies(gseurat_staging shaders)
+add_dependencies(gseurat_staging shaders sync_assets)
 
 # Copy example assets to build directory so runtime paths resolve unchanged.
 add_custom_target(sync_assets ALL

--- a/examples/island_demo/assets/scenes/northern_forest.json
+++ b/examples/island_demo/assets/scenes/northern_forest.json
@@ -74672,12 +74672,12 @@
       "center": [
         192,
         0,
-        -260
+        -96
       ],
       "half_extents": [
-        100,
+        120,
         50,
-        130
+        96
       ],
       "music_config": "assets/audio/forest_night.music.json",
       "crossfade_ms": 3000,

--- a/examples/island_demo/assets/scenes/seurat_island.json
+++ b/examples/island_demo/assets/scenes/seurat_island.json
@@ -73840,7 +73840,8 @@
             1
           ],
           "transition_duration": 0.5,
-          "effect_type": 2
+          "effect_type": 2,
+          "require_interact": true
         }
       }
     },
@@ -75410,8 +75411,8 @@
       "mode": "orbit",
       "blend_time": 1.5,
       "allow_user_orbit": true,
-      "pitch_min": -60,
-      "pitch_max": 10,
+      "pitch_min": 15,
+      "pitch_max": 55,
       "yaw_min": -180,
       "yaw_max": 180,
       "fov": 45,
@@ -75447,8 +75448,8 @@
             6,
             -12
           ],
-          "pitch_min": -45,
-          "pitch_max": 5,
+          "pitch_min": 20,
+          "pitch_max": 50,
           "fov": 42
         }
       },
@@ -75472,8 +75473,8 @@
             12,
             -20
           ],
-          "pitch_min": -70,
-          "pitch_max": -10,
+          "pitch_min": 20,
+          "pitch_max": 60,
           "fov": 50
         }
       },
@@ -75525,8 +75526,8 @@
             -8
           ],
           "fov": 40,
-          "pitch_min": -30,
-          "pitch_max": 0
+          "pitch_min": 15,
+          "pitch_max": 45
         }
       }
     ],
@@ -75569,27 +75570,27 @@
         "control_points": [
           [
             150,
-            8,
+            18,
             100
           ],
           [
             170,
-            6,
+            16,
             140
           ],
           [
             185,
-            5,
+            15,
             175
           ],
           [
             195,
-            4,
+            14,
             190
           ],
           [
             210,
-            5,
+            15,
             180
           ]
         ]

--- a/examples/island_demo/tools_data/bricklayer/northern_forest.bricklayer
+++ b/examples/island_demo/tools_data/bricklayer/northern_forest.bricklayer
@@ -1078,12 +1078,12 @@
         "center": [
           192,
           0,
-          -260
+          -96
         ],
         "half_extents": [
-          100,
+          120,
           50,
-          130
+          96
         ],
         "music_config": "assets/audio/forest_night.music.json",
         "crossfade_ms": 3000,

--- a/examples/island_demo/tools_data/bricklayer/seurat_island.bricklayer
+++ b/examples/island_demo/tools_data/bricklayer/seurat_island.bricklayer
@@ -293,7 +293,8 @@
               1
             ],
             "transition_duration": 0.5,
-            "effect_type": 2
+            "effect_type": 2,
+            "require_interact": true
           }
         }
       },
@@ -2088,8 +2089,8 @@
           "priority": 1,
           "blend_time": 1.5,
           "allow_user_orbit": true,
-          "pitch_min": -45,
-          "pitch_max": 5,
+          "pitch_min": 20,
+          "pitch_max": 50,
           "yaw_min": -180,
           "yaw_max": 180,
           "fov": 42,
@@ -2118,8 +2119,8 @@
           "priority": 2,
           "blend_time": 1.5,
           "allow_user_orbit": true,
-          "pitch_min": -70,
-          "pitch_max": -10,
+          "pitch_min": 20,
+          "pitch_max": 60,
           "yaw_min": -180,
           "yaw_max": 180,
           "fov": 50,
@@ -2152,8 +2153,8 @@
           "priority": 1,
           "blend_time": 1.5,
           "allow_user_orbit": true,
-          "pitch_min": -60,
-          "pitch_max": 10,
+          "pitch_min": 15,
+          "pitch_max": 55,
           "yaw_min": -180,
           "yaw_max": 180,
           "fov": 48,
@@ -2182,8 +2183,8 @@
           "priority": 3,
           "blend_time": 1.5,
           "allow_user_orbit": true,
-          "pitch_min": -30,
-          "pitch_max": 0,
+          "pitch_min": 15,
+          "pitch_max": 45,
           "yaw_min": -180,
           "yaw_max": 180,
           "fov": 40,
@@ -2239,27 +2240,27 @@
         "control_points": [
           [
             150,
-            8,
+            18,
             100
           ],
           [
             170,
-            6,
+            16,
             140
           ],
           [
             185,
-            5,
+            15,
             175
           ],
           [
             195,
-            4,
+            14,
             190
           ],
           [
             210,
-            5,
+            15,
             180
           ]
         ],
@@ -2270,8 +2271,8 @@
       "mode": "orbit",
       "blend_time": 1.5,
       "allow_user_orbit": true,
-      "pitch_min": -60,
-      "pitch_max": 10,
+      "pitch_min": 15,
+      "pitch_max": 55,
       "yaw_min": -180,
       "yaw_max": 180,
       "fov": 45,

--- a/examples/island_demo/tools_data/weaver/island_demo.weaver
+++ b/examples/island_demo/tools_data/weaver/island_demo.weaver
@@ -8,7 +8,7 @@
       "name": "Field",
       "bpm": 130,
       "loop_start": 0,
-      "loop_end": 0,
+      "loop_end": 388057,
       "loop_enabled": true,
       "markers": [],
       "stems": [
@@ -20,19 +20,19 @@
         },
         {
           "source": "assets/audio/field/music_harmony.wav",
-          "initial_volume": 0.58,
+          "initial_volume": 0.84,
           "muted": false,
           "soloed": false
         },
         {
           "source": "assets/audio/field/music_melody.wav",
-          "initial_volume": 1,
+          "initial_volume": 0.64,
           "muted": false,
           "soloed": false
         },
         {
           "source": "assets/audio/field/music_percussion.wav",
-          "initial_volume": 1,
+          "initial_volume": 0.46,
           "muted": false,
           "soloed": false
         }

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -166,6 +166,19 @@ private:
 
     // RTPC index for dungeon music muffling (LPF cutoff)
     static constexpr uint32_t kRtpcMusicFilter = 10;
+
+    // Audio zone crossfade state
+    struct AudioZoneState {
+        glm::vec3 bounds_min{0};
+        glm::vec3 bounds_max{0};
+        uint32_t  group_id = 0;
+        float     crossfade_ms = 2000.0f;
+        float     ambient_volume = 1.0f;
+        bool      player_inside = false;
+    };
+    std::vector<AudioZoneState> audio_zones_;
+    uint32_t active_music_group_ = 0;   // currently playing music group
+    uint32_t island_music_group_ = 0;   // field_theme group ID (default)
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/camera_volume.hpp
+++ b/include/gseurat/engine/camera_volume.hpp
@@ -124,6 +124,7 @@ struct CameraParams {
     glm::vec3 offset{0.0f, 5.0f, -10.0f};
     glm::vec3 fixed_position{0.0f};
     int rail_index{-1};
+    float min_ground_clearance{10.0f};  // Minimum Y above player (terrain) for rail cameras
 };
 
 struct CameraVolume {

--- a/include/gseurat/engine/ecs/components/portal_target.hpp
+++ b/include/gseurat/engine/ecs/components/portal_target.hpp
@@ -12,6 +12,7 @@ struct PortalTarget {
     glm::vec3   transition_color{1.0f};
     float       transition_duration{0.5f};
     int         effect_type{0};
+    bool        require_interact{false};  // When true, player must press interact key
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/scene_loader.hpp
+++ b/include/gseurat/engine/scene_loader.hpp
@@ -195,6 +195,17 @@ struct SceneData {
 
     // Audio preload hints (track group names to preload on scene load)
     std::vector<std::string> audio_preload_track_groups;
+
+    // Audio zones (spatial music/ambient triggers)
+    struct AudioZoneRef {
+        std::string id;
+        glm::vec3 center{0.0f};
+        glm::vec3 half_extents{0.0f};
+        std::string music_config;   // path to .music.json
+        float crossfade_ms = 2000.0f;
+        float ambient_volume = 1.0f;
+    };
+    std::vector<AudioZoneRef> audio_zones;
 };
 
 class SceneLoader {

--- a/include/gseurat/engine/systems/portal_trigger_handler.hpp
+++ b/include/gseurat/engine/systems/portal_trigger_handler.hpp
@@ -7,6 +7,7 @@ namespace gseurat {
 /// Consumes ProximityTrigger.triggered on entities that also have PortalTarget
 /// and spawns a transient SceneTransition entity. Enforces the one-transition-
 /// at-a-time invariant by checking for existing ScreenFade entities.
-void portal_trigger_handler(ecs::World& world);
+/// @param interact_pressed  true if the player pressed the interact key this frame
+void portal_trigger_handler(ecs::World& world, bool interact_pressed = false);
 
 }  // namespace gseurat

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -63,6 +63,9 @@ void IslandDemoState::on_enter(AppBase& app) {
     app.feature_flags().apply_platform_defaults(app.renderer().context().is_apple_gpu());
     app.init_scene(scene_path_);
 
+    // Collect audio zones from all scenes (populated below during scene loading)
+    std::vector<SceneData::AudioZoneRef> scene_audio_zones;
+
     // Disable app-level parallax — we manage our own camera
     app.gs_terrain().parallax_active = false;
 
@@ -76,6 +79,8 @@ void IslandDemoState::on_enter(AppBase& app) {
     app.feature_flags().point_lights = true;
     app.feature_flags().gs_lod = true;
     app.feature_flags().animation = true;  // GS animation effects (orbit, wave, etc.)
+    app.feature_flags().music = true;
+    app.feature_flags().sfx = true;
 
     // Enable GS lighting: directional sun + point lights for interactive effects
     app.renderer().gs_renderer().set_light_mode(2);  // point light mode (includes directional)
@@ -202,6 +207,16 @@ void IslandDemoState::on_enter(AppBase& app) {
             forest_grid_loaded_ = true;
             std::fprintf(stderr, "[IslandDemo] Forest collision loaded: %ux%u (origin Z=%.0f)\n",
                 forest_collision_grid_.width, forest_collision_grid_.height, forest_grid_origin_.y);
+        }
+
+        // Collect audio zones from loaded scenes for later setup
+        for (const auto& az : forest_scene.audio_zones) {
+            scene_audio_zones.push_back(az);
+        }
+
+        auto dungeon_scene = SceneLoader::load("assets/scenes/dungeon.json");
+        for (const auto& az : dungeon_scene.audio_zones) {
+            scene_audio_zones.push_back(az);
         }
     }
 
@@ -555,10 +570,32 @@ void IslandDemoState::on_enter(AppBase& app) {
             }
             ae->set_rtpc(kRtpcMusicFilter, 1.0f);  // start fully open
             ae->play_group(r.value());
+            island_music_group_ = r.value();
+            active_music_group_ = r.value();
             std::fprintf(stderr, "[IslandDemo] Field theme loaded and playing (group %u)\n", r.value());
         } else {
             std::fprintf(stderr, "[IslandDemo] WARNING: Failed to load field_theme.music.json (error %u)\n",
                          static_cast<uint32_t>(r.error()));
+        }
+
+        // Load audio zones from other scenes and build crossfade state
+        for (const auto& az : scene_audio_zones) {
+            if (az.music_config.empty()) continue;
+            auto gr = ae->load_track_group(az.music_config);
+            if (!gr) {
+                std::fprintf(stderr, "[IslandDemo] WARNING: Failed to load audio zone music '%s'\n",
+                             az.music_config.c_str());
+                continue;
+            }
+            AudioZoneState zs;
+            zs.bounds_min = az.center - az.half_extents;
+            zs.bounds_max = az.center + az.half_extents;
+            zs.group_id = gr.value();
+            zs.crossfade_ms = az.crossfade_ms;
+            zs.ambient_volume = az.ambient_volume;
+            audio_zones_.push_back(zs);
+            std::fprintf(stderr, "[IslandDemo] Audio zone '%s' loaded (group %u, xfade %.0fms)\n",
+                         az.id.c_str(), gr.value(), az.crossfade_ms);
         }
     }
 
@@ -700,9 +737,34 @@ void IslandDemoState::update(AppBase& app, float dt) {
         update_player(app, dt);
     }
 
-    // Audio: update listener position + footstep SFX
+    // Audio: update listener position + footstep SFX + audio zone crossfade
     if (auto* ae = app.audio()) {
         ae->set_listener_position(character_origin_.x, character_origin_.y, character_origin_.z);
+
+        // Audio zone crossfade: check if player entered/exited any zone
+        if (app.feature_flags().music) {
+            uint32_t desired_group = island_music_group_;  // default to island music
+            float xfade_ms = 2000.0f;
+
+            for (auto& z : audio_zones_) {
+                const bool inside = character_origin_.x >= z.bounds_min.x
+                                 && character_origin_.x <= z.bounds_max.x
+                                 && character_origin_.z >= z.bounds_min.z
+                                 && character_origin_.z <= z.bounds_max.z;
+                if (inside) {
+                    desired_group = z.group_id;
+                    xfade_ms = z.crossfade_ms;
+                }
+                z.player_inside = inside;
+            }
+
+            if (desired_group != active_music_group_ && desired_group != 0 && active_music_group_ != 0) {
+                ae->request_transition(active_music_group_, desired_group, xfade_ms);
+                std::fprintf(stderr, "[IslandDemo] Music crossfade: group %u -> %u (%.0fms)\n",
+                             active_music_group_, desired_group, xfade_ms);
+                active_music_group_ = desired_group;
+            }
+        }
     }
     if (sfx_loaded_) {
         const bool moving = glm::length(glm::vec2(player_velocity_.x, player_velocity_.z)) > 1.0f;

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -379,6 +379,7 @@ void AppBase::init_game_object_system() {
             if (j.contains("transition_color")) c.transition_color = SceneLoader::parse_vec3(j["transition_color"]);
             if (j.contains("transition_duration")) c.transition_duration = j["transition_duration"].get<float>();
             if (j.contains("effect_type")) c.effect_type = j["effect_type"].get<int>();
+            if (j.contains("require_interact")) c.require_interact = j["require_interact"].get<bool>();
             return c;
         },
         [](const PortalTarget& c) -> nlohmann::json {
@@ -387,7 +388,8 @@ void AppBase::init_game_object_system() {
                 {"target_position", {c.target_position.x, c.target_position.y, c.target_position.z}},
                 {"transition_color", {c.transition_color.x, c.transition_color.y, c.transition_color.z}},
                 {"transition_duration", c.transition_duration},
-                {"effect_type", c.effect_type}
+                {"effect_type", c.effect_type},
+                {"require_interact", c.require_interact}
             };
         });
 
@@ -465,7 +467,9 @@ void AppBase::init_game_object_system() {
         }, {}, {}});
 
     system_scheduler_.add_system({"portal_trigger_handler",
-        [](ecs::World& w, float) { portal_trigger_handler(w); },
+        [this](ecs::World& w, float) {
+            portal_trigger_handler(w, input_.was_key_pressed(GLFW_KEY_E));
+        },
         /* reads */ {}, /* writes */ {}});
 
     system_scheduler_.add_system({"transition_system",

--- a/src/engine/camera_zone_system.cpp
+++ b/src/engine/camera_zone_system.cpp
@@ -205,6 +205,14 @@ CameraState CameraZoneSystem::evaluate_vcam(const CameraParams& params,
 
             // Snap directly to rail — no spring on position.
             state.position = rails_[ri].path.evaluate(t);
+
+            // Enforce minimum height above player (terrain) to prevent camera
+            // sinking into the ground when rail Y is lower than terrain.
+            float min_y = player_pos.y + params.min_ground_clearance;
+            if (state.position.y < min_y) {
+                state.position.y = min_y;
+            }
+
             spring_position_ = state.position;  // keep spring in sync
 
             if (rails_[ri].has_target_path && rails_[ri].target_path.valid()) {

--- a/src/engine/scene_loader.cpp
+++ b/src/engine/scene_loader.cpp
@@ -31,6 +31,7 @@ CameraParams parse_camera_params(const nlohmann::json& j) {
     p.orbit_distance = j.value("orbit_distance", 10.0f);
     if (j.contains("offset")) p.offset = SceneLoader::parse_vec3(j["offset"]);
     if (j.contains("fixed_position")) p.fixed_position = SceneLoader::parse_vec3(j["fixed_position"]);
+    p.min_ground_clearance = j.value("min_ground_clearance", 3.0f);
     // rail_id resolved later by caller
     return p;
 }
@@ -598,6 +599,20 @@ SceneData SceneLoader::from_json(const nlohmann::json& j) {
     if (j.contains("audio") && j["audio"].contains("preload_track_groups")) {
         for (const auto& s : j["audio"]["preload_track_groups"]) {
             data.audio_preload_track_groups.push_back(s.get<std::string>());
+        }
+    }
+
+    // Audio zones (spatial music triggers)
+    if (j.contains("audio_zones")) {
+        for (const auto& az : j["audio_zones"]) {
+            SceneData::AudioZoneRef ref;
+            ref.id = az.value("id", "");
+            if (az.contains("center")) ref.center = parse_vec3(az["center"]);
+            if (az.contains("half_extents")) ref.half_extents = parse_vec3(az["half_extents"]);
+            ref.music_config = az.value("music_config", "");
+            ref.crossfade_ms = az.value("crossfade_ms", 2000.0f);
+            ref.ambient_volume = az.value("ambient_volume", 1.0f);
+            data.audio_zones.push_back(std::move(ref));
         }
     }
 

--- a/src/engine/systems/portal_trigger_handler.cpp
+++ b/src/engine/systems/portal_trigger_handler.cpp
@@ -10,7 +10,7 @@
 
 namespace gseurat {
 
-void portal_trigger_handler(ecs::World& world) {
+void portal_trigger_handler(ecs::World& world, bool interact_pressed) {
     bool transition_in_flight = false;
     world.view<ScreenFade>().each(
         [&](ecs::Entity, ScreenFade&) { transition_in_flight = true; });
@@ -23,6 +23,7 @@ void portal_trigger_handler(ecs::World& world) {
             if (to_spawn.has_value()) return;
             if (!trig.triggered) return;
             if (portal.target_scene.empty()) return;
+            if (portal.require_interact && !interact_pressed) return;
             to_spawn = portal;
             consumed_portal_entity = e;
         });


### PR DESCRIPTION
## Summary

- **Portal require_interact** — Dungeon portal now requires pressing E instead of proximity-only, preventing accidental teleportation during gameplay and automated Game Director tours (#330)
- **Asset sync dependency** — `sync_assets` is now a build dependency of `gseurat_demo` and `gseurat_staging`, ensuring new audio/VFX assets are always copied to the build directory (#331)
- **Music/SFX enabled** — Both feature flags are now ON by default in the demo (#332)
- **Camera elevation fix** — Camera zone pitch ranges corrected from negative/near-zero to proper isometric angles (20-55°); added `min_ground_clearance` safety for rail cameras
- **Audio zone crossfade** — Parsed `audio_zones` from scene JSON, loaded forest_night and dungeon_depths music configs, smooth crossfade via `request_transition()` when player enters/exits zone boundaries (3s crossfade)

Closes #330, closes #331, closes #332

## Test plan

- [x] Build succeeds (`cmake --build --preset macos-release`)
- [x] Game Director tour completes all 29 stops without portal teleportation
- [x] `features` shows Music: ON, SFX: ON
- [x] Camera stays above ground at all POIs (house, crystals, shores)
- [x] Walking north into forest triggers `Music crossfade: group 1 -> 2 (3000ms)`
- [x] Walking back to island triggers `Music crossfade: group 2 -> 1 (2000ms)`
- [x] Bricklayer sync validation passes for all 3 scenes

🤖 Generated with [Claude Code](https://claude.com/claude-code)