### PR TITLE
feat(bricklayer): expose cinematic rail camera parameters

### DIFF
--- a/tools/apps/bricklayer/src/lib/sceneExport.ts
+++ b/tools/apps/bricklayer/src/lib/sceneExport.ts
@@ -428,6 +428,14 @@ export function exportSceneJson(
         if (p.offset && (p.offset[0] !== 0 || p.offset[1] !== 5 || p.offset[2] !== -10)) params.offset = p.offset;
         if (p.fixed_position) params.fixed_position = p.fixed_position;
         if (p.rail_id) params.rail_id = p.rail_id;
+        // Cinematic rail parameters (only export non-defaults)
+        if (p.cinematic_duration !== undefined && p.cinematic_duration !== 5.0) params.cinematic_duration = p.cinematic_duration;
+        if (p.cinematic_easing && p.cinematic_easing !== 'in_out_quad') params.cinematic_easing = p.cinematic_easing;
+        if (p.cinematic_playback && p.cinematic_playback !== 'once') params.cinematic_playback = p.cinematic_playback;
+        if (p.play_on_enter === false) params.play_on_enter = false;
+        if (p.target_mode && p.target_mode !== 'player') params.target_mode = p.target_mode;
+        if (p.min_ground_clearance !== undefined && p.min_ground_clearance !== 10) params.min_ground_clearance = p.min_ground_clearance;
+        if (p.target_y_offset !== undefined && p.target_y_offset !== 2.5) params.target_y_offset = p.target_y_offset;
         if (Object.keys(params).length > 0) out.params = params;
         return out;
       });

--- a/tools/apps/bricklayer/src/panels/CameraRailEditor.tsx
+++ b/tools/apps/bricklayer/src/panels/CameraRailEditor.tsx
@@ -82,10 +82,12 @@ export function CameraRailEditor({ rail }: { rail: CameraZoneRail }) {
                 onChange={(v) => updateRailControlPoint(rail.id, i, v)}
               />
             </div>
-            <button
-              style={{ padding: '0 4px', border: 'none', background: 'transparent', color: '#844', cursor: 'pointer', fontSize: 13, lineHeight: '1', flexShrink: 0 }}
-              onClick={() => removeRailControlPoint(rail.id, i)}
-            >&times;</button>
+            {rail.control_points.length > 2 && (
+              <button
+                style={{ padding: '0 4px', border: 'none', background: 'transparent', color: '#844', cursor: 'pointer', fontSize: 13, lineHeight: '1', flexShrink: 0 }}
+                onClick={() => removeRailControlPoint(rail.id, i)}
+              >&times;</button>
+            )}
           </div>
         ))}
       </div>

--- a/tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx
+++ b/tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx
@@ -210,7 +210,7 @@ export function CameraVolumeEditor({ volume }: { volume: CameraZoneVolume }) {
         </div>
       )}
 
