### PR TITLE
docs: add design spec and plan for viewport collider visualization

### DIFF
--- a/docs/superpowers/plans/2026-04-23-viewport-collider-visualization.md
+++ b/docs/superpowers/plans/2026-04-23-viewport-collider-visualization.md
@@ -1,0 +1,344 @@
+# Viewport Collider Visualization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add wireframe collider overlays to Bricklayer's 3D viewport so level designers can see and click collision shapes directly in the editor.
+
+**Architecture:** A new `ColliderMarkers.tsx` component renders Three.js `EdgesGeometry` wireframes for Box/Sphere/Capsule colliders, with invisible hit meshes for click-to-select. Visibility follows a two-tier model: all colliders faint when `showCollision` is ON, selected collider always bright. A "Colliders" toggle in the View menu wires the existing `showCollision` store flag.
+
+**Tech Stack:** React Three Fiber, Three.js (EdgesGeometry, BoxGeometry, SphereGeometry, CapsuleGeometry), Zustand (useSceneStore)
+
+---
+
+### Task 1: Create ColliderMarkers component
+
+**Files:**
+- Create: `tools/apps/bricklayer/src/viewport/ColliderMarkers.tsx`
+
+- [ ] **Step 1: Create ColliderMarkers.tsx**
+
+```tsx
+import React, { useMemo } from 'react';
+import * as THREE from 'three';
+import { useSceneStore } from '../store/useSceneStore.js';
+
+const DEG2RAD = THREE.MathUtils.degToRad;
+
+interface ColliderShape {
+  type: string;
+  half_extents?: [number, number, number];
+  radius?: number;
+  half_height?: number;
+}
+
+function ColliderWireframe({ shape, color, opacity }: {
+  shape: ColliderShape;
+  color: string;
+  opacity: number;
+}) {
+  const edgesGeo = useMemo(() => {
+    if (shape.type === 'box') {
+      const [hx, hy, hz] = shape.half_extents ?? [0.5, 0.5, 0.5];
+      return new THREE.EdgesGeometry(new THREE.BoxGeometry(2 * hx, 2 * hy, 2 * hz));
+    } else if (shape.type === 'sphere') {
+      const r = shape.radius ?? 0.5;
+      return new THREE.EdgesGeometry(new THREE.SphereGeometry(r, 24, 16));
+    } else {
+      // capsule
+      const r = shape.radius ?? 0.3;
+      const hh = shape.half_height ?? 0.5;
+      return new THREE.EdgesGeometry(new THREE.CapsuleGeometry(r, 2 * hh, 12, 8));
+    }
+  }, [shape.type, shape.half_extents, shape.radius, shape.half_height]);
+
+  return (
+    <lineSegments geometry={edgesGeo}>
+      <lineBasicMaterial color={color} transparent opacity={opacity} />
+    </lineSegments>
+  );
+}
+
+function ColliderFill({ shape, color, opacity }: {
+  shape: ColliderShape;
+  color: string;
+  opacity: number;
+}) {
+  if (shape.type === 'box') {
+    const [hx, hy, hz] = shape.half_extents ?? [0.5, 0.5, 0.5];
+    return (
+      <mesh>
+        <boxGeometry args={[2 * hx, 2 * hy, 2 * hz]} />
+        <meshBasicMaterial color={color} opacity={opacity} transparent side={THREE.DoubleSide} />
+      </mesh>
+    );
+  } else if (shape.type === 'sphere') {
+    const r = shape.radius ?? 0.5;
+    return (
+      <mesh>
+        <sphereGeometry args={[r, 24, 16]} />
+        <meshBasicMaterial color={color} opacity={opacity} transparent side={THREE.DoubleSide} />
+      </mesh>
+    );
+  } else {
+    const r = shape.radius ?? 0.3;
+    const hh = shape.half_height ?? 0.5;
+    return (
+      <mesh>
+        <capsuleGeometry args={[r, 2 * hh, 12, 8]} />
+        <meshBasicMaterial color={color} opacity={opacity} transparent side={THREE.DoubleSide} />
+      </mesh>
+    );
+  }
+}
+
+function ColliderHitMesh({ shape, onSelect }: {
+  shape: ColliderShape;
+  onSelect: () => void;
+}) {
+  if (shape.type === 'box') {
+    const [hx, hy, hz] = shape.half_extents ?? [0.5, 0.5, 0.5];
+    return (
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
+        <boxGeometry args={[2 * hx, 2 * hy, 2 * hz]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+    );
+  } else if (shape.type === 'sphere') {
+    const r = shape.radius ?? 0.5;
+    return (
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
+        <sphereGeometry args={[r, 24, 16]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+    );
+  } else {
+    const r = shape.radius ?? 0.3;
+    const hh = shape.half_height ?? 0.5;
+    return (
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
+        <capsuleGeometry args={[r, 2 * hh, 12, 8]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+    );
+  }
+}
+
+function SingleColliderMarker({ objId, objPosition, objRotation, collider, isSelected, showCollision, onSelect }: {
+  objId: string;
+  objPosition: [number, number, number];
+  objRotation: [number, number, number];
+  collider: Record<string, unknown>;
+  isSelected: boolean;
+  showCollision: boolean;
+  onSelect: () => void;
+}) {
+  const shape = collider.shape as ColliderShape | undefined;
+  if (!shape || !shape.type) return null;
+
+  const offset = (collider.offset as [number, number, number]) ?? [0, 0, 0];
+  const isTrigger = (collider.is_trigger as boolean) ?? false;
+  const localRotation = (collider.local_rotation as [number, number, number, number]) ?? [0, 0, 0, 1];
+
+  // Visibility: selected always visible; unselected only when showCollision is ON
+  const visible = isSelected || showCollision;
+  if (!visible) return null;
+
+  // Colors: green for solid, orange for trigger
+  const wireColor = isTrigger
+    ? (isSelected ? '#ff8800' : '#885500')
+    : (isSelected ? '#00ff44' : '#228833');
+  const wireOpacity = isSelected ? 1.0 : 0.3;
+  const fillOpacity = isSelected ? 0.08 : 0.04;
+
+  return (
+    <group
+      position={objPosition}
+      rotation={[DEG2RAD(objRotation[0]), DEG2RAD(objRotation[1]), DEG2RAD(objRotation[2])]}
+    >
+      <group quaternion={localRotation}>
+        <group position={offset}>
+          <ColliderWireframe shape={shape} color={wireColor} opacity={wireOpacity} />
+          <ColliderFill shape={shape} color={wireColor} opacity={fillOpacity} />
+          <ColliderHitMesh shape={shape} onSelect={onSelect} />
+        </group>
+      </group>
+    </group>
+  );
+}
+
+export function ColliderMarkers() {
+  const gameObjects = useSceneStore((s) => s.gameObjects);
+  const showGizmos = useSceneStore((s) => s.showGizmos);
+  const showCollision = useSceneStore((s) => s.showCollision);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
+
+  if (!showGizmos) return null;
+
+  return (
+    <group>
+      {gameObjects.map((obj) => {
+        const collider = obj.components['ColliderComponent'] as Record<string, unknown> | undefined;
+        if (!collider) return null;
+        const isSelected = selectedEntity?.type === 'game_object' && selectedEntity.id === obj.id;
+        return (
+          <SingleColliderMarker
+            key={obj.id}
+            objId={obj.id}
+            objPosition={obj.position}
+            objRotation={obj.rotation}
+            collider={collider}
+            isSelected={isSelected}
+            showCollision={showCollision}
+            onSelect={() => setSelectedEntity({ type: 'game_object', id: obj.id })}
+          />
+        );
+      })}
+    </group>
+  );
+}
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `cd tools && pnpm --filter bricklayer exec tsc --noEmit 2>&1 | grep -v simulation-wasm | grep -v ERR_PNPM | grep -v undefined | grep -v '^$'`
+
+Expected: Only the pre-existing simulation-wasm error (no new errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/viewport/ColliderMarkers.tsx
+git commit -m "feat(bricklayer): add ColliderMarkers component with wireframe shapes"
+```
+
+---
+
+### Task 2: Wire ColliderMarkers into Viewport
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/viewport/Viewport.tsx:8,311`
+
+- [ ] **Step 1: Add import**
+
+At line 8 of `Viewport.tsx`, after the `GameObjectMarkers` import, add:
+
+```typescript
+import { ColliderMarkers } from './ColliderMarkers.js';
+```
+
+- [ ] **Step 2: Add component to SceneContent**
+
+At line 312 (after `<GameObjectMarkers />`), add:
+
+```tsx
+      <ColliderMarkers />
+```
+
+So the block reads:
+
+```tsx
+      <GameObjectMarkers />
+      <ColliderMarkers />
+      <GsEmitterMarkers />
+```
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run: `cd tools && pnpm --filter bricklayer exec tsc --noEmit 2>&1 | grep -v simulation-wasm | grep -v ERR_PNPM | grep -v undefined | grep -v '^$'`
+
+Expected: No new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/viewport/Viewport.tsx
+git commit -m "feat(bricklayer): wire ColliderMarkers into Viewport SceneContent"
+```
+
+---
+
+### Task 3: Add Colliders toggle to View menu
+
+**Files:**
+- Modify: `tools/apps/bricklayer/src/panels/MenuBar.tsx:566`
+
+- [ ] **Step 1: Add Colliders menu item**
+
+After the "Object PLY" entry (line 566, after its closing `},`), add:
+
+```typescript
+    {
+      label: `${useSceneStore.getState().showCollision ? '\u2713 ' : ''}Colliders`,
+      action: () => {
+        const s = useSceneStore.getState();
+        s.setShowCollision(!s.showCollision);
+      },
+    },
+```
+
+So the viewItems array reads:
+
+```typescript
+    {
+      label: `${useSceneStore.getState().showObjectPly ? '\u2713 ' : ''}Object PLY`,
+      action: () => {
+        const s = useSceneStore.getState();
+        s.setShowObjectPly(!s.showObjectPly);
+      },
+    },
+    {
+      label: `${useSceneStore.getState().showCollision ? '\u2713 ' : ''}Colliders`,
+      action: () => {
+        const s = useSceneStore.getState();
+        s.setShowCollision(!s.showCollision);
+      },
+    },
+    {
+      label: `${useSceneStore.getState().stagingAutoSync ? '\u2713 ' : ''}Auto-Sync Staging`,
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `cd tools && pnpm --filter bricklayer exec tsc --noEmit 2>&1 | grep -v simulation-wasm | grep -v ERR_PNPM | grep -v undefined | grep -v '^$'`
+
+Expected: No new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/apps/bricklayer/src/panels/MenuBar.tsx
+git commit -m "feat(bricklayer): add Colliders toggle to View menu"
+```
+
+---
+
+### Task 4: Verify end-to-end
+
+- [ ] **Step 1: Final type-check**
+
+Run: `cd tools && pnpm --filter bricklayer exec tsc --noEmit 2>&1 | grep -v simulation-wasm | grep -v ERR_PNPM | grep -v undefined | grep -v '^$'`
+
+Expected: No new errors.
+
+- [ ] **Step 2: Verify showCollision store flag exists**
+
+```bash
+cd tools && grep -n 'showCollision' apps/bricklayer/src/store/useSceneStore.ts | head -5
+```
+
+Expected: Lines showing `showCollision: boolean` (type), `showCollision: false` (default), `setShowCollision: (v) => set({ showCollision: v })` (setter).
+
+- [ ] **Step 3: Verify ColliderMarkers renders for KCC objects**
+
+Check that the scene JSON has game objects with `ColliderComponent`:
+
+```bash
+grep -c 'ColliderComponent' examples/island_demo/assets/scenes/seurat_island.json
+```
+
+Expected: `8` (the 8 KCC courtyard objects).
+
+- [ ] **Step 4: No commit needed — verification only**
+
+No files changed. If all checks pass, the feature is complete.

