### PR TITLE
fix(bricklayer): remove Player from navigation tree

### DIFF
--- a/tools/apps/bricklayer/src/panels/MasterTree.tsx
+++ b/tools/apps/bricklayer/src/panels/MasterTree.tsx
@@ -525,12 +525,6 @@ function SceneChildren({
             </TreeNode>
           </TreeNode>
 
-          {/* Player */}
-          <TreeNode
-            icon={icons.player} label="Player"
-            isActive={isActive({ kind: 'player' })}
-            onClick={() => click({ kind: 'player' })}
-          />
         </TreeNode>
       </div>
 

--- a/tools/apps/bricklayer/src/viewport/PlayerMarker.tsx
+++ b/tools/apps/bricklayer/src/viewport/PlayerMarker.tsx
@@ -9,11 +9,9 @@ export function PlayerMarker() {
 
   const isSelected = selectedEntity?.type === 'player';
 
-  if (!showGizmos) return null;
-
   return (
     <group position={player.position}>
-      {/* Invisible hit box */}
+      {/* Invisible hit box — always rendered so player is selectable even with gizmos off */}
       <mesh
         position={[0, 1.0, 0]}
         onPointerDown={(e) => { e.stopPropagation(); setSelectedEntity({ type: 'player', id: 'player' }); }}
@@ -21,20 +19,24 @@ export function PlayerMarker() {
         <cylinderGeometry args={[1.0, 1.0, 2.8, 12]} />
         <meshBasicMaterial visible={false} />
       </mesh>
-      {/* Visible cylinder */}
-      <mesh position={[0, 1.0, 0]}>
-        <cylinderGeometry args={[0.6, 0.6, 2.0, 12]} />
-        <meshStandardMaterial
-          color={isSelected ? '#ffffff' : '#66bb6a'}
-          transparent
-          opacity={isSelected ? 0.8 : 0.7}
-        />
-      </mesh>
-      {/* Direction arrow */}
-      <mesh position={[0, 2.3, 0]} rotation={[Math.PI, 0, 0]}>
-        <coneGeometry args={[0.4, 0.7, 8]} />
-        <meshStandardMaterial color="#66bb6a" />
-      </mesh>
+      {showGizmos && (
+        <>
+          {/* Visible cylinder */}
+          <mesh position={[0, 1.0, 0]}>
+            <cylinderGeometry args={[0.6, 0.6, 2.0, 12]} />
+            <meshStandardMaterial
+              color={isSelected ? '#ffffff' : '#66bb6a'}
+              transparent
+              opacity={isSelected ? 0.8 : 0.7}
+            />
+          </mesh>
+          {/* Direction arrow */}
+          <mesh position={[0, 2.3, 0]} rotation={[Math.PI, 0, 0]}>
+            <coneGeometry args={[0.4, 0.7, 8]} />
+            <meshStandardMaterial color="#66bb6a" />
+          </mesh>
+        </>
+      )}
     </group>
   );
 }


### PR DESCRIPTION
## Summary
- Remove the Player item from Bricklayer's navigation tree — not needed for current workflow
- Player marker and viewport gizmo selection remain functional

## Test plan
- [ ] Bricklayer builds (`pnpm --filter bricklayer build`)
- [ ] Navigation tree no longer shows Player node
- [ ] Player marker still visible in viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)