### PR TITLE
fix: collider dimension clamping and bridge reconnect resync

### DIFF
--- a/src/engine/collision/intersect.cpp
+++ b/src/engine/collision/intersect.cpp
@@ -10,13 +10,15 @@ namespace gseurat {
 AABB compute_aabb(const BoxData& box, const glm::vec3& pos, const glm::quat& rot) {
     // For an OBB, project each local axis into world space and take the absolute
     // value to compute the maximum extent in each world axis.
+    // Clamp to non-negative to prevent inverted AABBs from malformed data.
+    glm::vec3 safe_ext = glm::max(box.half_extents, glm::vec3(0.0f));
     glm::mat3 rotMat = glm::mat3_cast(rot);
 
     glm::vec3 expanded;
     for (int i = 0; i < 3; ++i) {
-        expanded[i] = std::abs(rotMat[0][i]) * box.half_extents.x
-                    + std::abs(rotMat[1][i]) * box.half_extents.y
-                    + std::abs(rotMat[2][i]) * box.half_extents.z;
+        expanded[i] = std::abs(rotMat[0][i]) * safe_ext.x
+                    + std::abs(rotMat[1][i]) * safe_ext.y
+                    + std::abs(rotMat[2][i]) * safe_ext.z;
     }
 
     return AABB{pos - expanded, pos + expanded};
@@ -24,22 +26,26 @@ AABB compute_aabb(const BoxData& box, const glm::vec3& pos, const glm::quat& rot
 
 AABB compute_aabb(const SphereData& sphere, const glm::vec3& pos, const glm::quat& /*rot*/) {
     // Rotation is irrelevant for a sphere.
-    glm::vec3 r{sphere.radius};
+    float safe_r = std::max(sphere.radius, 0.0f);
+    glm::vec3 r{safe_r};
     return AABB{pos - r, pos + r};
 }
 
 AABB compute_aabb(const CapsuleData& capsule, const glm::vec3& pos, const glm::quat& rot) {
     // Capsule is aligned along local Y-axis. The two hemisphere centers are offset
     // by ±half_height along the rotated Y axis.
+    // Clamp to non-negative to prevent inverted AABBs from malformed data.
+    float safe_hh = std::max(capsule.half_height, 0.0f);
+    float safe_r  = std::max(capsule.radius, 0.0f);
     glm::vec3 local_y{0.0f, 1.0f, 0.0f};
-    glm::vec3 offset = rot * local_y * capsule.half_height;
+    glm::vec3 offset = rot * local_y * safe_hh;
 
     glm::vec3 top    = pos + offset;
     glm::vec3 bottom = pos - offset;
 
     // Compute AABB of the two hemisphere centers, then expand by radius.
-    glm::vec3 aabb_min = glm::min(top, bottom) - glm::vec3(capsule.radius);
-    glm::vec3 aabb_max = glm::max(top, bottom) + glm::vec3(capsule.radius);
+    glm::vec3 aabb_min = glm::min(top, bottom) - glm::vec3(safe_r);
+    glm::vec3 aabb_max = glm::max(top, bottom) + glm::vec3(safe_r);
 
     return AABB{aabb_min, aabb_max};
 }

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -444,6 +444,26 @@ export function MenuBar() {
       if (!useSceneStore.getState().stagingAutoSync) return;
       const s = useSceneStore.getState();
       const scene = exportSceneJson(s) as Record<string, unknown>;
+      const bridgePath = s.bridgeConnectedPath;
+
+      // Resolve relative PLY paths to absolute using bridge project root
+      if (bridgePath) {
+        const resolve = (p: string) =>
+          p && !p.startsWith('/') ? `${bridgePath}/${p}` : p;
+        const gs = scene.gaussian_splat as Record<string, unknown> | undefined;
+        if (gs?.ply_file) gs.ply_file = resolve(gs.ply_file as string);
+        if (gs?.morph) {
+          const m = gs.morph as Record<string, unknown>;
+          if (m.pair_ply) m.pair_ply = resolve(m.pair_ply as string);
+        }
+        const gos = scene.game_objects as Array<Record<string, unknown>> | undefined;
+        if (gos) {
+          for (const go of gos) {
+            if (go.ply_file) go.ply_file = resolve(go.ply_file as string);
+          }
+        }
+      }
+
       const json = JSON.stringify(scene);
       const vfxCmds = pushVfxFiles(s);
       sendBridgeCommands([...vfxCmds, { cmd: 'load_scene_json', json }]);

--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -4,7 +4,7 @@ import { useSceneStore } from '../store/useSceneStore.js';
 import { exportSceneJson } from '../lib/sceneExport.js';
 import { computeFingerprint, isStructuralChange, type SceneFingerprint } from '../lib/sceneFingerprint.js';
 import { hasFileSystemAccess, openProjectDirectory, saveProject as saveProjectDir, loadProject as loadProjectDir, saveProjectAsZip, loadProjectFromZip, importAssetToProject } from '../lib/projectIO.js';
-import { sendBridgeCommand, sendBridgeCommands } from '@gseurat/engine-client';
+import { sendBridgeCommand, sendBridgeCommands, onBridgeReconnect } from '@gseurat/engine-client';
 import type { BricklayerFile } from '../store/types.js';
 import {
   saveProjectRootHandle,
@@ -437,6 +437,19 @@ export function MenuBar() {
       if (autoSyncTimer.current) clearTimeout(autoSyncTimer.current);
     };
   }, [stagingAutoSync]);
+
+  // Re-sync full scene to Staging after bridge reconnects (prevents stale state).
+  useEffect(() => {
+    onBridgeReconnect(() => {
+      if (!useSceneStore.getState().stagingAutoSync) return;
+      const s = useSceneStore.getState();
+      const scene = exportSceneJson(s) as Record<string, unknown>;
+      const json = JSON.stringify(scene);
+      const vfxCmds = pushVfxFiles(s);
+      sendBridgeCommands([...vfxCmds, { cmd: 'load_scene_json', json }]);
+      prevFingerprint.current = null; // force next auto-sync to be structural
+    });
+  }, []);
 
   const handleImportAsset = () => {
     const input = document.createElement('input');

--- a/tools/packages/engine-client/src/bridge.ts
+++ b/tools/packages/engine-client/src/bridge.ts
@@ -13,6 +13,8 @@ const RECONNECT_INTERVAL = 3000; // ms
 let client: EngineClient | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let connecting = false;
+let wasConnected = false;
+let reconnectCallback: (() => void) | null = null;
 
 function scheduleReconnect() {
   if (reconnectTimer) return;
@@ -33,6 +35,11 @@ async function ensureConnected(): Promise<EngineClient | null> {
     }
     await client.connect();
     connecting = false;
+    // Fire reconnect callback if this is a reconnection (not the first connect)
+    if (wasConnected && reconnectCallback) {
+      reconnectCallback();
+    }
+    wasConnected = true;
     return client;
   } catch {
     connecting = false;
@@ -77,6 +84,14 @@ export async function sendBridgeCommands(payloads: Record<string, unknown>[]): P
  */
 export function getBridgeClient(): EngineClient | null {
   return client?.isConnected ? client : null;
+}
+
+/**
+ * Register a callback that fires when the bridge reconnects after a disconnect.
+ * Does NOT fire on the initial connection — only on subsequent reconnections.
+ */
+export function onBridgeReconnect(cb: () => void): void {
+  reconnectCallback = cb;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Engine**: Clamp Box/Sphere/Capsule dimensions to non-negative in `compute_aabb()` — prevents inverted AABBs from malformed JSON
- **Bridge**: Add `onBridgeReconnect()` callback in engine-client — fires after WebSocket reconnection (not initial connect)
- **Bricklayer**: Register reconnect handler to push full `load_scene_json` — Staging no longer stays stale after bridge disconnect

Addresses QA findings #1 (degenerate geometry crashes BVH) and #2 (Staging desync after bridge disconnect).

## Test plan
- [ ] C++ build passes with intersect.cpp changes
- [ ] Negative radius in scene JSON produces zero-volume AABB (not inverted)
- [ ] Disconnect bridge mid-edit, reconnect — Staging receives full scene resync
- [ ] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)