--- a/docs/superpowers/specs/2026-04-23-viewport-collider-visualization-design.md
+++ b/docs/superpowers/specs/2026-04-23-viewport-collider-visualization-design.md
@@ -1,0 +1,151 @@
+# Viewport Collider Visualization in Bricklayer — Design Spec
+
+## Goal
+
+Add wireframe collider overlays to Bricklayer's 3D viewport so level designers can see and click collision shapes (Box, Sphere, Capsule) directly in the editor without switching to Staging's F10 debug view.
+
+## Architecture
+
+A new `ColliderMarkers.tsx` React Three Fiber component renders Three.js wireframe geometry for every game object that has a `ColliderComponent`. It follows the established pattern of `CameraZoneMarkers.tsx` — `EdgesGeometry` wireframes, invisible hit meshes, color-coded by state, gated behind the existing `showGizmos` master toggle.
+
+No new store state, bridge commands, or engine changes are needed. The existing `showCollision` boolean (already in `useSceneStore` but currently unwired) controls the global toggle. A new "Colliders" entry in MenuBar's View menu wires it up.
+
+## 1. Visibility Rules
+
+| `showCollision` | Object selected? | Has collider? | Visible? | Alpha |
+|-----------------|-------------------|---------------|----------|-------|
+| ON              | Yes               | Yes           | Yes      | 1.0   |
+| ON              | No                | Yes           | Yes      | 0.3   |
+| OFF             | Yes               | Yes           | Yes      | 1.0   |
+| OFF             | No                | Yes           | No       | —     |
+
+Gated behind `showGizmos` (master toggle) — if gizmos are off, no colliders render regardless of `showCollision`.
+
+**Rationale:** When `showCollision` is ON, all colliders are faintly visible for spatial context (aligning adjacent objects). The selected object's collider is always bright. When OFF, only the selected object's collider shows so the designer knows what they're editing.
+
+## 2. Shape Rendering
+
+Each collider shape maps to Three.js geometry:
+
+**Box:** `EdgesGeometry(BoxGeometry(2*hx, 2*hy, 2*hz))` — clean wireframe edges without face diagonals. Hit mesh: matching `BoxGeometry`.
+
+**Sphere:** `EdgesGeometry(SphereGeometry(r, 24, 16))` — 24 longitude, 16 latitude for smooth appearance. Hit mesh: matching `SphereGeometry`.
+
+**Capsule:** `EdgesGeometry(CapsuleGeometry(r, 2*half_height, 12, 8))` — Three.js native capsule geometry. Hit mesh: matching `CapsuleGeometry`.
+
+**Semi-transparent fill:** Each shape also renders a faint solid mesh (alpha 0.04 unselected, 0.08 selected) for depth perception and intuitive click feel.
+
+All geometries are memoized via `useMemo` keyed on shape parameters to avoid per-frame allocation.
+
+## 3. Transform Stack
+
+Collider wireframes must correctly compose the game object's Euler rotation with the collider's local quaternion rotation and offset:
+
+```
+<group position={obj.position} rotation={eulerFromDegrees(obj.rotation)}>
+  <group quaternion={collider.local_rotation ?? [0, 0, 0, 1]}>
+    <group position={collider.offset}>
+      {/* EdgesGeometry wireframe */}
+      {/* Invisible hit mesh */}
+      {/* Semi-transparent fill */}
+    </group>
+  </group>
+</group>
+```
+
+- **Outer group:** Game object world position + Euler rotation (degrees converted to radians via `THREE.MathUtils.degToRad`)
+- **Middle group:** Collider `local_rotation` quaternion applied via `quaternion` prop (identity `[0,0,0,1]` when unset)
+- **Inner group:** Collider `offset` as local translation
+
+This matches the engine's transform composition order.
+
+## 4. Color Scheme
+
+| State                | Wireframe Color | Fill Color  |
+|----------------------|-----------------|-------------|
+| Solid — selected     | `#00ff44`       | `#00ff44` alpha 0.08 |
+| Solid — unselected   | `#228833`       | `#228833` alpha 0.04 |
+| Trigger — selected   | `#ff8800`       | `#ff8800` alpha 0.08 |
+| Trigger — unselected | `#885500`       | `#885500` alpha 0.04 |
+
+Green for physics colliders, orange for triggers — instantly distinguishable at a glance. Both distinct from cyan camera zones and blue game object cubes.
+
+## 5. Hit Testing (Interactive)
+
+Each collider renders an invisible solid mesh matching the collider's shape and dimensions. Clicking anywhere inside the volume selects the parent game object:
+
+```typescript
+<mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
+  <boxGeometry args={[2*hx, 2*hy, 2*hz]} />
+  <meshBasicMaterial visible={false} />
+</mesh>
+```
+
+This replaces the tiny 1.5-unit origin cube as the primary click target when colliders are visible, matching industry-standard editor behavior (Unity, Unreal).
+
+The existing `GameObjectMarkers` cube remains for objects without colliders and when `showCollision` is off.
+
+## 6. UI Toggle
+
+Add a "Colliders" entry to the `viewItems` array in `MenuBar.tsx`, after "Object PLY":
+
+```typescript
+{
+  label: `${useSceneStore.getState().showCollision ? '\u2713 ' : ''}Colliders`,
+  action: () => {
+    const s = useSceneStore.getState();
+    s.setShowCollision(!s.showCollision);
+  },
+},
+```
+
+Uses the existing `showCollision` / `setShowCollision` store state (default `false`).
+
+## 7. Component Integration
+
+In `Viewport.tsx`'s `SceneContent`, add `<ColliderMarkers />` alongside the other marker components:
+
+```typescript
+<GameObjectMarkers />
+<ColliderMarkers />    {/* new */}
+<CameraZoneMarkers />
+<LightGizmos />
+```
+
+## 8. Data Access
+
+```typescript
+const gameObjects = useSceneStore((s) => s.gameObjects);
+const showCollision = useSceneStore((s) => s.showCollision);
+const showGizmos = useSceneStore((s) => s.showGizmos);
+const selectedEntity = useSceneStore((s) => s.selectedEntity);
+
+// For each game object:
+const collider = obj.components['ColliderComponent'] as Record<string, unknown> | undefined;
+if (!collider) continue;
+
+const shape = collider.shape as { type: string; half_extents?: number[]; radius?: number; half_height?: number };
+const offset = (collider.offset as [number, number, number]) ?? [0, 0, 0];
+const isTrigger = (collider.is_trigger as boolean) ?? false;
+const localRotation = (collider.local_rotation as [number, number, number, number]) ?? [0, 0, 0, 1];
+const isSelected = selectedEntity?.type === 'game_object' && selectedEntity.id === obj.id;
+```
+
+## Out of Scope
+
+- **Collider editing via viewport gizmos** — resize handles, drag-to-move offset (future work)
+- **Collision mask visualization** — bitmask layer coloring
+- **Dynamic collider animation** — real-time physics preview
+- **Multi-select collider operations** — batch editing
+
+## Testing
+
+- Toggle View > Colliders ON -> all game objects with `ColliderComponent` show green/orange wireframes
+- Toggle OFF -> only selected object's collider visible
+- Select `kcc_wall_a` -> bright green box wireframe at correct position/rotation
+- Select `kcc_boulder_a` -> bright green sphere wireframe matching radius 1.2
+- Select `kcc_pillar_a` -> bright green capsule wireframe matching r=0.5 h=1.5
+- Click on a collider wireframe -> selects the parent game object
+- Toggle `is_trigger` in ColliderEditor -> wireframe color changes to orange
+- Toggle `showGizmos` OFF -> all collider wireframes disappear
+- Type-check passes: `pnpm --filter bricklayer exec tsc --noEmit`


### PR DESCRIPTION
## Summary
- Design spec for viewport collider visualization in Bricklayer
- Implementation plan (4 tasks) for the feature

## Test plan
- [ ] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)