### PR TITLE
fix(camera-sync): address PR #346 review comments

### DIFF
--- a/include/gseurat/engine/command_context.hpp
+++ b/include/gseurat/engine/command_context.hpp
@@ -38,6 +38,7 @@ struct CommandContext {
 
     ControlServer* control_server = nullptr;
     bool camera_sync_override = false;
+    std::string camera_sync_source;  // source of last sync_camera command for echo suppression
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/control_server.hpp
+++ b/include/gseurat/engine/control_server.hpp
@@ -83,6 +83,7 @@ private:
 #endif
 
     std::set<std::string> subscribed_events_;
+    bool has_subscriptions_ = false;  // true after subscribe, false after unsubscribe
 };
 
 }  // namespace gseurat

--- a/scripts/ply_to_gseurat.py
+++ b/scripts/ply_to_gseurat.py
@@ -176,8 +176,12 @@ def ply_to_gsvx(ply_path: Path) -> bytes:
     out["color_pad"][:, 3] = emission
 
     # --- Compute AABB from baked positions ---
-    aabb_min = (float(px.min()), float(py.min()), float(pz.min()))
-    aabb_max = (float(px.max()), float(py.max()), float(pz.max()))
+    if count == 0:
+        aabb_min = (0.0, 0.0, 0.0)
+        aabb_max = (0.0, 0.0, 0.0)
+    else:
+        aabb_min = (float(px.min()), float(py.min()), float(pz.min()))
+        aabb_max = (float(px.max()), float(py.max()), float(pz.max()))
 
     # --- Build binary (v2: 64-byte header with baked AABB) ---
     header = struct.pack("<4sIII3f3f24s",

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -155,9 +155,10 @@ void AppBase::main_loop() {
             camera_broadcast_timer_ = 0.0f;
             auto pos = renderer_.camera().position();
             auto tgt = renderer_.camera().target();
+            auto& src = command_dispatcher_.context().camera_sync_source;
             control_server_.broadcast(nlohmann::json{
                 {"event", "camera_sync"},
-                {"source", "engine"},
+                {"source", src.empty() ? "engine" : src},
                 {"position", {pos.x, pos.y, pos.z}},
                 {"target", {tgt.x, tgt.y, tgt.z}}
             });
@@ -165,6 +166,7 @@ void AppBase::main_loop() {
 
         // Reset camera sync override at frame end
         command_dispatcher_.context().camera_sync_override = false;
+        command_dispatcher_.context().camera_sync_source.clear();
 
         upload_bone_transforms();
         gameplay_.play_time += dt;

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -162,11 +162,13 @@ void AppBase::main_loop() {
                 {"position", {pos.x, pos.y, pos.z}},
                 {"target", {tgt.x, tgt.y, tgt.z}}
             });
+            // Clear source after broadcast so it isn't lost between
+            // throttled intervals when sync_camera arrives mid-cycle.
+            src.clear();
         }
 
         // Reset camera sync override at frame end
         command_dispatcher_.context().camera_sync_override = false;
-        command_dispatcher_.context().camera_sync_source.clear();
 
         upload_bone_transforms();
         gameplay_.play_time += dt;

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -621,6 +621,7 @@ void CommandDispatcher::register_default_commands() {
         cam.set_position(glm::vec3(pos[0], pos[1], pos[2]));
         cam.set_target(glm::vec3(tgt[0], tgt[1], tgt[2]));
         ctx_.camera_sync_override = true;
+        ctx_.camera_sync_source = cmd.value("source", std::string("engine"));
 
         return json{{"type", "ok"}};
     });

