### PR TITLE
feat: collision editor integration — bridge CRUD, wireframes, Bricklayer UI, migration (Spec 2a)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ add_library(gseurat_core ${_gseurat_lib_type}
     src/engine/collision/intersect.cpp
     src/engine/collision/bvh.cpp
     src/engine/collision/collision_system.cpp
+    src/engine/collision/debug_wireframe.cpp
     src/engine/save_system.cpp
     src/engine/slab_allocator.cpp
     src/engine/async_loader.cpp

--- a/docs/superpowers/plans/2026-04-22-collision-editor-integration.md
+++ b/docs/superpowers/plans/2026-04-22-collision-editor-integration.md
@@ -1,0 +1,775 @@
+# Collision Editor Integration Implementation Plan (Spec 2a)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable level designers to create, edit, and visualize primitive colliders through Bricklayer and see 3D wireframes in the engine viewport. Migrate existing CollisionGrid data to the new system.
+
+**Architecture:** Bridge CRUD commands operate on ECS entities with ColliderComponent. Bricklayer manages collider data in its Zustand store and syncs via bridge. The engine renders depth-tested wireframes via a dedicated VK_POLYGON_MODE_LINE pipeline. A Python migration script converts CollisionGrid to Box collider entities.
+
+**Tech Stack:** C++23, Vulkan, GLSL 450, TypeScript/React, Python 3
+
+**Spec:** `docs/superpowers/specs/2026-04-22-collision-editor-integration-design.md`
+
+---
+
+## File Structure
+
+### New Files — Engine
+
+| File | Responsibility |
+|------|----------------|
+| `include/gseurat/engine/ecs/components/nav_zone_volume.hpp` | NavZoneVolume component |
+| `include/gseurat/engine/ecs/components/light_probe.hpp` | LightProbe component |
+| `include/gseurat/engine/collision/debug_wireframe.hpp` | DebugColliderDrawInfo struct, wireframe mesh generation declarations |
+| `src/engine/collision/debug_wireframe.cpp` | Wireframe vertex generation, pipeline setup, draw method |
+| `shaders/debug_wireframe.vert` | Wireframe vertex shader with shape-aware scaling |
+| `shaders/debug_wireframe.frag` | Wireframe fragment shader |
+
+### New Files — Bricklayer
+
+| File | Responsibility |
+|------|----------------|
+| `tools/apps/level-designer/src/components/ColliderPropertiesPanel.tsx` | Selected collider editing panel |
+| `tools/apps/level-designer/src/components/ColliderListPanel.tsx` | Scrollable collider list with selection |
+| `tools/apps/level-designer/src/utils/math-utils.ts` | Euler/quaternion conversion utilities |
+
+### New Files — Scripts
+
+| File | Responsibility |
+|------|----------------|
+| `scripts/migrate_collision_grid.py` | Migration script |
+| `tests/test_migration.py` | Migration unit tests |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `include/gseurat/engine/command_context.hpp` | Add `CollisionSystem*` pointer |
+| `include/gseurat/engine/feature_flags.hpp` | Add `debug_colliders` flag |
+| `src/engine/command_dispatcher.cpp` | Register 4 collider commands |
+| `src/engine/app_base.cpp` | Register NavZoneVolume + LightProbe |
+| `src/demo/island_demo_state.cpp` | Wire CollisionSystem into CommandContext, build wireframe draw list |
+| `src/engine/renderer.hpp` | Add wireframe pipeline members |
+| `src/engine/renderer.cpp` | Add wireframe pipeline creation + draw pass |
+| `schemas/scene.schema.json` | Add NavZoneVolume + LightProbe component schemas |
+| `tools/apps/level-designer/src/store/useEditorStore.ts` | Add colliders state |
+| `tools/apps/level-designer/src/hooks/useEngine.ts` | Add collider command helpers |
+| `tools/apps/level-designer/src/hooks/useEngineSync.ts` | Add collider sync |
+| `CMakeLists.txt` | Add new sources, shader compilation |
+
+---
+
+## Task 1: NavZoneVolume & LightProbe Components
+
+**Files:**
+- Create: `include/gseurat/engine/ecs/components/nav_zone_volume.hpp`
+- Create: `include/gseurat/engine/ecs/components/light_probe.hpp`
+- Modify: `src/engine/app_base.cpp`
+- Modify: `schemas/scene.schema.json`
+
+### Steps
+
+- [ ] **Step 1:** Create `include/gseurat/engine/ecs/components/nav_zone_volume.hpp`:
+
+```cpp
+#pragma once
+#include <cstdint>
+#include <nlohmann/json.hpp>
+
+namespace gseurat {
+
+struct NavZoneVolume {
+    uint8_t zone_id{0};
+};
+
+inline NavZoneVolume nav_zone_volume_from_json(const nlohmann::json& j) {
+    NavZoneVolume v;
+    if (j.contains("zone_id")) v.zone_id = j["zone_id"].get<uint8_t>();
+    return v;
+}
+
+inline nlohmann::json nav_zone_volume_to_json(const NavZoneVolume& v) {
+    return {{"zone_id", v.zone_id}};
+}
+
+}  // namespace gseurat
+```
+
+- [ ] **Step 2:** Create `include/gseurat/engine/ecs/components/light_probe.hpp`:
+
+```cpp
+#pragma once
+#include <glm/glm.hpp>
+#include <nlohmann/json.hpp>
+
+namespace gseurat {
+
+struct LightProbe {
+    glm::vec3 color{0.5f};
+};
+
+inline LightProbe light_probe_from_json(const nlohmann::json& j) {
+    LightProbe lp;
+    if (j.contains("color") && j["color"].is_array()) {
+        auto& c = j["color"];
+        lp.color = glm::vec3(c[0].get<float>(), c[1].get<float>(), c[2].get<float>());
+    }
+    return lp;
+}
+
+inline nlohmann::json light_probe_to_json(const LightProbe& lp) {
+    return {{"color", {lp.color.x, lp.color.y, lp.color.z}}};
+}
+
+}  // namespace gseurat
+```
+
+- [ ] **Step 3:** Register both components in `app_base.cpp` inside `init_game_object_system()`, alongside existing registrations:
+
+```cpp
+#include "gseurat/engine/ecs/components/nav_zone_volume.hpp"
+#include "gseurat/engine/ecs/components/light_probe.hpp"
+
+// In init_game_object_system():
+component_registry_.register_component<NavZoneVolume>("NavZoneVolume",
+    [](const nlohmann::json& j) -> NavZoneVolume { return nav_zone_volume_from_json(j); },
+    [](const NavZoneVolume& v) -> nlohmann::json { return nav_zone_volume_to_json(v); });
+
+component_registry_.register_component<LightProbe>("LightProbe",
+    [](const nlohmann::json& j) -> LightProbe { return light_probe_from_json(j); },
+    [](const LightProbe& lp) -> nlohmann::json { return light_probe_to_json(lp); });
+```
+
+- [ ] **Step 4:** Add schema entries to `schemas/scene.schema.json` under the components properties:
+
+```json
+"NavZoneVolume": {
+  "type": "object",
+  "properties": {
+    "zone_id": { "type": "integer", "minimum": 0, "maximum": 255, "default": 0 }
+  }
+},
+"LightProbe": {
+  "type": "object",
+  "properties": {
+    "color": { "type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3 }
+  }
+}
+```
+
+- [ ] **Step 5:** Build to verify: `cmake --preset macos-debug && cmake --build --preset macos-debug`
+
+- [ ] **Step 6:** Commit:
+```bash
+git add include/gseurat/engine/ecs/components/nav_zone_volume.hpp \
+        include/gseurat/engine/ecs/components/light_probe.hpp \
+        src/engine/app_base.cpp schemas/scene.schema.json
+git commit -m "feat(collision): add NavZoneVolume and LightProbe ECS components"
+```
+
+---
+
+## Task 2: Bridge Commands — CommandContext + add/update/remove/list_colliders
+
+**Files:**
+- Modify: `include/gseurat/engine/command_context.hpp`
+- Modify: `src/engine/command_dispatcher.cpp`
+- Modify: `src/demo/island_demo_state.cpp`
+
+### Context
+
+Commands follow the existing pattern in `command_dispatcher.cpp`. The `CommandContext` gets a `CollisionSystem*` pointer (same pattern as `CameraZoneSystem*`). Commands use `SceneObjectState::game_objects` for ID lookup.
+
+### Steps
+
+- [ ] **Step 1:** Add `CollisionSystem*` to `CommandContext` in `command_context.hpp`:
+
+```cpp
+// Add forward declaration before the struct:
+class CollisionSystem;
+
+// Add inside CommandContext struct, after camera_zone_system:
+CollisionSystem* collision_system = nullptr;
+```
+
+- [ ] **Step 2:** Wire the pointer in `island_demo_state.cpp`, in the same location where `camera_zone_system` is wired into CommandContext (typically in `on_enter()` after collision system init, and nulled in `on_exit()` before cleanup).
+
+- [ ] **Step 3:** Register `add_collider` command in `command_dispatcher.cpp`:
+
+The handler creates an ECS entity with Transform + ColliderComponent, stores the game object data in `scene_objects.game_objects`, and marks the collision system dirty.
+
+Parse: `id` (string), `name` (string), `position` (vec3 array), `rotation` (vec4 array, quaternion [x,y,z,w]), `collider` (object matching ColliderComponent JSON format from Spec 1).
+
+Create entity: `world.create()`, add Transform from position, add ColliderComponent parsed via `collider_from_json()`. Store game object info in `scene_objects`. Call `collision_system->mark_dirty()`.
+
+Return: `{"type": "ok", "id": "<id>"}`.
+
+- [ ] **Step 4:** Register `update_collider` command:
+
+Lookup entity by `id` in `scene_objects.game_objects`. If not found, return error. Update Transform position and/or ColliderComponent fields (partial update — only specified fields change). Mark dirty.
+
+Return: `{"type": "ok"}`.
+
+- [ ] **Step 5:** Register `remove_collider` command:
+
+Lookup entity by `id`. Destroy entity via `world.destroy()`. Remove from `scene_objects.game_objects`. Mark dirty.
+
+Return: `{"type": "ok"}`.
+
+- [ ] **Step 6:** Register `list_colliders` command:
+
+Query `world.view<ecs::Transform, ColliderComponent>()`. For each entity, find matching game object data from `scene_objects.game_objects` to get the ID and name. Build JSON array of all colliders with their full state.
+
+Return: `{"type": "ok", "colliders": [...]}`.
+
+- [ ] **Step 7:** Build to verify: `cmake --build --preset macos-debug`
+
+- [ ] **Step 8:** Commit:
+```bash
+git add include/gseurat/engine/command_context.hpp src/engine/command_dispatcher.cpp \
+        src/demo/island_demo_state.cpp
+git commit -m "feat(collision): add bridge commands for collider CRUD"
+```
+
+---
+
+## Task 3: Feature Flag + Wireframe Shaders
+
+**Files:**
+- Modify: `include/gseurat/engine/feature_flags.hpp`
+- Modify: `src/engine/command_dispatcher.cpp` (add to flag_map)
+- Create: `shaders/debug_wireframe.vert`
+- Create: `shaders/debug_wireframe.frag`
+
+### Steps
+
+- [ ] **Step 1:** Add `debug_colliders` to `FeatureFlags` struct:
+
+```cpp
+// Under "// Effects" section:
+bool debug_colliders = false;    // Collider wireframe debug visualization
+```
+
+Update `entries()` array to include it (increment array size, add entry):
+```cpp
+{"Debug Colliders", "---", "DEBUG", &FeatureFlags::debug_colliders},
+```
+
+Update `gs_viewer()` to include it as `false`.
+
+- [ ] **Step 2:** Add `"debug_colliders"` to the `flag_map` in `set_feature` command handler in `command_dispatcher.cpp`:
+
+```cpp
+{"debug_colliders", &FeatureFlags::debug_colliders},
+```
+
+- [ ] **Step 3:** Create `shaders/debug_wireframe.vert`:
+
+```glsl
+#version 450
+
+layout(location = 0) in vec3 in_position;
+
+layout(set = 0, binding = 0) uniform UBO {
+    mat4 vp;
+} ubo;
+
+layout(push_constant) uniform PushConstants {
+    mat4 model;        // Translation + rotation (no non-uniform scale)
+    vec4 color;
+    vec4 shape_params; // x=type(0=box,1=sphere,2=capsule), y=radius, z=half_height
+    vec4 extents;      // Box half_extents.xyz
+} pc;
+
+layout(location = 0) out vec4 frag_color;
+
+void main() {
+    vec3 pos = in_position;
+    int shape_type = int(pc.shape_params.x);
+
+    if (shape_type == 0) {
+        // Box: scale unit cube vertices by half_extents
+        pos *= pc.extents.xyz;
+    } else if (shape_type == 1) {
+        // Sphere: scale by radius
+        pos *= pc.shape_params.y;
+    } else {
+        // Capsule: vertex.y convention:
+        //   |y| <= 0.501 → cylinder segment
+        //   |y| > 0.501  → hemisphere cap
+        float r = pc.shape_params.y;
+        float hh = pc.shape_params.z;
+
+        if (abs(pos.y) <= 0.501) {
+            pos.x *= r;
+            pos.z *= r;
+            pos.y *= hh * 2.0;
+        } else {
+            float sign_y = sign(pos.y);
+            vec3 local_pos = vec3(pos.x, abs(pos.y) - 0.5, pos.z);
+            local_pos *= r * 2.0;
+            pos = vec3(local_pos.x, local_pos.y + sign_y * hh, local_pos.z);
+        }
+    }
+
+    gl_Position = ubo.vp * pc.model * vec4(pos, 1.0);
+    frag_color = pc.color;
+}
+```
+
+- [ ] **Step 4:** Create `shaders/debug_wireframe.frag`:
+
+```glsl
+#version 450
+
+layout(location = 0) in vec4 frag_color;
+layout(location = 0) out vec4 out_color;
+
+void main() {
+    out_color = frag_color;
+}
+```
+
+- [ ] **Step 5:** Compile shaders (follow existing shader compilation pattern in CMakeLists.txt or build script):
+
+```bash
+glslc shaders/debug_wireframe.vert -o shaders/debug_wireframe.vert.spv
+glslc shaders/debug_wireframe.frag -o shaders/debug_wireframe.frag.spv
+```
+
+Add shader compilation to CMakeLists.txt if there's an existing shader compile target. Otherwise, compile manually and commit the .spv files.
+
+- [ ] **Step 6:** Build to verify feature flag compiles: `cmake --build --preset macos-debug`
+
+- [ ] **Step 7:** Commit:
+```bash
+git add include/gseurat/engine/feature_flags.hpp src/engine/command_dispatcher.cpp \
+        shaders/debug_wireframe.vert shaders/debug_wireframe.frag \
+        shaders/debug_wireframe.vert.spv shaders/debug_wireframe.frag.spv
+git commit -m "feat(collision): add debug_colliders feature flag and wireframe shaders"
+```
+
+---
+
+## Task 4: Wireframe Pipeline + Base Meshes + Rendering
+
+**Files:**
+- Create: `include/gseurat/engine/collision/debug_wireframe.hpp`
+- Create: `src/engine/collision/debug_wireframe.cpp`
+- Modify: `include/gseurat/engine/renderer.hpp`
+- Modify: `src/engine/renderer.cpp`
+- Modify: `src/demo/island_demo_state.cpp`
+- Modify: `CMakeLists.txt`
+
+### Context
+
+This task creates the Vulkan wireframe pipeline, generates base shape line-list meshes (cube, sphere, capsule), and integrates the draw pass into the renderer. The demo state builds a `DebugColliderDrawInfo` vector from the collision caches each frame.
+
+### Steps
+
+- [ ] **Step 1:** Create `include/gseurat/engine/collision/debug_wireframe.hpp`:
+
+```cpp
+#pragma once
+
+#include "gseurat/engine/collision/primitive.hpp"
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+#include <vector>
+
+namespace gseurat {
+
+struct DebugColliderDrawInfo {
+    glm::mat4 model;            // Translation + rotation (no scale)
+    glm::vec4 color;
+    ColliderType shape_type;
+    float radius{0.0f};
+    float half_height{0.0f};
+    glm::vec3 half_extents{0.0f};
+};
+
+// Shape mesh ranges in the shared vertex buffer
+struct WireframeMeshRange {
+    uint32_t offset;  // vertex offset
+    uint32_t count;   // vertex count
+};
+
+struct WireframeMeshData {
+    std::vector<glm::vec3> vertices;  // All shapes concatenated
+    WireframeMeshRange cube;
+    WireframeMeshRange sphere;
+    WireframeMeshRange capsule;
+};
+
+// Generate all base shape line-list vertices
+WireframeMeshData generate_wireframe_meshes();
+
+}  // namespace gseurat
+```
+
+- [ ] **Step 2:** Implement `src/engine/collision/debug_wireframe.cpp`:
+
+Generate unit cube (12 edges = 24 vertices), unit sphere (3 great circles × 32 segments = 192 vertices), unit capsule (~256 vertices with hemisphere caps, cylinder lines, equator circles).
+
+The cube vertices are edges of [-1,1]^3. The sphere vertices are 3 orthogonal circles (XY, XZ, YZ planes). The capsule uses the vertex Y convention: `|y| <= 0.5` for cylinder, `|y| > 0.5` for hemisphere caps.
+
+- [ ] **Step 3:** Add wireframe pipeline members to `renderer.hpp`:
+
+```cpp
+// Under private section:
+VkPipeline wireframe_pipeline_{VK_NULL_HANDLE};
+VkPipelineLayout wireframe_pipeline_layout_{VK_NULL_HANDLE};
+VkBuffer wireframe_vertex_buffer_{VK_NULL_HANDLE};
+VmaAllocation wireframe_vertex_alloc_{nullptr};
+WireframeMeshData wireframe_meshes_;
+
+void create_wireframe_pipeline();
+void destroy_wireframe_pipeline();
+
+public:
+void draw_debug_colliders(VkCommandBuffer cmd,
+                          const std::vector<DebugColliderDrawInfo>& draw_list);
+```
+
+- [ ] **Step 4:** Implement wireframe pipeline creation in `renderer.cpp`:
+
+Use `PipelineBuilder` with:
+- `set_rasterizer(VK_POLYGON_MODE_LINE, VK_CULL_MODE_NONE)`
+- `set_input_assembly(VK_PRIMITIVE_TOPOLOGY_LINE_LIST)`
+- `set_depth_stencil(true, false)` — read depth, don't write
+- `set_color_blend_alpha()` — translucent wireframes
+- Push constant range: 112 bytes (mat4 + vec4 + vec4 + vec4)
+- Render pass: same scene render pass as sprites
+
+Create vertex buffer from `generate_wireframe_meshes()` output. Upload via staging buffer (following existing VMA patterns).
+
+Call `create_wireframe_pipeline()` from existing pipeline initialization code.
+
+- [ ] **Step 5:** Implement `draw_debug_colliders()`:
+
+For each `DebugColliderDrawInfo`:
+1. Bind wireframe pipeline (once at start)
+2. Push constants: model, color, shape_params (type, radius, half_height), extents (half_extents)
+3. Select mesh range based on `shape_type`
+4. `vkCmdDraw(range.count, 1, range.offset, 0)`
+
+- [ ] **Step 6:** Insert wireframe draw call in `draw_scene()`, after entity rendering, guarded by `feature_flags.debug_colliders`.
+
+- [ ] **Step 7:** In `island_demo_state.cpp`, build the wireframe draw list in `build_draw_lists()`:
+
+Iterate `collision_system_.static_cache()` and `collision_system_.dynamic_cache()`. For each `ColliderInstance`, construct a `DebugColliderDrawInfo` with:
+- `model` = translation(world_position) * mat4_cast(world_rotation)
+- `color` from the color scheme (green for static solid, cyan for dynamic, yellow for trigger)
+- Shape params from the variant
+
+Pass the draw list to the renderer.
+
+- [ ] **Step 8:** Add `src/engine/collision/debug_wireframe.cpp` to `gseurat_core` in `CMakeLists.txt`.
+
+- [ ] **Step 9:** Build to verify: `cmake --build --preset macos-debug`
+
+- [ ] **Step 10:** Commit:
+```bash
+git add include/gseurat/engine/collision/debug_wireframe.hpp \
+        src/engine/collision/debug_wireframe.cpp \
+        include/gseurat/engine/renderer.hpp src/engine/renderer.cpp \
+        src/demo/island_demo_state.cpp CMakeLists.txt
+git commit -m "feat(collision): add Vulkan wireframe debug rendering pipeline"
+```
+
+---
+
+## Task 5: Bricklayer — Math Utils + Store Extensions
+
+**Files:**
+- Create: `tools/apps/level-designer/src/utils/math-utils.ts`
+- Modify: `tools/apps/level-designer/src/store/useEditorStore.ts`
+
+### Steps
+
+- [ ] **Step 1:** Create `tools/apps/level-designer/src/utils/math-utils.ts`:
+
+```typescript
+// Euler angles (degrees) to quaternion [x, y, z, w]
+// Uses ZYX convention (yaw-pitch-roll)
+export function eulerToQuat(
+  pitchDeg: number,
+  yawDeg: number,
+  rollDeg: number,
+): [number, number, number, number] {
+  const p = (pitchDeg * Math.PI) / 360; // half angle in radians
+  const y = (yawDeg * Math.PI) / 360;
+  const r = (rollDeg * Math.PI) / 360;
+
+  const cp = Math.cos(p), sp = Math.sin(p);
+  const cy = Math.cos(y), sy = Math.sin(y);
+  const cr = Math.cos(r), sr = Math.sin(r);
+
+  return [
+    sr * cp * cy - cr * sp * sy, // x
+    cr * sp * cy + sr * cp * sy, // y
+    cr * cp * sy - sr * sp * cy, // z
+    cr * cp * cy + sr * sp * sy, // w
+  ];
+}
+
+// Quaternion [x, y, z, w] to Euler angles (degrees)
+export function quatToEuler(
+  q: [number, number, number, number],
+): [number, number, number] {
+  const [x, y, z, w] = q;
+
+  // Pitch (X)
+  const sinP = 2 * (w * x + y * z);
+  const cosP = 1 - 2 * (x * x + y * y);
+  const pitch = Math.atan2(sinP, cosP);
+
+  // Yaw (Y)
+  const sinY = 2 * (w * y - z * x);
+  const yaw = Math.abs(sinY) >= 1
+    ? (Math.sign(sinY) * Math.PI) / 2
+    : Math.asin(sinY);
+
+  // Roll (Z)
+  const sinR = 2 * (w * z + x * y);
+  const cosR = 1 - 2 * (y * y + z * z);
+  const roll = Math.atan2(sinR, cosR);
+
+  return [
+    (pitch * 180) / Math.PI,
+    (yaw * 180) / Math.PI,
+    (roll * 180) / Math.PI,
+  ];
+}
+```
+
+- [ ] **Step 2:** Add collider types and state to `useEditorStore.ts`:
+
+```typescript
+export interface ColliderData {
+  id: string;
+  name: string;
+  position: [number, number, number];
+  rotation: [number, number, number, number]; // quaternion [x,y,z,w]
+  shape:
+    | { type: 'box'; half_extents: [number, number, number] }
+    | { type: 'sphere'; radius: number }
+    | { type: 'capsule'; radius: number; half_height: number };
+  collision_mask: number;
+  is_trigger: boolean;
+  is_dynamic: boolean;
+}
+```
+
+Add state fields:
+```typescript
+colliders: ColliderData[];
+selectedColliderId: string | null;
+```
+
+Add actions:
+```typescript
+addCollider: (data: ColliderData) => void;
+updateCollider: (id: string, partial: Partial<ColliderData>) => void;
+removeCollider: (id: string) => void;
+setSelectedCollider: (id: string | null) => void;
+setColliders: (data: ColliderData[]) => void;
+```
+
+- [ ] **Step 3:** Build to verify: `cd tools && pnpm build`
+
+- [ ] **Step 4:** Commit:
+```bash
+git add tools/apps/level-designer/src/utils/math-utils.ts \
+        tools/apps/level-designer/src/store/useEditorStore.ts
+git commit -m "feat(bricklayer): add collider data model and Euler/quaternion utils"
+```
+
+---
+
+## Task 6: Bricklayer — useEngine + useEngineSync Extensions
+
+**Files:**
+- Modify: `tools/apps/level-designer/src/hooks/useEngine.ts`
+- Modify: `tools/apps/level-designer/src/hooks/useEngineSync.ts`
+
+### Steps
+
+- [ ] **Step 1:** Add collider command helpers to `useEngine.ts`:
+
+```typescript
+// Cinematic rail section is the model — add after it:
+
+// ── Collider management ──
+
+const addCollider = useCallback(
+  (data: ColliderData): Promise<OkResponse | null> =>
+    sendCommand<OkResponse>({
+      cmd: 'add_collider',
+      id: data.id,
+      name: data.name,
+      position: data.position,
+      rotation: data.rotation,
+      collider: {
+        shape: data.shape,
+        collision_mask: data.collision_mask,
+        is_trigger: data.is_trigger,
+        is_dynamic: data.is_dynamic,
+      },
+    }),
+  [sendCommand],
+);
+
+const updateCollider = useCallback(
+  (id: string, data: Partial<ColliderData>): Promise<OkResponse | null> =>
+    sendCommand<OkResponse>({ cmd: 'update_collider', id, ...data }),
+  [sendCommand],
+);
+
+const removeCollider = useCallback(
+  (id: string): Promise<OkResponse | null> =>
+    sendCommand<OkResponse>({ cmd: 'remove_collider', id }),
+  [sendCommand],
+);
+
+interface ListCollidersResponse {
+  type: string;
+  colliders: ColliderData[];
+}
+
+const listColliders = useCallback(
+  (): Promise<ListCollidersResponse | null> =>
+    sendCommand<ListCollidersResponse>({ cmd: 'list_colliders' }),
+  [sendCommand],
+);
+```
+
+Add all four to the return object.
+
+- [ ] **Step 2:** Add collider sync to `useEngineSync.ts`:
+
+On connect: call `listColliders()`, populate store with `setColliders()`.
+
+Subscribe to store changes on `colliders` array — diff and dispatch bridge commands (same pattern as lights sync: additions → `addCollider`, removals → `removeCollider`, updates → `updateCollider`).
+
+When colliders layer becomes active: `setFeature("debug_colliders", true)`. When deactivated: `setFeature("debug_colliders", false)`.
+
+- [ ] **Step 3:** Build: `cd tools && pnpm build`
+
+- [ ] **Step 4:** Commit:
+```bash
+git add tools/apps/level-designer/src/hooks/useEngine.ts \
+        tools/apps/level-designer/src/hooks/useEngineSync.ts
+git commit -m "feat(bricklayer): add collider bridge commands and sync"
+```
+
+---
+
+## Task 7: Bricklayer — ColliderListPanel + ColliderPropertiesPanel
+
+**Files:**
+- Create: `tools/apps/level-designer/src/components/ColliderListPanel.tsx`
+- Create: `tools/apps/level-designer/src/components/ColliderPropertiesPanel.tsx`
+- Modify: parent component that renders panels based on active layer
+
+### Steps
+
+- [ ] **Step 1:** Create `ColliderListPanel.tsx`:
+
+Scrollable list of colliders from the store. Each item shows name + shape type icon/label. Click to select (sets `selectedColliderId`). Selected item highlighted. "+" button at top creates a new collider with default values (box at origin). Delete via right-click or inline button.
+
+Uses `useEditorStore` for state, `useEngine` for commands.
+
+- [ ] **Step 2:** Create `ColliderPropertiesPanel.tsx`:
+
+Renders when `selectedColliderId` matches a collider. Fields per spec Section 2.2:
+- Name (TextInput)
+- Position (Vec3Input)
+- Rotation (Vec3Input in degrees — uses `eulerToQuat`/`quatToEuler` from math-utils.ts)
+- Shape type (dropdown — changing type resets shape params to defaults)
+- Shape-specific params (conditional rendering)
+- Flags (checkboxes)
+- Collision mask (collapsible advanced section)
+- Delete button
+
+Uses existing UI-kit components: `NumberSlider` or `NumberInput`, following the pattern in the existing `PropertiesPanel.tsx`.
+
+On field change: calls `updateCollider(id, partial)` on the store, which triggers sync.
+
+- [ ] **Step 3:** Wire panels into the layout — when `activeLayer === 'colliders'`, render `ColliderListPanel` in the sidebar and `ColliderPropertiesPanel` in the properties area. Follow the existing layer-switching pattern.
+
+- [ ] **Step 4:** Add `'colliders'` to the `activeLayer` type union in the store.
+
+- [ ] **Step 5:** Build: `cd tools && pnpm build`
+
+- [ ] **Step 6:** Commit:
+```bash
+git add tools/apps/level-designer/src/components/ColliderListPanel.tsx \
+        tools/apps/level-designer/src/components/ColliderPropertiesPanel.tsx \
+        tools/apps/level-designer/src/store/useEditorStore.ts
+git commit -m "feat(bricklayer): add collider list and properties panels"
+```
+
+---
+
+## Task 8: Migration Script
+
+**Files:**
+- Create: `scripts/migrate_collision_grid.py`
+- Create: `tests/test_migration.py`
+
+### Steps
+
+- [ ] **Step 1:** Create `scripts/migrate_collision_grid.py`:
+
+Implements the greedy rectangle merge algorithm:
+1. Load scene JSON
+2. Extract `collision` field (width, height, cell_size, solid[], elevation[])
+3. Greedy merge: scan cells, expand right/down only when `solid == True AND elevation == start_elevation`
+4. For each merged rectangle: compute position (grid coords), half_extents, elevation-aligned Y
+5. Generate `game_objects` entries with `ColliderComponent`
+6. Optionally migrate `nav_zone[]` → `NavZoneVolume` boxes (no elevation constraint for zones)
+7. Optionally migrate `light_probe[]` → `LightProbe` entities with NxN downsampling
+8. Append to scene JSON `game_objects` array
+9. Optionally remove `collision` field (`--remove-grid`)
+
+ID convention: `migrated_floor_001`, `migrated_navzone_3_001`, `migrated_probe_001`.
+
+CLI: `python3 scripts/migrate_collision_grid.py <scene.json> [--output <path>] [--remove-grid] [--skip-nav-zones] [--skip-light-probes] [--probe-block-size N] [--dry-run]`
+
+- [ ] **Step 2:** Create `tests/test_migration.py`:
+
+Test with an 8x8 grid:
+- 4x4 block of solid cells at same elevation → merges into 1 box
+- Two 2x2 blocks at different elevations → 2 separate boxes (elevation constraint)
+- Single isolated solid cell → 1 box
+- Verify box positions and half_extents match expected values
+- Verify nav zone migration produces trigger boxes with zone IDs
+- Verify light probe downsampling reduces entity count (4x4 block → 1 probe)
+- Verify `--dry-run` doesn't modify the file
+
+- [ ] **Step 3:** Run tests: `python3 -m pytest tests/test_migration.py -v`
+
+- [ ] **Step 4:** Integration test: run on `examples/island_demo/assets/scenes/seurat_island.json`, verify output is valid JSON with collider game objects
+
+- [ ] **Step 5:** Commit:
+```bash
+git add scripts/migrate_collision_grid.py tests/test_migration.py
+git commit -m "feat(collision): add CollisionGrid migration script with greedy merge"
+```
+
+---
+
+## Verification Checklist
+
+After all tasks complete:
+
+- [ ] Spec Section 1 (Bridge CRUD): add/update/remove/list_colliders commands — **Task 2**
+- [ ] Spec Section 2 (Bricklayer Panel): Store, properties panel, list panel, sync — **Tasks 5, 6, 7**
+- [ ] Spec Section 3 (Wireframe Rendering): Pipeline, shaders, base meshes, feature flag — **Tasks 3, 4**
+- [ ] Spec Section 4 (Migration): Script, greedy merge, elevation constraint, nav zones, light probes — **Task 8**
+- [ ] Spec Section 5 (Components): NavZoneVolume, LightProbe — **Task 1**
+- [ ] Engine build: `cmake --build --preset macos-debug` — no new warnings
+- [ ] Tools build: `cd tools && pnpm build` — succeeds
+- [ ] All existing collision tests still pass: `ctest --test-dir build/macos-debug -R "test_primitive|test_intersect|test_bvh|test_collision|test_kcc|test_collider"`
+- [ ] Migration tests pass: `python3 -m pytest tests/test_migration.py`

--- a/docs/superpowers/specs/2026-04-22-collision-editor-integration-design.md
+++ b/docs/superpowers/specs/2026-04-22-collision-editor-integration-design.md
@@ -1,0 +1,602 @@
+# Collision Editor Integration — Spec 2a: Bridge CRUD, Bricklayer Panel, Wireframes, Migration
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable level designers to create, edit, and visualize primitive colliders through Bricklayer's property panel and see accurate 3D wireframes in the engine viewport. Migrate existing CollisionGrid data to the new system.
+
+**Scope:** Bridge commands, Bricklayer UI panel, Vulkan wireframe pipeline, migration script. No 3D gizmo interaction (raycasting, drag handles) — that's Spec 2b.
+
+**Depends on:** Spec 1 (PR #353, merged) — ColliderComponent, KinematicBody, CollisionSystem, BVH, KCC.
+
+---
+
+## 1. Bridge Commands for Collider CRUD
+
+### 1.1 Command Set
+
+| Command | Direction | Purpose |
+|---------|-----------|---------|
+| `add_collider` | Bricklayer -> Engine | Create entity with Transform + ColliderComponent |
+| `update_collider` | Bricklayer -> Engine | Modify shape, position, rotation, flags |
+| `remove_collider` | Bricklayer -> Engine | Destroy collider entity |
+| `list_colliders` | Bricklayer -> Engine | Get all colliders for initial sync |
+| `collider_updated` | Engine -> Bricklayer | Event: engine modified a collider (Spec 2b gizmo prep) |
+
+### 1.2 Addressing
+
+Colliders are addressed by **game object ID** (string), not array index. Game object IDs are stable across add/remove operations and match the `game_objects[].id` field in scene JSON.
+
+### 1.3 Command Payloads
+
+**add_collider:**
+```json
+{
+  "cmd": "add_collider",
+  "id": "floor_001",
+  "name": "Floor",
+  "position": [0, -0.5, 0],
+  "rotation": [0, 0, 0, 1],
+  "collider": {
+    "shape": {"type": "box", "half_extents": [10, 0.5, 10]},
+    "is_trigger": false,
+    "is_dynamic": false,
+    "collision_mask": 4294967295
+  }
+}
+```
+
+- `position`: world-space `[x, y, z]`
+- `rotation`: quaternion `[x, y, z, w]` applied as `ColliderComponent::local_rotation`
+- `collider`: matches `ColliderComponent` JSON format from Spec 1
+- Returns: `{"type": "ok", "id": "floor_001"}`
+
+**update_collider:**
+```json
+{
+  "cmd": "update_collider",
+  "id": "floor_001",
+  "position": [0, -1, 0],
+  "rotation": [0, 0, 0, 1],
+  "collider": {"shape": {"type": "box", "half_extents": [12, 0.5, 12]}}
+}
+```
+
+Partial update — only specified fields change. Missing fields are left unchanged. Marks `CollisionSystem` dirty for BVH rebuild.
+
+**remove_collider:**
+```json
+{"cmd": "remove_collider", "id": "floor_001"}
+```
+
+Returns `{"type": "ok"}`. Marks `CollisionSystem` dirty.
+
+**list_colliders:**
+```json
+{"cmd": "list_colliders"}
+```
+
+Returns:
+```json
+{
+  "type": "ok",
+  "colliders": [
+    {
+      "id": "floor_001",
+      "name": "Floor",
+      "position": [0, -0.5, 0],
+      "rotation": [0, 0, 0, 1],
+      "collider": {
+        "shape": {"type": "box", "half_extents": [10, 0.5, 10]},
+        "is_trigger": false,
+        "is_dynamic": false,
+        "collision_mask": 4294967295
+      }
+    }
+  ]
+}
+```
+
+### 1.4 Engine Integration
+
+Commands registered in `command_dispatcher.cpp`. The `CollisionSystem*` pointer is added to `CommandContext` (same pattern as `CameraZoneSystem*`).
+
+**Entity lookup:** A private helper `find_entity_by_game_object_id(world, id)` scans entities with a `GameObjectId` component (or uses the existing `SceneObjectState::game_object_ids` map if available). This lookup is used by `update_collider` and `remove_collider`.
+
+**add_collider flow:**
+1. `world.create()` + `world.add<Transform>(pos)` + `world.add<ColliderComponent>(parsed)` 
+2. Store game object ID mapping
+3. `collision_system->mark_dirty()`
+
+**update_collider flow:**
+1. Look up entity by ID
+2. Modify `Transform::position` and/or `ColliderComponent` fields
+3. `collision_system->mark_dirty()`
+
+**remove_collider flow:**
+1. Look up entity by ID
+2. `world.destroy(entity)`
+3. Remove from ID mapping
+4. `collision_system->mark_dirty()`
+
+### 1.5 Event: collider_updated
+
+Broadcast when the engine modifies a collider (stub for now — used by Spec 2b gizmo):
+```json
+{
+  "event": "collider_updated",
+  "id": "floor_001",
+  "position": [0, -0.5, 0],
+  "rotation": [0, 0, 0, 1],
+  "collider": { ... }
+}
+```
+
+Only broadcast if `control_server_.is_event_subscribed("collider_updated")`.
+
+---
+
+## 2. Bricklayer Collider Properties Panel
+
+### 2.1 Data Model (Zustand Store)
+
+Add to `useEditorStore`:
+
+```typescript
+interface ColliderData {
+  id: string;
+  name: string;
+  position: [number, number, number];
+  rotation: [number, number, number, number]; // quaternion [x,y,z,w]
+  shape:
+    | { type: 'box'; half_extents: [number, number, number] }
+    | { type: 'sphere'; radius: number }
+    | { type: 'capsule'; radius: number; half_height: number };
+  collision_mask: number;
+  is_trigger: boolean;
+  is_dynamic: boolean;
+}
+```
+
+Store additions:
+- `colliders: ColliderData[]`
+- `selectedColliderId: string | null`
+- `addCollider(data: ColliderData): void`
+- `updateCollider(id: string, partial: Partial<ColliderData>): void`
+- `removeCollider(id: string): void`
+- `setSelectedCollider(id: string | null): void`
+- `setColliders(data: ColliderData[]): void` — bulk load from `list_colliders`
+
+### 2.2 Properties Panel
+
+New component: `ColliderPropertiesPanel.tsx`
+
+Rendered when `selectedColliderId` is set and matches a collider in the store. Fields:
+
+| Field | Widget | Notes |
+|-------|--------|-------|
+| Name | TextInput | Free text |
+| Position | Vec3Input (x, y, z) | World-space |
+| Rotation | Vec3Input (pitch, yaw, roll degrees) | **Euler angles for UX**. Converted to/from quaternion internally using `glm`-compatible ZYX convention |
+| Shape type | Dropdown (box/sphere/capsule) | Changing type resets shape params to defaults |
+| Half extents | Vec3Input | Box only |
+| Radius | NumberInput | Sphere and capsule |
+| Half height | NumberInput | Capsule only |
+| Is trigger | Checkbox | |
+| Is dynamic | Checkbox | |
+| Collision mask | NumberInput | Collapsed "Advanced" section |
+| Delete | Button | Confirmation dialog |
+
+**Euler-to-quaternion conversion:** Uses the standard ZYX (yaw-pitch-roll) convention:
+```typescript
+function eulerToQuat(pitchDeg: number, yawDeg: number, rollDeg: number): [number, number, number, number]
+function quatToEuler(q: [number, number, number, number]): [number, number, number]
+```
+
+These utilities live in a shared `math-utils.ts` file in the level-designer app.
+
+### 2.3 Collider List Panel
+
+New component: `ColliderListPanel.tsx`
+
+Shown in the sidebar when the colliders layer is active:
+- Scrollable list of all colliders (name + shape icon)
+- Click to select (sets `selectedColliderId`)
+- Selected item highlighted
+- "+" button at top to add new collider at position (0, 0, 0)
+- Right-click context menu: duplicate, delete
+
+### 2.4 Layer Integration
+
+Add `'colliders'` to the `activeLayer` type union. When active:
+- `ColliderListPanel` shown in sidebar
+- `ColliderPropertiesPanel` shown when a collider is selected
+- Wireframe rendering auto-enabled in engine via `set_feature("debug_colliders", true)`
+
+### 2.5 useEngine Hook Extensions
+
+Add to `useEngine.ts`:
+
+```typescript
+const addCollider = useCallback(
+  (data: ColliderData): Promise<OkResponse | null> =>
+    sendCommand<OkResponse>({ cmd: 'add_collider', ...data }),
+  [sendCommand],
+);
+
+const updateCollider = useCallback(
+  (id: string, data: Partial<ColliderData>): Promise<OkResponse | null> =>
+    sendCommand<OkResponse>({ cmd: 'update_collider', id, ...data }),
+  [sendCommand],
+);
+
+const removeCollider = useCallback(
+  (id: string): Promise<OkResponse | null> =>
+    sendCommand<OkResponse>({ cmd: 'remove_collider', id }),
+  [sendCommand],
+);
+
+const listColliders = useCallback(
+  (): Promise<ListCollidersResponse | null> =>
+    sendCommand<ListCollidersResponse>({ cmd: 'list_colliders' }),
+  [sendCommand],
+);
+```
+
+### 2.6 Sync Pattern
+
+Extend `useEngineSync.ts`:
+- On Bricklayer connect: call `listColliders()`, populate store with `setColliders()`
+- Store collider mutations → diff → bridge commands
+- Subscribe to `collider_updated` event → update store (prep for Spec 2b)
+
+---
+
+## 3. Vulkan Wireframe Debug Rendering
+
+### 3.1 Pipeline
+
+New `DebugWireframePipeline` built via existing `PipelineBuilder`:
+
+| Setting | Value |
+|---------|-------|
+| Polygon mode | `VK_POLYGON_MODE_LINE` |
+| Primitive topology | `VK_PRIMITIVE_TOPOLOGY_LINE_LIST` |
+| Cull mode | `VK_CULL_MODE_NONE` |
+| Depth test | Read enabled, write disabled |
+| Blending | Alpha blend (translucent wireframes) |
+| Line width | 1.0 (default, no `wideLines` requirement) |
+| Render pass | Same scene render pass as sprites |
+
+### 3.2 Shaders
+
+**`shaders/debug_wireframe.vert`:**
+
+```glsl
+#version 450
+
+layout(location = 0) in vec3 in_position;
+
+layout(set = 0, binding = 0) uniform UBO {
+    mat4 vp;
+} ubo;
+
+layout(push_constant) uniform PushConstants {
+    mat4 model;       // Translation + rotation only (no non-uniform scale)
+    vec4 color;
+    vec4 shape_params; // x=type(0=box,1=sphere,2=capsule), y=radius, z=half_height, w=unused
+    vec4 extents;      // Box: half_extents.xyz. Sphere/Capsule: unused.
+} pc;
+
+layout(location = 0) out vec4 frag_color;
+
+void main() {
+    vec3 pos = in_position;
+    int shape_type = int(pc.shape_params.x);
+
+    if (shape_type == 0) {
+        // Box: scale unit cube by half_extents
+        pos *= pc.extents.xyz;
+    } else if (shape_type == 1) {
+        // Sphere: scale unit sphere by radius
+        pos *= pc.shape_params.y;
+    } else {
+        // Capsule: vertex.y sign determines hemisphere vs cylinder
+        // Vertices are authored with y in [-1, 1]:
+        //   |y| <= 0.5 → cylinder segment, scale xz by radius, y by half_height*2
+        //   y > 0.5 → top hemisphere, scale by radius, translate +half_height
+        //   y < -0.5 → bottom hemisphere, scale by radius, translate -half_height
+        float r = pc.shape_params.y;
+        float hh = pc.shape_params.z;
+
+        if (abs(pos.y) <= 0.501) {
+            // Cylinder region
+            pos.x *= r;
+            pos.z *= r;
+            pos.y *= hh * 2.0;
+        } else {
+            // Hemisphere cap
+            float sign_y = sign(pos.y);
+            vec3 local = vec3(pos.x, abs(pos.y) - 0.5, pos.z); // normalize to unit hemi
+            local *= r * 2.0; // scale hemisphere to radius
+            pos = vec3(local.x, local.y + sign_y * hh, local.z);
+        }
+    }
+
+    gl_Position = ubo.vp * pc.model * vec4(pos, 1.0);
+    frag_color = pc.color;
+}
+```
+
+**`shaders/debug_wireframe.frag`:**
+
+```glsl
+#version 450
+
+layout(location = 0) in vec4 frag_color;
+layout(location = 0) out vec4 out_color;
+
+void main() {
+    out_color = frag_color;
+}
+```
+
+### 3.3 Base Shape Meshes (Line Lists)
+
+Generated once at pipeline creation. Stored in a single shared `VkBuffer` with known offset/count ranges:
+
+| Shape | Description | Approx vertices |
+|-------|-------------|-----------------|
+| Unit Cube | 12 edges of [-1,1]^3 as line pairs | 24 |
+| Unit Sphere | 3 orthogonal great circles, 32 segments each | 192 |
+| Unit Capsule | 2 hemisphere half-circles (top/bottom), 4 longitudinal lines, 2 equator circles | ~256 |
+
+Each vertex is a `glm::vec3` (position only — color comes from push constants).
+
+**Capsule vertex convention:**
+- Vertices with `|y| <= 0.5` are in the cylinder region
+- Vertices with `y > 0.5` belong to the top hemisphere
+- Vertices with `y < -0.5` belong to the bottom hemisphere
+- The vertex shader uses this convention to apply shape-specific scaling
+
+### 3.4 Color Scheme
+
+| State | Color (RGBA) |
+|-------|-------------|
+| Static solid | `(0.2, 0.9, 0.2, 0.8)` — green |
+| Dynamic solid | `(0.2, 0.8, 0.9, 0.8)` — cyan |
+| Trigger volume | `(0.9, 0.9, 0.2, 0.5)` — yellow, more transparent |
+| Selected | `(1.0, 1.0, 1.0, 1.0)` — white |
+
+### 3.5 Draw List Interface
+
+The renderer is decoupled from the collision system via a draw info struct:
+
+```cpp
+struct DebugColliderDrawInfo {
+    glm::mat4 model;          // Translation + rotation (no scale)
+    glm::vec4 color;
+    ColliderType shape_type;
+    float radius{0.0f};       // Sphere/Capsule
+    float half_height{0.0f};  // Capsule
+    glm::vec3 half_extents{0.0f}; // Box
+};
+```
+
+The demo state builds a `std::vector<DebugColliderDrawInfo>` each frame from the collision caches and passes it to the renderer's draw method.
+
+### 3.6 Rendering Integration
+
+Inserted in `Renderer::draw_scene()` after entity rendering, before post-process:
+
+1. If `feature_flags.debug_colliders` is false, skip
+2. Bind wireframe pipeline
+3. Bind UBO descriptor set (same VP matrix as scene)
+4. Bind wireframe vertex buffer
+5. For each `DebugColliderDrawInfo`:
+   - Push constants: `{model, color, shape_params, extents}`
+   - `vkCmdDraw(vertex_count, 1, vertex_offset, 0)` for the appropriate shape mesh
+
+### 3.7 Feature Flag
+
+`FeatureFlags::debug_colliders` (default `false`). Controlled via:
+- Bridge: `set_feature("debug_colliders", true)` (existing `set_feature` command)
+- Bricklayer: auto-enables when colliders layer is active
+- Engine: F10 keyboard toggle
+
+---
+
+## 4. Migration Script
+
+### 4.1 Purpose
+
+Convert existing `CollisionGrid` data in scene JSON to Box collider game objects. Also migrate `nav_zone[]` and `light_probe[]` to component-based entities.
+
+### 4.2 Greedy Rectangle Merge
+
+For solid cells and nav zones, adjacent cells are merged into larger boxes:
+
+1. Build 2D boolean grid from `solid[]`
+2. Scan left-to-right, top-to-bottom
+3. For each unvisited solid cell at `(gx, gz)` with elevation `e`:
+   - Expand right: while next cell is solid, unvisited, AND `elevation == e`
+   - Expand down: while all cells in the current width are solid, unvisited, AND `elevation == e`
+   - Mark all cells in the merged rectangle as visited
+   - Emit one box
+
+**Critical constraint:** Only merge cells with matching elevation. Cells with different elevations become separate boxes to preserve terrain topology (stairs, steps, slopes).
+
+### 4.3 Box Generation
+
+For each merged rectangle `(gx, gz, width, height)` with elevation `e`:
+- `half_extents.x = (width * cell_size) / 2`
+- `half_extents.z = (height * cell_size) / 2`
+- `half_extents.y = 0.25` (0.5 units thick floor slab)
+- `position.x = (gx + width/2) * cell_size` (center of merged rect, in grid coords)
+- `position.z = (gz + height/2) * cell_size`
+- `position.y = e - 0.25` (top of box aligns with grid elevation)
+
+Position values are in grid coordinates (scene JSON space). The engine's scene loader handles the conversion to world space via terrain AABB offset.
+
+### 4.4 NavZoneVolume Migration
+
+For each unique non-zero `nav_zone` ID:
+1. Run greedy merge on cells with that zone ID (elevation constraint not required for zones — they're volumes, not floors)
+2. Output game objects with both `ColliderComponent` (`is_trigger: true`) and `NavZoneVolume` (`zone_id: N`)
+3. Box Y position at grid elevation, `half_extents.y = 2.0` (tall enough to encompass walking entities)
+
+**NavZoneVolume component:**
+```cpp
+struct NavZoneVolume {
+    uint8_t zone_id{0};
+};
+```
+
+Registered via `ComponentRegistry`. JSON: `{"NavZoneVolume": {"zone_id": 3}}`.
+
+### 4.5 LightProbe Migration
+
+For each cell with a non-default light probe color (not `(0.5, 0.5, 0.5)`):
+1. Downsample: one probe per 4x4 cell block (average colors in the block)
+2. Emit point entity with `LightProbe` component at block center position
+
+**LightProbe component:**
+```cpp
+struct LightProbe {
+    glm::vec3 color{0.5f};
+};
+```
+
+Registered via `ComponentRegistry`. JSON: `{"LightProbe": {"color": [0.6, 0.5, 0.4]}}`.
+
+### 4.6 Script
+
+Python script: `scripts/migrate_collision_grid.py`
+
+```
+Usage:
+  python3 scripts/migrate_collision_grid.py <scene.json> [options]
+
+Options:
+  --output <path>      Write to separate file (default: overwrite input)
+  --remove-grid        Remove the "collision" field after migration
+  --skip-nav-zones     Don't migrate nav_zone data
+  --skip-light-probes  Don't migrate light_probe data
+  --probe-block-size N Downsample probes to NxN blocks (default: 4)
+  --dry-run            Print statistics without modifying files
+```
+
+Output: appends generated game objects to `game_objects[]` array in the scene JSON.
+
+### 4.7 Generated ID Convention
+
+- Floor colliders: `"migrated_floor_001"`, `"migrated_floor_002"`, ...
+- Nav zones: `"migrated_navzone_3_001"` (zone ID 3, instance 1)
+- Light probes: `"migrated_probe_001"`, ...
+
+### 4.8 Testing
+
+- Python unit test: 8x8 grid with known pattern → verify merged box count, positions, and elevation-respecting boundaries
+- Integration: run on `seurat_island.json`, load in engine, verify KCC movement matches old grid behavior
+
+---
+
+## 5. New ECS Components
+
+### 5.1 NavZoneVolume
+
+New file: `include/gseurat/engine/ecs/components/nav_zone_volume.hpp`
+
+```cpp
+struct NavZoneVolume {
+    uint8_t zone_id{0};
+};
+```
+
+JSON: `{"NavZoneVolume": {"zone_id": 3}}`
+
+Registered in `app_base.cpp`. Entities with NavZoneVolume also have `ColliderComponent` with `is_trigger: true`. Game code reads zone ID from overlap results.
+
+### 5.2 LightProbe
+
+New file: `include/gseurat/engine/ecs/components/light_probe.hpp`
+
+```cpp
+struct LightProbe {
+    glm::vec3 color{0.5f};
+};
+```
+
+JSON: `{"LightProbe": {"color": [0.6, 0.5, 0.4]}}`
+
+Registered in `app_base.cpp`. Used by the renderer for ambient color sampling (replaces grid-based light probe lookup).
+
+---
+
+## 6. File Layout
+
+### New Files — Engine
+
+| File | Purpose |
+|------|---------|
+| `include/gseurat/engine/collision/debug_wireframe.hpp` | DebugColliderDrawInfo struct, wireframe mesh generation |
+| `src/engine/collision/debug_wireframe.cpp` | Wireframe vertex generation + pipeline setup |
+| `shaders/debug_wireframe.vert` | Wireframe vertex shader |
+| `shaders/debug_wireframe.frag` | Wireframe fragment shader |
+| `include/gseurat/engine/ecs/components/nav_zone_volume.hpp` | NavZoneVolume component |
+| `include/gseurat/engine/ecs/components/light_probe.hpp` | LightProbe component |
+
+### New Files — Bricklayer
+
+| File | Purpose |
+|------|---------|
+| `tools/apps/level-designer/src/components/ColliderPropertiesPanel.tsx` | Collider editing panel |
+| `tools/apps/level-designer/src/components/ColliderListPanel.tsx` | Collider list sidebar |
+| `tools/apps/level-designer/src/utils/math-utils.ts` | Euler/quaternion conversion |
+
+### New Files — Scripts
+
+| File | Purpose |
+|------|---------|
+| `scripts/migrate_collision_grid.py` | Migration script |
+| `tests/test_migration.py` | Migration unit tests |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/engine/command_dispatcher.cpp` | Register 4 collider commands |
+| `include/gseurat/engine/command_context.hpp` | Add `CollisionSystem*` pointer |
+| `src/demo/island_demo_state.cpp` | Wire `CollisionSystem*` into CommandContext, build wireframe draw list |
+| `src/engine/renderer.cpp` | Add wireframe pipeline creation + draw method |
+| `include/gseurat/engine/renderer.hpp` | Add wireframe pipeline members |
+| `include/gseurat/engine/feature_flags.hpp` | Add `debug_colliders` flag |
+| `src/engine/app_base.cpp` | Register NavZoneVolume + LightProbe components |
+| `schemas/scene.schema.json` | Add NavZoneVolume + LightProbe component schemas |
+| `tools/apps/level-designer/src/store/useEditorStore.ts` | Add colliders state |
+| `tools/apps/level-designer/src/hooks/useEngine.ts` | Add collider command helpers |
+| `tools/apps/level-designer/src/hooks/useEngineSync.ts` | Add collider sync |
+| `CMakeLists.txt` | Add wireframe sources, shader compilation |
+
+---
+
+## 7. Constraints
+
+- No changes to existing CollisionGrid behavior — it continues to work alongside the new system during the transition period
+- No 3D gizmo interaction (raycasting, drag handles) — deferred to Spec 2b
+- Wireframe rendering uses the existing scene render pass — no new render pass
+- Push constants stay within the 128-byte guaranteed minimum (`mat4` + `vec4` + `vec4` + `vec4` = 112 bytes)
+- All bridge commands are JSON-over-WebSocket, matching existing protocol
+- Migration script is Python (matching existing scripts like `scenario_runner.py`)
+
+---
+
+## 8. Testing Strategy
+
+1. **Bridge commands:** Game Director integration test — add, list, update, remove colliders via socket, verify state
+2. **Wireframe pipeline:** Visual verification via Staging or engine screenshot — load scene with colliders, enable `debug_colliders`, confirm wireframes render correctly
+3. **Bricklayer panel:** Build succeeds (`pnpm build` in tools/), component renders (browser check)
+4. **Collider sync:** Bridge round-trip — add in Bricklayer, verify in engine via `list_colliders`
+5. **Migration script:** Python unit test with 8x8 grid, known pattern, verify box count/positions/elevations
+6. **Migration integration:** Run on `seurat_island.json`, load in engine, verify KCC walks correctly on generated boxes
+7. **Feature flag:** Toggle `debug_colliders` on/off, verify wireframes appear/disappear
+8. **Build verification:** `cmake --build --preset macos-debug` and `pnpm build` both succeed

--- a/include/gseurat/engine/collision/debug_wireframe.hpp
+++ b/include/gseurat/engine/collision/debug_wireframe.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "gseurat/engine/collision/primitive.hpp"
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+#include <vector>
+#include <cstdint>
+
+namespace gseurat {
+
+struct DebugColliderDrawInfo {
+    glm::mat4 model;
+    glm::vec4 color;
+    ColliderType shape_type;
+    float radius{0.0f};
+    float half_height{0.0f};
+    glm::vec3 half_extents{0.0f};
+};
+
+struct WireframeMeshRange {
+    uint32_t offset;  // vertex offset in shared buffer
+    uint32_t count;   // vertex count
+};
+
+struct WireframeMeshData {
+    std::vector<glm::vec3> vertices;  // All shapes concatenated as LINE_LIST
+    WireframeMeshRange cube;
+    WireframeMeshRange sphere;
+    WireframeMeshRange capsule;
+};
+
+/// Generate all base wireframe shape meshes (cube, sphere, capsule)
+WireframeMeshData generate_wireframe_meshes();
+
+}  // namespace gseurat

--- a/include/gseurat/engine/command_context.hpp
+++ b/include/gseurat/engine/command_context.hpp
@@ -18,6 +18,7 @@ class DebugDumpRegistry;
 class ControlServer;
 struct FeatureFlags;
 class CameraZoneSystem;
+class CollisionSystem;
 struct CommandContext {
     const GsTerrainState& terrain;
     SceneObjectState& scene_objects;
@@ -41,6 +42,7 @@ struct CommandContext {
     bool camera_sync_override = false;
     std::string camera_sync_source;  // source of last sync_camera command for echo suppression
     CameraZoneSystem* camera_zone_system = nullptr;
+    CollisionSystem* collision_system = nullptr;
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/draw_lists.hpp
+++ b/include/gseurat/engine/draw_lists.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "gseurat/engine/collision/debug_wireframe.hpp"
 #include "gseurat/engine/sprite_batch.hpp"
 
 #include <vector>
@@ -14,10 +15,12 @@ struct DrawLists {
     std::vector<SpriteDrawInfo> overlay;
     std::vector<SpriteDrawInfo> ui;
     std::vector<SpriteDrawInfo> minimap;
+    std::vector<DebugColliderDrawInfo> debug_colliders;
 
     void clear_per_frame() {
         overlay.clear();
         ui.clear();
+        debug_colliders.clear();
     }
 };
 

--- a/include/gseurat/engine/ecs/components/light_probe.hpp
+++ b/include/gseurat/engine/ecs/components/light_probe.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include <glm/glm.hpp>
+#include <nlohmann/json.hpp>
+
+namespace gseurat {
+
+struct LightProbe {
+    glm::vec3 color{0.5f};
+};
+
+inline LightProbe light_probe_from_json(const nlohmann::json& j) {
+    LightProbe lp;
+    if (j.contains("color") && j["color"].is_array()) {
+        auto& c = j["color"];
+        lp.color = glm::vec3(c[0].get<float>(), c[1].get<float>(), c[2].get<float>());
+    }
+    return lp;
+}
+
+inline nlohmann::json light_probe_to_json(const LightProbe& lp) {
+    return {{"color", {lp.color.x, lp.color.y, lp.color.z}}};
+}
+
+}  // namespace gseurat

--- a/include/gseurat/engine/ecs/components/nav_zone_volume.hpp
+++ b/include/gseurat/engine/ecs/components/nav_zone_volume.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <cstdint>
+#include <nlohmann/json.hpp>
+
+namespace gseurat {
+
+struct NavZoneVolume {
+    uint8_t zone_id{0};
+};
+
+inline NavZoneVolume nav_zone_volume_from_json(const nlohmann::json& j) {
+    NavZoneVolume v;
+    if (j.contains("zone_id")) v.zone_id = j["zone_id"].get<uint8_t>();
+    return v;
+}
+
+inline nlohmann::json nav_zone_volume_to_json(const NavZoneVolume& v) {
+    return {{"zone_id", v.zone_id}};
+}
+
+}  // namespace gseurat

--- a/include/gseurat/engine/feature_flags.hpp
+++ b/include/gseurat/engine/feature_flags.hpp
@@ -61,6 +61,9 @@ struct FeatureFlags {
     bool gs_parallax = true;        // Shadow-box parallax camera
     bool gs_tile_binning = true;    // Per-tile Gaussian binning (disable on Apple TBDR)
 
+    // Debug
+    bool debug_colliders = false;    // Collider wireframe debug visualization
+
     struct Entry {
         std::string_view name;
         std::string_view phase;
@@ -76,7 +79,8 @@ struct FeatureFlags {
             false, false, false, false, false,                       // Effects 9-13
             false, false, false, false,                              // Gameplay (4)
             false, false,                                            // Audio (2)
-            true, true, true, true, false, true   // GS (6): rendering, chunk_cull, lod, budget, parallax=off, tile_binning
+            true, true, true, true, false, true,  // GS (6): rendering, chunk_cull, lod, budget, parallax=off, tile_binning
+            false                                  // Debug: debug_colliders
         };
     }
 
@@ -86,7 +90,7 @@ struct FeatureFlags {
         (void)apple_gpu;
     }
 
-    static constexpr std::array<Entry, 33> entries() {
+    static constexpr std::array<Entry, 34> entries() {
         return {{
             {"Parallax BG",    "24",  "RENDERING", &FeatureFlags::parallax_backgrounds},
             {"Point Lights",   "11",  "RENDERING", &FeatureFlags::point_lights},
@@ -121,6 +125,7 @@ struct FeatureFlags {
             {"GS Budget",      "GS10","3DGS",      &FeatureFlags::gs_adaptive_budget},
             {"GS Parallax",    "GS9", "3DGS",     &FeatureFlags::gs_parallax},
             {"GS Tile Bin",    "GS9", "3DGS",     &FeatureFlags::gs_tile_binning},
+            {"Debug Colliders","---", "DEBUG",     &FeatureFlags::debug_colliders},
         }};
     }
 };

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -20,6 +20,7 @@
 #include "gseurat/engine/sync.hpp"
 #include "gseurat/engine/texture.hpp"
 #include "gseurat/engine/types.hpp"
+#include "gseurat/engine/collision/debug_wireframe.hpp"
 #include "gseurat/engine/feature_flags.hpp"
 #include "gseurat/engine/ui/ui_context.hpp"
 #include "gseurat/engine/vk_context.hpp"
@@ -85,7 +86,12 @@ public:
                     const std::vector<SpriteDrawInfo>& particles = {},
                     const std::vector<SpriteDrawInfo>& overlay = {},
                     const std::vector<ui::UIDrawBatch>& ui_batches = {},
+                    const std::vector<DebugColliderDrawInfo>& debug_colliders_list = {},
                     const FeatureFlags& flags = {});
+
+    /// Draw debug collider wireframes. Call between scene pass begin and end.
+    void draw_debug_colliders(VkCommandBuffer cmd,
+                              const std::vector<DebugColliderDrawInfo>& draw_list);
     void shutdown();
 
     Camera& camera() { return camera_; }
@@ -160,6 +166,7 @@ private:
     void create_sprite_pipeline();
     void create_outline_pipeline();
     void create_ui_pipeline();
+    void create_wireframe_pipeline();
     void create_uniform_buffers();
     void update_uniform_buffer(uint32_t frame_index, const UniformBufferObject& ubo);
 
@@ -185,6 +192,13 @@ private:
     VkPipelineLayout outline_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline outline_pipeline_ = VK_NULL_HANDLE;
     VkPipeline ui_pipeline_ = VK_NULL_HANDLE;
+
+    // Debug wireframe rendering
+    VkPipeline wireframe_pipeline_ = VK_NULL_HANDLE;
+    VkPipelineLayout wireframe_pipeline_layout_ = VK_NULL_HANDLE;
+    VkBuffer wireframe_vb_ = VK_NULL_HANDLE;
+    VmaAllocation wireframe_vb_alloc_ = VK_NULL_HANDLE;
+    WireframeMeshData wireframe_meshes_;
 
     SpriteBatch sprite_batch_;
     std::array<Buffer, kMaxFramesInFlight> uniform_buffers_;

--- a/include/gseurat/engine/scene_object_state.hpp
+++ b/include/gseurat/engine/scene_object_state.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "gseurat/engine/ecs/types.hpp"
 #include "gseurat/engine/scene_loader.hpp"
 #include "gseurat/engine/world_manifest.hpp"
 
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace gseurat {
@@ -15,6 +17,9 @@ struct SceneObjectState {
     bool transitioning = false;
     uint32_t scene_data_version = 0;  // incremented by update_scene_data
     std::optional<WorldManifest> world_manifest;
+
+    /// Map from collider ID to ECS entity — avoids fragile position-based lookup
+    std::unordered_map<std::string, ecs::Entity> collider_entity_map;
 };
 
 }  // namespace gseurat

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -286,6 +286,18 @@
                 "desired_jump_height": { "type": "number", "default": 2.0, "minimum": 0 },
                 "time_to_apex": { "type": "number", "default": 0.4, "minimum": 0 }
               }
+            },
+            "NavZoneVolume": {
+              "type": "object",
+              "properties": {
+                "zone_id": { "type": "integer", "minimum": 0, "maximum": 255, "default": 0 }
+              }
+            },
+            "LightProbe": {
+              "type": "object",
+              "properties": {
+                "color": { "type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3 }
+              }
             }
           },
           "additionalProperties": { "type": "object" }

--- a/scripts/migrate_collision_grid.py
+++ b/scripts/migrate_collision_grid.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Migrate CollisionGrid data to primitive Box colliders.
+
+Converts solid[] cells to Box collider game objects using greedy rectangle
+merging. Optionally migrates nav_zone[] to NavZoneVolume trigger boxes and
+light_probe[] to LightProbe point entities.
+
+Usage:
+    python3 scripts/migrate_collision_grid.py <scene.json> [options]
+
+Options:
+    --output <path>         Write to separate file (default: overwrite input)
+    --remove-grid           Remove the "collision" field after migration
+    --skip-nav-zones        Don't migrate nav_zone data
+    --skip-light-probes     Don't migrate light_probe data
+    --probe-block-size N    Downsample probes to NxN blocks (default: 4)
+    --dry-run               Print statistics without modifying files
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def greedy_merge(grid_width, grid_height, cell_predicate):
+    """Merge adjacent cells into rectangles using greedy expansion.
+
+    cell_predicate(x, z) returns True if the cell should be included.
+    Returns list of (x, z, width, height) tuples in grid coordinates.
+    """
+    visited = [[False] * grid_width for _ in range(grid_height)]
+    rectangles = []
+
+    for z in range(grid_height):
+        for x in range(grid_width):
+            if visited[z][x] or not cell_predicate(x, z):
+                continue
+
+            # Expand right
+            w = 1
+            while (x + w < grid_width and
+                   not visited[z][x + w] and
+                   cell_predicate(x + w, z)):
+                w += 1
+
+            # Expand down
+            h = 1
+            while z + h < grid_height:
+                row_ok = True
+                for dx in range(w):
+                    if visited[z + h][x + dx] or not cell_predicate(x + dx, z + h):
+                        row_ok = False
+                        break
+                if not row_ok:
+                    break
+                h += 1
+
+            # Mark visited
+            for dz in range(h):
+                for dx in range(w):
+                    visited[z + dz][x + dx] = True
+
+            rectangles.append((x, z, w, h))
+
+    return rectangles
+
+
+def migrate_solid_cells(collision, cell_size):
+    """Convert solid cells to Box collider game objects.
+
+    CRITICAL: Only merges cells with matching elevation to preserve
+    terrain topology (stairs, steps, slopes).
+    """
+    width = collision['width']
+    height = collision['height']
+    solid = collision.get('solid', [])
+    elevation = collision.get('elevation', [])
+
+    if not solid:
+        return []
+
+    game_objects = []
+    counter = 1
+
+    # Group cells by elevation value (rounded to avoid float comparison issues)
+    def get_elevation(x, z):
+        idx = z * width + x
+        if idx < len(elevation):
+            return round(elevation[idx], 4)
+        return 0.0
+
+    # Find all unique elevations for solid cells
+    elevation_groups = {}
+    for z in range(height):
+        for x in range(width):
+            idx = z * width + x
+            if idx < len(solid) and solid[idx]:
+                elev = get_elevation(x, z)
+                if elev not in elevation_groups:
+                    elevation_groups[elev] = True
+
+    # For each elevation, run greedy merge
+    visited_global = [[False] * width for _ in range(height)]
+
+    for elev in sorted(elevation_groups.keys()):
+        def predicate(x, z, _elev=elev):
+            if visited_global[z][x]:
+                return False
+            idx = z * width + x
+            if idx >= len(solid) or not solid[idx]:
+                return False
+            return get_elevation(x, z) == _elev
+
+        rects = greedy_merge(width, height, predicate)
+
+        for (rx, rz, rw, rh) in rects:
+            # Mark globally visited
+            for dz in range(rh):
+                for dx in range(rw):
+                    visited_global[rz + dz][rx + dx] = True
+
+            # Compute box position (center of rectangle, in grid coords)
+            cx = (rx + rw / 2.0) * cell_size
+            cz = (rz + rh / 2.0) * cell_size
+            cy = elev - 0.25  # Top of box aligns with grid elevation
+
+            # Half extents
+            hex_ = (rw * cell_size) / 2.0
+            hez = (rh * cell_size) / 2.0
+            hey = 0.25  # 0.5 units thick floor slab
+
+            game_objects.append({
+                'id': f'migrated_floor_{counter:03d}',
+                'name': 'Floor (migrated)',
+                'position': [round(cx, 4), round(cy, 4), round(cz, 4)],
+                'components': {
+                    'ColliderComponent': {
+                        'shape': {
+                            'type': 'box',
+                            'half_extents': [round(hex_, 4), round(hey, 4), round(hez, 4)]
+                        },
+                        'is_trigger': False
+                    }
+                }
+            })
+            counter += 1
+
+    return game_objects
+
+
+def migrate_nav_zones(collision, cell_size):
+    """Convert nav_zone[] to NavZoneVolume trigger boxes."""
+    width = collision['width']
+    height = collision['height']
+    nav_zones = collision.get('nav_zone', [])
+
+    if not nav_zones:
+        return []
+
+    game_objects = []
+
+    # Find unique non-zero zone IDs
+    zone_ids = set()
+    for z_val in nav_zones:
+        if z_val > 0:
+            zone_ids.add(z_val)
+
+    for zone_id in sorted(zone_ids):
+        counter = 1
+
+        def predicate(x, z, _zone_id=zone_id):
+            idx = z * width + x
+            return idx < len(nav_zones) and nav_zones[idx] == _zone_id
+
+        rects = greedy_merge(width, height, predicate)
+
+        for (rx, rz, rw, rh) in rects:
+            cx = (rx + rw / 2.0) * cell_size
+            cz = (rz + rh / 2.0) * cell_size
+            cy = 1.0  # Center of trigger volume
+
+            hex_ = (rw * cell_size) / 2.0
+            hez = (rh * cell_size) / 2.0
+            hey = 2.0  # Tall enough for walking entities
+
+            game_objects.append({
+                'id': f'migrated_navzone_{zone_id}_{counter:03d}',
+                'name': f'NavZone {zone_id} (migrated)',
+                'position': [round(cx, 4), round(cy, 4), round(cz, 4)],
+                'components': {
+                    'ColliderComponent': {
+                        'shape': {
+                            'type': 'box',
+                            'half_extents': [round(hex_, 4), round(hey, 4), round(hez, 4)]
+                        },
+                        'is_trigger': True
+                    },
+                    'NavZoneVolume': {
+                        'zone_id': zone_id
+                    }
+                }
+            })
+            counter += 1
+
+    return game_objects
+
+
+def migrate_light_probes(collision, cell_size, block_size=4):
+    """Convert light_probe[] to LightProbe point entities with downsampling."""
+    width = collision['width']
+    height = collision['height']
+    probes = collision.get('light_probe', [])
+
+    if not probes:
+        return []
+
+    game_objects = []
+    counter = 1
+    default_color = [0.5, 0.5, 0.5]
+
+    # Downsample: average colors in block_size x block_size blocks
+    for bz in range(0, height, block_size):
+        for bx in range(0, width, block_size):
+            r_sum, g_sum, b_sum = 0.0, 0.0, 0.0
+            count = 0
+            has_non_default = False
+
+            for dz in range(min(block_size, height - bz)):
+                for dx in range(min(block_size, width - bx)):
+                    idx = (bz + dz) * width + (bx + dx)
+                    pi = idx * 3
+                    if pi + 2 < len(probes):
+                        r, g, b = probes[pi], probes[pi + 1], probes[pi + 2]
+                        r_sum += r
+                        g_sum += g
+                        b_sum += b
+                        count += 1
+                        if abs(r - 0.5) > 0.01 or abs(g - 0.5) > 0.01 or abs(b - 0.5) > 0.01:
+                            has_non_default = True
+
+            if count == 0 or not has_non_default:
+                continue
+
+            avg_r = r_sum / count
+            avg_g = g_sum / count
+            avg_b = b_sum / count
+
+            cx = (bx + min(block_size, width - bx) / 2.0) * cell_size
+            cz = (bz + min(block_size, height - bz) / 2.0) * cell_size
+
+            game_objects.append({
+                'id': f'migrated_probe_{counter:03d}',
+                'name': 'LightProbe (migrated)',
+                'position': [round(cx, 4), 0.0, round(cz, 4)],
+                'components': {
+                    'LightProbe': {
+                        'color': [round(avg_r, 4), round(avg_g, 4), round(avg_b, 4)]
+                    }
+                }
+            })
+            counter += 1
+
+    return game_objects
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Migrate CollisionGrid to primitive colliders')
+    parser.add_argument('scene', help='Path to scene JSON file')
+    parser.add_argument('--output', help='Output path (default: overwrite input)')
+    parser.add_argument('--remove-grid', action='store_true', help='Remove collision field after migration')
+    parser.add_argument('--skip-nav-zones', action='store_true')
+    parser.add_argument('--skip-light-probes', action='store_true')
+    parser.add_argument('--probe-block-size', type=int, default=4)
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args()
+
+    scene_path = Path(args.scene)
+    with open(scene_path, 'r') as f:
+        scene = json.load(f)
+
+    collision = scene.get('collision')
+    if not collision:
+        print('No collision field found in scene. Nothing to migrate.')
+        return
+
+    cell_size = collision.get('cell_size', 1.0)
+
+    # Migrate
+    floor_objects = migrate_solid_cells(collision, cell_size)
+    nav_objects = [] if args.skip_nav_zones else migrate_nav_zones(collision, cell_size)
+    probe_objects = [] if args.skip_light_probes else migrate_light_probes(collision, cell_size, args.probe_block_size)
+
+    total = len(floor_objects) + len(nav_objects) + len(probe_objects)
+
+    print(f'Migration results:')
+    print(f'  Floor colliders: {len(floor_objects)}')
+    print(f'  Nav zone volumes: {len(nav_objects)}')
+    print(f'  Light probes: {len(probe_objects)}')
+    print(f'  Total entities: {total}')
+
+    if args.dry_run:
+        print('(dry run — no files modified)')
+        return
+
+    # Append to game_objects
+    if 'game_objects' not in scene:
+        scene['game_objects'] = []
+    scene['game_objects'].extend(floor_objects)
+    scene['game_objects'].extend(nav_objects)
+    scene['game_objects'].extend(probe_objects)
+
+    if args.remove_grid:
+        del scene['collision']
+        print('  Removed collision field.')
+
+    output_path = Path(args.output) if args.output else scene_path
+    with open(output_path, 'w') as f:
+        json.dump(scene, f, indent=2)
+
+    print(f'  Written to: {output_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -35,6 +35,8 @@ set(SHADER_SOURCES
     ${SHADER_SOURCE_DIR}/gs_onesweep_scatter.comp
     ${SHADER_SOURCE_DIR}/gs_post_process.comp
     ${SHADER_SOURCE_DIR}/pbd_solver.comp
+    ${SHADER_SOURCE_DIR}/debug_wireframe.vert
+    ${SHADER_SOURCE_DIR}/debug_wireframe.frag
 )
 
 set(SHADER_OUTPUTS "")

--- a/shaders/debug_wireframe.frag
+++ b/shaders/debug_wireframe.frag
@@ -1,0 +1,8 @@
+#version 450
+
+layout(location = 0) in vec4 frag_color;
+layout(location = 0) out vec4 out_color;
+
+void main() {
+    out_color = frag_color;
+}

--- a/shaders/debug_wireframe.vert
+++ b/shaders/debug_wireframe.vert
@@ -1,0 +1,53 @@
+#version 450
+
+layout(location = 0) in vec3 in_position;
+
+layout(set = 0, binding = 0) uniform UBO {
+    mat4 vp;
+    // Remaining UBO fields exist but we only read vp
+} ubo;
+
+layout(push_constant) uniform PushConstants {
+    mat4 model;        // 64 bytes: translation + rotation (no non-uniform scale)
+    vec4 color;        // 16 bytes: wireframe color RGBA
+    vec4 shape_params; // 16 bytes: x=type(0=box,1=sphere,2=capsule), y=radius, z=half_height
+    vec4 extents;      // 16 bytes: box half_extents.xyz (total: 112 bytes)
+} pc;
+
+layout(location = 0) out vec4 frag_color;
+
+void main() {
+    vec3 pos = in_position;
+    int shape_type = int(pc.shape_params.x);
+
+    if (shape_type == 0) {
+        // Box: scale unit cube vertices by half_extents
+        pos *= pc.extents.xyz;
+    } else if (shape_type == 1) {
+        // Sphere: uniform scale by radius
+        pos *= pc.shape_params.y;
+    } else {
+        // Capsule: shape-aware vertex transformation
+        // Vertex convention:
+        //   |y| <= 0.501 → cylinder segment
+        //   |y| > 0.501  → hemisphere cap
+        float r = pc.shape_params.y;
+        float hh = pc.shape_params.z;
+
+        if (abs(pos.y) <= 0.501) {
+            // Cylinder region: scale XZ by radius, Y by half_height*2
+            pos.x *= r;
+            pos.z *= r;
+            pos.y *= hh * 2.0;
+        } else {
+            // Hemisphere cap: scale by radius, translate by +-half_height
+            float sign_y = sign(pos.y);
+            vec3 local_pos = vec3(pos.x, abs(pos.y) - 0.5, pos.z);
+            local_pos *= r * 2.0;
+            pos = vec3(local_pos.x, local_pos.y + sign_y * hh, local_pos.z);
+        }
+    }
+
+    gl_Position = ubo.vp * pc.model * vec4(pos, 1.0);
+    frag_color = pc.color;
+}

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -291,6 +291,7 @@ void IslandDemoState::on_enter(AppBase& app) {
 
         // Wire up camera_zone_system for bridge commands.
         app.command_dispatcher().context().camera_zone_system = camera_zone_system_.get();
+        app.command_dispatcher().context().collision_system = &collision_system_;
 
         std::fprintf(stderr, "[IslandDemo] Camera zone system loaded: %d volumes, %zu triggers, %zu rails\n",
                      next_zone_id, cz.triggers.size(), rail_count);
@@ -676,6 +677,7 @@ void IslandDemoState::on_exit(AppBase& app) {
 
     // Release camera zone system
     app.command_dispatcher().context().camera_zone_system = nullptr;
+    app.command_dispatcher().context().collision_system = nullptr;
     camera_zone_system_.reset();
 
     // Release animation registry references
@@ -2031,6 +2033,7 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
 
     // Reset camera zone system — island zones are invalid in instances
     app.command_dispatcher().context().camera_zone_system = nullptr;
+    app.command_dispatcher().context().collision_system = nullptr;
     camera_zone_system_.reset();
 
     // Reset camera target to avoid stale smoothing from old scene

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1581,6 +1581,51 @@ void IslandDemoState::build_draw_lists(AppBase& app) {
     // Gizmos render independently of HUD mode
     draw_gizmos(app);
 
+    // Build debug collider wireframe draw list
+    if (app.feature_flags().debug_colliders) {
+        auto& debug_colliders = app.draw_lists().debug_colliders;
+
+        auto build_draw_info = [](const ColliderInstance& inst) -> DebugColliderDrawInfo {
+            DebugColliderDrawInfo info;
+            info.model = glm::translate(glm::mat4(1.0f), inst.world_position) *
+                         glm::mat4_cast(inst.world_rotation);
+
+            // Color scheme: yellow for triggers, green for solid
+            if (inst.is_trigger) {
+                info.color = glm::vec4(0.9f, 0.9f, 0.2f, 0.5f);
+            } else {
+                info.color = glm::vec4(0.2f, 0.9f, 0.2f, 0.8f);
+            }
+
+            // Shape params
+            std::visit([&](const auto& shape) {
+                using T = std::decay_t<decltype(shape)>;
+                if constexpr (std::is_same_v<T, BoxData>) {
+                    info.shape_type = ColliderType::Box;
+                    info.half_extents = shape.half_extents;
+                } else if constexpr (std::is_same_v<T, SphereData>) {
+                    info.shape_type = ColliderType::Sphere;
+                    info.radius = shape.radius;
+                } else if constexpr (std::is_same_v<T, CapsuleData>) {
+                    info.shape_type = ColliderType::Capsule;
+                    info.radius = shape.radius;
+                    info.half_height = shape.half_height;
+                }
+            }, inst.shape);
+
+            return info;
+        };
+
+        for (const auto& inst : collision_system_.static_cache()) {
+            debug_colliders.push_back(build_draw_info(inst));
+        }
+        for (const auto& inst : collision_system_.dynamic_cache()) {
+            auto di = build_draw_info(inst);
+            di.color = glm::vec4(0.2f, 0.8f, 0.9f, 0.8f);  // cyan for dynamic
+            debug_colliders.push_back(di);
+        }
+    }
+
     if (hud_mode_ == HudMode::kOff) return;
 
     auto& ui = app.ui_ctx();

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -18,6 +18,8 @@
 #include "gseurat/engine/ecs/components/player_jump.hpp"
 #include "gseurat/engine/ecs/components/collider_component.hpp"
 #include "gseurat/engine/ecs/components/kinematic_body.hpp"
+#include "gseurat/engine/ecs/components/nav_zone_volume.hpp"
+#include "gseurat/engine/ecs/components/light_probe.hpp"
 #include "gseurat/engine/systems/portal_trigger_handler.hpp"
 
 #define GLFW_INCLUDE_VULKAN
@@ -505,6 +507,14 @@ void AppBase::init_game_object_system() {
         [](const KinematicBody& kb) -> nlohmann::json {
             return kinematic_body_to_json(kb);
         });
+
+    component_registry_.register_component<NavZoneVolume>("NavZoneVolume",
+        [](const nlohmann::json& j) -> NavZoneVolume { return nav_zone_volume_from_json(j); },
+        [](const NavZoneVolume& v) -> nlohmann::json { return nav_zone_volume_to_json(v); });
+
+    component_registry_.register_component<LightProbe>("LightProbe",
+        [](const nlohmann::json& j) -> LightProbe { return light_probe_from_json(j); },
+        [](const LightProbe& lp) -> nlohmann::json { return light_probe_to_json(lp); });
 
     // Register engine-level systems
     system_scheduler_.add_system({"bone_animation",

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -251,7 +251,7 @@ void AppBase::main_loop() {
 
         renderer_.draw_scene(scene_, draw_lists_.entity, draw_lists_.outline, draw_lists_.reflection,
                              draw_lists_.shadow, particle_sprites, draw_lists_.overlay, ui_batches,
-                             feature_flags_);
+                             draw_lists_.debug_colliders, feature_flags_);
     }
 }
 

--- a/src/engine/collision/debug_wireframe.cpp
+++ b/src/engine/collision/debug_wireframe.cpp
@@ -1,0 +1,153 @@
+#include "gseurat/engine/collision/debug_wireframe.hpp"
+
+#include <cmath>
+#include <numbers>
+
+namespace gseurat {
+
+namespace {
+
+constexpr float kPi = std::numbers::pi_v<float>;
+constexpr float kTwoPi = 2.0f * kPi;
+
+void generate_cube(std::vector<glm::vec3>& verts, WireframeMeshRange& range) {
+    range.offset = static_cast<uint32_t>(verts.size());
+
+    // 8 corners of a [-1,1]^3 cube
+    glm::vec3 corners[8] = {
+        {-1, -1, -1}, { 1, -1, -1}, { 1,  1, -1}, {-1,  1, -1},
+        {-1, -1,  1}, { 1, -1,  1}, { 1,  1,  1}, {-1,  1,  1}
+    };
+
+    // 12 edges: bottom face, top face, verticals
+    constexpr int edges[12][2] = {
+        {0, 1}, {1, 2}, {2, 3}, {3, 0},  // bottom
+        {4, 5}, {5, 6}, {6, 7}, {7, 4},  // top
+        {0, 4}, {1, 5}, {2, 6}, {3, 7}   // verticals
+    };
+
+    for (const auto& e : edges) {
+        verts.push_back(corners[e[0]]);
+        verts.push_back(corners[e[1]]);
+    }
+
+    range.count = static_cast<uint32_t>(verts.size()) - range.offset;  // 24
+}
+
+void generate_sphere(std::vector<glm::vec3>& verts, WireframeMeshRange& range) {
+    range.offset = static_cast<uint32_t>(verts.size());
+
+    constexpr int segments = 32;
+
+    // XY plane circle
+    for (int i = 0; i < segments; ++i) {
+        float a1 = kTwoPi * static_cast<float>(i) / static_cast<float>(segments);
+        float a2 = kTwoPi * static_cast<float>(i + 1) / static_cast<float>(segments);
+        verts.push_back({std::cos(a1), std::sin(a1), 0.0f});
+        verts.push_back({std::cos(a2), std::sin(a2), 0.0f});
+    }
+
+    // XZ plane circle
+    for (int i = 0; i < segments; ++i) {
+        float a1 = kTwoPi * static_cast<float>(i) / static_cast<float>(segments);
+        float a2 = kTwoPi * static_cast<float>(i + 1) / static_cast<float>(segments);
+        verts.push_back({std::cos(a1), 0.0f, std::sin(a1)});
+        verts.push_back({std::cos(a2), 0.0f, std::sin(a2)});
+    }
+
+    // YZ plane circle
+    for (int i = 0; i < segments; ++i) {
+        float a1 = kTwoPi * static_cast<float>(i) / static_cast<float>(segments);
+        float a2 = kTwoPi * static_cast<float>(i + 1) / static_cast<float>(segments);
+        verts.push_back({0.0f, std::cos(a1), std::sin(a1)});
+        verts.push_back({0.0f, std::cos(a2), std::sin(a2)});
+    }
+
+    range.count = static_cast<uint32_t>(verts.size()) - range.offset;  // 192
+}
+
+void generate_capsule(std::vector<glm::vec3>& verts, WireframeMeshRange& range) {
+    range.offset = static_cast<uint32_t>(verts.size());
+
+    constexpr int segments = 32;
+    constexpr int half_segments = segments / 2;
+
+    // The capsule is oriented along Y. The cylinder region spans y in [-0.5, +0.5].
+    // Hemispheres extend beyond: top cap y > 0.5, bottom cap y < -0.5.
+    // The shader uses this Y convention to scale by radius/half_height.
+
+    // ── Top hemisphere: 2 half-circles (XY and ZY planes, y > 0.5) ──
+    for (int i = 0; i < half_segments; ++i) {
+        float a1 = kPi * static_cast<float>(i) / static_cast<float>(half_segments);       // 0 to PI
+        float a2 = kPi * static_cast<float>(i + 1) / static_cast<float>(half_segments);
+        // XY plane arc, y >= 0.5
+        verts.push_back({std::sin(a1), 0.5f + std::cos(a1) * 0.5f, 0.0f});
+        verts.push_back({std::sin(a2), 0.5f + std::cos(a2) * 0.5f, 0.0f});
+    }
+    for (int i = 0; i < half_segments; ++i) {
+        float a1 = kPi * static_cast<float>(i) / static_cast<float>(half_segments);
+        float a2 = kPi * static_cast<float>(i + 1) / static_cast<float>(half_segments);
+        // ZY plane arc, y >= 0.5
+        verts.push_back({0.0f, 0.5f + std::cos(a1) * 0.5f, std::sin(a1)});
+        verts.push_back({0.0f, 0.5f + std::cos(a2) * 0.5f, std::sin(a2)});
+    }
+
+    // ── Bottom hemisphere: 2 half-circles (XY and ZY planes, y < -0.5) ──
+    for (int i = 0; i < half_segments; ++i) {
+        float a1 = kPi + kPi * static_cast<float>(i) / static_cast<float>(half_segments);  // PI to 2PI
+        float a2 = kPi + kPi * static_cast<float>(i + 1) / static_cast<float>(half_segments);
+        // XY plane arc, y <= -0.5
+        verts.push_back({std::sin(a1), -0.5f + std::cos(a1) * 0.5f, 0.0f});
+        verts.push_back({std::sin(a2), -0.5f + std::cos(a2) * 0.5f, 0.0f});
+    }
+    for (int i = 0; i < half_segments; ++i) {
+        float a1 = kPi + kPi * static_cast<float>(i) / static_cast<float>(half_segments);
+        float a2 = kPi + kPi * static_cast<float>(i + 1) / static_cast<float>(half_segments);
+        // ZY plane arc, y <= -0.5
+        verts.push_back({0.0f, -0.5f + std::cos(a1) * 0.5f, std::sin(a1)});
+        verts.push_back({0.0f, -0.5f + std::cos(a2) * 0.5f, std::sin(a2)});
+    }
+
+    // ── Top equator circle (at y = +0.5, in cylinder region) ──
+    for (int i = 0; i < segments; ++i) {
+        float a1 = kTwoPi * static_cast<float>(i) / static_cast<float>(segments);
+        float a2 = kTwoPi * static_cast<float>(i + 1) / static_cast<float>(segments);
+        verts.push_back({std::cos(a1), 0.5f, std::sin(a1)});
+        verts.push_back({std::cos(a2), 0.5f, std::sin(a2)});
+    }
+
+    // ── Bottom equator circle (at y = -0.5, in cylinder region) ──
+    for (int i = 0; i < segments; ++i) {
+        float a1 = kTwoPi * static_cast<float>(i) / static_cast<float>(segments);
+        float a2 = kTwoPi * static_cast<float>(i + 1) / static_cast<float>(segments);
+        verts.push_back({std::cos(a1), -0.5f, std::sin(a1)});
+        verts.push_back({std::cos(a2), -0.5f, std::sin(a2)});
+    }
+
+    // ── 4 vertical lines connecting equators ──
+    verts.push_back({ 1.0f,  0.5f,  0.0f});
+    verts.push_back({ 1.0f, -0.5f,  0.0f});
+    verts.push_back({-1.0f,  0.5f,  0.0f});
+    verts.push_back({-1.0f, -0.5f,  0.0f});
+    verts.push_back({ 0.0f,  0.5f,  1.0f});
+    verts.push_back({ 0.0f, -0.5f,  1.0f});
+    verts.push_back({ 0.0f,  0.5f, -1.0f});
+    verts.push_back({ 0.0f, -0.5f, -1.0f});
+
+    range.count = static_cast<uint32_t>(verts.size()) - range.offset;
+}
+
+}  // namespace
+
+WireframeMeshData generate_wireframe_meshes() {
+    WireframeMeshData data;
+    data.vertices.reserve(512);
+
+    generate_cube(data.vertices, data.cube);
+    generate_sphere(data.vertices, data.sphere);
+    generate_capsule(data.vertices, data.capsule);
+
+    return data;
+}
+
+}  // namespace gseurat

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -1,9 +1,11 @@
 #include "gseurat/engine/camera_zone_system.hpp"
+#include "gseurat/engine/collision/collision_system.hpp"
 #include "gseurat/engine/command_dispatcher.hpp"
 #include "gseurat/engine/component_registry.hpp"
 #include "gseurat/engine/control_server.hpp"
 #include "gseurat/engine/debug_dump.hpp"
 #include "gseurat/engine/coordinate.hpp"
+#include "gseurat/engine/ecs/components/collider_component.hpp"
 #include "gseurat/engine/ecs/default_components.hpp"
 #include "gseurat/engine/ecs/ecs.hpp"
 #include "gseurat/engine/feature_flags.hpp"
@@ -659,6 +661,198 @@ void CommandDispatcher::register_default_commands() {
         }
         ctx_.control_server->unsubscribe_all();
         return json{{"type", "ok"}};
+    });
+
+    // --- Collider CRUD commands ---
+
+    register_command("add_collider", [this, ok](const json& cmd) -> CommandResult {
+        if (!ctx_.collision_system)
+            return std::unexpected(std::string("collision_system not available"));
+
+        std::string id = cmd.value("id", "");
+        if (id.empty())
+            return std::unexpected(std::string("missing 'id' field"));
+
+        std::string name = cmd.value("name", id);
+
+        // Parse position
+        glm::vec3 pos{0.0f};
+        if (cmd.contains("position") && cmd["position"].is_array()) {
+            auto& p = cmd["position"];
+            pos = glm::vec3(p[0].get<float>(), p[1].get<float>(), p[2].get<float>());
+        }
+
+        // Parse collider component from "collider" field
+        ColliderComponent collider;
+        if (cmd.contains("collider") && cmd["collider"].is_object()) {
+            collider = collider_from_json(cmd["collider"]);
+        }
+
+        // Parse rotation as quaternion [x,y,z,w] and apply to collider's local_rotation
+        if (cmd.contains("rotation") && cmd["rotation"].is_array()) {
+            auto& r = cmd["rotation"];
+            collider.local_rotation = glm::quat(
+                r[3].get<float>(), r[0].get<float>(), r[1].get<float>(), r[2].get<float>());
+        }
+
+        // Create ECS entity
+        auto entity = ctx_.world.create();
+        ctx_.world.add<ecs::Transform>(entity,
+            ecs::Transform{coord::WorldPos(pos), {1.0f, 1.0f}});
+        ctx_.world.add<ColliderComponent>(entity, collider);
+
+        // Store in scene_objects for ID tracking
+        GameObjectData go_data;
+        go_data.id = id;
+        go_data.name = name;
+        go_data.position = coord::GridPos(pos);
+        go_data.components = cmd.contains("collider") ? json{{"ColliderComponent", cmd["collider"]}} : json::object();
+        ctx_.scene_objects.game_objects.push_back(go_data);
+
+        ctx_.collision_system->mark_dirty();
+
+        json response = ok().value();
+        response["id"] = id;
+        return response;
+    });
+
+    register_command("update_collider", [this, ok](const json& cmd) -> CommandResult {
+        if (!ctx_.collision_system)
+            return std::unexpected(std::string("collision_system not available"));
+
+        std::string id = cmd.value("id", "");
+        if (id.empty())
+            return std::unexpected(std::string("missing 'id' field"));
+
+        // Find the game object and its entity
+        auto& game_objects = ctx_.scene_objects.game_objects;
+        auto go_it = std::find_if(game_objects.begin(), game_objects.end(),
+            [&id](const GameObjectData& go) { return go.id == id; });
+        if (go_it == game_objects.end())
+            return std::unexpected(std::string("collider not found: " + id));
+
+        // Find the ECS entity — scan entities with ColliderComponent
+        // Match by position (WorldPos from GridPos)
+        ecs::Entity target_entity = ecs::kNullEntity;
+        glm::vec3 go_pos = go_it->position.vec();
+
+        ctx_.world.view<ecs::Transform, ColliderComponent>().each(
+            [&](ecs::Entity e, ecs::Transform& t, ColliderComponent&) {
+                if (target_entity == ecs::kNullEntity) {
+                    glm::vec3 epos = t.position.vec();
+                    if (glm::length(epos - go_pos) < 0.01f) {
+                        target_entity = e;
+                    }
+                }
+            });
+
+        if (target_entity == ecs::kNullEntity)
+            return std::unexpected(std::string("entity not found for collider: " + id));
+
+        // Update position
+        if (cmd.contains("position") && cmd["position"].is_array()) {
+            auto& p = cmd["position"];
+            glm::vec3 new_pos(p[0].get<float>(), p[1].get<float>(), p[2].get<float>());
+            ctx_.world.get<ecs::Transform>(target_entity).position = coord::WorldPos(new_pos);
+            go_it->position = coord::GridPos(new_pos);
+        }
+
+        // Update collider fields (partial)
+        if (cmd.contains("collider") && cmd["collider"].is_object()) {
+            auto& cc = ctx_.world.get<ColliderComponent>(target_entity);
+            auto& cj = cmd["collider"];
+
+            if (cj.contains("shape")) {
+                // Re-parse the whole collider to get the new shape
+                ColliderComponent updated = collider_from_json(cj);
+                cc.shape = updated.shape;
+            }
+            if (cj.contains("is_trigger")) cc.is_trigger = cj["is_trigger"].get<bool>();
+            if (cj.contains("is_dynamic")) cc.is_dynamic = cj["is_dynamic"].get<bool>();
+            if (cj.contains("collision_mask")) cc.collision_mask = cj["collision_mask"].get<uint32_t>();
+        }
+
+        // Update rotation
+        if (cmd.contains("rotation") && cmd["rotation"].is_array()) {
+            auto& r = cmd["rotation"];
+            auto& cc = ctx_.world.get<ColliderComponent>(target_entity);
+            cc.local_rotation = glm::quat(
+                r[3].get<float>(), r[0].get<float>(), r[1].get<float>(), r[2].get<float>());
+        }
+
+        ctx_.collision_system->mark_dirty();
+        return ok();
+    });
+
+    register_command("remove_collider", [this, ok](const json& cmd) -> CommandResult {
+        if (!ctx_.collision_system)
+            return std::unexpected(std::string("collision_system not available"));
+
+        std::string id = cmd.value("id", "");
+        if (id.empty())
+            return std::unexpected(std::string("missing 'id' field"));
+
+        auto& game_objects = ctx_.scene_objects.game_objects;
+        auto go_it = std::find_if(game_objects.begin(), game_objects.end(),
+            [&id](const GameObjectData& go) { return go.id == id; });
+        if (go_it == game_objects.end())
+            return std::unexpected(std::string("collider not found: " + id));
+
+        // Find and destroy the ECS entity
+        glm::vec3 go_pos = go_it->position.vec();
+        ecs::Entity target_entity = ecs::kNullEntity;
+
+        ctx_.world.view<ecs::Transform, ColliderComponent>().each(
+            [&](ecs::Entity e, ecs::Transform& t, ColliderComponent&) {
+                if (target_entity == ecs::kNullEntity) {
+                    glm::vec3 epos = t.position.vec();
+                    if (glm::length(epos - go_pos) < 0.01f) {
+                        target_entity = e;
+                    }
+                }
+            });
+
+        if (target_entity != ecs::kNullEntity) {
+            ctx_.world.destroy(target_entity);
+        }
+
+        game_objects.erase(go_it);
+        ctx_.collision_system->mark_dirty();
+        return ok();
+    });
+
+    register_command("list_colliders", [this](const json&) -> CommandResult {
+        json response;
+        response["type"] = "ok";
+
+        auto colliders = json::array();
+        ctx_.world.view<ecs::Transform, ColliderComponent>().each(
+            [&](ecs::Entity e, ecs::Transform& t, ColliderComponent& cc) {
+                // Find matching game object for ID/name
+                std::string id = "";
+                std::string name = "";
+                glm::vec3 pos = t.position.vec();
+
+                for (const auto& go : ctx_.scene_objects.game_objects) {
+                    if (glm::length(go.position.vec() - pos) < 0.01f) {
+                        id = go.id;
+                        name = go.name;
+                        break;
+                    }
+                }
+
+                json entry;
+                entry["id"] = id;
+                entry["name"] = name;
+                entry["position"] = {pos.x, pos.y, pos.z};
+                entry["rotation"] = {cc.local_rotation.x, cc.local_rotation.y,
+                                      cc.local_rotation.z, cc.local_rotation.w};
+                entry["collider"] = collider_to_json(cc);
+                colliders.push_back(entry);
+            });
+
+        response["colliders"] = colliders;
+        return response;
     });
 }
 

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -105,6 +105,7 @@ void CommandDispatcher::register_default_commands() {
             {"screen_effects",     &FeatureFlags::screen_effects},
             {"music",              &FeatureFlags::music},
             {"sfx",                &FeatureFlags::sfx},
+            {"debug_colliders",    &FeatureFlags::debug_colliders},
         };
 
         auto it = flag_map.find(name);

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -702,6 +702,9 @@ void CommandDispatcher::register_default_commands() {
             ecs::Transform{coord::WorldPos(pos), {1.0f, 1.0f}});
         ctx_.world.add<ColliderComponent>(entity, collider);
 
+        // Store id→entity mapping for reliable lookup
+        ctx_.scene_objects.collider_entity_map[id] = entity;
+
         // Store in scene_objects for ID tracking
         GameObjectData go_data;
         go_data.id = id;
@@ -725,37 +728,24 @@ void CommandDispatcher::register_default_commands() {
         if (id.empty())
             return std::unexpected(std::string("missing 'id' field"));
 
-        // Find the game object and its entity
+        // Look up entity by ID map
+        auto entity_it = ctx_.scene_objects.collider_entity_map.find(id);
+        if (entity_it == ctx_.scene_objects.collider_entity_map.end())
+            return std::unexpected(std::string("entity not found for collider: " + id));
+        ecs::Entity target_entity = entity_it->second;
+
+        // Find the game object data for metadata updates
         auto& game_objects = ctx_.scene_objects.game_objects;
         auto go_it = std::find_if(game_objects.begin(), game_objects.end(),
             [&id](const GameObjectData& go) { return go.id == id; });
-        if (go_it == game_objects.end())
-            return std::unexpected(std::string("collider not found: " + id));
-
-        // Find the ECS entity — scan entities with ColliderComponent
-        // Match by position (WorldPos from GridPos)
-        ecs::Entity target_entity = ecs::kNullEntity;
-        glm::vec3 go_pos = go_it->position.vec();
-
-        ctx_.world.view<ecs::Transform, ColliderComponent>().each(
-            [&](ecs::Entity e, ecs::Transform& t, ColliderComponent&) {
-                if (target_entity == ecs::kNullEntity) {
-                    glm::vec3 epos = t.position.vec();
-                    if (glm::length(epos - go_pos) < 0.01f) {
-                        target_entity = e;
-                    }
-                }
-            });
-
-        if (target_entity == ecs::kNullEntity)
-            return std::unexpected(std::string("entity not found for collider: " + id));
 
         // Update position
         if (cmd.contains("position") && cmd["position"].is_array()) {
             auto& p = cmd["position"];
             glm::vec3 new_pos(p[0].get<float>(), p[1].get<float>(), p[2].get<float>());
             ctx_.world.get<ecs::Transform>(target_entity).position = coord::WorldPos(new_pos);
-            go_it->position = coord::GridPos(new_pos);
+            if (go_it != game_objects.end())
+                go_it->position = coord::GridPos(new_pos);
         }
 
         // Update collider fields (partial)
@@ -793,31 +783,20 @@ void CommandDispatcher::register_default_commands() {
         if (id.empty())
             return std::unexpected(std::string("missing 'id' field"));
 
+        // Look up and destroy ECS entity by ID map
+        auto entity_it = ctx_.scene_objects.collider_entity_map.find(id);
+        if (entity_it != ctx_.scene_objects.collider_entity_map.end()) {
+            ctx_.world.destroy(entity_it->second);
+            ctx_.scene_objects.collider_entity_map.erase(entity_it);
+        }
+
+        // Remove from game_objects list
         auto& game_objects = ctx_.scene_objects.game_objects;
         auto go_it = std::find_if(game_objects.begin(), game_objects.end(),
             [&id](const GameObjectData& go) { return go.id == id; });
-        if (go_it == game_objects.end())
-            return std::unexpected(std::string("collider not found: " + id));
+        if (go_it != game_objects.end())
+            game_objects.erase(go_it);
 
-        // Find and destroy the ECS entity
-        glm::vec3 go_pos = go_it->position.vec();
-        ecs::Entity target_entity = ecs::kNullEntity;
-
-        ctx_.world.view<ecs::Transform, ColliderComponent>().each(
-            [&](ecs::Entity e, ecs::Transform& t, ColliderComponent&) {
-                if (target_entity == ecs::kNullEntity) {
-                    glm::vec3 epos = t.position.vec();
-                    if (glm::length(epos - go_pos) < 0.01f) {
-                        target_entity = e;
-                    }
-                }
-            });
-
-        if (target_entity != ecs::kNullEntity) {
-            ctx_.world.destroy(target_entity);
-        }
-
-        game_objects.erase(go_it);
         ctx_.collision_system->mark_dirty();
         return ok();
     });
@@ -827,30 +806,33 @@ void CommandDispatcher::register_default_commands() {
         response["type"] = "ok";
 
         auto colliders = json::array();
-        ctx_.world.view<ecs::Transform, ColliderComponent>().each(
-            [&](ecs::Entity e, ecs::Transform& t, ColliderComponent& cc) {
-                // Find matching game object for ID/name
-                std::string id = "";
-                std::string name = "";
-                glm::vec3 pos = t.position.vec();
+        for (const auto& [id, entity] : ctx_.scene_objects.collider_entity_map) {
+            if (!ctx_.world.has<ecs::Transform>(entity) ||
+                !ctx_.world.has<ColliderComponent>(entity))
+                continue;
 
-                for (const auto& go : ctx_.scene_objects.game_objects) {
-                    if (glm::length(go.position.vec() - pos) < 0.01f) {
-                        id = go.id;
-                        name = go.name;
-                        break;
-                    }
+            auto& t = ctx_.world.get<ecs::Transform>(entity);
+            auto& cc = ctx_.world.get<ColliderComponent>(entity);
+            glm::vec3 pos = t.position.vec();
+
+            // Find matching game object for name
+            std::string name = id;
+            for (const auto& go : ctx_.scene_objects.game_objects) {
+                if (go.id == id) {
+                    name = go.name;
+                    break;
                 }
+            }
 
-                json entry;
-                entry["id"] = id;
-                entry["name"] = name;
-                entry["position"] = {pos.x, pos.y, pos.z};
-                entry["rotation"] = {cc.local_rotation.x, cc.local_rotation.y,
-                                      cc.local_rotation.z, cc.local_rotation.w};
-                entry["collider"] = collider_to_json(cc);
-                colliders.push_back(entry);
-            });
+            json entry;
+            entry["id"] = id;
+            entry["name"] = name;
+            entry["position"] = {pos.x, pos.y, pos.z};
+            entry["rotation"] = {cc.local_rotation.x, cc.local_rotation.y,
+                                  cc.local_rotation.z, cc.local_rotation.w};
+            entry["collider"] = collider_to_json(cc);
+            colliders.push_back(entry);
+        }
 
         response["colliders"] = colliders;
         return response;

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -81,6 +81,7 @@ void Renderer::init(GLFWwindow* window, ResourceManager& resources,
     create_sprite_pipeline();
     create_outline_pipeline();
     create_ui_pipeline();
+    create_wireframe_pipeline();
 
     float aspect = static_cast<float>(kWindowWidth) / static_cast<float>(kWindowHeight);
     camera_.configure_hd2d(aspect);
@@ -270,6 +271,7 @@ void Renderer::draw_scene(Scene& scene,
                            const std::vector<SpriteDrawInfo>& particles,
                            const std::vector<SpriteDrawInfo>& overlay,
                            const std::vector<ui::UIDrawBatch>& ui_batches,
+                           const std::vector<DebugColliderDrawInfo>& debug_colliders_list,
                            const FeatureFlags& flags) {
     auto device = context_.device();
     const auto& frame_sync = sync_.frame(current_frame_);
@@ -522,6 +524,11 @@ void Renderer::draw_scene(Scene& scene,
             draw_sprite_pass(cmd, overlay, font_descriptor_sets_[current_frame_]);
         }
 
+        // Debug collider wireframes (after all sprite passes, before end render pass)
+        if (flags.debug_colliders && !debug_colliders_list.empty()) {
+            draw_debug_colliders(cmd, debug_colliders_list);
+        }
+
         vkCmdEndRenderPass(cmd);
     }
 
@@ -693,6 +700,15 @@ void Renderer::shutdown() {
     }
     if (ui_pipeline_ != VK_NULL_HANDLE) {
         vkDestroyPipeline(context_.device(), ui_pipeline_, nullptr);
+    }
+    if (wireframe_pipeline_ != VK_NULL_HANDLE) {
+        vkDestroyPipeline(context_.device(), wireframe_pipeline_, nullptr);
+    }
+    if (wireframe_pipeline_layout_ != VK_NULL_HANDLE) {
+        vkDestroyPipelineLayout(context_.device(), wireframe_pipeline_layout_, nullptr);
+    }
+    if (wireframe_vb_ != VK_NULL_HANDLE) {
+        vmaDestroyBuffer(context_.allocator(), wireframe_vb_, wireframe_vb_alloc_);
     }
     vkDestroyPipelineLayout(context_.device(), sprite_pipeline_layout_, nullptr);
 
@@ -1181,6 +1197,132 @@ void Renderer::record_ui_pass(VkCommandBuffer cmd,
     }
 
     vkCmdSetScissor(cmd, 0, 1, &full_scissor);
+}
+
+void Renderer::create_wireframe_pipeline() {
+    auto device = context_.device();
+
+    // Generate wireframe meshes
+    wireframe_meshes_ = generate_wireframe_meshes();
+
+    // Create vertex buffer (host-visible for simplicity — small data, created once)
+    VkBufferCreateInfo buf_info{};
+    buf_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    buf_info.size = wireframe_meshes_.vertices.size() * sizeof(glm::vec3);
+    buf_info.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+    buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo alloc_info{};
+    alloc_info.usage = VMA_MEMORY_USAGE_AUTO;
+    alloc_info.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                       VMA_ALLOCATION_CREATE_MAPPED_BIT;
+
+    VmaAllocationInfo alloc_result;
+    vmaCreateBuffer(context_.allocator(), &buf_info, &alloc_info,
+                    &wireframe_vb_, &wireframe_vb_alloc_, &alloc_result);
+
+    // Upload vertex data
+    std::memcpy(alloc_result.pMappedData, wireframe_meshes_.vertices.data(),
+                wireframe_meshes_.vertices.size() * sizeof(glm::vec3));
+
+    // Create pipeline layout with push constants
+    VkPushConstantRange push_range{};
+    push_range.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+    push_range.offset = 0;
+    push_range.size = 112;  // mat4(64) + vec4(16) + vec4(16) + vec4(16)
+
+    VkPipelineLayoutCreateInfo layout_info{};
+    layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    auto desc_layout = descriptors_.sprite_layout();
+    layout_info.setLayoutCount = 1;
+    layout_info.pSetLayouts = &desc_layout;
+    layout_info.pushConstantRangeCount = 1;
+    layout_info.pPushConstantRanges = &push_range;
+
+    vkCreatePipelineLayout(device, &layout_info, nullptr, &wireframe_pipeline_layout_);
+
+    // Load shaders
+    auto vert = load_shader_module(device, "shaders/debug_wireframe.vert.spv");
+    auto frag = load_shader_module(device, "shaders/debug_wireframe.frag.spv");
+
+    // Vertex input: just vec3 position
+    VkVertexInputBindingDescription binding{};
+    binding.binding = 0;
+    binding.stride = sizeof(glm::vec3);
+    binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+    VkVertexInputAttributeDescription attr{};
+    attr.binding = 0;
+    attr.location = 0;
+    attr.format = VK_FORMAT_R32G32B32_SFLOAT;
+    attr.offset = 0;
+
+    // Build pipeline
+    wireframe_pipeline_ = PipelineBuilder()
+        .set_shaders(vert, frag)
+        .set_vertex_input(binding, &attr, 1)
+        .set_input_assembly(VK_PRIMITIVE_TOPOLOGY_LINE_LIST)
+        .set_viewport_scissor(swapchain_.extent())
+        .set_rasterizer(VK_POLYGON_MODE_LINE, VK_CULL_MODE_NONE)
+        .set_multisampling(VK_SAMPLE_COUNT_1_BIT)
+        .set_depth_stencil(true, false)  // read depth, don't write
+        .set_color_blend_alpha()
+        .set_layout(wireframe_pipeline_layout_)
+        .set_render_pass(post_process_.scene_render_pass(), 0)
+        .build(device);
+
+    vkDestroyShaderModule(device, frag, nullptr);
+    vkDestroyShaderModule(device, vert, nullptr);
+}
+
+void Renderer::draw_debug_colliders(VkCommandBuffer cmd,
+                                     const std::vector<DebugColliderDrawInfo>& draw_list) {
+    if (draw_list.empty() || wireframe_pipeline_ == VK_NULL_HANDLE) return;
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, wireframe_pipeline_);
+
+    // Bind the same UBO descriptor set (set 0) — shares VP matrix
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                            wireframe_pipeline_layout_, 0, 1,
+                            &descriptor_sets_[current_frame_], 0, nullptr);
+
+    // Bind wireframe vertex buffer
+    VkDeviceSize offset = 0;
+    vkCmdBindVertexBuffers(cmd, 0, 1, &wireframe_vb_, &offset);
+
+    for (const auto& info : draw_list) {
+        // Push constants
+        struct PushConstants {
+            glm::mat4 model;
+            glm::vec4 color;
+            glm::vec4 shape_params;  // type, radius, half_height, 0
+            glm::vec4 extents;       // half_extents.xyz, 0
+        } pc;
+
+        pc.model = info.model;
+        pc.color = info.color;
+        pc.shape_params = glm::vec4(
+            static_cast<float>(static_cast<uint8_t>(info.shape_type)),
+            info.radius, info.half_height, 0.0f);
+        pc.extents = glm::vec4(info.half_extents, 0.0f);
+
+        vkCmdPushConstants(cmd, wireframe_pipeline_layout_,
+                           VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(pc), &pc);
+
+        // Select mesh range
+        WireframeMeshRange range{};
+        switch (info.shape_type) {
+            case ColliderType::Box:     range = wireframe_meshes_.cube; break;
+            case ColliderType::Sphere:  range = wireframe_meshes_.sphere; break;
+            case ColliderType::Capsule: range = wireframe_meshes_.capsule; break;
+        }
+
+        vkCmdDraw(cmd, range.count, 1, range.offset, 0);
+    }
+
+    // Re-bind sprite pipeline for any subsequent passes
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, sprite_pipeline_);
+    sprite_batch_.bind(cmd, current_frame_);
 }
 
 void Renderer::add_gs_particle_emitter(const GsEmitterConfig& config) {

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Unit tests for collision grid migration script."""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+# Add scripts/ to path so we can import the migration module
+sys.path.insert(0, str(Path(__file__).parent.parent / 'scripts'))
+
+from migrate_collision_grid import (
+    greedy_merge,
+    migrate_solid_cells,
+    migrate_nav_zones,
+    migrate_light_probes,
+)
+
+passed = 0
+failed = 0
+
+
+def check(cond, msg):
+    global passed, failed
+    if cond:
+        print(f'  PASS: {msg}')
+        passed += 1
+    else:
+        print(f'  FAIL: {msg}')
+        failed += 1
+
+
+def test_greedy_merge_single_block():
+    """4x4 block of solid cells at same elevation → 1 rectangle."""
+    def pred(x, z):
+        return 0 <= x < 4 and 0 <= z < 4
+    rects = greedy_merge(8, 8, pred)
+    check(len(rects) == 1, 'single 4x4 block → 1 rectangle')
+    check(rects[0] == (0, 0, 4, 4), 'rectangle is (0,0,4,4)')
+
+
+def test_greedy_merge_two_separated():
+    """Two 2x2 blocks → 2 rectangles."""
+    def pred(x, z):
+        return (0 <= x < 2 and 0 <= z < 2) or (5 <= x < 7 and 5 <= z < 7)
+    rects = greedy_merge(8, 8, pred)
+    check(len(rects) == 2, 'two separated blocks → 2 rectangles')
+
+
+def test_elevation_constraint():
+    """Adjacent cells with different elevations → separate boxes."""
+    collision = {
+        'width': 4, 'height': 1, 'cell_size': 1.0,
+        'solid': [True, True, True, True],
+        'elevation': [0.0, 0.0, 2.0, 2.0],  # Two different elevations
+    }
+    objects = migrate_solid_cells(collision, 1.0)
+    check(len(objects) == 2, 'different elevations → 2 separate boxes')
+
+
+def test_elevation_same():
+    """Adjacent cells with same elevation → merged into 1 box."""
+    collision = {
+        'width': 4, 'height': 1, 'cell_size': 1.0,
+        'solid': [True, True, True, True],
+        'elevation': [1.0, 1.0, 1.0, 1.0],
+    }
+    objects = migrate_solid_cells(collision, 1.0)
+    check(len(objects) == 1, 'same elevation → 1 merged box')
+
+
+def test_box_position_and_extents():
+    """Verify position and half_extents of a simple merged box."""
+    collision = {
+        'width': 4, 'height': 2, 'cell_size': 2.0,
+        'solid': [True, True, True, True, True, True, True, True],
+        'elevation': [0.0] * 8,
+    }
+    objects = migrate_solid_cells(collision, 2.0)
+    check(len(objects) == 1, '4x2 grid → 1 box')
+
+    obj = objects[0]
+    shape = obj['components']['ColliderComponent']['shape']
+    check(shape['type'] == 'box', 'shape is box')
+    # half_extents.x = (4 * 2.0) / 2 = 4.0
+    check(abs(shape['half_extents'][0] - 4.0) < 0.01, 'half_extents.x = 4.0')
+    # half_extents.y = 0.25 (floor slab)
+    check(abs(shape['half_extents'][1] - 0.25) < 0.01, 'half_extents.y = 0.25')
+    # half_extents.z = (2 * 2.0) / 2 = 2.0
+    check(abs(shape['half_extents'][2] - 2.0) < 0.01, 'half_extents.z = 2.0')
+
+
+def test_single_isolated_cell():
+    """Single solid cell → 1 box."""
+    solid = [False] * 64
+    solid[27] = True  # (3, 3) in 8x8
+    collision = {
+        'width': 8, 'height': 8, 'cell_size': 1.0,
+        'solid': solid, 'elevation': [0.0] * 64,
+    }
+    objects = migrate_solid_cells(collision, 1.0)
+    check(len(objects) == 1, 'single cell → 1 box')
+
+
+def test_nav_zone_migration():
+    """Nav zones produce trigger boxes with zone IDs."""
+    collision = {
+        'width': 4, 'height': 4, 'cell_size': 1.0,
+        'solid': [False] * 16,
+        'nav_zone': [0,0,3,3, 0,0,3,3, 0,0,0,0, 0,0,0,0],
+    }
+    objects = migrate_nav_zones(collision, 1.0)
+    check(len(objects) == 1, 'one nav zone group → 1 trigger box')
+    check(objects[0]['components']['ColliderComponent']['is_trigger'] == True, 'is_trigger = True')
+    check(objects[0]['components']['NavZoneVolume']['zone_id'] == 3, 'zone_id = 3')
+
+
+def test_light_probe_downsampling():
+    """4x4 block with non-default probes → 1 entity after downsampling."""
+    probes = []
+    for _ in range(16):
+        probes.extend([0.8, 0.6, 0.4])  # Non-default RGB
+    collision = {
+        'width': 4, 'height': 4, 'cell_size': 1.0,
+        'light_probe': probes,
+    }
+    objects = migrate_light_probes(collision, 1.0, block_size=4)
+    check(len(objects) == 1, '4x4 block with block_size=4 → 1 probe')
+    color = objects[0]['components']['LightProbe']['color']
+    check(abs(color[0] - 0.8) < 0.01, 'averaged R ≈ 0.8')
+
+
+def test_dry_run():
+    """Dry run doesn't modify files."""
+    import subprocess
+
+    scene = {
+        'collision': {
+            'width': 2, 'height': 2, 'cell_size': 1.0,
+            'solid': [True, True, True, True],
+            'elevation': [0.0, 0.0, 0.0, 0.0],
+        },
+        'game_objects': []
+    }
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump(scene, f)
+        tmp_path = f.name
+
+    result = subprocess.run(
+        [sys.executable, 'scripts/migrate_collision_grid.py', tmp_path, '--dry-run'],
+        capture_output=True, text=True,
+        cwd=str(Path(__file__).parent.parent)
+    )
+    check(result.returncode == 0, 'dry-run exits 0')
+
+    with open(tmp_path, 'r') as f:
+        after = json.load(f)
+    check(len(after.get('game_objects', [])) == 0, 'dry-run: game_objects unchanged')
+
+    Path(tmp_path).unlink()
+
+
+if __name__ == '__main__':
+    print('=== test_migration ===')
+    test_greedy_merge_single_block()
+    test_greedy_merge_two_separated()
+    test_elevation_constraint()
+    test_elevation_same()
+    test_box_position_and_extents()
+    test_single_isolated_cell()
+    test_nav_zone_migration()
+    test_light_probe_downsampling()
+    test_dry_run()
+    print(f'\n=== Results: {passed} passed, {failed} failed ===')
+    sys.exit(1 if failed > 0 else 0)

--- a/tools/apps/level-designer/src/components/ColliderListPanel.tsx
+++ b/tools/apps/level-designer/src/components/ColliderListPanel.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { useEditorStore, type ColliderData } from '../store/useEditorStore.js';
+
+export function ColliderListPanel() {
+  const colliders = useEditorStore((s) => s.colliders);
+  const selectedColliderId = useEditorStore((s) => s.selectedColliderId);
+  const setSelectedCollider = useEditorStore((s) => s.setSelectedCollider);
+  const addCollider = useEditorStore((s) => s.addCollider);
+  const removeCollider = useEditorStore((s) => s.removeCollider);
+
+  const handleAdd = () => {
+    const id = `collider_${Date.now()}`;
+    addCollider({
+      id,
+      name: 'New Collider',
+      position: [0, 0, 0],
+      rotation: [0, 0, 0, 1], // identity quaternion
+      shape: { type: 'box', half_extents: [1, 1, 1] },
+      collision_mask: 0xFFFFFFFF,
+      is_trigger: false,
+      is_dynamic: false,
+    });
+    setSelectedCollider(id);
+  };
+
+  const handleDelete = (id: string) => {
+    removeCollider(id);
+  };
+
+  const shapeIcon = (shape: ColliderData['shape']) => {
+    switch (shape.type) {
+      case 'box': return '□';
+      case 'sphere': return '○';
+      case 'capsule': return '⬭';
+      default: return '?';
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        padding: '4px 8px', borderBottom: '1px solid #444',
+      }}>
+        <span style={{ fontWeight: 'bold', fontSize: 12 }}>Colliders</span>
+        <button
+          onClick={handleAdd}
+          style={{
+            background: '#4a9eff', color: '#fff', border: 'none',
+            borderRadius: 3, padding: '2px 8px', cursor: 'pointer', fontSize: 12,
+          }}
+        >
+          + Add
+        </button>
+      </div>
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {colliders.map((c) => (
+          <div
+            key={c.id}
+            onClick={() => setSelectedCollider(c.id)}
+            style={{
+              display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+              padding: '4px 8px', cursor: 'pointer',
+              background: selectedColliderId === c.id ? '#3a5a8a' : 'transparent',
+              borderBottom: '1px solid #333',
+            }}
+          >
+            <span style={{ fontSize: 12 }}>
+              {shapeIcon(c.shape)} {c.name || c.id}
+            </span>
+            <button
+              onClick={(e) => { e.stopPropagation(); handleDelete(c.id); }}
+              style={{
+                background: 'none', border: 'none', color: '#f55',
+                cursor: 'pointer', fontSize: 12, padding: '0 4px',
+              }}
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+        {colliders.length === 0 && (
+          <div style={{ padding: 8, fontSize: 12, color: '#888', textAlign: 'center' }}>
+            No colliders. Click "+ Add" to create one.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/tools/apps/level-designer/src/components/ColliderPropertiesPanel.tsx
+++ b/tools/apps/level-designer/src/components/ColliderPropertiesPanel.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import { useEditorStore, type ColliderData } from '../store/useEditorStore.js';
+import { eulerToQuat, quatToEuler } from '../utils/math-utils.js';
+
+export function ColliderPropertiesPanel() {
+  const colliders = useEditorStore((s) => s.colliders);
+  const selectedColliderId = useEditorStore((s) => s.selectedColliderId);
+  const updateCollider = useEditorStore((s) => s.updateCollider);
+
+  const collider = colliders.find((c) => c.id === selectedColliderId);
+  if (!collider) return null;
+
+  const [pitch, yaw, roll] = quatToEuler(collider.rotation);
+
+  const update = (partial: Partial<ColliderData>) => {
+    updateCollider(collider.id, partial);
+  };
+
+  const updatePosition = (axis: number, value: number) => {
+    const pos: [number, number, number] = [...collider.position];
+    pos[axis] = value;
+    update({ position: pos });
+  };
+
+  const updateRotation = (axis: number, valueDeg: number) => {
+    const euler = [pitch, yaw, roll];
+    euler[axis] = valueDeg;
+    update({ rotation: eulerToQuat(euler[0], euler[1], euler[2]) });
+  };
+
+  const updateShapeType = (type: string) => {
+    let shape: ColliderData['shape'];
+    switch (type) {
+      case 'box': shape = { type: 'box', half_extents: [1, 1, 1] }; break;
+      case 'sphere': shape = { type: 'sphere', radius: 0.5 }; break;
+      case 'capsule': shape = { type: 'capsule', radius: 0.3, half_height: 0.5 }; break;
+      default: return;
+    }
+    update({ shape });
+  };
+
+  const labelStyle: React.CSSProperties = { fontSize: 11, color: '#aaa', marginBottom: 2 };
+  const rowStyle: React.CSSProperties = { display: 'flex', gap: 4, marginBottom: 6 };
+  const inputStyle: React.CSSProperties = {
+    width: '100%', background: '#2a2a2a', color: '#ddd', border: '1px solid #555',
+    borderRadius: 3, padding: '3px 6px', fontSize: 12,
+  };
+
+  return (
+    <div style={{ padding: 8, fontSize: 12 }}>
+      <div style={{ fontWeight: 'bold', marginBottom: 8 }}>Collider Properties</div>
+
+      {/* Name */}
+      <div style={labelStyle}>Name</div>
+      <input
+        style={{ ...inputStyle, marginBottom: 6 }}
+        value={collider.name}
+        onChange={(e) => update({ name: e.target.value })}
+      />
+
+      {/* Position */}
+      <div style={{ ...labelStyle, marginTop: 8 }}>Position</div>
+      <div style={rowStyle}>
+        {(['X', 'Y', 'Z'] as const).map((label, i) => (
+          <div key={label} style={{ flex: 1 }}>
+            <div style={{ fontSize: 10, color: '#888' }}>{label}</div>
+            <input
+              type="number" step="0.1" style={inputStyle}
+              value={collider.position[i]}
+              onChange={(e) => updatePosition(i, parseFloat(e.target.value) || 0)}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Rotation (Euler degrees) */}
+      <div style={labelStyle}>Rotation (degrees)</div>
+      <div style={rowStyle}>
+        {(['Pitch', 'Yaw', 'Roll'] as const).map((label, i) => (
+          <div key={label} style={{ flex: 1 }}>
+            <div style={{ fontSize: 10, color: '#888' }}>{label}</div>
+            <input
+              type="number" step="1" style={inputStyle}
+              value={Math.round([pitch, yaw, roll][i] * 10) / 10}
+              onChange={(e) => updateRotation(i, parseFloat(e.target.value) || 0)}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Shape type */}
+      <div style={labelStyle}>Shape</div>
+      <select
+        style={{ ...inputStyle, marginBottom: 6 }}
+        value={collider.shape.type}
+        onChange={(e) => updateShapeType(e.target.value)}
+      >
+        <option value="box">Box</option>
+        <option value="sphere">Sphere</option>
+        <option value="capsule">Capsule</option>
+      </select>
+
+      {/* Shape-specific params — capture narrowed shape in a local var to preserve TS narrowing in callbacks */}
+      {collider.shape.type === 'box' && (() => {
+        const boxShape = collider.shape as { type: 'box'; half_extents: [number, number, number] };
+        return (
+          <>
+            <div style={labelStyle}>Half Extents</div>
+            <div style={rowStyle}>
+              {(['X', 'Y', 'Z'] as const).map((label, i) => (
+                <div key={label} style={{ flex: 1 }}>
+                  <div style={{ fontSize: 10, color: '#888' }}>{label}</div>
+                  <input
+                    type="number" step="0.1" min="0" style={inputStyle}
+                    value={boxShape.half_extents[i]}
+                    onChange={(e) => {
+                      const he: [number, number, number] = [...boxShape.half_extents];
+                      he[i] = Math.max(0, parseFloat(e.target.value) || 0);
+                      update({ shape: { type: 'box', half_extents: he } });
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          </>
+        );
+      })()}
+
+      {collider.shape.type === 'sphere' && (() => {
+        const sphereShape = collider.shape as { type: 'sphere'; radius: number };
+        return (
+          <>
+            <div style={labelStyle}>Radius</div>
+            <input
+              type="number" step="0.1" min="0" style={{ ...inputStyle, marginBottom: 6 }}
+              value={sphereShape.radius}
+              onChange={(e) =>
+                update({ shape: { type: 'sphere', radius: Math.max(0, parseFloat(e.target.value) || 0) } })
+              }
+            />
+          </>
+        );
+      })()}
+
+      {collider.shape.type === 'capsule' && (() => {
+        const capsuleShape = collider.shape as { type: 'capsule'; radius: number; half_height: number };
+        return (
+          <>
+            <div style={labelStyle}>Radius</div>
+            <input
+              type="number" step="0.1" min="0" style={{ ...inputStyle, marginBottom: 6 }}
+              value={capsuleShape.radius}
+              onChange={(e) =>
+                update({
+                  shape: {
+                    type: 'capsule',
+                    radius: Math.max(0, parseFloat(e.target.value) || 0),
+                    half_height: capsuleShape.half_height,
+                  },
+                })
+              }
+            />
+            <div style={{ ...labelStyle, marginTop: 4 }}>Half Height</div>
+            <input
+              type="number" step="0.1" min="0" style={{ ...inputStyle, marginBottom: 6 }}
+              value={capsuleShape.half_height}
+              onChange={(e) =>
+                update({
+                  shape: {
+                    type: 'capsule',
+                    radius: capsuleShape.radius,
+                    half_height: Math.max(0, parseFloat(e.target.value) || 0),
+                  },
+                })
+              }
+            />
+          </>
+        );
+      })()}
+
+      {/* Flags */}
+      <div style={{ ...labelStyle, marginTop: 8 }}>Flags</div>
+      <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+        <input
+          type="checkbox" checked={collider.is_trigger}
+          onChange={(e) => update({ is_trigger: e.target.checked })}
+        />
+        Is Trigger
+      </label>
+      <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+        <input
+          type="checkbox" checked={collider.is_dynamic}
+          onChange={(e) => update({ is_dynamic: e.target.checked })}
+        />
+        Is Dynamic
+      </label>
+
+      {/* Advanced (collapsed) */}
+      <details style={{ marginTop: 8 }}>
+        <summary style={{ fontSize: 11, color: '#888', cursor: 'pointer' }}>Advanced</summary>
+        <div style={{ ...labelStyle, marginTop: 4 }}>Collision Mask</div>
+        <input
+          type="number" style={{ ...inputStyle, marginTop: 2 }}
+          value={collider.collision_mask}
+          onChange={(e) => update({ collision_mask: parseInt(e.target.value) || 0 })}
+        />
+      </details>
+    </div>
+  );
+}

--- a/tools/apps/level-designer/src/components/PropertiesPanel.tsx
+++ b/tools/apps/level-designer/src/components/PropertiesPanel.tsx
@@ -5,6 +5,8 @@ import {
   ColorPicker,
   Vec2Input,
 } from '@gseurat/ui-kit';
+import { ColliderListPanel } from './ColliderListPanel.js';
+import { ColliderPropertiesPanel } from './ColliderPropertiesPanel.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -413,7 +415,47 @@ function PortalProperties({ index }: { index: number }) {
 // PropertiesPanel
 // ---------------------------------------------------------------------------
 export function PropertiesPanel() {
-  const { selectedEntity, activeLayer } = useEditorStore();
+  const { selectedEntity, activeLayer, selectedColliderId } = useEditorStore();
+
+  // Collider layer: show the list + optional properties panel
+  if (activeLayer === 'colliders') {
+    return (
+      <div style={{
+        width: 220,
+        background: '#222',
+        borderLeft: '1px solid #333',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}>
+        {/* Header */}
+        <div style={{
+          padding: '8px 10px',
+          background: '#1e1e1e',
+          borderBottom: '1px solid #333',
+          fontFamily: 'monospace',
+          fontSize: 11,
+          color: '#aaa',
+          fontWeight: 600,
+          letterSpacing: '0.04em',
+        }}>
+          Colliders
+        </div>
+
+        {/* List (top half) + Properties (bottom half when selected) */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+          <div style={{ flex: selectedColliderId ? '0 0 40%' : '1', overflow: 'hidden' }}>
+            <ColliderListPanel />
+          </div>
+          {selectedColliderId && (
+            <div style={{ flex: 1, overflowY: 'auto', borderTop: '1px solid #444' }}>
+              <ColliderPropertiesPanel />
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   let content: React.ReactNode;
 

--- a/tools/apps/level-designer/src/hooks/useEngine.ts
+++ b/tools/apps/level-designer/src/hooks/useEngine.ts
@@ -436,6 +436,75 @@ export function useEngine() {
   );
 
   // -------------------------------------------------------------------------
+  // Collider management
+  // -------------------------------------------------------------------------
+
+  /**
+   * Add a new collider entity to the engine.
+   */
+  const addCollider = useCallback(
+    (data: {
+      id: string;
+      name: string;
+      position: [number, number, number];
+      rotation: [number, number, number, number];
+      collider: {
+        shape: { type: string; half_extents?: [number, number, number]; radius?: number; half_height?: number };
+        collision_mask?: number;
+        is_trigger?: boolean;
+        is_dynamic?: boolean;
+      };
+    }): Promise<OkResponse | null> =>
+      sendCommand<OkResponse>({
+        cmd: 'add_collider',
+        id: data.id,
+        name: data.name,
+        position: data.position,
+        rotation: data.rotation,
+        collider: data.collider,
+      }),
+    [sendCommand],
+  );
+
+  /**
+   * Update an existing collider's properties.
+   */
+  const updateCollider = useCallback(
+    (id: string, data: Record<string, unknown>): Promise<OkResponse | null> =>
+      sendCommand<OkResponse>({ cmd: 'update_collider', id, ...data }),
+    [sendCommand],
+  );
+
+  /**
+   * Remove a collider entity by ID.
+   */
+  const removeCollider = useCallback(
+    (id: string): Promise<OkResponse | null> =>
+      sendCommand<OkResponse>({ cmd: 'remove_collider', id }),
+    [sendCommand],
+  );
+
+  interface ListCollidersResponse {
+    type: string;
+    colliders: Array<{
+      id: string;
+      name: string;
+      position: [number, number, number];
+      rotation: [number, number, number, number];
+      collider: Record<string, unknown>;
+    }>;
+  }
+
+  /**
+   * Fetch all colliders from the engine for initial sync.
+   */
+  const listColliders = useCallback(
+    (): Promise<ListCollidersResponse | null> =>
+      sendCommand<ListCollidersResponse>({ cmd: 'list_colliders' }),
+    [sendCommand],
+  );
+
+  // -------------------------------------------------------------------------
   // Return
   // -------------------------------------------------------------------------
 
@@ -491,5 +560,11 @@ export function useEngine() {
     // Cinematic rail
     setCinematicT,
     advanceCinematicT,
+
+    // Colliders
+    addCollider,
+    updateCollider,
+    removeCollider,
+    listColliders,
   };
 }

--- a/tools/apps/level-designer/src/hooks/useEngineSync.ts
+++ b/tools/apps/level-designer/src/hooks/useEngineSync.ts
@@ -14,6 +14,7 @@ export function useEngineSync(engine: Engine) {
   const prevPortalsRef = useRef<PortalPlacement[]>([]);
   const prevAmbientRef = useRef<[number, number, number, number]>([0.25, 0.28, 0.45, 1.0]);
   const prevCollidersRef = useRef<ColliderData[]>([]);
+  const hydratingCollidersRef = useRef(false);
 
   useEffect(() => {
     // Initialize refs with current store state
@@ -23,12 +24,14 @@ export function useEngineSync(engine: Engine) {
     prevAmbientRef.current = state.ambientColor;
     prevCollidersRef.current = state.colliders;
 
-    // Initial collider sync from engine
+    // Initial collider sync from engine — set hydration flag to prevent
+    // the subscriber from echoing these colliders back as add_collider commands
     void (async () => {
       if (!engine.isConnected()) return;
       const collidersResp = await engine.listColliders();
       if (collidersResp?.colliders) {
         const store = useEditorStore.getState();
+        hydratingCollidersRef.current = true;
         store.setColliders(collidersResp.colliders.map(c => ({
           id: c.id,
           name: c.name,
@@ -39,6 +42,7 @@ export function useEngineSync(engine: Engine) {
           is_trigger: (c.collider.is_trigger as boolean) ?? false,
           is_dynamic: (c.collider.is_dynamic as boolean) ?? false,
         })));
+        hydratingCollidersRef.current = false;
       }
     })();
 
@@ -61,8 +65,8 @@ export function useEngineSync(engine: Engine) {
         syncPortals(engine, prevState.portals, state.portals);
       }
 
-      // --- Colliders sync ---
-      if (state.colliders !== prevState.colliders) {
+      // --- Colliders sync (skip during hydration from engine) ---
+      if (state.colliders !== prevState.colliders && !hydratingCollidersRef.current) {
         syncColliders(engine, prevState.colliders, state.colliders);
       }
 

--- a/tools/apps/level-designer/src/hooks/useEngineSync.ts
+++ b/tools/apps/level-designer/src/hooks/useEngineSync.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useEditorStore } from '../store/useEditorStore.js';
-import type { LightPlacement, PortalPlacement } from '../store/useEditorStore.js';
+import type { LightPlacement, PortalPlacement, ColliderData } from '../store/useEditorStore.js';
 
 type Engine = ReturnType<typeof import('./useEngine.js').useEngine>;
 
@@ -13,6 +13,7 @@ export function useEngineSync(engine: Engine) {
   const prevLightsRef = useRef<LightPlacement[]>([]);
   const prevPortalsRef = useRef<PortalPlacement[]>([]);
   const prevAmbientRef = useRef<[number, number, number, number]>([0.25, 0.28, 0.45, 1.0]);
+  const prevCollidersRef = useRef<ColliderData[]>([]);
 
   useEffect(() => {
     // Initialize refs with current store state
@@ -20,6 +21,26 @@ export function useEngineSync(engine: Engine) {
     prevLightsRef.current = state.lights;
     prevPortalsRef.current = state.portals;
     prevAmbientRef.current = state.ambientColor;
+    prevCollidersRef.current = state.colliders;
+
+    // Initial collider sync from engine
+    void (async () => {
+      if (!engine.isConnected()) return;
+      const collidersResp = await engine.listColliders();
+      if (collidersResp?.colliders) {
+        const store = useEditorStore.getState();
+        store.setColliders(collidersResp.colliders.map(c => ({
+          id: c.id,
+          name: c.name,
+          position: c.position,
+          rotation: c.rotation,
+          shape: c.collider.shape as ColliderData['shape'],
+          collision_mask: (c.collider.collision_mask as number) ?? 0xFFFFFFFF,
+          is_trigger: (c.collider.is_trigger as boolean) ?? false,
+          is_dynamic: (c.collider.is_dynamic as boolean) ?? false,
+        })));
+      }
+    })();
 
     const unsub = useEditorStore.subscribe((state, prevState) => {
       if (!engine.isConnected()) return;
@@ -38,6 +59,20 @@ export function useEngineSync(engine: Engine) {
       // --- Portals sync ---
       if (state.portals !== prevState.portals) {
         syncPortals(engine, prevState.portals, state.portals);
+      }
+
+      // --- Colliders sync ---
+      if (state.colliders !== prevState.colliders) {
+        syncColliders(engine, prevState.colliders, state.colliders);
+      }
+
+      // --- Auto-enable wireframes when colliders layer is active ---
+      if (state.activeLayer !== prevState.activeLayer) {
+        if (state.activeLayer === 'colliders') {
+          engine.setFeature('debug_colliders', true);
+        } else if (prevState.activeLayer === 'colliders') {
+          engine.setFeature('debug_colliders', false);
+        }
       }
     });
 
@@ -119,6 +154,59 @@ function syncPortals(
   if (next.length < prev.length) {
     for (let i = prev.length - 1; i >= next.length; i--) {
       engine.removePortal(i);
+    }
+  }
+}
+
+async function syncColliders(
+  engine: Engine,
+  prev: ColliderData[],
+  next: ColliderData[],
+) {
+  const prevIds = new Set(prev.map(c => c.id));
+  const nextIds = new Set(next.map(c => c.id));
+
+  // Additions
+  for (const c of next) {
+    if (!prevIds.has(c.id)) {
+      await engine.addCollider({
+        id: c.id,
+        name: c.name,
+        position: c.position,
+        rotation: c.rotation,
+        collider: {
+          shape: c.shape,
+          collision_mask: c.collision_mask,
+          is_trigger: c.is_trigger,
+          is_dynamic: c.is_dynamic,
+        },
+      });
+    }
+  }
+
+  // Removals
+  for (const c of prev) {
+    if (!nextIds.has(c.id)) {
+      await engine.removeCollider(c.id);
+    }
+  }
+
+  // Updates (check by reference — Zustand immutable updates create new objects)
+  for (const c of next) {
+    if (prevIds.has(c.id)) {
+      const prevC = prev.find(p => p.id === c.id);
+      if (prevC && prevC !== c) {
+        await engine.updateCollider(c.id, {
+          position: c.position,
+          rotation: c.rotation,
+          collider: {
+            shape: c.shape,
+            collision_mask: c.collision_mask,
+            is_trigger: c.is_trigger,
+            is_dynamic: c.is_dynamic,
+          },
+        });
+      }
     }
   }
 }

--- a/tools/apps/level-designer/src/store/useEditorStore.ts
+++ b/tools/apps/level-designer/src/store/useEditorStore.ts
@@ -54,8 +54,22 @@ interface CollisionGridData {
   solid: boolean[];
 }
 
+export interface ColliderData {
+  id: string;
+  name: string;
+  position: [number, number, number];
+  rotation: [number, number, number, number]; // quaternion [x,y,z,w]
+  shape:
+    | { type: 'box'; half_extents: [number, number, number] }
+    | { type: 'sphere'; radius: number }
+    | { type: 'capsule'; radius: number; half_height: number };
+  collision_mask: number;
+  is_trigger: boolean;
+  is_dynamic: boolean;
+}
+
 type Tool = 'paint' | 'erase' | 'fill' | 'select' | 'collision';
-type Layer = 'tiles' | 'lights' | 'npcs' | 'portals' | 'backgrounds' | 'environment' | 'collision';
+type Layer = 'tiles' | 'lights' | 'npcs' | 'portals' | 'backgrounds' | 'environment' | 'collision' | 'colliders';
 
 interface HistoryEntry {
   tiles: TileData[];
@@ -134,6 +148,15 @@ interface EditorState {
   collisionGrid: CollisionGridData | null;
   setCollisionGrid: (grid: CollisionGridData | null) => void;
   toggleCollisionCell: (x: number, y: number) => void;
+
+  // Colliders
+  colliders: ColliderData[];
+  selectedColliderId: string | null;
+  addCollider: (data: ColliderData) => void;
+  updateCollider: (id: string, partial: Partial<ColliderData>) => void;
+  removeCollider: (id: string) => void;
+  setSelectedCollider: (id: string | null) => void;
+  setColliders: (data: ColliderData[]) => void;
 
   // Scene file
   currentScenePath: string;
@@ -399,6 +422,35 @@ export const useEditorStore = create<EditorState>()((set, get) => ({
   },
 
   // ---------------------------------------------------------------------------
+  // Colliders
+  // ---------------------------------------------------------------------------
+  colliders: [],
+  selectedColliderId: null,
+
+  addCollider: (data) =>
+    set((state) => ({ colliders: [...state.colliders, data], dirty: true })),
+
+  updateCollider: (id, partial) =>
+    set((state) => {
+      const next = state.colliders.map((c) =>
+        c.id === id ? { ...c, ...partial } : c
+      );
+      return { colliders: next, dirty: true };
+    }),
+
+  removeCollider: (id) =>
+    set((state) => {
+      const next = state.colliders.filter((c) => c.id !== id);
+      const selectedColliderId =
+        state.selectedColliderId === id ? null : state.selectedColliderId;
+      return { colliders: next, selectedColliderId, dirty: true };
+    }),
+
+  setSelectedCollider: (id) => set({ selectedColliderId: id }),
+
+  setColliders: (data) => set({ colliders: data }),
+
+  // ---------------------------------------------------------------------------
   // Scene file
   // ---------------------------------------------------------------------------
   currentScenePath: 'assets/scenes/untitled.json',
@@ -421,3 +473,4 @@ export type {
   HistoryEntry,
   EditorState,
 };
+// ColliderData is already exported via `export interface` above.

--- a/tools/apps/level-designer/src/utils/math-utils.ts
+++ b/tools/apps/level-designer/src/utils/math-utils.ts
@@ -1,0 +1,51 @@
+// Euler angles (degrees) to quaternion [x, y, z, w]
+// Uses ZYX convention (yaw-pitch-roll)
+export function eulerToQuat(
+  pitchDeg: number,
+  yawDeg: number,
+  rollDeg: number,
+): [number, number, number, number] {
+  const p = (pitchDeg * Math.PI) / 360; // half angle in radians
+  const y = (yawDeg * Math.PI) / 360;
+  const r = (rollDeg * Math.PI) / 360;
+
+  const cp = Math.cos(p), sp = Math.sin(p);
+  const cy = Math.cos(y), sy = Math.sin(y);
+  const cr = Math.cos(r), sr = Math.sin(r);
+
+  return [
+    sr * cp * cy - cr * sp * sy, // x
+    cr * sp * cy + sr * cp * sy, // y
+    cr * cp * sy - sr * sp * cy, // z
+    cr * cp * cy + sr * sp * sy, // w
+  ];
+}
+
+// Quaternion [x, y, z, w] to Euler angles [pitch, yaw, roll] in degrees
+export function quatToEuler(
+  q: [number, number, number, number],
+): [number, number, number] {
+  const [x, y, z, w] = q;
+
+  // Pitch (X-axis rotation)
+  const sinP = 2 * (w * x + y * z);
+  const cosP = 1 - 2 * (x * x + y * y);
+  const pitch = Math.atan2(sinP, cosP);
+
+  // Yaw (Y-axis rotation)
+  const sinY = 2 * (w * y - z * x);
+  const yaw = Math.abs(sinY) >= 1
+    ? (Math.sign(sinY) * Math.PI) / 2
+    : Math.asin(sinY);
+
+  // Roll (Z-axis rotation)
+  const sinR = 2 * (w * z + x * y);
+  const cosR = 1 - 2 * (y * y + z * z);
+  const roll = Math.atan2(sinR, cosR);
+
+  return [
+    (pitch * 180) / Math.PI,
+    (yaw * 180) / Math.PI,
+    (roll * 180) / Math.PI,
+  ];
+}

--- a/tools/apps/level-designer/src/utils/math-utils.ts
+++ b/tools/apps/level-designer/src/utils/math-utils.ts
@@ -1,47 +1,51 @@
 // Euler angles (degrees) to quaternion [x, y, z, w]
-// Uses ZYX convention (yaw-pitch-roll)
+// Uses YXZ convention: yaw (Y) applied first, then pitch (X), then roll (Z).
+// This matches the standard game-engine convention where yaw rotates around
+// the vertical Y-axis, pitch tilts around X, and roll spins around Z.
 export function eulerToQuat(
-  pitchDeg: number,
-  yawDeg: number,
-  rollDeg: number,
+  pitchDeg: number,  // X-axis rotation
+  yawDeg: number,    // Y-axis rotation
+  rollDeg: number,   // Z-axis rotation
 ): [number, number, number, number] {
-  const p = (pitchDeg * Math.PI) / 360; // half angle in radians
-  const y = (yawDeg * Math.PI) / 360;
-  const r = (rollDeg * Math.PI) / 360;
+  const px = (pitchDeg * Math.PI) / 360; // half angle
+  const yy = (yawDeg * Math.PI) / 360;
+  const rz = (rollDeg * Math.PI) / 360;
 
-  const cp = Math.cos(p), sp = Math.sin(p);
-  const cy = Math.cos(y), sy = Math.sin(y);
-  const cr = Math.cos(r), sr = Math.sin(r);
+  const cx = Math.cos(px), sx = Math.sin(px);
+  const cy = Math.cos(yy), sy = Math.sin(yy);
+  const cz = Math.cos(rz), sz = Math.sin(rz);
 
+  // Quaternion product: Qy * Qx * Qz
   return [
-    sr * cp * cy - cr * sp * sy, // x
-    cr * sp * cy + sr * cp * sy, // y
-    cr * cp * sy - sr * sp * cy, // z
-    cr * cp * cy + sr * sp * sy, // w
+    cy * sx * cz + sy * cx * sz,  // x
+    sy * cx * cz - cy * sx * sz,  // y
+    cy * cx * sz - sy * sx * cz,  // z
+    cy * cx * cz + sy * sx * sz,  // w
   ];
 }
 
 // Quaternion [x, y, z, w] to Euler angles [pitch, yaw, roll] in degrees
+// Inverse of eulerToQuat — uses YXZ decomposition.
 export function quatToEuler(
   q: [number, number, number, number],
 ): [number, number, number] {
   const [x, y, z, w] = q;
 
-  // Pitch (X-axis rotation)
-  const sinP = 2 * (w * x + y * z);
-  const cosP = 1 - 2 * (x * x + y * y);
-  const pitch = Math.atan2(sinP, cosP);
+  // Pitch (X-axis rotation) — extracted from the YXZ matrix sin(pitch) element
+  const sinP = 2 * (w * x - y * z);
+  const pitch = Math.abs(sinP) >= 1
+    ? (Math.sign(sinP) * Math.PI) / 2
+    : Math.asin(sinP);
 
   // Yaw (Y-axis rotation)
-  const sinY = 2 * (w * y - z * x);
-  const yaw = Math.abs(sinY) >= 1
-    ? (Math.sign(sinY) * Math.PI) / 2
-    : Math.asin(sinY);
+  const sinYcosP = 2 * (w * y + x * z);
+  const cosYcosP = 1 - 2 * (x * x + y * y);
+  const yaw = Math.atan2(sinYcosP, cosYcosP);
 
   // Roll (Z-axis rotation)
-  const sinR = 2 * (w * z + x * y);
-  const cosR = 1 - 2 * (y * y + z * z);
-  const roll = Math.atan2(sinR, cosR);
+  const sinRcosP = 2 * (w * z + x * y);
+  const cosRcosP = 1 - 2 * (x * x + z * z);
+  const roll = Math.atan2(sinRcosP, cosRcosP);
 
   return [
     (pitch * 180) / Math.PI,


### PR DESCRIPTION
## Summary

- **Bridge CRUD**: add_collider, update_collider, remove_collider, list_colliders commands via CommandContext + CollisionSystem
- **Vulkan wireframes**: VK_POLYGON_MODE_LINE pipeline with shape-aware vertex shader (box/sphere/capsule), depth-tested, push-constant driven, toggled by debug_colliders feature flag
- **Bricklayer UI**: ColliderListPanel (add/select/delete) + ColliderPropertiesPanel (position, Euler rotation, shape type/params, flags), Zustand store with collider sync
- **NavZoneVolume + LightProbe**: New ECS components for migrated spatial data
- **Migration script**: Python greedy rectangle merge with elevation constraint, nav zone volumes, light probe downsampling

## Design docs
- Spec: docs/superpowers/specs/2026-04-22-collision-editor-integration-design.md
- Plan: docs/superpowers/plans/2026-04-22-collision-editor-integration.md

## Test plan
- [x] C++ collision tests (6 suites, 157 assertions) — all pass
- [x] Python migration tests (18 assertions) — all pass
- [x] Full engine build: 514/514 targets
- [x] Bricklayer TypeScript builds (no new errors)
- [ ] CI pipeline green

Generated with [Claude Code](https://claude.com/claude-code)