### PR TITLE
feat(control): add game_objects command; fix forest NPC coords

### DIFF
--- a/examples/island_demo/assets/scenes/northern_forest.json
+++ b/examples/island_demo/assets/scenes/northern_forest.json
@@ -39,9 +39,9 @@
     },
     {
       "position": [
-        175,
-        1.2892,
-        -55
+        95.0,
+        3.2038,
+        95.0
       ],
       "radius": 8,
       "color": [
@@ -54,9 +54,9 @@
     },
     {
       "position": [
-        200,
+        140.0,
         2.9122,
-        -130
+        40.0
       ],
       "radius": 8,
       "color": [
@@ -69,9 +69,9 @@
     },
     {
       "position": [
-        145,
-        1.6091,
-        -110
+        90.0,
+        3.2597,
+        85.0
       ],
       "radius": 8,
       "color": [
@@ -84,9 +84,9 @@
     },
     {
       "position": [
-        230,
-        2.4193,
-        -80
+        175.0,
+        3.0626,
+        90.0
       ],
       "radius": 8,
       "color": [
@@ -133,9 +133,9 @@
       "id": "forest_deer_1",
       "name": "Deer",
       "position": [
-        180,
-        1.9543,
-        -100
+        95.0,
+        3.288,
+        90.0
       ],
       "rotation": [
         0,
@@ -155,9 +155,9 @@
       "id": "forest_deer_2",
       "name": "Deer",
       "position": [
-        220,
-        0.7985,
-        -120
+        175.0,
+        3.086,
+        85.0
       ],
       "rotation": [
         0,
@@ -177,9 +177,9 @@
       "id": "forest_wolf",
       "name": "Wolf",
       "position": [
-        150,
-        1.5266,
-        -130
+        90.0,
+        3.0489,
+        80.0
       ],
       "rotation": [
         0,
@@ -199,9 +199,9 @@
       "id": "forest_mushroom_1",
       "name": "Glowing Mushroom",
       "position": [
-        175,
-        1.2892,
-        -55
+        95.0,
+        3.2038,
+        95.0
       ],
       "rotation": [
         0,
@@ -227,9 +227,9 @@
       "id": "forest_mushroom_2",
       "name": "Glowing Mushroom",
       "position": [
-        200,
+        140.0,
         2.9122,
-        -130
+        40.0
       ],
       "rotation": [
         0,
@@ -255,9 +255,9 @@
       "id": "forest_mushroom_3",
       "name": "Glowing Mushroom",
       "position": [
-        145,
-        1.6091,
-        -110
+        90.0,
+        3.2597,
+        85.0
       ],
       "rotation": [
         0,
@@ -283,9 +283,9 @@
       "id": "forest_mushroom_4",
       "name": "Glowing Mushroom",
       "position": [
-        230,
-        2.4193,
-        -80
+        175.0,
+        3.0626,
+        90.0
       ],
       "rotation": [
         0,
@@ -311,9 +311,9 @@
       "id": "forest_guardian",
       "name": "Forest Guardian",
       "position": [
-        134,
-        0,
-        -25
+        135.0,
+        3.1672,
+        35.0
       ],
       "rotation": [
         0,
@@ -338,9 +338,9 @@
       "id": "forest_patrol_knight",
       "name": "Forest Knight",
       "position": [
-        130,
-        0,
-        -37
+        140.0,
+        3.1784,
+        30.0
       ],
       "rotation": [
         0,
@@ -365,9 +365,9 @@
       "id": "firefly_1",
       "name": "Firefly 1",
       "position": [
-        185,
+        125.0,
         1.4939,
-        -50
+        120.0
       ],
       "rotation": [
         0,
@@ -388,9 +388,9 @@
       "id": "firefly_2",
       "name": "Firefly 2",
       "position": [
-        195,
-        0.7926,
-        -110
+        130.0,
+        3.0533,
+        30.0
       ],
       "rotation": [
         0,
@@ -411,9 +411,9 @@
       "id": "firefly_3",
       "name": "Firefly 3",
       "position": [
-        165,
-        2.0177,
-        -115
+        95.0,
+        3.1611,
+        85.0
       ],
       "rotation": [
         0,
@@ -434,9 +434,9 @@
       "id": "firefly_4",
       "name": "Firefly 4",
       "position": [
-        220,
-        0.8529,
-        -110
+        160.0,
+        2.945,
+        120.0
       ],
       "rotation": [
         0,
@@ -457,9 +457,9 @@
       "id": "firefly_5",
       "name": "Firefly 5",
       "position": [
-        200,
-        3.1784,
-        -140
+        135.0,
+        3.2659,
+        30.0
       ],
       "rotation": [
         0,
@@ -647,9 +647,9 @@
   "particle_emitters": [
     {
       "position": [
-        195,
-        1.5045,
-        -50
+        135.0,
+        2.9539,
+        120.0
       ],
       "spawn_rate": 10,
       "lifetime_min": 1,
@@ -701,9 +701,9 @@
     },
     {
       "position": [
-        180,
-        1.6178,
-        -95
+        120.0,
+        3.0533,
+        75.0
       ],
       "spawn_rate": 10,
       "lifetime_min": 1,
@@ -755,9 +755,9 @@
     },
     {
       "position": [
-        205,
-        1.8544,
-        -120
+        145.0,
+        2.945,
+        50.0
       ],
       "spawn_rate": 10,
       "lifetime_min": 1,

--- a/scripts/game_director.py
+++ b/scripts/game_director.py
@@ -100,18 +100,22 @@ class GameConnection:
             self.sock.close()
             self.sock = None
 
-    def send(self, cmd: dict) -> dict:
+    def send(self, cmd: dict, timeout: float = None) -> dict:
         """Send a command and wait for response (JSON line)."""
         if not self.sock:
             self.connect()
+        if timeout:
+            self.sock.settimeout(timeout)
         payload = json.dumps(cmd) + "\n"
         self.sock.sendall(payload.encode("utf-8"))
         data = b""
         while b"\n" not in data:
-            chunk = self.sock.recv(4096)
+            chunk = self.sock.recv(65536)
             if not chunk:
                 raise ConnectionError("Server closed connection")
             data += chunk
+        if timeout:
+            self.sock.settimeout(10)
         return json.loads(data.decode("utf-8").strip())
 
     def __enter__(self):
@@ -159,6 +163,10 @@ def get_features() -> dict:
 
 def get_triggers() -> dict:
     return send_command({"cmd": "get_triggers"})
+
+
+def get_game_objects() -> dict:
+    return send_command({"cmd": "get_game_objects"})
 
 
 def camera_review(action: str) -> dict:
@@ -606,6 +614,31 @@ def main():
                 state = "ACTIVE" if t["triggered"] else "idle"
                 print(f"  [{state:>6}] ({t['x']:.0f}, {t['y']:.1f}, {t['z']:.0f}) "
                       f"r={t['radius']:.0f}")
+
+        elif cmd == "game_objects":
+            data = get_game_objects()
+            scene_objs = data.get("scene_objects", [])
+            live_npcs = data.get("live_npcs", [])
+            print(f"Scene objects: {len(scene_objs)}, Live NPCs: {len(live_npcs)}")
+            print()
+            if scene_objs:
+                print("Scene objects (from JSON):")
+                for obj in scene_objs:
+                    pos = obj.get("scene_position", [0, 0, 0])
+                    comps = obj.get("components", [])
+                    comp_str = ", ".join(comps) if comps else "none"
+                    print(f"  {obj['id']:25s} ({pos[0]:7.1f}, {pos[1]:5.1f}, {pos[2]:7.1f}) "
+                          f"[{comp_str}]")
+            if live_npcs:
+                print()
+                print("Live NPCs (ECS runtime):")
+                for npc in live_npcs:
+                    pos = npc.get("position", [0, 0, 0])
+                    home = npc.get("home", [0, 0])
+                    state = "paused" if npc.get("paused") else "walking"
+                    print(f"  entity={npc['entity']:3d}  pos=({pos[0]:7.1f}, {pos[1]:5.1f}, {pos[2]:7.1f}) "
+                          f"home=({home[0]:7.1f}, {home[1]:7.1f}) "
+                          f"r={npc['patrol_radius']:.0f} [{state}]")
 
         elif cmd == "walk":
             if len(sys.argv) < 3:

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -500,6 +500,48 @@ void CommandDispatcher::register_default_commands() {
         return response;
     });
 
+    register_command("get_game_objects", [this](const json&) -> CommandResult {
+        json response;
+        response["type"] = "game_objects";
+
+        // Scene-level game object data (only objects with components)
+        auto objects = json::array();
+        for (const auto& go : ctx_.scene_objects.game_objects) {
+            if (go.components.empty() || go.components.is_null()) continue;
+            json obj;
+            obj["id"] = go.id;
+            obj["name"] = go.name;
+            obj["position"] = {
+                go.position.x(), go.position.y(), go.position.z()
+            };
+            json comp_names = json::array();
+            for (auto& [name, _] : go.components.items()) {
+                comp_names.push_back(name);
+            }
+            obj["components"] = comp_names;
+            objects.push_back(obj);
+        }
+        response["scene_objects"] = objects;
+
+        // Live NPC positions from ECS
+        auto npcs = json::array();
+        ctx_.world.view<NpcWalker, ecs::Transform>().each(
+            [&](ecs::Entity e, NpcWalker& npc, ecs::Transform& t) {
+                npcs.push_back({
+                    {"entity", e.id},
+                    {"position", {t.position.x(), t.position.y(), t.position.z()}},
+                    {"home", {npc.home_x, npc.home_z}},
+                    {"target", {npc.target_x, npc.target_z}},
+                    {"patrol_radius", npc.patrol_radius},
+                    {"speed", npc.speed},
+                    {"paused", npc.paused},
+                });
+            });
+        response["live_npcs"] = npcs;
+
+        return response;
+    });
+
     register_command("set_project_root", [ok](const json& cmd) -> CommandResult {
         std::string p = cmd.value("path", "");
         set_project_root(p);


### PR DESCRIPTION
## Summary
- Added `get_game_objects` control server command reporting scene objects and live NPC positions from ECS
- Added `game_objects` CLI command to Game Director (`python3 scripts/game_director.py game_objects`)
- Fixed all forest NPC positions: were using world coords instead of grid coords (offset by terrain AABB min), placing them ~200 units outside the map
- Fixed mushroom glow lights and particle emitters to also use grid coords

## Root cause
Game object positions in scene JSON are **grid coordinates** (relative to terrain AABB min). The forest terrain AABB min is approximately (60, 0, -170). Previous fixes set positions as world coordinates, which got shifted by +60 X and -170 Z during `to_world()` conversion.

## Test plan
- [x] `game_objects` command shows correct NPC positions within forest bounds
- [x] Robot (entity 34) at world pos ~(192, -126) with home (196, -134)
- [x] Knight (entity 35) at world pos ~(202, -142) with home (201, -139)  
- [x] Screenshot shows robot visible on forest terrain next to player

🤖 Generated with [Claude Code](https://claude.com/claude-code)