--- a/src/engine/control_server.cpp
+++ b/src/engine/control_server.cpp
@@ -192,13 +192,16 @@ void ControlServer::subscribe_events(const std::vector<std::string>& events) {
     for (const auto& e : events) {
         subscribed_events_.insert(e);
     }
+    has_subscriptions_ = true;
 }
 
 void ControlServer::unsubscribe_all() {
     subscribed_events_.clear();
+    has_subscriptions_ = false;
 }
 
 bool ControlServer::is_event_subscribed(const std::string& event) const {
+    if (!has_subscriptions_) return false;
     if (subscribed_events_.empty()) return true;
     return subscribed_events_.count(event) > 0;
 }

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -444,6 +444,19 @@ void StagingState::update(AppBase& app, float dt) {
         if (sync_override && app.renderer().has_gs_cloud()) {
             auto pos = app.renderer().camera().position();
             auto tgt = app.renderer().camera().target();
+
+            // Keep orbit state in sync so world streaming, gizmo
+            // projection, and other orbit-derived logic use the
+            // externally synced camera rather than stale values.
+            target_ = tgt;
+            glm::vec3 delta = pos - tgt;
+            distance_ = glm::length(delta);
+            if (distance_ > 0.001f) {
+                glm::vec3 dir = delta / distance_;
+                azimuth_ = std::atan2(dir.x, dir.z);
+                elevation_ = std::asin(std::clamp(dir.y / 1.0f, -1.0f, 1.0f));
+            }
+
             auto& gs_renderer = app.renderer().gs_renderer();
             float aspect = static_cast<float>(gs_renderer.output_width()) /
                            static_cast<float>(gs_renderer.output_height());

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -347,6 +347,7 @@ void StagingState::update(AppBase& app, float dt) {
 
     bool wants_mouse = app.dev_overlay().wants_mouse();
     bool wants_keyboard = app.dev_overlay().wants_keyboard();
+    const bool sync_override = app.command_dispatcher().context().camera_sync_override;
 
     if (camera_review_ && camera_review_->is_active()) {
         // ── Camera Review Mode ──
@@ -371,7 +372,6 @@ void StagingState::update(AppBase& app, float dt) {
 #else
         bool typing_in_widget = false;
 #endif
-        const bool sync_override = app.command_dispatcher().context().camera_sync_override;
         camera_review_->set_camera_override(sync_override);
         camera_review_->update(dt, app.input(), wants_mouse, typing_in_widget,
                                mouse_dx, mouse_dy);
@@ -437,8 +437,26 @@ void StagingState::update(AppBase& app, float dt) {
         }
     } else {
         // ── Orbit Camera (default) ──
+
+        // When sync_camera override is active in orbit mode, apply the
+        // externally synced camera directly instead of computing from
+        // azimuth/elevation/distance.
+        if (sync_override && app.renderer().has_gs_cloud()) {
+            auto pos = app.renderer().camera().position();
+            auto tgt = app.renderer().camera().target();
+            auto& gs_renderer = app.renderer().gs_renderer();
+            float aspect = static_cast<float>(gs_renderer.output_width()) /
+                           static_cast<float>(gs_renderer.output_height());
+            auto view = glm::lookAt(pos, tgt, glm::vec3(0, 1, 0));
+            auto proj = glm::perspective(glm::radians(45.0f), aspect, 0.1f, 1000.0f);
+            auto proj_gizmo = proj;
+            proj[1][1] *= -1.0f;  // Vulkan Y-flip
+            app.renderer().set_gs_camera(view, proj);
+            gs_vp_ = proj_gizmo * view;
+        }
+
         // Camera orbit — only when ImGui doesn't want the mouse
-        if (!wants_mouse) {
+        if (!wants_mouse && !sync_override) {
             auto* window = app.window();
             double mx, my;
             glfwGetCursorPos(window, &mx, &my);
@@ -496,8 +514,8 @@ void StagingState::update(AppBase& app, float dt) {
             camera_initialized_ = true;
         }
 
-        // Apply camera
-        if (app.renderer().has_gs_cloud()) {
+        // Apply camera (skip when sync override already applied above)
+        if (!sync_override && app.renderer().has_gs_cloud()) {
             float cos_el = std::cos(elevation_);
             glm::vec3 eye{
                 target_.x + distance_ * cos_el * std::sin(azimuth_),


### PR DESCRIPTION
## Summary
- Fix `unsubscribe` not stopping `camera_sync` broadcasts — added `has_subscriptions_` flag so empty set after unsubscribe means "none" instead of "all"
- Fix zero-vertex PLY crash in `ply_to_gseurat.py` — guard AABB min/max with `count == 0` check
- Fix camera sync ignored in Staging orbit mode — hoist `sync_override` before orbit path, apply synced camera directly
- Fix broadcast echoing wrong source — preserve `camera_sync_source` from `sync_camera` command instead of hard-coding `"engine"`

Addresses all open Codex review comments from #346.

## Test plan
- [ ] Build succeeds (`cmake --build --preset macos-debug`)
- [ ] `test_gaussian_cloud` passes (23/23)
- [ ] Toggle Camera Lock in Bricklayer, orbit → Staging follows in both orbit and camera review modes
- [ ] Toggle Camera Lock off → broadcasts stop (no more `camera_sync` events)
- [ ] Cook a zero-vertex PLY with `ply_to_gseurat.py` → produces valid 64-byte GSVX with count=0
- [ ] Verify no echo jitter: orbit in Bricklayer, source field preserved through broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)