### PR TITLE
fix(bricklayer): preserve terrain PLY path on export

### DIFF
--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -497,7 +497,7 @@ export async function switchScene(
         npcAuraEmitter: { spawn_rate: 0, particle_lifetime_min: 0, particle_lifetime_max: 0, velocity_min: [0, 0], velocity_max: [0, 0], acceleration: [0, 0], size_min: 0, size_max: 0, size_end_scale: 0, color_start: [0, 0, 0, 0], color_end: [0, 0, 0, 0], tile: '', z: 0, spawn_offset_min: [0, 0], spawn_offset_max: [0, 0] },
         weather: { enabled: false, type: 'rain', emitter: { spawn_rate: 0, particle_lifetime_min: 0, particle_lifetime_max: 0, velocity_min: [0, 0], velocity_max: [0, 0], acceleration: [0, 0], size_min: 0, size_max: 0, size_end_scale: 0, color_start: [0, 0, 0, 0], color_end: [0, 0, 0, 0], tile: '', z: 0, spawn_offset_min: [0, 0], spawn_offset_max: [0, 0] }, ambient_override: [0, 0, 0, 0], fog_density: 0, fog_color: [0, 0, 0], transition_speed: 0 },
         dayNight: { enabled: false, cycle_speed: 1, initial_time: 0, keyframes: [] },
-        gaussianSplat: { camera: { position: [0, 10, 20], target: [0, 0, 0], fov: 45 }, render_width: 1920, render_height: 1080, scale_multiplier: 1, background_image: '', parallax: { azimuth_range: 30, elevation_min: -10, elevation_max: 20, distance_range: 5, parallax_strength: 1 }, morphPairPly: '', morphDuration: 2, morphDefaultBlend: 0, morphEasing: 'linear' },
+        gaussianSplat: { ply_file: '', camera: { position: [0, 10, 20], target: [0, 0, 0], fov: 45 }, render_width: 1920, render_height: 1080, scale_multiplier: 1, background_image: '', parallax: { azimuth_range: 30, elevation_min: -10, elevation_max: 20, distance_range: 5, parallax_strength: 1 }, morphPairPly: '', morphDuration: 2, morphDefaultBlend: 0, morphEasing: 'linear' },
       },
     });
     globalToLocal();
@@ -590,6 +590,7 @@ export async function importEngineScene(
     // Convert gaussian splat config
     const gsConfig = engine.gaussian_splat ?? {};
     const gaussianSplat = {
+      ply_file: gsConfig.ply_file ?? '',
       camera: gsConfig.camera ?? { position: [0, 10, 20], target: [0, 0, 0], fov: 45 },
       render_width: gsConfig.render_width ?? 1920,
       render_height: gsConfig.render_height ?? 1080,

--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -246,8 +246,8 @@ export function exportSceneJson(
     };
   }
 
-  // Terrain PLY path: assets/maps/<project_name>.ply
-  const terrainPly = `assets/maps/${state.projectName || 'map'}.ply`;
+  // Terrain PLY path: use stored path, fall back to project-name-derived path
+  const terrainPly = state.gaussianSplat.ply_file || `assets/maps/${state.projectName || 'map'}.ply`;
 
   // Auto-compute camera to look at scene center if using default target
   const cam = state.gaussianSplat.camera;

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -120,6 +120,7 @@ export interface DayNightData {
 export type MorphEasing = 'linear' | 'ease_in_out';
 
 export interface GaussianSplatConfig {
+  ply_file: string;  // terrain PLY path (e.g. "assets/maps/plaza_present.ply")
   camera: {
     position: [number, number, number];
     target: [number, number, number];

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -177,6 +177,7 @@ function defaultDayNight(): DayNightData {
 
 function defaultGaussianSplat(): GaussianSplatConfig {
   return {
+    ply_file: '',
     camera: { position: [0, 5, 10], target: [0, 0, 0], fov: 45 },
     render_width: 320,
     render_height: 240,


### PR DESCRIPTION
## Summary
- Added `ply_file` field to `GaussianSplatConfig` in the Bricklayer store
- Import reads `gaussian_splat.ply_file` from scene JSON and persists it
- Export uses the stored path instead of deriving from project name
- Falls back to `assets/maps/${projectName}.ply` only for new scenes (empty `ply_file`)

## Problem
`exportSceneJson()` generated `assets/maps/${projectName}.ply` — overwriting manually set paths like `assets/maps/plaza_present.ply`. Every Bricklayer save required manually fixing the PLY paths.

## Test plan
- [x] Bricklayer build succeeds
- [x] New scenes still get project-name-derived path (fallback)
- [x] Existing scenes with custom `ply_file` preserve their path on export

🤖 Generated with [Claude Code](https://claude.com/claude-code)