### PR TITLE
fix(engine): resolve PLY paths through project_root for Staging

### DIFF
--- a/src/engine/gs_chunk_streamer.cpp
+++ b/src/engine/gs_chunk_streamer.cpp
@@ -1,4 +1,5 @@
 #include "gseurat/engine/gs_chunk_streamer.hpp"
+#include "gseurat/engine/project_root.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -23,7 +24,7 @@ ChunkManifest ChunkManifest::from_json(const nlohmann::json& j) {
             StreamChunkMeta meta;
             meta.grid_x = cj.value("grid_x", 0);
             meta.grid_z = cj.value("grid_z", 0);
-            meta.ply_path = cj.value("ply_file", std::string{});
+            meta.ply_path = resolve_asset_path(cj.value("ply_file", std::string{})).string();
             meta.gaussian_count = cj.value("gaussian_count", 0u);
 
             if (cj.contains("bounds_min")) {

--- a/src/engine/gs_scene_loader.cpp
+++ b/src/engine/gs_scene_loader.cpp
@@ -15,6 +15,7 @@
 #include "gseurat/engine/component_registry.hpp"
 #include "gseurat/engine/trigger_components.hpp"
 #include "gseurat/engine/ecs/components/player_controller.hpp"
+#include "gseurat/engine/project_root.hpp"
 
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/quaternion.hpp>
@@ -49,7 +50,7 @@ void GsSceneLoader::load(SceneLoadContext& ctx, const SceneData& scene_data,
     if (scene_data.gaussian_splat) {
         const auto& gs = *scene_data.gaussian_splat;
         try {
-            cloud = GaussianCloud::load_ply(gs.ply_file);
+            cloud = GaussianCloud::load_ply(resolve_asset_path(gs.ply_file).string());
             has_terrain = !cloud.empty();
         } catch (const std::runtime_error& e) {
             std::fprintf(stderr, "[GS] Warning: %s\n", e.what());
@@ -157,7 +158,7 @@ void GsSceneLoader::load(SceneLoadContext& ctx, const SceneData& scene_data,
                     const auto& go = snapped_objects[i];
                     if (go.ply_file.empty()) continue;
                     try {
-                        auto placed_cloud = GaussianCloud::load_ply(go.ply_file);
+                        auto placed_cloud = GaussianCloud::load_ply(resolve_asset_path(go.ply_file).string());
                         if (placed_cloud.empty()) continue;
                         // Compute local AABB
                         glm::vec3 local_min(1e9f);


### PR DESCRIPTION
## Summary
- `gs_scene_loader.cpp`: terrain PLY and game object PLY loads now use `resolve_asset_path()` instead of raw relative paths
- `gs_chunk_streamer.cpp`: chunk PLY paths resolved at manifest parse time

## Problem
When Staging receives a scene via bridge from a consumer project (e.g., Akashic), PLY paths like `assets/maps/tunnel_present.ply` are relative to the game project root. Staging runs from `build/macos-debug/` so the files weren't found. The `project_root` mechanism exists for exactly this, but PLY loading wasn't using it.

## Test plan
- [x] Build succeeds
- [x] Island demo (no project_root set) continues to work (resolve_asset_path returns path as-is)
- [ ] Staging with `set_project_root` correctly loads PLY from consumer project

🤖 Generated with [Claude Code](https://claude.com/claude-code)