### PR TITLE
feat: GSVX v2 baked AABB, viewport camera sync, GPU buffer clear fix

### DIFF
--- a/docs/superpowers/plans/2026-04-21-gsvx-v2-baked-aabb.md
+++ b/docs/superpowers/plans/2026-04-21-gsvx-v2-baked-aabb.md
@@ -1,0 +1,465 @@
+# GSVX v2 Baked AABB Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the GSVX binary format from v1 (32-byte header) to v2 (64-byte header with baked AABB), enabling zero-parse bounds retrieval.
+
+**Architecture:** Grow `GsvxHeader` to 64 bytes embedding `aabb_min[3]` and `aabb_max[3]`. The C++ loader dispatches on version (1 vs 2). The Python cooker writes v2. Backward compat: v2 loader reads v1 files by falling back to position scan.
+
+**Tech Stack:** C++23, Python 3 (numpy), CMake
+
+---
+
+### Task 1: Add `GsvxHeaderV2` struct and update loader to dispatch on version
+
+**Files:**
+- Modify: `include/gseurat/engine/gaussian_cloud.hpp:62-70`
+- Modify: `src/engine/gaussian_cloud.cpp:370-436`
+
+- [ ] **Step 1: Write failing test — v2 round-trip with baked AABB**
+
+Add to `tests/test_gaussian_cloud.cpp` after the existing Test 13 block (~line 505). First, add a v2 test helper and test:
+
+```cpp
+// Helper: write a v2 .gsvx file with baked AABB
+static void write_test_gsvx_v2(const std::string& path,
+                                const std::vector<gseurat::GpuGaussian>& gaussians,
+                                const gseurat::AABB& aabb) {
+    std::ofstream out(path, std::ios::binary);
+
+    gseurat::GsvxHeaderV2 header{};
+    std::memcpy(header.magic, "GSVX", 4);
+    header.version = 2;
+    header.count = static_cast<uint32_t>(gaussians.size());
+    header.flags = 0;
+    header.aabb_min[0] = aabb.min.x;
+    header.aabb_min[1] = aabb.min.y;
+    header.aabb_min[2] = aabb.min.z;
+    header.aabb_max[0] = aabb.max.x;
+    header.aabb_max[1] = aabb.max.y;
+    header.aabb_max[2] = aabb.max.z;
+    std::memset(header.reserved, 0, sizeof(header.reserved));
+    out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+
+    if (!gaussians.empty()) {
+        out.write(reinterpret_cast<const char*>(gaussians.data()),
+                  static_cast<std::streamsize>(gaussians.size() * sizeof(gseurat::GpuGaussian)));
+    }
+}
+```
+
+Then add the test itself:
+
+```cpp
+// ====== Test N: GSVX v2 round-trip with baked AABB ======
+{
+    // Reuse 5-Gaussian PLY data from Test 10
+    const std::string ply_path = tmp_dir + "/test_standard.ply";
+    write_test_ply(ply_path, 5);
+    auto cloud = GaussianCloud::load_ply(ply_path);
+
+    std::vector<GpuGaussian> data(cloud.count());
+    AABB expected_aabb;
+    for (uint32_t i = 0; i < cloud.count(); ++i) {
+        const auto& g = cloud.gaussians()[i];
+        float bone_as_float;
+        uint32_t bone_idx = g.bone_index;
+        std::memcpy(&bone_as_float, &bone_idx, sizeof(float));
+        data[i].pos_opacity = glm::vec4(g.position, g.opacity);
+        data[i].scale_pad = glm::vec4(g.scale, bone_as_float);
+        data[i].rot = glm::vec4(g.rotation.x, g.rotation.y, g.rotation.z, g.rotation.w);
+        data[i].color_pad = glm::vec4(g.color, g.emission);
+        expected_aabb.expand(g.position);
+    }
+
+    const std::string gsvx_path = tmp_dir + "/test_v2.gsvx";
+    write_test_gsvx_v2(gsvx_path, data, expected_aabb);
+
+    auto payload = GaussianCloud::load_gsvx(gsvx_path);
+    assert(payload.count == 5 && "v2 GSVX should load 5 Gaussians");
+    assert(approx(payload.bounds.min.x, expected_aabb.min.x) && "v2 AABB min.x from header");
+    assert(approx(payload.bounds.min.y, expected_aabb.min.y) && "v2 AABB min.y from header");
+    assert(approx(payload.bounds.min.z, expected_aabb.min.z) && "v2 AABB min.z from header");
+    assert(approx(payload.bounds.max.x, expected_aabb.max.x) && "v2 AABB max.x from header");
+    assert(approx(payload.bounds.max.y, expected_aabb.max.y) && "v2 AABB max.y from header");
+    assert(approx(payload.bounds.max.z, expected_aabb.max.z) && "v2 AABB max.z from header");
+
+    // Verify Gaussian data still matches
+    for (uint32_t i = 0; i < payload.count; ++i) {
+        assert(approx(payload.gpu_gaussians[i].pos_opacity.x, data[i].pos_opacity.x));
+        assert(approx(payload.gpu_gaussians[i].pos_opacity.w, data[i].pos_opacity.w));
+    }
+
+    printf("PASS: Test N - GSVX v2 round-trip with baked AABB\n");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmake --build --preset macos-debug --target test_gaussian_cloud && ./build/macos-debug/test_gaussian_cloud`
+Expected: FAIL — `GsvxHeaderV2` not defined
+
+- [ ] **Step 3: Add `GsvxHeaderV2` struct to header**
+
+In `include/gseurat/engine/gaussian_cloud.hpp`, after the existing `GsvxHeader` struct (line 70):
+
+```cpp
+/// GSVX v2 binary file header (64 bytes, little-endian).
+/// Embeds pre-computed AABB for zero-parse bounds retrieval.
+struct GsvxHeaderV2 {
+    char     magic[4];     // "GSVX"
+    uint32_t version;      // 2
+    uint32_t count;        // Number of Gaussians in payload
+    uint32_t flags;        // Reserved (must be 0)
+    float    aabb_min[3];  // Bounding box minimum (x, y, z)
+    float    aabb_max[3];  // Bounding box maximum (x, y, z)
+    uint8_t  reserved[24]; // Zero-filled padding to 64 bytes
+};
+static_assert(sizeof(GsvxHeaderV2) == 64, "GsvxHeaderV2 must be 64 bytes");
+```
+
+- [ ] **Step 4: Update `load_gsvx()` to handle v1 and v2**
+
+In `src/engine/gaussian_cloud.cpp`, replace the `load_gsvx()` implementation (lines 362-436):
+
+```cpp
+GsvxPayload GaussianCloud::load_gsvx(const std::string& path) {
+    auto resolved = resolve_asset_path(path);
+    std::ifstream file(resolved, std::ios::binary);
+    if (!file) {
+        throw std::runtime_error("Cannot open GSVX file: " + resolved.string());
+    }
+
+    // Get file size for validation
+    file.seekg(0, std::ios::end);
+    const auto file_size = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    // Read first 8 bytes to determine version
+    char magic[4]{};
+    uint32_t version = 0;
+    file.read(magic, 4);
+    file.read(reinterpret_cast<char*>(&version), 4);
+    if (!file || std::memcmp(magic, "GSVX", 4) != 0) {
+        throw std::runtime_error("Invalid GSVX magic number: " + resolved.string());
+    }
+
+    uint32_t count = 0;
+    uint32_t flags = 0;
+    size_t header_size = 0;
+    AABB baked_aabb;
+    bool has_baked_aabb = false;
+
+    if (version == 1) {
+        header_size = sizeof(GsvxHeader);
+        if (file_size < static_cast<std::streamoff>(header_size)) {
+            throw std::runtime_error("GSVX file smaller than v1 header: " + resolved.string());
+        }
+        file.read(reinterpret_cast<char*>(&count), 4);
+        file.read(reinterpret_cast<char*>(&flags), 4);
+        // Skip remaining 16 reserved bytes
+        file.seekg(static_cast<std::streamoff>(header_size), std::ios::beg);
+    } else if (version == 2) {
+        header_size = sizeof(GsvxHeaderV2);
+        if (file_size < static_cast<std::streamoff>(header_size)) {
+            throw std::runtime_error("GSVX file smaller than v2 header: " + resolved.string());
+        }
+        // Re-read as full v2 header
+        file.seekg(0, std::ios::beg);
+        GsvxHeaderV2 h2{};
+        file.read(reinterpret_cast<char*>(&h2), sizeof(h2));
+        if (!file) {
+            throw std::runtime_error("Failed to read GSVX v2 header: " + resolved.string());
+        }
+        count = h2.count;
+        flags = h2.flags;
+        baked_aabb.min = glm::vec3(h2.aabb_min[0], h2.aabb_min[1], h2.aabb_min[2]);
+        baked_aabb.max = glm::vec3(h2.aabb_max[0], h2.aabb_max[1], h2.aabb_max[2]);
+        has_baked_aabb = true;
+    } else {
+        throw std::runtime_error("Unsupported GSVX version " +
+                                 std::to_string(version) + ": " + resolved.string());
+    }
+
+    if (flags != 0) {
+        throw std::runtime_error("GSVX reserved flags must be 0, got " +
+                                 std::to_string(flags) + ": " + resolved.string());
+    }
+
+    // Validate file size matches header + payload
+    const auto expected_size = static_cast<std::streamoff>(header_size) +
+                                static_cast<std::streamoff>(count) *
+                                static_cast<std::streamoff>(sizeof(GpuGaussian));
+    if (file_size != expected_size) {
+        throw std::runtime_error("GSVX file size " + std::to_string(file_size) +
+                                 " does not match header count " +
+                                 std::to_string(count) + " (expected " +
+                                 std::to_string(expected_size) + " bytes): " +
+                                 resolved.string());
+    }
+
+    GsvxPayload payload;
+    payload.count = count;
+
+    if (payload.count == 0) {
+        if (has_baked_aabb) {
+            payload.bounds = baked_aabb;
+        }
+        return payload;
+    }
+
+    // Bulk-read payload directly into vector (zero per-element parsing)
+    payload.gpu_gaussians.resize(payload.count);
+    const auto payload_bytes = static_cast<std::streamsize>(
+        static_cast<size_t>(payload.count) * sizeof(GpuGaussian));
+    file.read(reinterpret_cast<char*>(payload.gpu_gaussians.data()), payload_bytes);
+    if (!file) {
+        throw std::runtime_error("Failed to read GSVX payload (" +
+                                 std::to_string(payload.count) + " gaussians): " +
+                                 resolved.string());
+    }
+
+    if (has_baked_aabb) {
+        // v2: use header AABB (skip position scan)
+        payload.bounds = baked_aabb;
+    } else {
+        // v1: compute AABB from pre-baked positions
+        for (const auto& g : payload.gpu_gaussians) {
+            payload.bounds.expand(glm::vec3(g.pos_opacity));
+        }
+    }
+
+    return payload;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cmake --build --preset macos-debug --target test_gaussian_cloud && ./build/macos-debug/test_gaussian_cloud`
+Expected: All tests PASS including the new v2 test
+
+- [ ] **Step 6: Write test — v1 file still loads correctly with v2-aware loader**
+
+Add to test file:
+
+```cpp
+// ====== Test N+1: v1 GSVX still loads with v2-aware loader ======
+{
+    const std::string ply_path = tmp_dir + "/test_standard.ply";
+    write_test_ply(ply_path, 5);
+    auto cloud = GaussianCloud::load_ply(ply_path);
+
+    std::vector<GpuGaussian> data(cloud.count());
+    for (uint32_t i = 0; i < cloud.count(); ++i) {
+        const auto& g = cloud.gaussians()[i];
+        float bone_as_float;
+        uint32_t bone_idx = g.bone_index;
+        std::memcpy(&bone_as_float, &bone_idx, sizeof(float));
+        data[i].pos_opacity = glm::vec4(g.position, g.opacity);
+        data[i].scale_pad = glm::vec4(g.scale, bone_as_float);
+        data[i].rot = glm::vec4(g.rotation.x, g.rotation.y, g.rotation.z, g.rotation.w);
+        data[i].color_pad = glm::vec4(g.color, g.emission);
+    }
+
+    const std::string gsvx_path = tmp_dir + "/test_v1_compat.gsvx";
+    write_test_gsvx(gsvx_path, data);  // v1 format
+
+    auto payload = GaussianCloud::load_gsvx(gsvx_path);
+    assert(payload.count == 5 && "v1 compat: should load 5 Gaussians");
+    // v1: AABB computed via position scan
+    assert(approx(payload.bounds.min.x, 0.0f) && "v1 compat: AABB min.x from scan");
+    assert(approx(payload.bounds.max.x, 4.0f) && "v1 compat: AABB max.x from scan");
+
+    printf("PASS: Test N+1 - v1 GSVX loads with v2-aware loader\n");
+}
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `cmake --build --preset macos-debug --target test_gaussian_cloud && ./build/macos-debug/test_gaussian_cloud`
+Expected: All tests PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add include/gseurat/engine/gaussian_cloud.hpp src/engine/gaussian_cloud.cpp tests/test_gaussian_cloud.cpp
+git commit -m "feat(gsvx): add v2 header with baked AABB for zero-parse bounds"
+```
+
+---
+
+### Task 2: Update Python cooker to write v2 format
+
+**Files:**
+- Modify: `scripts/ply_to_gseurat.py`
+
+- [ ] **Step 1: Write failing test — Python cooker outputs v2 header**
+
+Create `tests/test_ply_to_gseurat.py`:
+
+```python
+#!/usr/bin/env python3
+"""Test the ply_to_gseurat cooker writes valid v2 GSVX files."""
+
+import struct
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+# Add scripts/ to path so we can import the cooker
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from ply_to_gseurat import ply_to_gsvx
+
+# We need a real PLY file to test with — create a minimal binary one.
+def make_test_ply(path: Path, count: int = 3) -> None:
+    """Write a minimal binary PLY with `count` Gaussians."""
+    import struct as st
+    with open(path, "wb") as f:
+        header = (
+            "ply\n"
+            "format binary_little_endian 1.0\n"
+            f"element vertex {count}\n"
+            "property float x\n"
+            "property float y\n"
+            "property float z\n"
+            "property float f_dc_0\n"
+            "property float f_dc_1\n"
+            "property float f_dc_2\n"
+            "property float opacity\n"
+            "property float scale_0\n"
+            "property float scale_1\n"
+            "property float scale_2\n"
+            "property float rot_0\n"
+            "property float rot_1\n"
+            "property float rot_2\n"
+            "property float rot_3\n"
+            "end_header\n"
+        )
+        f.write(header.encode("ascii"))
+        for i in range(count):
+            pos = (float(i), float(i * 2), float(i * 3))
+            f_dc = (0.0, 0.0, 0.0)
+            opacity = 0.0
+            scale = (0.0, 0.0, 0.0)
+            rot = (1.0, 0.0, 0.0, 0.0)
+            f.write(st.pack("<14f", *pos, *f_dc, opacity, *scale, *rot))
+
+
+def test_v2_header():
+    with tempfile.TemporaryDirectory() as tmp:
+        ply_path = Path(tmp) / "test.ply"
+        make_test_ply(ply_path, count=3)
+
+        data = ply_to_gsvx(ply_path)
+
+        # Header should be 64 bytes
+        assert len(data) == 64 + 3 * 64, f"Expected {64 + 3*64} bytes, got {len(data)}"
+
+        # Parse header
+        magic, version, count, flags = struct.unpack_from("<4sIII", data, 0)
+        assert magic == b"GSVX"
+        assert version == 2, f"Expected version 2, got {version}"
+        assert count == 3
+        assert flags == 0
+
+        # Parse AABB
+        aabb_min = struct.unpack_from("<3f", data, 16)
+        aabb_max = struct.unpack_from("<3f", data, 28)
+
+        # Positions are (0,0,0), (1,2,3), (2,4,6)
+        assert abs(aabb_min[0] - 0.0) < 0.01, f"aabb_min.x = {aabb_min[0]}"
+        assert abs(aabb_min[1] - 0.0) < 0.01, f"aabb_min.y = {aabb_min[1]}"
+        assert abs(aabb_min[2] - 0.0) < 0.01, f"aabb_min.z = {aabb_min[2]}"
+        assert abs(aabb_max[0] - 2.0) < 0.01, f"aabb_max.x = {aabb_max[0]}"
+        assert abs(aabb_max[1] - 4.0) < 0.01, f"aabb_max.y = {aabb_max[1]}"
+        assert abs(aabb_max[2] - 6.0) < 0.01, f"aabb_max.z = {aabb_max[2]}"
+
+        # Reserved bytes should be zero
+        reserved = data[40:64]
+        assert all(b == 0 for b in reserved), "Reserved bytes must be zero"
+
+    print("PASS: test_v2_header")
+
+
+if __name__ == "__main__":
+    test_v2_header()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_ply_to_gseurat.py`
+Expected: FAIL — header is 32 bytes (v1), assertion on `len(data)` fails
+
+- [ ] **Step 3: Update cooker to write v2 format**
+
+In `scripts/ply_to_gseurat.py`, change the constants and header packing:
+
+Replace lines 36-38:
+```python
+GSVX_VERSION = 2
+HEADER_SIZE = 64
+```
+
+Replace the header packing block (lines 178-187):
+```python
+    # --- Compute AABB from baked positions ---
+    aabb_min = (float(px.min()), float(py.min()), float(pz.min()))
+    aabb_max = (float(px.max()), float(py.max()), float(pz.max()))
+
+    # --- Build binary (v2: 64-byte header with baked AABB) ---
+    header = struct.pack("<4sIII3f3f24s",
+                         GSVX_MAGIC,
+                         GSVX_VERSION,
+                         count,
+                         0,               # flags
+                         *aabb_min,
+                         *aabb_max,
+                         b"\x00" * 24)    # reserved
+    assert len(header) == HEADER_SIZE
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_ply_to_gseurat.py`
+Expected: PASS
+
+- [ ] **Step 5: Run C++ tests to verify cross-language compatibility**
+
+Run: `cmake --build --preset macos-debug --target test_gaussian_cloud && ./build/macos-debug/test_gaussian_cloud`
+Expected: All PASS (v1 tests still work; v2 C++ loader can read cooker output)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/ply_to_gseurat.py tests/test_ply_to_gseurat.py
+git commit -m "feat(gsvx): update Python cooker to write v2 format with baked AABB"
+```
+
+---
+
+### Task 3: Re-cook existing .gsvx assets
+
+**Files:**
+- Modify: any existing `.gsvx` files in `examples/island_demo/assets/`
+
+- [ ] **Step 1: Find and re-cook all existing .gsvx files**
+
+```bash
+find examples/island_demo/assets -name "*.gsvx" -exec echo "Re-cooking: {}" \;
+# For each .gsvx that has a corresponding .ply:
+# python3 scripts/ply_to_gseurat.py <ply_path> -o <gsvx_path>
+```
+
+- [ ] **Step 2: Verify re-cooked assets load correctly**
+
+Run: `cmake --build --preset macos-debug --target test_gaussian_cloud && ./build/macos-debug/test_gaussian_cloud`
+Expected: All PASS
+
+- [ ] **Step 3: Commit re-cooked assets**
+
+```bash
+git add examples/island_demo/assets/
+git commit -m "chore: re-cook .gsvx assets with v2 format (baked AABB)"
+```

--- a/docs/superpowers/plans/2026-04-21-staging-gpu-buffer-clear.md
+++ b/docs/superpowers/plans/2026-04-21-staging-gpu-buffer-clear.md
@@ -1,0 +1,91 @@
+# Staging GPU Buffer Clear Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the bug where old Gaussian data persists in GPU buffers when Staging switches scenes in streaming mode.
+
+**Architecture:** Add chunk cleanup (slab checkin + `active_chunks_.clear()`) at the top of `GsRenderer::load_cloud()` before allocating new slabs. The GPU idle wait already precedes this point.
+
+**Tech Stack:** C++23, Vulkan (VMA)
+
+---
+
+### Task 1: Add chunk cleanup to `load_cloud()`
+
+**Files:**
+- Modify: `src/engine/gs_renderer.cpp:815-830`
+
+- [ ] **Step 1: Read current `load_cloud()` to confirm exact insertion point**
+
+Read `src/engine/gs_renderer.cpp` lines 815-835. The cleanup goes after `vkDeviceWaitIdle(device_)` (line 826) and before `sort_done_once_ = false` (line 828).
+
+- [ ] **Step 2: Add chunk cleanup block**
+
+In `src/engine/gs_renderer.cpp`, after line 826 (`vkDeviceWaitIdle(device_);` inside the `if (initialized_)` block) and before `sort_done_once_ = false;` (line 828), insert:
+
+```cpp
+    // Release old scene data — return slabs to allocator, reset tracking state.
+    // Without this, loading a second scene appends to active_chunks_ and old
+    // Gaussian data persists in GPU buffers (visual corruption + VRAM leak).
+    for (auto& chunk : active_chunks_) {
+        slab_allocator_->release(chunk.handle);
+    }
+    active_chunks_.clear();
+    static_count_ = 0;
+    total_active_splats_ = 0;
+```
+
+This uses `slab_allocator_->release()` — the same method used by `unload_cloud()` at line 925.
+
+- [ ] **Step 3: Build and verify compilation**
+
+Run: `cmake --build --preset macos-debug`
+Expected: Build succeeds
+
+- [ ] **Step 4: Run existing tests**
+
+Run: `cmake --build --preset macos-debug --target test_gaussian_cloud && ./build/macos-debug/test_gaussian_cloud`
+Expected: All existing tests PASS (this change only affects streaming-mode `load_cloud`, not tested by unit tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/engine/gs_renderer.cpp
+git commit -m "fix(gs-renderer): clear active chunks on scene switch in streaming mode
+
+load_cloud() was appending new chunks without clearing old ones,
+causing old Gaussian data to persist in GPU buffers. Now returns
+slabs to the allocator and resets tracking state before loading."
+```
+
+---
+
+### Task 2: Verify fix via Game Director (if engine is runnable)
+
+**Files:**
+- None (manual verification)
+
+- [ ] **Step 1: Build release for visual verification**
+
+Run: `cmake --build --preset macos-release`
+
+- [ ] **Step 2: Launch Staging and test scene switch**
+
+If the engine is runnable locally:
+
+```bash
+# Terminal 1: launch staging
+./build/macos-release/staging
+
+# Terminal 2: load scene A, then scene B
+python3 scripts/game_director.py snapshot save scene_a
+python3 scripts/game_director.py load_scene examples/island_demo/assets/scenes/seurat_island.json
+python3 scripts/game_director.py snapshot save scene_b
+python3 scripts/game_director.py snapshot diff scene_a
+```
+
+Verify: snapshot diff shows only scene B elements, no lingering scene A Gaussians.
+
+- [ ] **Step 3: Document verification result**
+
+If manual testing was performed, note the result. If not runnable locally, the fix is verified by code review — the pattern matches `init_streaming()` line 804 and `unload_cloud()` line 925-926.

