### PR TITLE
fix(bricklayer): backfill ply_file from engine scene for legacy files

### DIFF
--- a/tools/apps/bricklayer/src/lib/projectIO.ts
+++ b/tools/apps/bricklayer/src/lib/projectIO.ts
@@ -384,6 +384,18 @@ export async function loadProject(handle: FileSystemDirectoryHandle): Promise<bo
     const data = JSON.parse(text) as BricklayerFile;
     useSceneStore.getState().loadProject(data);
 
+    // Backfill ply_file from engine scene JSON if missing (legacy .bricklayer files)
+    if (!useSceneStore.getState().gaussianSplat?.ply_file) {
+      const scenePath = engineScenePath(useSceneStore.getState().projectName);
+      try {
+        const engineBlob = await readFileAtPath(handle, scenePath);
+        const engineScene = JSON.parse(await engineBlob.text());
+        if (engineScene.gaussian_splat?.ply_file) {
+          useSceneStore.getState().setGaussianSplat({ ply_file: engineScene.gaussian_splat.ply_file });
+        }
+      } catch { /* engine scene not available */ }
+    }
+
     // Load component schemas from project
     try {
       const assetsDir = await handle.getDirectoryHandle('assets').catch(() => null);
@@ -472,6 +484,18 @@ export async function switchScene(
     const text = await blob.text();
     const data = JSON.parse(text) as BricklayerFile;
     sceneStore.loadProject(data);
+
+    // Backfill ply_file from engine scene JSON if missing (legacy .bricklayer files)
+    if (!sceneStore.gaussianSplat?.ply_file) {
+      try {
+        const engineBlob = await readFileAtPath(handle, sceneFile);
+        const engineScene = JSON.parse(await engineBlob.text());
+        if (engineScene.gaussian_splat?.ply_file) {
+          sceneStore.setGaussianSplat({ ply_file: engineScene.gaussian_splat.ply_file });
+        }
+      } catch { /* engine scene not available — fallback to project name */ }
+    }
+
     globalToLocal();
     centerCameraOnScene();
     console.info(`[bricklayer] Switched to scene: ${bricklayerPath}`);


### PR DESCRIPTION
Fixes #341

## Summary
When loading a `.bricklayer` file created before `ply_file` was added (PR #340), the field is empty and export falls back to the project-name-derived path, overwriting the correct PLY path.

Now both `loadProject()` and `switchScene()` read the corresponding engine scene JSON to backfill `gaussian_splat.ply_file` when it's missing from the store.

## Test plan
- [x] Bricklayer build succeeds
- [x] Legacy `.bricklayer` files get `ply_file` backfilled from engine scene JSON on load
- [x] Files with `ply_file` already set are not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)