-      {mode === 'fixed_point' && (
+      {(mode === 'fixed_point' || (mode === 'cinematic_rail' && (volume.params.target_mode ?? 'player') === 'fixed_point')) && (
         <div style={styles.section}>
           <span style={styles.label}>Fixed Position</span>
           <Vec3Input

--- a/tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx
+++ b/tools/apps/bricklayer/src/panels/CameraVolumeEditor.tsx
@@ -236,6 +236,113 @@ export function CameraVolumeEditor({ volume }: { volume: CameraZoneVolume }) {
         </div>
       )}
 
+      {mode === 'cinematic_rail' && (
+        <>
+          <div style={styles.section}>
+            <span style={styles.label}>Duration (s)</span>
+            <NumberInput
+              value={volume.params.cinematic_duration ?? 5.0}
+              min={0.1}
+              step={0.5}
+              onChange={(v) => updateParams({ cinematic_duration: v })}
+              style={styles.input}
+            />
+          </div>
+
+          <div style={styles.section}>
+            <span style={styles.label}>Easing</span>
+            <select
+              style={styles.select}
+              value={volume.params.cinematic_easing ?? 'in_out_quad'}
+              onChange={(e) => updateParams({ cinematic_easing: e.target.value })}
+            >
+              <option value="linear">Linear</option>
+              <option value="in_quad">In Quad</option>
+              <option value="out_quad">Out Quad</option>
+              <option value="in_out_quad">In Out Quad</option>
+              <option value="in_cubic">In Cubic</option>
+              <option value="out_cubic">Out Cubic</option>
+              <option value="in_out_cubic">In Out Cubic</option>
+              <option value="in_sine">In Sine</option>
+              <option value="out_sine">Out Sine</option>
+              <option value="in_out_sine">In Out Sine</option>
+              <option value="in_expo">In Expo</option>
+              <option value="out_expo">Out Expo</option>
+              <option value="in_out_expo">In Out Expo</option>
+              <option value="in_elastic">In Elastic</option>
+              <option value="out_elastic">Out Elastic</option>
+              <option value="in_out_elastic">In Out Elastic</option>
+              <option value="in_back">In Back</option>
+              <option value="out_back">Out Back</option>
+              <option value="in_out_back">In Out Back</option>
+              <option value="in_bounce">In Bounce</option>
+              <option value="out_bounce">Out Bounce</option>
+              <option value="in_out_bounce">In Out Bounce</option>
+            </select>
+          </div>
+
+          <div style={styles.section}>
+            <span style={styles.label}>Playback</span>
+            <select
+              style={styles.select}
+              value={volume.params.cinematic_playback ?? 'once'}
+              onChange={(e) => updateParams({ cinematic_playback: e.target.value as any })}
+            >
+              <option value="once">Once</option>
+              <option value="loop">Loop</option>
+              <option value="ping_pong">Ping Pong</option>
+              <option value="manual">Manual</option>
+            </select>
+          </div>
+
+          <div style={styles.section}>
+            <label style={{ fontSize: 12, color: '#ddd', display: 'flex', alignItems: 'center', gap: 6 }}>
+              <input
+                type="checkbox"
+                checked={volume.params.play_on_enter ?? true}
+                onChange={(e) => updateParams({ play_on_enter: e.target.checked })}
+              />
+              Play On Enter
+            </label>
+          </div>
+
+          <div style={styles.section}>
+            <span style={styles.label}>Target Mode</span>
+            <select
+              style={styles.select}
+              value={volume.params.target_mode ?? 'player'}
+              onChange={(e) => updateParams({ target_mode: e.target.value as any })}
+            >
+              <option value="player">Player</option>
+              <option value="target_path">Target Path</option>
+              <option value="fixed_point">Fixed Point</option>
+            </select>
+          </div>
+
+          <div style={styles.section}>
+            <span style={styles.label}>Min Ground Clearance</span>
+            <NumberInput
+              value={volume.params.min_ground_clearance ?? 10}
+              min={0}
+              step={1}
+              onChange={(v) => updateParams({ min_ground_clearance: v })}
+              style={styles.input}
+            />
+          </div>
+
+          <div style={styles.section}>
+            <span style={styles.label}>Target Y Offset</span>
+            <NumberInput
+              value={volume.params.target_y_offset ?? 2.5}
+              min={0}
+              step={0.5}
+              onChange={(v) => updateParams({ target_y_offset: v })}
+              style={styles.input}
+            />
+          </div>
+        </>
+      )}
+
     </div>
   );
 }

--- a/tools/apps/bricklayer/src/store/types.ts
+++ b/tools/apps/bricklayer/src/store/types.ts
@@ -324,6 +324,14 @@ export interface CameraZoneParams {
   offset: [number, number, number];
   fixed_position?: [number, number, number];
   rail_id?: string;
+  // Cinematic rail parameters
+  cinematic_duration: number;
+  cinematic_easing: string;
+  cinematic_playback: 'once' | 'loop' | 'ping_pong' | 'manual';
+  play_on_enter: boolean;
+  target_mode: 'player' | 'target_path' | 'fixed_point';
+  min_ground_clearance: number;
+  target_y_offset: number;
 }
 
 export const DEFAULT_CAMERA_ZONE_PARAMS: CameraZoneParams = {
@@ -338,6 +346,13 @@ export const DEFAULT_CAMERA_ZONE_PARAMS: CameraZoneParams = {
   fov: 45,
   orbit_distance: 10,
   offset: [0, 5, -10],
+  cinematic_duration: 5.0,
+  cinematic_easing: 'in_out_quad',
+  cinematic_playback: 'once',
+  play_on_enter: true,
+  target_mode: 'player',
+  min_ground_clearance: 10,
+  target_y_offset: 2.5,
 };
 
 export interface CameraZoneVolume {


### PR DESCRIPTION
## Summary
- Add cinematic rail parameter controls to CameraVolumeEditor (Duration, Easing, Playback, Play On Enter, Target Mode, Min Ground Clearance, Target Y Offset)
- Add minimum-point guard to CameraRailEditor — spline requires >= 2 points, delete buttons hidden at that threshold
- Extend `CameraZoneParams` type with cinematic fields and defaults
- Scene export emits new fields only when non-default (sparse export pattern)

Addresses gaps found in exploratory QA: cinematic_rail mode was selectable but its parameters were only settable via raw JSON. Spline editor allowed deleting all control points, causing silent camera-at-origin failure.

## Test plan
- [ ] Select a CameraVolume, set mode to `cinematic_rail` — new fields appear
- [ ] Change easing/playback/duration — values persist in store
- [ ] Export scene JSON — cinematic fields only appear when non-default
- [ ] Camera rail with 2 points — delete buttons are hidden
- [ ] Camera rail with 3+ points — delete buttons visible, removing down to 2 hides them

🤖 Generated with [Claude Code](https://claude.com/claude-code)