--- a/docs/superpowers/plans/2026-04-21-viewport-camera-sync.md
+++ b/docs/superpowers/plans/2026-04-21-viewport-camera-sync.md
@@ -1,0 +1,519 @@
+# Viewport-Linked Camera Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bidirectional camera state sync between Bricklayer (Three.js) and Staging (C++ engine) via a "Staging Camera Lock" toggle, so orbiting in one moves the other.
+
+**Architecture:** Bricklayer sends `sync_camera` commands over the WebSocket bridge when OrbitControls changes. The C++ engine registers a `sync_camera` command handler that overrides the Camera directly (bypassing CameraZoneSystem). The engine broadcasts `camera_sync` events to subscribed clients. Echo suppression via `source` field prevents infinite loops.
+
+**Tech Stack:** TypeScript (React/Three.js/Zustand), C++23, WebSocket bridge
+
+---
+
+### Task 1: Add `sync_camera` command handler to C++ engine
+
+**Files:**
+- Modify: `src/engine/command_dispatcher.cpp:49` (register in `register_default_commands`)
+- Modify: `include/gseurat/engine/command_dispatcher.hpp` (add `camera_override_` flag)
+
+- [ ] **Step 1: Read the current `register_default_commands` to find insertion point**
+
+Read `src/engine/command_dispatcher.cpp` lines 49-80. New command registration goes alongside existing commands.
+
+- [ ] **Step 2: Read `CommandDispatcher` header for context struct**
+
+Read `include/gseurat/engine/command_dispatcher.hpp` to understand `CommandContext` and how the renderer/camera is accessed.
+
+- [ ] **Step 3: Add `camera_sync_override` flag and `control_server` pointer to `CommandContext`**
+
+In `include/gseurat/engine/command_context.hpp`, add two fields to the `CommandContext` struct (after the `clear_scene` function, before the closing `};`):
+
+```cpp
+    ControlServer* control_server = nullptr;  // For subscribe/broadcast commands
+    bool camera_sync_override = false;        // Set by sync_camera, suppresses CameraZoneSystem for one frame
+```
+
+Also add forward declaration at the top of the file (after `class DebugDumpRegistry;`):
+
+```cpp
+class ControlServer;
+```
+
+Wherever `CommandContext` is constructed (search for `CommandContext{` in `app_base.cpp` or `staging_state.cpp`), add `&control_server_` to the initializer.
+
+- [ ] **Step 4: Register `sync_camera` command**
+
+In `src/engine/command_dispatcher.cpp`, inside `register_default_commands()`, add:
+
+```cpp
+    register_command("sync_camera", [this](const json& cmd) -> CommandResult {
+        auto pos = cmd.value("position", std::vector<float>{0, 0, 0});
+        auto tgt = cmd.value("target", std::vector<float>{0, 0, 0});
+
+        if (pos.size() < 3 || tgt.size() < 3) {
+            return std::unexpected(std::string("sync_camera requires position and target arrays of length 3"));
+        }
+
+        auto& cam = ctx_.renderer->camera();
+        cam.set_position(glm::vec3(pos[0], pos[1], pos[2]));
+        cam.set_target(glm::vec3(tgt[0], tgt[1], tgt[2]));
+        ctx_.camera_sync_override = true;
+
+        return json{{"type", "ok"}};
+    });
+```
+
+- [ ] **Step 5: Register `subscribe` command (if not already registered)**
+
+In `src/engine/command_dispatcher.cpp`, inside `register_default_commands()`, add:
+
+```cpp
+    register_command("subscribe", [this](const json& cmd) -> CommandResult {
+        if (!ctx_.control_server) {
+            return std::unexpected(std::string("control_server not available"));
+        }
+        auto events = cmd.value("events", std::vector<std::string>{});
+        ctx_.control_server->subscribe_events(events);
+        return json{{"type", "ok"}, {"subscribed", events}};
+    });
+
+    register_command("unsubscribe", [this](const json& cmd) -> CommandResult {
+        if (!ctx_.control_server) {
+            return std::unexpected(std::string("control_server not available"));
+        }
+        ctx_.control_server->unsubscribe_all();
+        return json{{"type", "ok"}};
+    });
+```
+
+Note: Check if `ctx_` has a `control_server` pointer. If not, it needs to be added to `CommandContext`. Read the header to confirm.
+
+- [ ] **Step 6: Build and verify**
+
+Run: `cmake --build --preset macos-debug`
+Expected: Build succeeds
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/engine/command_dispatcher.cpp include/gseurat/engine/command_dispatcher.hpp
+git commit -m "feat(bridge): add sync_camera and subscribe commands for camera sync"
+```
+
+---
+
+### Task 2: Add per-frame camera broadcast in `AppBase`
+
+**Files:**
+- Modify: `src/engine/app_base.cpp:117` (after `poll_control_server()`)
+- Modify: `include/gseurat/engine/app_base.hpp` (add throttle timestamp)
+
+- [ ] **Step 1: Add broadcast throttle state to AppBase**
+
+In `include/gseurat/engine/app_base.hpp`, add to private members:
+
+```cpp
+float camera_broadcast_timer_ = 0.0f;
+static constexpr float kCameraBroadcastInterval = 1.0f / 30.0f;  // 30 Hz
+```
+
+- [ ] **Step 2: Add camera broadcast after state update**
+
+In `src/engine/app_base.cpp`, after `state_stack_.update(*this, dt);` (line 148), add:
+
+```cpp
+        // Broadcast camera state to subscribed clients (throttled to 30 Hz)
+        camera_broadcast_timer_ += dt;
+        if (camera_broadcast_timer_ >= kCameraBroadcastInterval &&
+            control_server_.has_client() &&
+            control_server_.is_event_subscribed("camera_sync")) {
+            camera_broadcast_timer_ = 0.0f;
+            auto pos = renderer_.camera().position();
+            auto tgt = renderer_.camera().target();
+            control_server_.broadcast(nlohmann::json{
+                {"event", "camera_sync"},
+                {"source", "engine"},
+                {"position", {pos.x, pos.y, pos.z}},
+                {"target", {tgt.x, tgt.y, tgt.z}}
+            });
+        }
+
+        // Reset camera sync override at frame end
+        command_dispatcher_.context().camera_sync_override = false;
+```
+
+- [ ] **Step 3: Add `context()` accessor to CommandDispatcher**
+
+In `include/gseurat/engine/command_dispatcher.hpp`, add public accessor:
+
+```cpp
+    CommandContext& context() { return ctx_; }
+    const CommandContext& context() const { return ctx_; }
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cmake --build --preset macos-debug`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/engine/app_base.cpp include/gseurat/engine/app_base.hpp include/gseurat/engine/command_dispatcher.hpp
+git commit -m "feat(bridge): broadcast camera_sync events at 30Hz to subscribed clients"
+```
+
+---
+
+### Task 3: Wire camera override into CameraZoneSystem skip
+
+**Files:**
+- Modify: `src/staging/staging_state.cpp` or `src/demo/island_demo_state.cpp` (wherever CameraZoneSystem::update is called)
+
+- [ ] **Step 1: Find where CameraZoneSystem::update is called**
+
+The camera zone system update is in `src/demo/island_demo_state.cpp:1023-1037` and `src/staging/camera_review_state.cpp:186`. Both need to check the override flag.
+
+- [ ] **Step 2: Add override check before CameraZoneSystem update in island_demo_state**
+
+In `src/demo/island_demo_state.cpp`, around line 1023, wrap the camera zone system update:
+
+```cpp
+    if (camera_zone_system_ && !app.command_dispatcher().context().camera_sync_override) {
+        CameraZoneSystem::InputState input{};
+        // ... existing code ...
+        camera_zone_system_->update(dt, player_pos, player_velocity_, input);
+        auto state = camera_zone_system_->current_state();
+        // ... apply camera state ...
+    }
+```
+
+- [ ] **Step 3: Add override check in camera_review_state**
+
+In `src/staging/camera_review_state.cpp`, around line 186, add the same guard. The `CameraReviewState` needs access to the override flag — pass it via the `update()` method parameter or check `AppBase`'s dispatcher.
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cmake --build --preset macos-debug`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/demo/island_demo_state.cpp src/staging/camera_review_state.cpp
+git commit -m "feat(camera): skip CameraZoneSystem when sync_camera override is active"
+```
+
+---
+
+### Task 4: Add TypeScript bridge types
+
+**Files:**
+- Modify: `tools/packages/engine-client/src/types.ts:190`
+
+- [ ] **Step 1: Add SyncCameraCommand type**
+
+In `tools/packages/engine-client/src/types.ts`, after `SetCameraCommand` (line 190):
+
+```typescript
+export interface SyncCameraCommand {
+  cmd: "sync_camera";
+  source: "bricklayer";
+  position: [number, number, number];
+  target: [number, number, number];
+}
+
+export interface CameraSyncEvent {
+  event: "camera_sync";
+  source: "engine" | "bricklayer";
+  position: [number, number, number];
+  target: [number, number, number];
+}
+```
+
+- [ ] **Step 2: Add to Command union type**
+
+Find the `Command` union type in `types.ts` and add `SyncCameraCommand`:
+
+```typescript
+export type Command = ... | SyncCameraCommand;
+```
+
+- [ ] **Step 3: Build packages**
+
+Run: `cd tools && pnpm build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/packages/engine-client/src/types.ts
+git commit -m "feat(engine-client): add SyncCameraCommand and CameraSyncEvent types"
+```
+
+---
+
+### Task 5: Add `stagingCameraLock` to Bricklayer store
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/store/types.ts:273` (near `cameraShowDebugVolumes`)
+- Modify: `tools/apps/bricklayer/src/store/useSceneStore.ts:420,657`
+
+- [ ] **Step 1: Add type to store types**
+
+In `tools/apps/bricklayer/src/store/types.ts`, near `cameraShowDebugVolumes` (line 273):
+
+```typescript
+  stagingCameraLock: boolean;
+```
+
+- [ ] **Step 2: Add default value and action to store**
+
+In `tools/apps/bricklayer/src/store/useSceneStore.ts`:
+
+Add default near line 420 (next to `cameraShowDebugVolumes: false`):
+```typescript
+  stagingCameraLock: false,
+```
+
+Add setter near line 657 (next to `setCameraShowDebugVolumes`):
+```typescript
+  setStagingCameraLock: (v) => set({ stagingCameraLock: v }),
+```
+
+- [ ] **Step 3: Build**
+
+Run: `cd tools && pnpm build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/store/types.ts tools/apps/bricklayer/src/store/useSceneStore.ts
+git commit -m "feat(bricklayer): add stagingCameraLock store field"
+```
+
+---
+
+### Task 6: Create StagingCameraSync component
+
+**Files:**
+- Create: `tools/apps/bricklayer/src/viewport/StagingCameraSync.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `tools/apps/bricklayer/src/viewport/StagingCameraSync.tsx`:
+
+```tsx
+/**
+ * StagingCameraSync — bidirectional camera sync between Bricklayer and Staging.
+ *
+ * When stagingCameraLock is true:
+ * - Sends Bricklayer's OrbitControls camera to Staging via sync_camera command (throttled 60Hz)
+ * - Listens for camera_sync events from Staging and applies them to OrbitControls
+ * - Uses source field for echo suppression
+ */
+import { useEffect, useRef } from 'react';
+import { useThree } from '@react-three/fiber';
+import { sendBridgeCommand, getBridgeClient } from '@gseurat/engine-client';
+import { useSceneStore } from '../store/useSceneStore.js';
+import { getOrbitControls } from './Viewport.js';
+import type { CameraSyncEvent } from '@gseurat/engine-client';
+
+const SEND_INTERVAL_MS = 16; // ~60 Hz
+
+export function StagingCameraSync() {
+  const locked = useSceneStore((s) => s.stagingCameraLock);
+  const { camera } = useThree();
+  const lastSendRef = useRef(0);
+  const isRemoteUpdateRef = useRef(false);
+
+  // Subscribe to camera_sync events when locked
+  useEffect(() => {
+    if (!locked) return;
+
+    // Tell engine we want camera_sync events
+    sendBridgeCommand({ cmd: 'subscribe', events: ['camera_sync'] });
+
+    const client = getBridgeClient();
+    if (!client) return;
+
+    const off = client.on('camera_sync', (data: unknown) => {
+      const event = data as CameraSyncEvent;
+      if (event.source === 'bricklayer') return; // Echo suppression
+
+      const controls = getOrbitControls();
+      if (!controls) return;
+
+      isRemoteUpdateRef.current = true;
+      camera.position.set(event.position[0], event.position[1], event.position[2]);
+      controls.target.set(event.target[0], event.target[1], event.target[2]);
+      controls.update();
+      isRemoteUpdateRef.current = false;
+    });
+
+    return () => {
+      off();
+      sendBridgeCommand({ cmd: 'unsubscribe' });
+    };
+  }, [locked, camera]);
+
+  // Send camera state on each frame when locked
+  useEffect(() => {
+    if (!locked) return;
+
+    let frameId: number;
+
+    const sendLoop = () => {
+      frameId = requestAnimationFrame(sendLoop);
+
+      const now = performance.now();
+      if (now - lastSendRef.current < SEND_INTERVAL_MS) return;
+      if (isRemoteUpdateRef.current) return; // Don't echo back
+
+      const controls = getOrbitControls();
+      if (!controls) return;
+
+      const pos = camera.position;
+      const tgt = controls.target;
+
+      lastSendRef.current = now;
+      sendBridgeCommand({
+        cmd: 'sync_camera',
+        source: 'bricklayer',
+        position: [pos.x, pos.y, pos.z],
+        target: [tgt.x, tgt.y, tgt.z],
+      });
+    };
+
+    frameId = requestAnimationFrame(sendLoop);
+    return () => cancelAnimationFrame(frameId);
+  }, [locked, camera]);
+
+  return null; // Render nothing — pure side-effect component
+}
+```
+
+- [ ] **Step 2: Add to Viewport's SceneContent**
+
+In `tools/apps/bricklayer/src/viewport/Viewport.tsx`, add import:
+
+```typescript
+import { StagingCameraSync } from './StagingCameraSync.js';
+```
+
+Add `<StagingCameraSync />` inside `SceneContent()`, before `<OrbitControls>` (around line 324):
+
+```tsx
+      <StagingCameraSync />
+      <OrbitControls
+```
+
+- [ ] **Step 3: Build**
+
+Run: `cd tools && pnpm build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/viewport/StagingCameraSync.tsx tools/apps/bricklayer/src/viewport/Viewport.tsx
+git commit -m "feat(bricklayer): add StagingCameraSync component for bidirectional camera sync"
+```
+
+---
+
+### Task 7: Add Staging Camera Lock toggle button to viewport
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/viewport/Viewport.tsx`
+
+- [ ] **Step 1: Add toggle button to the Viewport component**
+
+In `tools/apps/bricklayer/src/viewport/Viewport.tsx`, in the `Viewport()` function (line 348), add a toolbar overlay inside the wrapper div, after the `<Canvas>`:
+
+```tsx
+export function Viewport() {
+  useComponentRegistry('Viewport');
+  const gridWidth = useSceneStore((s) => s.gridWidth);
+  const gridDepth = useSceneStore((s) => s.gridDepth);
+  const stagingCameraLock = useSceneStore((s) => s.stagingCameraLock);
+  const setStagingCameraLock = useSceneStore((s) => s.setStagingCameraLock);
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <Canvas
+        camera={{ position: [gridWidth / 2, 30, gridDepth + 20], fov: 50 }}
+        style={{
+          background: '#16162a',
+          border: stagingCameraLock ? '2px solid #f59e0b' : '2px solid transparent',
+        }}
+        onContextMenu={(e) => e.preventDefault()}
+      >
+        <SceneContent />
+      </Canvas>
+      <button
+        onClick={() => setStagingCameraLock(!stagingCameraLock)}
+        title={stagingCameraLock ? 'Unlock Staging camera' : 'Lock to Staging camera'}
+        style={{
+          position: 'absolute',
+          top: 8,
+          right: 8,
+          padding: '4px 8px',
+          fontSize: 12,
+          background: stagingCameraLock ? '#f59e0b' : '#374151',
+          color: stagingCameraLock ? '#000' : '#d1d5db',
+          border: 'none',
+          borderRadius: 4,
+          cursor: 'pointer',
+        }}
+      >
+        {stagingCameraLock ? 'Camera Locked' : 'Camera Lock'}
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cd tools && pnpm build`
+Expected: Build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/viewport/Viewport.tsx
+git commit -m "feat(bricklayer): add Staging Camera Lock toggle button with visual indicator"
+```
+
+---
+
+### Task 8: Add expected-components entry and integration test
+
+**Files:**
+- Modify: relevant `expected-components.json` for Bricklayer
+- Test via browser automation
+
+- [ ] **Step 1: Add StagingCameraSync to expected components (if applicable)**
+
+Check if `StagingCameraSync` needs to be in `expected-components.json`. Since it renders `null` and doesn't use `useComponentRegistry`, it does NOT need an entry. Skip if not needed.
+
+- [ ] **Step 2: Run component registry health check**
+
+Via Chrome MCP (if available):
+```javascript
+JSON.stringify(window.__COMPONENT_REGISTRY__.health())
+```
+Expected: No missing components
+
+- [ ] **Step 3: Run Bricklayer build and verify no console errors**
+
+Run: `cd tools && pnpm build`
+Expected: Build succeeds with no TypeScript errors
+
+- [ ] **Step 4: Commit (if any changes)**
+
+```bash
+git commit -m "test(bricklayer): verify StagingCameraSync integration"
+```

--- a/docs/superpowers/specs/2026-04-21-gsvx-v2-baked-aabb-design.md
+++ b/docs/superpowers/specs/2026-04-21-gsvx-v2-baked-aabb-design.md
@@ -1,0 +1,99 @@
+# GSVX v2 Header with Baked AABB (Zero-Parse Bounds)
+
+## Problem
+
+GSVX v1 stores a 32-byte header with magic, version, count, and flags. The AABB is computed at load time by scanning all Gaussian positions — an O(n) pass over `pos_opacity.xyz`. For a 200K-splat scene this is fast (~0.3ms) but non-zero, and it prevents true zero-parse loading where bounds are available immediately after reading the header.
+
+Level designers switching between scenes in Bricklayer/Staging benefit from instant bounds for camera fitting and grid-to-world coordinate setup, without waiting for the full payload to load.
+
+## Solution
+
+Extend the GSVX header from 32 to 64 bytes, embedding the pre-computed AABB. Bump version to 2. The v1 loader already rejects unknown versions, so this is a safe breaking change within the format.
+
+## Binary Format Specification (v2)
+
+### Header (64 bytes)
+
+```
+Offset  Size  Type        Field       Description
+──────  ────  ──────────  ──────────  ─────────────────────────────
+0       4     char[4]     magic       "GSVX" (0x47 0x53 0x56 0x58)
+4       4     uint32_le   version     2
+8       4     uint32_le   count       Number of Gaussians in payload
+12      4     uint32_le   flags       Reserved (must be 0)
+16      12    float[3]    aabb_min    Bounding box minimum (x, y, z)
+28      12    float[3]    aabb_max    Bounding box maximum (x, y, z)
+40      24    uint8[24]   reserved    Zero-filled padding to 64 bytes
+```
+
+Payload begins at offset 64 (16-byte aligned). Per-Gaussian layout is unchanged from v1 (64 bytes per `GpuGaussian`).
+
+Total file size: `64 + count * 64` bytes.
+
+### Design Rationale
+
+- **64-byte header**: Power-of-2 alignment is optimal for CPU cache lines and GPU memory-mapped uploads. The 24 bytes of reserved padding provide runway for future fields (SH degree, importance range, compression metadata) without another version bump.
+- **AABB in header**: Eliminates the O(n) position scan. Bounds are available after reading the first 64 bytes — before the payload is even touched.
+- **Version bump to 2**: v1 loader rejects v2 files on version check (already implemented). v2 loader can still load v1 files by falling back to the position scan.
+
+## Component Changes
+
+### 1. C++ Header Struct (`gaussian_cloud.hpp`)
+
+```cpp
+struct GsvxHeaderV2 {
+    char     magic[4];     // "GSVX"
+    uint32_t version;      // 2
+    uint32_t count;        // Gaussian count
+    uint32_t flags;        // Reserved (0)
+    float    aabb_min[3];  // Bounding box min
+    float    aabb_max[3];  // Bounding box max
+    uint8_t  reserved[24]; // Zero padding
+};
+static_assert(sizeof(GsvxHeaderV2) == 64);
+```
+
+The existing `GsvxHeader` (32 bytes) is kept for v1 backward-compat reading. `load_gsvx()` reads the first 4+4 bytes (magic + version), then dispatches to v1 or v2 parsing.
+
+### 2. C++ Loader (`gaussian_cloud.cpp`)
+
+`load_gsvx()` changes:
+- Read magic + version first (8 bytes)
+- If version == 1: read remaining 24 bytes of v1 header, load payload at offset 32, compute AABB via position scan (existing behavior)
+- If version == 2: read full 64-byte header, extract AABB directly, load payload at offset 64, skip position scan
+- If version > 2: return error
+
+### 3. Python Cooker (`scripts/ply_to_gseurat.py`)
+
+- Compute AABB during the vectorized transform pass (free — already iterating positions for `pos_opacity`)
+- Write 64-byte header with version=2 and AABB fields
+- Payload offset moves from 32 to 64
+
+### 4. GsvxPayload
+
+No change — `GsvxPayload` already contains `AABB bounds`. The only difference is where it comes from (header vs. scan).
+
+## Backward Compatibility
+
+| Scenario | Behavior |
+|----------|----------|
+| v2 loader reads v1 file | Falls back to position scan for AABB |
+| v1 loader reads v2 file | Rejects on version check (existing guard) |
+| v2 cooker output | Always writes v2 format |
+
+## Testing
+
+1. **Round-trip test**: PLY -> cook (v2) -> load -> verify AABB matches position scan result within float epsilon
+2. **Header validation**: Corrupt aabb_min/max values -> verify loader detects inconsistency (optional, AABB is trusted)
+3. **v1 fallback**: Load a v1 .gsvx file with v2 loader -> verify AABB is computed via scan
+4. **File size check**: Verify `file_size == 64 + count * 64`
+5. **Visual test**: Load same scene via v1 and v2 paths in Staging -> camera fit should be identical
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `include/gseurat/engine/gaussian_cloud.hpp` | Add `GsvxHeaderV2` struct |
+| `src/engine/gaussian_cloud.cpp` | Version-dispatch in `load_gsvx()`, v2 AABB extraction |
+| `scripts/ply_to_gseurat.py` | Write 64-byte v2 header with AABB |
+| `tests/test_gaussian_cloud.cpp` | v2 round-trip, v1 fallback, header validation tests |

--- a/docs/superpowers/specs/2026-04-21-staging-gpu-buffer-clear-design.md
+++ b/docs/superpowers/specs/2026-04-21-staging-gpu-buffer-clear-design.md
@@ -1,0 +1,75 @@
+# Fix Staging GPU Buffer Clear on Scene Switch
+
+## Problem
+
+When Staging loads a new scene while streaming mode is active, old Gaussian data persists in GPU buffers. The `load_cloud()` method in `gs_renderer.cpp` appends new chunk state to `active_chunks_` without clearing old chunks, causing:
+
+1. **Visual corruption**: Old scene's Gaussians render alongside new scene's data
+2. **VRAM leak**: Physical slabs from old chunks are never returned to the slab allocator
+3. **Incorrect counts**: `static_count_` sums old + new chunks, inflating sort buffer sizes
+
+The bug does not occur in legacy (non-streaming) mode because `load_cloud_legacy()` destroys and recreates buffers on each load.
+
+## Root Cause
+
+In `gs_renderer.cpp`:
+
+- `init_streaming()` (line 804) properly calls `active_chunks_.clear()`
+- `load_cloud()` (line 815) does NOT clear chunks before appending
+
+When Staging switches scenes, it calls `init_gs()` -> `load_cloud()`. Since `streaming_initialized_` is already true, `init_streaming()` is not re-invoked, and `load_cloud()` appends the new scene's chunk on top of the old scene's chunks.
+
+## Fix
+
+Add chunk cleanup at the top of `load_cloud()`, after the GPU idle wait and before slab allocation:
+
+```cpp
+void GsRenderer::load_cloud(const GaussianCloud& cloud) {
+    if (!streaming_initialized_) {
+        load_cloud_legacy(cloud);
+        return;
+    }
+    if (cloud.empty()) return;
+    if (initialized_) { vkDeviceWaitIdle(device_); }
+
+    // ── Release old scene data ──
+    for (auto& chunk : active_chunks_) {
+        slab_allocator_->checkin(std::move(chunk.handle));
+    }
+    active_chunks_.clear();
+    static_count_ = 0;
+    total_active_splats_ = 0;
+    // ─────────────────────────────
+
+    sort_done_once_ = false;
+    static_dirty_ = true;
+    // ... rest of method unchanged
+```
+
+### Why This Is Safe
+
+1. **GPU idle**: `vkDeviceWaitIdle()` is called before cleanup, ensuring no in-flight commands reference the old slab data
+2. **Slab allocator checkin**: Returns physical slabs to the free pool, preventing VRAM accumulation
+3. **Page table offset**: Starts at 0 for the new scene because `active_chunks_` is empty when the loop at line 836 executes
+4. **Sort buffers**: Reinitialized downstream (lines 905-906) based on the new `static_count_`, so old sort state is overwritten
+5. **Chunk table**: Written at `chunk_idx = active_chunks_.size()` (line 874), which is 0 after clear
+
+### Edge Cases
+
+- **Empty cloud after non-empty**: Early return at `if (cloud.empty())` — old chunks remain. This is acceptable because an empty cloud means "no scene loaded" and the old data will be overwritten on next non-empty load. If strict cleanup is desired, add cleanup before the early return.
+- **Multiple `load_cloud()` calls in same frame**: Safe — each call clears previous and loads fresh.
+- **`unload_cloud()` after fix**: Still works correctly — it finds chunks by `chunk_id` in `active_chunks_` and returns slabs individually.
+
+## Testing
+
+1. **Unit test**: Load cloud A -> load cloud B -> assert `active_chunks_.size() == 1` and `static_count_ == B.count()`
+2. **VRAM test**: Load/unload 10 scenes in sequence -> verify slab allocator free count returns to initial value
+3. **Visual test (Game Director)**: Load scene A -> screenshot -> load scene B -> screenshot -> verify no artifacts from scene A in scene B screenshot
+4. **Snapshot diff**: `game_director.py snapshot save before` -> switch scene -> `game_director.py snapshot diff before` -> only new scene elements present
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/engine/gs_renderer.cpp` | Add chunk cleanup in `load_cloud()` before slab allocation |
+| `tests/test_gs_renderer.cpp` | Scene-switch test: load A, load B, verify clean state |

--- a/docs/superpowers/specs/2026-04-21-viewport-camera-sync-design.md
+++ b/docs/superpowers/specs/2026-04-21-viewport-camera-sync-design.md
@@ -1,0 +1,181 @@
+# Viewport-Linked Camera Sync (Bricklayer <-> Staging)
+
+## Problem
+
+Level designers author camera zones in Bricklayer's Three.js viewport but can only see the final result by exporting to JSON, loading in Staging, and walking through the scene. There is no real-time feedback loop — orbiting the camera in Bricklayer does not update Staging, and vice versa.
+
+This forces a slow export-reload-check cycle that breaks creative flow, especially when fine-tuning camera zone framing and transitions.
+
+## Solution
+
+Bidirectional camera state sync over the existing WebSocket bridge (port 9100), gated by a "Staging Camera Lock" toggle in Bricklayer. When locked, orbiting in either tool moves the camera in the other.
+
+## Protocol
+
+### New Bridge Commands
+
+**Bricklayer -> Engine (push camera state):**
+```json
+{
+  "cmd": "sync_camera",
+  "source": "bricklayer",
+  "position": [x, y, z],
+  "target": [x, y, z],
+  "fov": 45.0
+}
+```
+
+**Engine -> Bricklayer (camera state event, via broadcast):**
+```json
+{
+  "type": "camera_sync",
+  "source": "engine",
+  "position": [x, y, z],
+  "target": [x, y, z],
+  "fov": 45.0
+}
+```
+
+**Subscribe to camera events (uses existing subscribe infrastructure):**
+```json
+{"cmd": "subscribe", "events": ["camera_sync"]}
+```
+
+### Echo Suppression
+
+Each update carries a `source` field (`"bricklayer"` or `"engine"`). Recipients ignore updates whose source matches their own identity. This prevents the infinite echo loop:
+
+```
+Bricklayer sends camera -> Engine receives -> Engine broadcasts -> Bricklayer receives
+  (Bricklayer ignores because source == "bricklayer")
+```
+
+## Data Flow
+
+```
+┌─────────────────────┐                          ┌─────────────────────┐
+│   Bricklayer        │                          │   Engine / Staging  │
+│                     │                          │                     │
+│ OrbitControls       │  sync_camera (throttle)  │ Camera              │
+│   onChange ─────────┼─────────────────────────→│   set pos/target    │
+│                     │                          │   camera_override_  │
+│ update controls  ←──┼──────────────────────────┤ per-frame broadcast │
+│   (if source !=     │   camera_sync event      │   (if subscribed)   │
+│    "bricklayer")    │                          │                     │
+└─────────────────────┘                          └─────────────────────┘
+```
+
+### Throttling
+
+- **Bricklayer -> Engine**: Throttle to 60 Hz max (16ms). OrbitControls fires onChange on every pixel of mouse movement; sending every update would flood the bridge.
+- **Engine -> Bricklayer**: Throttle to 30 Hz (33ms). Lower rate is acceptable since Staging camera movement is smoother than mouse-driven orbit.
+
+## Bricklayer UI
+
+### Toggle Button
+
+- Location: Viewport toolbar (top-right, next to existing gizmo mode buttons)
+- Icon: Lock icon (locked = syncing, unlocked = independent)
+- Label: "Staging Camera Lock"
+- Visual feedback: Orange border on viewport when locked (matches existing selection highlight color)
+
+### Store
+
+```typescript
+// In useSceneStore
+stagingCameraLock: boolean;
+toggleStagingCameraLock: () => void;
+```
+
+### Behavior
+
+When `stagingCameraLock` is toggled ON:
+1. Send `subscribe` command for `camera_sync` events
+2. Attach throttled listener to `OrbitControls.onChange`
+3. Set `isRemoteUpdate` flag during incoming camera application (suppress onChange echo)
+
+When toggled OFF:
+1. Send `unsubscribe` for `camera_sync`
+2. Remove onChange listener
+3. Camera returns to independent operation
+
+## C++ Engine Side
+
+### New Command: `sync_camera`
+
+Registered in `CommandDispatcher`:
+
+```cpp
+register_command("sync_camera", [this](const json& cmd) -> CommandResult {
+    auto pos = cmd.value("position", std::vector<float>{0,0,0});
+    auto tgt = cmd.value("target", std::vector<float>{0,0,0});
+    float fov = cmd.value("fov", 45.0f);
+
+    camera_.set_position(glm::vec3(pos[0], pos[1], pos[2]));
+    camera_.set_target(glm::vec3(tgt[0], tgt[1], tgt[2]));
+    camera_.set_fov(fov);
+    camera_override_ = true;  // Skip CameraZoneSystem this frame
+
+    return {true, json{{"status", "ok"}}};
+});
+```
+
+### Camera Override Flag
+
+- `camera_override_` (bool) in `AppBase` or `StagingState`
+- When true: `CameraZoneSystem::update()` is skipped for that frame
+- Reset to false at end of frame
+- Allows engine's zone system to resume when no sync commands arrive
+
+### Per-Frame Broadcast
+
+In `AppBase::update()` or `StagingState::update()`:
+
+```cpp
+if (control_server_.has_subscribers("camera_sync")) {
+    auto pos = camera_.position();
+    auto tgt = camera_.target();
+    control_server_.broadcast(json{
+        {"type", "camera_sync"},
+        {"source", "engine"},
+        {"position", {pos.x, pos.y, pos.z}},
+        {"target", {tgt.x, tgt.y, tgt.z}},
+        {"fov", camera_.fov()}
+    });
+}
+```
+
+Throttled to 30 Hz via a frame counter or timestamp check.
+
+## Future-Proofing (Option B+: Capture Walkthrough)
+
+The `camera_sync` event stream already carries timestamped camera state from engine to client. A future "capture walkthrough" feature requires only:
+
+1. A "Record" button in Bricklayer that starts accumulating `camera_sync` events with timestamps
+2. A "Stop" button that converts the recorded stream to camera rail control points (Catmull-Rom fitting)
+3. Import the rail into `cameraRails[]` in the scene store
+
+No protocol changes are needed. The architecture supports this naturally.
+
+## Testing
+
+1. **Unit test (C++)**: Send `sync_camera` command via control server -> verify Camera position/target updated
+2. **Unit test (C++)**: Verify `camera_override_` suppresses CameraZoneSystem for one frame
+3. **Integration test**: Connect two bridge clients, send sync_camera from one, verify camera_sync broadcast received by the other
+4. **UI test**: Toggle Staging Camera Lock in Bricklayer, orbit viewport, verify Staging camera follows (Game Director screenshot comparison)
+5. **Echo test**: Verify no camera jitter when both sides are connected (source field filtering works)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `tools/packages/engine-client/src/types.ts` | Add `SyncCameraCommand`, `CameraSyncEvent` types |
+| `tools/packages/engine-client/src/bridge.ts` | Add camera sync helpers |
+| `tools/apps/bricklayer/src/store/types.ts` | Add `stagingCameraLock` field |
+| `tools/apps/bricklayer/src/store/useSceneStore.ts` | Add toggle action, camera sync logic |
+| `tools/apps/bricklayer/src/viewport/Viewport.tsx` | Add StagingCameraLock button, onChange hook |
+| `tools/apps/bricklayer/src/viewport/StagingCameraLockButton.tsx` | New — toggle button component |
+| `src/engine/command_dispatcher.cpp` | Register `sync_camera` command |
+| `src/engine/app_base.cpp` | Add per-frame camera broadcast (throttled) |
+| `src/staging/staging_state.cpp` | Add `camera_override_` flag, integrate with zone system |
+| `include/gseurat/engine/control_server.hpp` | Add `has_subscribers()` helper |

--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -273,6 +273,10 @@ protected:
     int pending_steps_ = 0;
     uint64_t tick_ = 0;
     static constexpr float kFixedDt = 1.0f / 60.0f;
+
+    // Camera broadcast throttle
+    float camera_broadcast_timer_ = 0.0f;
+    static constexpr float kCameraBroadcastInterval = 1.0f / 30.0f;  // 30 Hz
     std::string screenshot_response_path_;
 
     // Async asset loading

--- a/include/gseurat/engine/command_context.hpp
+++ b/include/gseurat/engine/command_context.hpp
@@ -15,6 +15,7 @@ namespace ecs { class World; }
 class ComponentRegistry;
 class InputManager;
 class DebugDumpRegistry;
+class ControlServer;
 struct FeatureFlags;
 struct CommandContext {
     const GsTerrainState& terrain;
@@ -34,6 +35,9 @@ struct CommandContext {
     std::function<void(const std::string&)> init_scene;
     std::function<void()> clear_scene;
     std::function<void(const std::string&)> load_character;  // optional: for staging animation preview
+
+    ControlServer* control_server = nullptr;
+    bool camera_sync_override = false;
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/command_dispatcher.hpp
+++ b/include/gseurat/engine/command_dispatcher.hpp
@@ -31,6 +31,9 @@ public:
     void register_default_commands();
     void dispatch(const nlohmann::json& cmd, nlohmann::json& response);
 
+    CommandContext& context() { return ctx_; }
+    const CommandContext& context() const { return ctx_; }
+
 private:
     CommandContext ctx_;
     std::unordered_map<std::string, CommandHandler> handlers_;

--- a/include/gseurat/engine/gaussian_cloud.hpp
+++ b/include/gseurat/engine/gaussian_cloud.hpp
@@ -69,6 +69,19 @@ struct GsvxHeader {
 };
 static_assert(sizeof(GsvxHeader) == 32, "GsvxHeader must be 32 bytes");
 
+/// GSVX v2 binary file header (64 bytes, little-endian).
+/// Embeds pre-computed AABB for zero-parse bounds retrieval.
+struct GsvxHeaderV2 {
+    char     magic[4];     // "GSVX"
+    uint32_t version;      // 2
+    uint32_t count;        // Number of Gaussians in payload
+    uint32_t flags;        // Reserved (must be 0)
+    float    aabb_min[3];  // Bounding box minimum (x, y, z)
+    float    aabb_max[3];  // Bounding box maximum (x, y, z)
+    uint8_t  reserved[24]; // Zero-filled padding to 64 bytes
+};
+static_assert(sizeof(GsvxHeaderV2) == 64, "GsvxHeaderV2 must be 64 bytes");
+
 /// Pre-baked GPU-ready Gaussian data loaded from a .gsvx file.
 struct GsvxPayload {
     std::vector<GpuGaussian> gpu_gaussians;

--- a/include/gseurat/staging/camera_review_state.hpp
+++ b/include/gseurat/staging/camera_review_state.hpp
@@ -58,6 +58,10 @@ public:
     MoveReference move_reference() const { return move_ref_; }
     void set_move_reference(MoveReference ref) { move_ref_ = ref; }
 
+    // Camera override — suppresses CameraZoneSystem for one frame when an
+    // external sync_camera command has set the camera position.
+    void set_camera_override(bool override_active) { camera_override_ = override_active; }
+
 #ifdef GSEURAT_DEV_MODE
     // Gizmo rendering
     void draw_gizmos(const glm::mat4& vp, float screen_w, float screen_h, ImDrawList* draw_list,
@@ -85,6 +89,7 @@ private:
 
     // State
     bool active_ = false;
+    bool camera_override_ = false;
     glm::vec3 initial_player_pos_{0.0f};
     int last_zone_entity_ = -1;  // for auto-switch on zone change only
 

--- a/scripts/ply_to_gseurat.py
+++ b/scripts/ply_to_gseurat.py
@@ -33,8 +33,8 @@ except ImportError:
 # ---------------------------------------------------------------------------
 
 GSVX_MAGIC = b"GSVX"
-GSVX_VERSION = 1
-HEADER_SIZE = 32
+GSVX_VERSION = 2
+HEADER_SIZE = 64
 GAUSSIAN_SIZE = 64
 SH_C0 = 0.28209479177387814  # 1 / (2 * sqrt(pi))
 
@@ -175,13 +175,19 @@ def ply_to_gsvx(ply_path: Path) -> bytes:
     out["color_pad"][:, 2] = cb
     out["color_pad"][:, 3] = emission
 
-    # --- Build binary ---
-    header = struct.pack("<4sIII16s",
+    # --- Compute AABB from baked positions ---
+    aabb_min = (float(px.min()), float(py.min()), float(pz.min()))
+    aabb_max = (float(px.max()), float(py.max()), float(pz.max()))
+
+    # --- Build binary (v2: 64-byte header with baked AABB) ---
+    header = struct.pack("<4sIII3f3f24s",
                          GSVX_MAGIC,
                          GSVX_VERSION,
                          count,
-                         0,
-                         b"\x00" * 16)
+                         0,               # flags
+                         *aabb_min,
+                         *aabb_max,
+                         b"\x00" * 24)    # reserved
     assert len(header) == HEADER_SIZE
 
     return header + out.tobytes()

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1019,8 +1019,25 @@ void IslandDemoState::update_camera(AppBase& app, float dt) {
     auto* transform = app.world().try_get<ecs::Transform>(player_entity_);
     if (!transform) return;
 
+    // When sync_camera override is active, use the renderer's camera directly
+    // and skip both the zone system and the orbit fallback.
+    if (app.command_dispatcher().context().camera_sync_override) {
+        auto pos = app.renderer().camera().position();
+        auto tgt = app.renderer().camera().target();
+        if (glm::length(pos - tgt) < 0.001f) {
+            pos = tgt + glm::vec3(0, 5, -10);
+        }
+        glm::mat4 view = glm::lookAt(pos, tgt, glm::vec3(0, 1, 0));
+        glm::mat4 proj = glm::perspective(
+            glm::radians(45.0f), 1280.0f / 720.0f, 0.1f, 1000.0f);
+        gizmo_vp_ = proj * view;
+        proj[1][1] *= -1.0f;
+        app.renderer().set_gs_camera(view, proj);
+        return;
+    }
+
     // Camera zone system path — data-driven camera volumes/triggers/rails
-    if (camera_zone_system_ && !app.command_dispatcher().context().camera_sync_override) {
+    if (camera_zone_system_) {
         CameraZoneSystem::InputState input{};
         // Feed orbit mouse delta from the existing drag handler
         auto& inp = app.input();

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1020,7 +1020,7 @@ void IslandDemoState::update_camera(AppBase& app, float dt) {
     if (!transform) return;
 
     // Camera zone system path — data-driven camera volumes/triggers/rails
-    if (camera_zone_system_) {
+    if (camera_zone_system_ && !app.command_dispatcher().context().camera_sync_override) {
         CameraZoneSystem::InputState input{};
         // Feed orbit mouse delta from the existing drag handler
         auto& inp = app.input();

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -146,6 +146,26 @@ void AppBase::main_loop() {
         dev_overlay_.begin_frame();
 
         state_stack_.update(*this, dt);
+
+        // Broadcast camera state to subscribed clients (throttled to 30 Hz)
+        camera_broadcast_timer_ += dt;
+        if (camera_broadcast_timer_ >= kCameraBroadcastInterval &&
+            control_server_.has_client() &&
+            control_server_.is_event_subscribed("camera_sync")) {
+            camera_broadcast_timer_ = 0.0f;
+            auto pos = renderer_.camera().position();
+            auto tgt = renderer_.camera().target();
+            control_server_.broadcast(nlohmann::json{
+                {"event", "camera_sync"},
+                {"source", "engine"},
+                {"position", {pos.x, pos.y, pos.z}},
+                {"target", {tgt.x, tgt.y, tgt.z}}
+            });
+        }
+
+        // Reset camera sync override at frame end
+        command_dispatcher_.context().camera_sync_override = false;
+
         upload_bone_transforms();
         gameplay_.play_time += dt;
         tick_++;

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -533,6 +533,7 @@ CommandContext AppBase::build_command_context() {
         .init_scene = [this](const std::string& path) { init_scene(path); },
         .clear_scene = [this]() { clear_scene(); },
         .load_character = [this](const std::string& path) { pending_character_path = path; },
+        .control_server = &control_server_,
     };
 }
 

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -1,5 +1,6 @@
 #include "gseurat/engine/command_dispatcher.hpp"
 #include "gseurat/engine/component_registry.hpp"
+#include "gseurat/engine/control_server.hpp"
 #include "gseurat/engine/debug_dump.hpp"
 #include "gseurat/engine/coordinate.hpp"
 #include "gseurat/engine/ecs/default_components.hpp"
@@ -606,6 +607,39 @@ void CommandDispatcher::register_default_commands() {
     register_command("quit", [this](const json&) -> CommandResult {
         glfwSetWindowShouldClose(ctx_.window, GLFW_TRUE);
         return json{{"type", "ok"}, {"message", "Shutting down"}};
+    });
+
+    register_command("sync_camera", [this](const json& cmd) -> CommandResult {
+        auto pos = cmd.value("position", std::vector<float>{0, 0, 0});
+        auto tgt = cmd.value("target", std::vector<float>{0, 0, 0});
+
+        if (pos.size() < 3 || tgt.size() < 3) {
+            return std::unexpected(std::string("sync_camera requires position and target arrays of length 3"));
+        }
+
+        auto& cam = ctx_.renderer.camera();
+        cam.set_position(glm::vec3(pos[0], pos[1], pos[2]));
+        cam.set_target(glm::vec3(tgt[0], tgt[1], tgt[2]));
+        ctx_.camera_sync_override = true;
+
+        return json{{"type", "ok"}};
+    });
+
+    register_command("subscribe", [this](const json& cmd) -> CommandResult {
+        if (!ctx_.control_server) {
+            return std::unexpected(std::string("control_server not available"));
+        }
+        auto events = cmd.value("events", std::vector<std::string>{});
+        ctx_.control_server->subscribe_events(events);
+        return json{{"type", "ok"}, {"subscribed", events}};
+    });
+
+    register_command("unsubscribe", [this](const json&) -> CommandResult {
+        if (!ctx_.control_server) {
+            return std::unexpected(std::string("control_server not available"));
+        }
+        ctx_.control_server->unsubscribe_all();
+        return json{{"type", "ok"}};
     });
 }
 

--- a/src/engine/gaussian_cloud.cpp
+++ b/src/engine/gaussian_cloud.cpp
@@ -365,54 +365,85 @@ void GaussianCloud::write_ply(const std::string& path,
 GsvxPayload GaussianCloud::load_gsvx(const std::string& path) {
     auto resolved = resolve_asset_path(path);
     std::ifstream file(resolved, std::ios::binary);
-    if (!file.is_open()) {
-        throw std::runtime_error("Failed to open GSVX file: " + resolved.string());
+    if (!file) {
+        throw std::runtime_error("Cannot open GSVX file: " + resolved.string());
     }
 
-    // Validate file size up front — cheap sanity check, prevents oversize allocation DoS
+    // Get file size for validation
     file.seekg(0, std::ios::end);
     const auto file_size = file.tellg();
     file.seekg(0, std::ios::beg);
-    if (file_size < static_cast<std::streamoff>(sizeof(GsvxHeader))) {
-        throw std::runtime_error("GSVX file smaller than header: " + resolved.string());
-    }
 
-    // Read and validate header
-    GsvxHeader header{};
-    file.read(reinterpret_cast<char*>(&header), sizeof(GsvxHeader));
-    if (!file) {
-        throw std::runtime_error("Failed to read GSVX header: " + resolved.string());
-    }
-
-    if (std::memcmp(header.magic, "GSVX", 4) != 0) {
+    // Read first 8 bytes to determine version
+    char magic[4]{};
+    uint32_t version = 0;
+    file.read(magic, 4);
+    file.read(reinterpret_cast<char*>(&version), 4);
+    if (!file || std::memcmp(magic, "GSVX", 4) != 0) {
         throw std::runtime_error("Invalid GSVX magic number: " + resolved.string());
     }
-    if (header.version != 1) {
+
+    uint32_t count = 0;
+    uint32_t flags = 0;
+    size_t header_size = 0;
+    AABB baked_aabb;
+    bool has_baked_aabb = false;
+
+    if (version == 1) {
+        header_size = sizeof(GsvxHeader);
+        if (file_size < static_cast<std::streamoff>(header_size)) {
+            throw std::runtime_error("GSVX file smaller than v1 header: " + resolved.string());
+        }
+        file.read(reinterpret_cast<char*>(&count), 4);
+        file.read(reinterpret_cast<char*>(&flags), 4);
+        // Skip remaining 16 reserved bytes
+        file.seekg(static_cast<std::streamoff>(header_size), std::ios::beg);
+    } else if (version == 2) {
+        header_size = sizeof(GsvxHeaderV2);
+        if (file_size < static_cast<std::streamoff>(header_size)) {
+            throw std::runtime_error("GSVX file smaller than v2 header: " + resolved.string());
+        }
+        // Re-read as full v2 header
+        file.seekg(0, std::ios::beg);
+        GsvxHeaderV2 h2{};
+        file.read(reinterpret_cast<char*>(&h2), sizeof(h2));
+        if (!file) {
+            throw std::runtime_error("Failed to read GSVX v2 header: " + resolved.string());
+        }
+        count = h2.count;
+        flags = h2.flags;
+        baked_aabb.min = glm::vec3(h2.aabb_min[0], h2.aabb_min[1], h2.aabb_min[2]);
+        baked_aabb.max = glm::vec3(h2.aabb_max[0], h2.aabb_max[1], h2.aabb_max[2]);
+        has_baked_aabb = true;
+    } else {
         throw std::runtime_error("Unsupported GSVX version " +
-                                 std::to_string(header.version) + ": " + resolved.string());
-    }
-    if (header.flags != 0) {
-        throw std::runtime_error("GSVX reserved flags must be 0, got " +
-                                 std::to_string(header.flags) + ": " + resolved.string());
+                                 std::to_string(version) + ": " + resolved.string());
     }
 
-    // Reject files whose advertised count doesn't match on-disk size.
-    // This also caps malicious headers claiming billions of gaussians before resize().
-    const auto expected_size = static_cast<std::streamoff>(sizeof(GsvxHeader)) +
-                                static_cast<std::streamoff>(header.count) *
+    if (flags != 0) {
+        throw std::runtime_error("GSVX reserved flags must be 0, got " +
+                                 std::to_string(flags) + ": " + resolved.string());
+    }
+
+    // Validate file size matches header + payload
+    const auto expected_size = static_cast<std::streamoff>(header_size) +
+                                static_cast<std::streamoff>(count) *
                                 static_cast<std::streamoff>(sizeof(GpuGaussian));
     if (file_size != expected_size) {
         throw std::runtime_error("GSVX file size " + std::to_string(file_size) +
                                  " does not match header count " +
-                                 std::to_string(header.count) + " (expected " +
+                                 std::to_string(count) + " (expected " +
                                  std::to_string(expected_size) + " bytes): " +
                                  resolved.string());
     }
 
     GsvxPayload payload;
-    payload.count = header.count;
+    payload.count = count;
 
     if (payload.count == 0) {
+        if (has_baked_aabb) {
+            payload.bounds = baked_aabb;
+        }
         return payload;
     }
 
@@ -427,9 +458,14 @@ GsvxPayload GaussianCloud::load_gsvx(const std::string& path) {
                                  resolved.string());
     }
 
-    // Compute AABB from pre-baked positions (trivial scan, no math)
-    for (const auto& g : payload.gpu_gaussians) {
-        payload.bounds.expand(glm::vec3(g.pos_opacity));
+    if (has_baked_aabb) {
+        // v2: use header AABB (skip position scan)
+        payload.bounds = baked_aabb;
+    } else {
+        // v1: compute AABB from pre-baked positions
+        for (const auto& g : payload.gpu_gaussians) {
+            payload.bounds.expand(glm::vec3(g.pos_opacity));
+        }
     }
 
     return payload;

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -825,6 +825,16 @@ void GsRenderer::load_cloud(const GaussianCloud& cloud) {
         vkDeviceWaitIdle(device_);
     }
 
+    // Release old scene data — return slabs to allocator, reset tracking state.
+    // Without this, loading a second scene appends to active_chunks_ and old
+    // Gaussian data persists in GPU buffers (visual corruption + VRAM leak).
+    for (auto& chunk : active_chunks_) {
+        slab_allocator_->release(chunk.handle);
+    }
+    active_chunks_.clear();
+    static_count_ = 0;
+    total_active_splats_ = 0;
+
     sort_done_once_ = false;
     static_dirty_ = true;
 

--- a/src/staging/camera_review_state.cpp
+++ b/src/staging/camera_review_state.cpp
@@ -191,6 +191,11 @@ void CameraReviewState::update(float dt, const InputManager& input,
     }
 
     // ── Zone system update ─────────────────────────────────────────────────
+    // Skip if an external sync_camera override is active for this frame.
+    if (camera_override_) {
+        camera_override_ = false;
+        return;
+    }
     zone_system_.update(dt, player_pos_, player_vel_, cam_input);
 
     // ── Auto-switch MoveReference on zone change only ──────────────────────

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -371,14 +371,25 @@ void StagingState::update(AppBase& app, float dt) {
 #else
         bool typing_in_widget = false;
 #endif
-        camera_review_->set_camera_override(
-            app.command_dispatcher().context().camera_sync_override);
+        const bool sync_override = app.command_dispatcher().context().camera_sync_override;
+        camera_review_->set_camera_override(sync_override);
         camera_review_->update(dt, app.input(), wants_mouse, typing_in_widget,
                                mouse_dx, mouse_dy);
 
         // Build view/proj from CameraState
         if (app.renderer().has_gs_cloud()) {
-            auto cam = camera_review_->camera_state();
+            // When sync_camera override is active, use the renderer's camera
+            // directly (set by the sync_camera command) instead of
+            // camera_review_ state, which would overwrite the synced position.
+            CameraState cam;
+            if (sync_override) {
+                cam.position = app.renderer().camera().position();
+                cam.target = app.renderer().camera().target();
+                cam.up = glm::vec3(0, 1, 0);
+                cam.fov = 45.0f;
+            } else {
+                cam = camera_review_->camera_state();
+            }
             auto& gs_renderer = app.renderer().gs_renderer();
             float aspect = static_cast<float>(gs_renderer.output_width()) /
                            static_cast<float>(gs_renderer.output_height());

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -371,6 +371,8 @@ void StagingState::update(AppBase& app, float dt) {
 #else
         bool typing_in_widget = false;
 #endif
+        camera_review_->set_camera_override(
+            app.command_dispatcher().context().camera_sync_override);
         camera_review_->update(dt, app.input(), wants_mouse, typing_in_widget,
                                mouse_dx, mouse_dy);
 

--- a/tests/test_gaussian_cloud.cpp
+++ b/tests/test_gaussian_cloud.cpp
@@ -191,6 +191,32 @@ static void write_test_gsvx(const std::string& path,
     }
 }
 
+// Helper: write a v2 .gsvx file with baked AABB
+static void write_test_gsvx_v2(const std::string& path,
+                                const std::vector<gseurat::GpuGaussian>& gaussians,
+                                const gseurat::AABB& aabb) {
+    std::ofstream out(path, std::ios::binary);
+
+    gseurat::GsvxHeaderV2 header{};
+    std::memcpy(header.magic, "GSVX", 4);
+    header.version = 2;
+    header.count = static_cast<uint32_t>(gaussians.size());
+    header.flags = 0;
+    header.aabb_min[0] = aabb.min.x;
+    header.aabb_min[1] = aabb.min.y;
+    header.aabb_min[2] = aabb.min.z;
+    header.aabb_max[0] = aabb.max.x;
+    header.aabb_max[1] = aabb.max.y;
+    header.aabb_max[2] = aabb.max.z;
+    std::memset(header.reserved, 0, sizeof(header.reserved));
+    out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+
+    if (!gaussians.empty()) {
+        out.write(reinterpret_cast<const char*>(gaussians.data()),
+                  static_cast<std::streamsize>(gaussians.size() * sizeof(gseurat::GpuGaussian)));
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Float comparison helper
 // ---------------------------------------------------------------------------
@@ -693,6 +719,77 @@ int main() {
         assert(approx(g.rotation.w, src[0].rotation.w, 0.02f) && "Round-trip rot.w preserved");
 
         printf("PASS: Test 21 - kVulkanYDown write+load recovers original\n");
+    }
+
+    // ====== Test 22: GSVX v2 round-trip with baked AABB ======
+    {
+        const std::string ply_path = tmp_dir + "/test_standard.ply";
+        write_test_ply(ply_path, 5);
+        auto cloud = GaussianCloud::load_ply(ply_path);
+
+        std::vector<GpuGaussian> data(cloud.count());
+        AABB expected_aabb;
+        for (uint32_t i = 0; i < cloud.count(); ++i) {
+            const auto& g = cloud.gaussians()[i];
+            float bone_as_float;
+            uint32_t bone_idx = g.bone_index;
+            std::memcpy(&bone_as_float, &bone_idx, sizeof(float));
+            data[i].pos_opacity = glm::vec4(g.position, g.opacity);
+            data[i].scale_pad = glm::vec4(g.scale, bone_as_float);
+            data[i].rot = glm::vec4(g.rotation.x, g.rotation.y, g.rotation.z, g.rotation.w);
+            data[i].color_pad = glm::vec4(g.color, g.emission);
+            expected_aabb.expand(g.position);
+        }
+
+        const std::string gsvx_path = tmp_dir + "/test_v2.gsvx";
+        write_test_gsvx_v2(gsvx_path, data, expected_aabb);
+
+        auto payload = GaussianCloud::load_gsvx(gsvx_path);
+        assert(payload.count == 5 && "v2 GSVX should load 5 Gaussians");
+        assert(approx(payload.bounds.min.x, expected_aabb.min.x) && "v2 AABB min.x from header");
+        assert(approx(payload.bounds.min.y, expected_aabb.min.y) && "v2 AABB min.y from header");
+        assert(approx(payload.bounds.min.z, expected_aabb.min.z) && "v2 AABB min.z from header");
+        assert(approx(payload.bounds.max.x, expected_aabb.max.x) && "v2 AABB max.x from header");
+        assert(approx(payload.bounds.max.y, expected_aabb.max.y) && "v2 AABB max.y from header");
+        assert(approx(payload.bounds.max.z, expected_aabb.max.z) && "v2 AABB max.z from header");
+
+        // Verify Gaussian data still matches
+        for (uint32_t i = 0; i < payload.count; ++i) {
+            assert(approx(payload.gpu_gaussians[i].pos_opacity.x, data[i].pos_opacity.x));
+            assert(approx(payload.gpu_gaussians[i].pos_opacity.w, data[i].pos_opacity.w));
+        }
+
+        printf("PASS: Test 22 - GSVX v2 round-trip with baked AABB\n");
+    }
+
+    // ====== Test 23: v1 GSVX still loads with v2-aware loader ======
+    {
+        const std::string ply_path = tmp_dir + "/test_standard.ply";
+        write_test_ply(ply_path, 5);
+        auto cloud = GaussianCloud::load_ply(ply_path);
+
+        std::vector<GpuGaussian> data(cloud.count());
+        for (uint32_t i = 0; i < cloud.count(); ++i) {
+            const auto& g = cloud.gaussians()[i];
+            float bone_as_float;
+            uint32_t bone_idx = g.bone_index;
+            std::memcpy(&bone_as_float, &bone_idx, sizeof(float));
+            data[i].pos_opacity = glm::vec4(g.position, g.opacity);
+            data[i].scale_pad = glm::vec4(g.scale, bone_as_float);
+            data[i].rot = glm::vec4(g.rotation.x, g.rotation.y, g.rotation.z, g.rotation.w);
+            data[i].color_pad = glm::vec4(g.color, g.emission);
+        }
+
+        const std::string gsvx_path = tmp_dir + "/test_v1_compat.gsvx";
+        write_test_gsvx(gsvx_path, data);  // v1 format
+
+        auto payload = GaussianCloud::load_gsvx(gsvx_path);
+        assert(payload.count == 5 && "v1 compat: should load 5 Gaussians");
+        // v1: AABB computed via position scan
+        assert(approx(payload.bounds.min.x, 0.0f) && "v1 compat: AABB min.x from scan");
+        assert(approx(payload.bounds.max.x, 4.0f) && "v1 compat: AABB max.x from scan");
+
+        printf("PASS: Test 23 - v1 GSVX loads with v2-aware loader\n");
     }
 
     // Cleanup temp files

--- a/tests/test_ply_to_gseurat.py
+++ b/tests/test_ply_to_gseurat.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Test the ply_to_gseurat cooker writes valid v2 GSVX files."""
+
+import struct
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from ply_to_gseurat import ply_to_gsvx
+
+
+def make_test_ply(path: Path, count: int = 3) -> None:
+    """Write a minimal binary PLY with `count` Gaussians."""
+    with open(path, "wb") as f:
+        header = (
+            "ply\n"
+            "format binary_little_endian 1.0\n"
+            f"element vertex {count}\n"
+            "property float x\n"
+            "property float y\n"
+            "property float z\n"
+            "property float f_dc_0\n"
+            "property float f_dc_1\n"
+            "property float f_dc_2\n"
+            "property float opacity\n"
+            "property float scale_0\n"
+            "property float scale_1\n"
+            "property float scale_2\n"
+            "property float rot_0\n"
+            "property float rot_1\n"
+            "property float rot_2\n"
+            "property float rot_3\n"
+            "end_header\n"
+        )
+        f.write(header.encode("ascii"))
+        for i in range(count):
+            pos = (float(i), float(i * 2), float(i * 3))
+            f_dc = (0.0, 0.0, 0.0)
+            opacity = 0.0
+            scale = (0.0, 0.0, 0.0)
+            rot = (1.0, 0.0, 0.0, 0.0)
+            f.write(struct.pack("<14f", *pos, *f_dc, opacity, *scale, *rot))
+
+
+def test_v2_header():
+    with tempfile.TemporaryDirectory() as tmp:
+        ply_path = Path(tmp) / "test.ply"
+        make_test_ply(ply_path, count=3)
+
+        data = ply_to_gsvx(ply_path)
+
+        # Header should be 64 bytes
+        assert len(data) == 64 + 3 * 64, f"Expected {64 + 3*64} bytes, got {len(data)}"
+
+        # Parse header
+        magic, version, count, flags = struct.unpack_from("<4sIII", data, 0)
+        assert magic == b"GSVX"
+        assert version == 2, f"Expected version 2, got {version}"
+        assert count == 3
+        assert flags == 0
+
+        # Parse AABB
+        aabb_min = struct.unpack_from("<3f", data, 16)
+        aabb_max = struct.unpack_from("<3f", data, 28)
+
+        # Positions are (0,0,0), (1,2,3), (2,4,6)
+        assert abs(aabb_min[0] - 0.0) < 0.01, f"aabb_min.x = {aabb_min[0]}"
+        assert abs(aabb_min[1] - 0.0) < 0.01, f"aabb_min.y = {aabb_min[1]}"
+        assert abs(aabb_min[2] - 0.0) < 0.01, f"aabb_min.z = {aabb_min[2]}"
+        assert abs(aabb_max[0] - 2.0) < 0.01, f"aabb_max.x = {aabb_max[0]}"
+        assert abs(aabb_max[1] - 4.0) < 0.01, f"aabb_max.y = {aabb_max[1]}"
+        assert abs(aabb_max[2] - 6.0) < 0.01, f"aabb_max.z = {aabb_max[2]}"
+
+        # Reserved bytes should be zero
+        reserved = data[40:64]
+        assert all(b == 0 for b in reserved), "Reserved bytes must be zero"
+
+    print("PASS: test_v2_header")
+
+
+if __name__ == "__main__":
+    test_v2_header()

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -271,6 +271,7 @@ export interface SceneStoreState {
   cameraRails: CameraZoneRail[];
   cameraDefaultParams: Partial<CameraZoneParams>;
   cameraShowDebugVolumes: boolean;
+  stagingCameraLock: boolean;
   savedEditorCamera: { position: [number,number,number]; target: [number,number,number] } | null;
   audioZones: AudioZoneData[];
 
@@ -324,6 +325,7 @@ export interface SceneStoreState {
   updateRailControlPoint: (railId: string, index: number, point: [number, number, number]) => void;
   updateCameraDefaultParams: (patch: Partial<CameraZoneParams>) => void;
   setCameraShowDebugVolumes: (show: boolean) => void;
+  setStagingCameraLock: (v: boolean) => void;
   importCameraZonesJson: (data: Record<string, unknown>) => void;
   updatePlayer: (patch: Partial<PlayerData>) => void;
   addBackgroundLayer: () => void;
@@ -420,6 +422,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
   cameraRails: [],
   cameraDefaultParams: {},
   cameraShowDebugVolumes: false,
+  stagingCameraLock: false,
   savedEditorCamera: null,
   audioZones: [] as AudioZoneData[],
 
@@ -658,6 +661,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     cameraDefaultParams: { ...get().cameraDefaultParams, ...patch }, isDirty: true,
   }),
   setCameraShowDebugVolumes: (show) => set({ cameraShowDebugVolumes: show }),
+  setStagingCameraLock: (v) => set({ stagingCameraLock: v }),
 
   importCameraZonesJson: (data) => {
     const zones = data.camera_zones as Record<string, unknown> | undefined;

--- a/tools/apps/bricklayer/src/viewport/StagingCameraSync.tsx
+++ b/tools/apps/bricklayer/src/viewport/StagingCameraSync.tsx
@@ -1,0 +1,87 @@
+/**
+ * StagingCameraSync — bidirectional camera sync between Bricklayer and Staging.
+ *
+ * When stagingCameraLock is true:
+ * - Sends Bricklayer's OrbitControls camera to Staging via sync_camera command (throttled 60Hz)
+ * - Listens for camera_sync events from Staging and applies them to OrbitControls
+ * - Uses source field for echo suppression
+ */
+import { useEffect, useRef } from 'react';
+import { useThree } from '@react-three/fiber';
+import { sendBridgeCommand, getBridgeClient } from '@gseurat/engine-client';
+import { useSceneStore } from '../store/useSceneStore.js';
+import { getOrbitControls } from './Viewport.js';
+import type { CameraSyncEvent } from '@gseurat/engine-client';
+
+const SEND_INTERVAL_MS = 16; // ~60 Hz
+
+export function StagingCameraSync() {
+  const locked = useSceneStore((s) => s.stagingCameraLock);
+  const { camera } = useThree();
+  const lastSendRef = useRef(0);
+  const isRemoteUpdateRef = useRef(false);
+
+  // Subscribe to camera_sync events when locked
+  useEffect(() => {
+    if (!locked) return;
+
+    // Tell engine we want camera_sync events
+    sendBridgeCommand({ cmd: 'subscribe', events: ['camera_sync'] });
+
+    const client = getBridgeClient();
+    if (!client) return;
+
+    const off = client.on('camera_sync', (data: unknown) => {
+      const event = data as CameraSyncEvent;
+      if (event.source === 'bricklayer') return; // Echo suppression
+
+      const controls = getOrbitControls();
+      if (!controls) return;
+
+      isRemoteUpdateRef.current = true;
+      camera.position.set(event.position[0], event.position[1], event.position[2]);
+      controls.target.set(event.target[0], event.target[1], event.target[2]);
+      controls.update();
+      isRemoteUpdateRef.current = false;
+    });
+
+    return () => {
+      off();
+      sendBridgeCommand({ cmd: 'unsubscribe' });
+    };
+  }, [locked, camera]);
+
+  // Send camera state on each frame when locked
+  useEffect(() => {
+    if (!locked) return;
+
+    let frameId: number;
+
+    const sendLoop = () => {
+      frameId = requestAnimationFrame(sendLoop);
+
+      const now = performance.now();
+      if (now - lastSendRef.current < SEND_INTERVAL_MS) return;
+      if (isRemoteUpdateRef.current) return; // Don't echo back
+
+      const controls = getOrbitControls();
+      if (!controls) return;
+
+      const pos = camera.position;
+      const tgt = controls.target;
+
+      lastSendRef.current = now;
+      sendBridgeCommand({
+        cmd: 'sync_camera',
+        source: 'bricklayer',
+        position: [pos.x, pos.y, pos.z],
+        target: [tgt.x, tgt.y, tgt.z],
+      });
+    };
+
+    frameId = requestAnimationFrame(sendLoop);
+    return () => cancelAnimationFrame(frameId);
+  }, [locked, camera]);
+
+  return null; // Render nothing — pure side-effect component
+}

--- a/tools/apps/bricklayer/src/viewport/StagingCameraSync.tsx
+++ b/tools/apps/bricklayer/src/viewport/StagingCameraSync.tsx
@@ -25,28 +25,38 @@ export function StagingCameraSync() {
   useEffect(() => {
     if (!locked) return;
 
-    // Tell engine we want camera_sync events
-    sendBridgeCommand({ cmd: 'subscribe', events: ['camera_sync'] });
+    let off: (() => void) | null = null;
+    let cancelled = false;
 
-    const client = getBridgeClient();
-    if (!client) return;
+    // Await bridge connection before registering event handler.
+    // sendBridgeCommand triggers async connect; getBridgeClient() may
+    // return null if called immediately after.
+    const setup = async () => {
+      await sendBridgeCommand({ cmd: 'subscribe', events: ['camera_sync'] });
+      if (cancelled) return;
 
-    const off = client.on('camera_sync', (data: unknown) => {
-      const event = data as CameraSyncEvent;
-      if (event.source === 'bricklayer') return; // Echo suppression
+      const client = getBridgeClient();
+      if (!client) return;
 
-      const controls = getOrbitControls();
-      if (!controls) return;
+      off = client.on('camera_sync', (data: unknown) => {
+        const event = data as CameraSyncEvent;
+        if (event.source === 'bricklayer') return; // Echo suppression
 
-      isRemoteUpdateRef.current = true;
-      camera.position.set(event.position[0], event.position[1], event.position[2]);
-      controls.target.set(event.target[0], event.target[1], event.target[2]);
-      controls.update();
-      isRemoteUpdateRef.current = false;
-    });
+        const controls = getOrbitControls();
+        if (!controls) return;
+
+        isRemoteUpdateRef.current = true;
+        camera.position.set(event.position[0], event.position[1], event.position[2]);
+        controls.target.set(event.target[0], event.target[1], event.target[2]);
+        controls.update();
+        isRemoteUpdateRef.current = false;
+      });
+    };
+    setup();
 
     return () => {
-      off();
+      cancelled = true;
+      off?.();
       sendBridgeCommand({ cmd: 'unsubscribe' });
     };
   }, [locked, camera]);

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -18,6 +18,7 @@ import { CameraFrustumGizmo } from './CameraFrustumGizmo.js';
 import { ChunkWireframes } from './ChunkWireframes.js';
 import { TerrainPlyReference } from './TerrainPlyReference.js';
 import { SplineEditor } from './SplineEditor.js';
+import { StagingCameraSync } from './StagingCameraSync.js';
 import { useSceneStore } from '../store/useSceneStore.js';
 
 // Module-level ref so App.tsx can access the orbit controls for F/Home keys
@@ -322,6 +323,8 @@ function SceneContent() {
       <GrabPlane />
       <SplineEditor />
 
+      <StagingCameraSync />
+
       <OrbitControls
         ref={(r: OrbitControlsRef | null) => {
           controlsRef.current = r;
@@ -349,16 +352,39 @@ export function Viewport() {
   useComponentRegistry('Viewport');
   const gridWidth = useSceneStore((s) => s.gridWidth);
   const gridDepth = useSceneStore((s) => s.gridDepth);
+  const stagingCameraLock = useSceneStore((s) => s.stagingCameraLock);
+  const setStagingCameraLock = useSceneStore((s) => s.setStagingCameraLock);
 
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <Canvas
         camera={{ position: [gridWidth / 2, 30, gridDepth + 20], fov: 50 }}
-        style={{ background: '#16162a' }}
+        style={{
+          background: '#16162a',
+          border: stagingCameraLock ? '2px solid #f59e0b' : '2px solid transparent',
+        }}
         onContextMenu={(e) => e.preventDefault()}
       >
         <SceneContent />
       </Canvas>
+      <button
+        onClick={() => setStagingCameraLock(!stagingCameraLock)}
+        title={stagingCameraLock ? 'Unlock Staging camera' : 'Lock to Staging camera'}
+        style={{
+          position: 'absolute',
+          top: 8,
+          right: 8,
+          padding: '4px 8px',
+          fontSize: 12,
+          background: stagingCameraLock ? '#f59e0b' : '#374151',
+          color: stagingCameraLock ? '#000' : '#d1d5db',
+          border: 'none',
+          borderRadius: 4,
+          cursor: 'pointer',
+        }}
+      >
+        {stagingCameraLock ? 'Camera Locked' : 'Camera Lock'}
+      </button>
     </div>
   );
 }

--- a/tools/packages/engine-client/src/types.ts
+++ b/tools/packages/engine-client/src/types.ts
@@ -189,6 +189,20 @@ export interface SetCameraCommand {
   follow_speed?: number;
 }
 
+export interface SyncCameraCommand {
+  cmd: "sync_camera";
+  source: "bricklayer";
+  position: [number, number, number];
+  target: [number, number, number];
+}
+
+export interface CameraSyncEvent {
+  event: "camera_sync";
+  source: "engine" | "bricklayer";
+  position: [number, number, number];
+  target: [number, number, number];
+}
+
 export interface SubscribeCommand {
   cmd: "subscribe";
   events: string[];
@@ -317,6 +331,7 @@ export type Command =
   | GetFeaturesCommand
   | SetFeatureCommand
   | SetCameraCommand
+  | SyncCameraCommand
   | SubscribeCommand
   | UnsubscribeCommand
   | MoveCommand


### PR DESCRIPTION
## Summary

Three followup tasks implementing design specs from the coordinate contract alignment work:

- **GSVX v2 header with baked AABB**: Extends the `.gsvx` binary format from 32-byte (v1) to 64-byte (v2) header embedding pre-computed AABB min/max. Eliminates the O(n) position scan at load time for true zero-parse bounds. Python cooker updated to write v2. Backward compat preserved — v1 files still load via position scan fallback.

- **Viewport-linked camera sync (Bricklayer ↔ Staging)**: Bidirectional camera state sync over the WebSocket bridge. "Staging Camera Lock" toggle in Bricklayer sends OrbitControls camera to engine via `sync_camera` command; engine broadcasts `camera_sync` events at 30Hz to subscribed clients. Echo suppression via `source` field. CameraZoneSystem skipped when override active.

- **Fix GPU buffer clear on scene switch**: `GsRenderer::load_cloud()` was appending new chunks without clearing old ones in streaming mode, causing old Gaussian data to persist. Now releases slabs back to allocator and resets tracking state before loading.

## Test plan

- [x] C++ build clean (macos-debug, 415/415 targets)
- [x] All 23 Gaussian cloud tests pass (including new v2 round-trip + v1 backward compat)
- [x] engine-client TypeScript build clean
- [x] Bricklayer TypeScript + Vite build clean
- [ ] Manual: toggle Camera Lock in Bricklayer, orbit viewport, verify Staging follows
- [ ] Manual: load scene A → load scene B in Staging, verify no lingering Gaussians
- [ ] Manual: re-cook .gsvx assets with `python3 scripts/ply_to_gseurat.py`, verify load

🤖 Generated with [Claude Code](https://claude.com/claude-code)