### PR TITLE
feat(bricklayer): add viewport collider visualization

### DIFF
--- a/tools/apps/bricklayer/src/panels/MenuBar.tsx
+++ b/tools/apps/bricklayer/src/panels/MenuBar.tsx
@@ -565,6 +565,13 @@ export function MenuBar() {
       },
     },
     {
+      label: `${useSceneStore.getState().showCollision ? '\u2713 ' : ''}Colliders`,
+      action: () => {
+        const s = useSceneStore.getState();
+        s.setShowCollision(!s.showCollision);
+      },
+    },
+    {
       label: `${useSceneStore.getState().stagingAutoSync ? '\u2713 ' : ''}Auto-Sync Staging`,
       action: () => {
         const s = useSceneStore.getState();

--- a/tools/apps/bricklayer/src/viewport/ColliderMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/ColliderMarkers.tsx
@@ -134,8 +134,8 @@ function SingleColliderMarker({ objPosition, objRotation, collider, isSelected, 
       position={objPosition}
       rotation={[DEG2RAD(objRotation[0]), DEG2RAD(objRotation[1]), DEG2RAD(objRotation[2])]}
     >
-      <group quaternion={localRotation}>
-        <group position={offset}>
+      <group position={offset}>
+        <group quaternion={localRotation}>
           <ColliderWireframe shape={shape} color={wireColor} opacity={wireOpacity} />
           <ColliderFill shape={shape} color={wireColor} opacity={fillOpacity} />
           <ColliderHitMesh shape={shape} onSelect={onSelect} />

--- a/tools/apps/bricklayer/src/viewport/ColliderMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/ColliderMarkers.tsx
@@ -1,0 +1,177 @@
+import React, { useMemo } from 'react';
+import * as THREE from 'three';
+import { useSceneStore } from '../store/useSceneStore.js';
+
+const DEG2RAD = THREE.MathUtils.degToRad;
+
+interface ColliderShape {
+  type: string;
+  half_extents?: [number, number, number];
+  radius?: number;
+  half_height?: number;
+}
+
+function ColliderWireframe({ shape, color, opacity }: {
+  shape: ColliderShape;
+  color: string;
+  opacity: number;
+}) {
+  const edgesGeo = useMemo(() => {
+    if (shape.type === 'box') {
+      const [hx, hy, hz] = shape.half_extents ?? [0.5, 0.5, 0.5];
+      return new THREE.EdgesGeometry(new THREE.BoxGeometry(2 * hx, 2 * hy, 2 * hz));
+    } else if (shape.type === 'sphere') {
+      const r = shape.radius ?? 0.5;
+      return new THREE.EdgesGeometry(new THREE.SphereGeometry(r, 24, 16));
+    } else {
+      // capsule
+      const r = shape.radius ?? 0.3;
+      const hh = shape.half_height ?? 0.5;
+      return new THREE.EdgesGeometry(new THREE.CapsuleGeometry(r, 2 * hh, 12, 8));
+    }
+  }, [shape.type, shape.half_extents, shape.radius, shape.half_height]);
+
+  return (
+    <lineSegments geometry={edgesGeo}>
+      <lineBasicMaterial color={color} transparent opacity={opacity} />
+    </lineSegments>
+  );
+}
+
+function ColliderFill({ shape, color, opacity }: {
+  shape: ColliderShape;
+  color: string;
+  opacity: number;
+}) {
+  if (shape.type === 'box') {
+    const [hx, hy, hz] = shape.half_extents ?? [0.5, 0.5, 0.5];
+    return (
+      <mesh>
+        <boxGeometry args={[2 * hx, 2 * hy, 2 * hz]} />
+        <meshBasicMaterial color={color} opacity={opacity} transparent side={THREE.DoubleSide} />
+      </mesh>
+    );
+  } else if (shape.type === 'sphere') {
+    const r = shape.radius ?? 0.5;
+    return (
+      <mesh>
+        <sphereGeometry args={[r, 24, 16]} />
+        <meshBasicMaterial color={color} opacity={opacity} transparent side={THREE.DoubleSide} />
+      </mesh>
+    );
+  } else {
+    const r = shape.radius ?? 0.3;
+    const hh = shape.half_height ?? 0.5;
+    return (
+      <mesh>
+        <capsuleGeometry args={[r, 2 * hh, 12, 8]} />
+        <meshBasicMaterial color={color} opacity={opacity} transparent side={THREE.DoubleSide} />
+      </mesh>
+    );
+  }
+}
+
+function ColliderHitMesh({ shape, onSelect }: {
+  shape: ColliderShape;
+  onSelect: () => void;
+}) {
+  if (shape.type === 'box') {
+    const [hx, hy, hz] = shape.half_extents ?? [0.5, 0.5, 0.5];
+    return (
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
+        <boxGeometry args={[2 * hx, 2 * hy, 2 * hz]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+    );
+  } else if (shape.type === 'sphere') {
+    const r = shape.radius ?? 0.5;
+    return (
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
+        <sphereGeometry args={[r, 24, 16]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+    );
+  } else {
+    const r = shape.radius ?? 0.3;
+    const hh = shape.half_height ?? 0.5;
+    return (
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
+        <capsuleGeometry args={[r, 2 * hh, 12, 8]} />
+        <meshBasicMaterial visible={false} />
+      </mesh>
+    );
+  }
+}
+
+function SingleColliderMarker({ objPosition, objRotation, collider, isSelected, showCollision, onSelect }: {
+  objPosition: [number, number, number];
+  objRotation: [number, number, number];
+  collider: Record<string, unknown>;
+  isSelected: boolean;
+  showCollision: boolean;
+  onSelect: () => void;
+}) {
+  const shape = collider.shape as ColliderShape | undefined;
+  if (!shape || !shape.type) return null;
+
+  const offset = (collider.offset as [number, number, number]) ?? [0, 0, 0];
+  const isTrigger = (collider.is_trigger as boolean) ?? false;
+  const localRotation = (collider.local_rotation as [number, number, number, number]) ?? [0, 0, 0, 1];
+
+  // Visibility: selected always visible; unselected only when showCollision is ON
+  const visible = isSelected || showCollision;
+  if (!visible) return null;
+
+  // Colors: green for solid, orange for trigger
+  const wireColor = isTrigger
+    ? (isSelected ? '#ff8800' : '#885500')
+    : (isSelected ? '#00ff44' : '#228833');
+  const wireOpacity = isSelected ? 1.0 : 0.3;
+  const fillOpacity = isSelected ? 0.08 : 0.04;
+
+  return (
+    <group
+      position={objPosition}
+      rotation={[DEG2RAD(objRotation[0]), DEG2RAD(objRotation[1]), DEG2RAD(objRotation[2])]}
+    >
+      <group quaternion={localRotation}>
+        <group position={offset}>
+          <ColliderWireframe shape={shape} color={wireColor} opacity={wireOpacity} />
+          <ColliderFill shape={shape} color={wireColor} opacity={fillOpacity} />
+          <ColliderHitMesh shape={shape} onSelect={onSelect} />
+        </group>
+      </group>
+    </group>
+  );
+}
+
+export function ColliderMarkers() {
+  const gameObjects = useSceneStore((s) => s.gameObjects);
+  const showGizmos = useSceneStore((s) => s.showGizmos);
+  const showCollision = useSceneStore((s) => s.showCollision);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
+
+  if (!showGizmos) return null;
+
+  return (
+    <group>
+      {gameObjects.map((obj) => {
+        const collider = obj.components['ColliderComponent'] as Record<string, unknown> | undefined;
+        if (!collider) return null;
+        const isSelected = selectedEntity?.type === 'game_object' && selectedEntity.id === obj.id;
+        return (
+          <SingleColliderMarker
+            key={obj.id}
+            objPosition={obj.position}
+            objRotation={obj.rotation}
+            collider={collider}
+            isSelected={isSelected}
+            showCollision={showCollision}
+            onSelect={() => setSelectedEntity({ type: 'game_object', id: obj.id })}
+          />
+        );
+      })}
+    </group>
+  );
+}

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -6,6 +6,7 @@ import * as THREE from 'three';
 import { GroundPlane } from './GroundPlane.js';
 import { LightGizmos } from './LightGizmos.js';
 import { GameObjectMarkers } from './GameObjectMarkers.js';
+import { ColliderMarkers } from './ColliderMarkers.js';
 import { GsEmitterMarkers } from './GsEmitterMarkers.js';
 import { GsEmitterParticles } from './GsEmitterParticles.js';
 import { GsAnimationMarkers } from './GsAnimationMarkers.js';
@@ -309,6 +310,7 @@ function SceneContent() {
       <TerrainPlyReference />
       <LightGizmos />
       <GameObjectMarkers />
+      <ColliderMarkers />
       <GsEmitterMarkers />
       <GsEmitterParticles />
       <GsAnimationMarkers />


### PR DESCRIPTION
## Summary
- Add `ColliderMarkers.tsx` — renders wireframe overlays for Box, Sphere, and Capsule colliders in Bricklayer's 3D viewport
- Wire into `Viewport.tsx` SceneContent alongside existing GameObjectMarkers
- Add "Colliders" toggle to View menu using existing `showCollision` store flag
- Green wireframes for solid colliders, orange for triggers; bright when selected, faint when not
- Click collider wireframe to select parent game object (interactive hit meshes)
- Selected object's collider always visible; unselected colliders shown only when toggle is ON

## Test plan
- [ ] Toggle View > Colliders ON — all 8 KCC courtyard objects show green wireframes
- [ ] Toggle OFF — only selected object's collider visible
- [ ] Select kcc_wall_a — bright green box wireframe at correct angle
- [ ] Select kcc_boulder_a — bright green sphere matching radius 1.2
- [ ] Select kcc_pillar_a — bright green capsule matching r=0.5 h=1.5
- [ ] Click on a collider wireframe — selects the parent game object
- [ ] Toggle is_trigger in ColliderEditor — wireframe changes to orange
- [ ] Toggle showGizmos OFF — all collider wireframes disappear
- [ ] Type-check passes: pnpm --filter bricklayer exec tsc --noEmit

🤖 Generated with [Claude Code](https://claude.com/claude-code)