### PR TITLE
fix(bricklayer): resolve collider viewport QA findings (P0/P1/P2)

### DIFF
--- a/tools/apps/bricklayer/src/viewport/ColliderMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/ColliderMarkers.tsx
@@ -20,7 +20,7 @@ function ColliderWireframe({ shape, color, opacity }: {
   const hx = shape.half_extents?.[0] ?? 0.5;
   const hy = shape.half_extents?.[1] ?? 0.5;
   const hz = shape.half_extents?.[2] ?? 0.5;
-  const r = shape.radius ?? 0.5;
+  const r = shape.radius ?? (shape.type === 'capsule' ? 0.3 : 0.5);
   const hh = shape.half_height ?? 0.5;
 
   const edgesGeo = useMemo(() => {

--- a/tools/apps/bricklayer/src/viewport/ColliderMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/ColliderMarkers.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import { useSceneStore } from '../store/useSceneStore.js';
 
@@ -16,20 +16,32 @@ function ColliderWireframe({ shape, color, opacity }: {
   color: string;
   opacity: number;
 }) {
+  const prevGeo = useRef<THREE.EdgesGeometry | null>(null);
+  const hx = shape.half_extents?.[0] ?? 0.5;
+  const hy = shape.half_extents?.[1] ?? 0.5;
+  const hz = shape.half_extents?.[2] ?? 0.5;
+  const r = shape.radius ?? 0.5;
+  const hh = shape.half_height ?? 0.5;
+
   const edgesGeo = useMemo(() => {
+    // Dispose previous geometry to prevent GPU memory leak
+    prevGeo.current?.dispose();
+    let geo: THREE.EdgesGeometry;
     if (shape.type === 'box') {
-      const [hx, hy, hz] = shape.half_extents ?? [0.5, 0.5, 0.5];
-      return new THREE.EdgesGeometry(new THREE.BoxGeometry(2 * hx, 2 * hy, 2 * hz));
+      geo = new THREE.EdgesGeometry(new THREE.BoxGeometry(2 * hx, 2 * hy, 2 * hz));
     } else if (shape.type === 'sphere') {
-      const r = shape.radius ?? 0.5;
-      return new THREE.EdgesGeometry(new THREE.SphereGeometry(r, 24, 16));
+      geo = new THREE.EdgesGeometry(new THREE.SphereGeometry(r, 24, 16));
     } else {
-      // capsule
-      const r = shape.radius ?? 0.3;
-      const hh = shape.half_height ?? 0.5;
-      return new THREE.EdgesGeometry(new THREE.CapsuleGeometry(r, 2 * hh, 12, 8));
+      geo = new THREE.EdgesGeometry(new THREE.CapsuleGeometry(r, 2 * hh, 12, 8));
     }
-  }, [shape.type, shape.half_extents, shape.radius, shape.half_height]);
+    prevGeo.current = geo;
+    return geo;
+  }, [shape.type, hx, hy, hz, r, hh]);
+
+  // Dispose on unmount
+  useEffect(() => {
+    return () => { prevGeo.current?.dispose(); };
+  }, []);
 
   return (
     <lineSegments geometry={edgesGeo}>

--- a/tools/apps/bricklayer/src/viewport/GameObjectMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/GameObjectMarkers.tsx
@@ -91,9 +91,10 @@ export function GameObjectMarkers() {
   return (
     <group>
       {gameObjects.map((obj, idx) => {
-        const hasCollider = 'ColliderComponent' in obj.components;
+        const collider = obj.components['ColliderComponent'] as Record<string, unknown> | undefined;
+        const hasCollider = !!(collider?.shape && (collider.shape as Record<string, unknown>).type);
         const isSelected = selectedEntity?.type === 'game_object' && selectedEntity.id === obj.id;
-        // Collider hit mesh is active when the collider wireframe is visible
+        // Collider hit mesh is active when the collider wireframe is visible and renderable
         const colliderActive = hasCollider && (showCollision || isSelected);
         return (
           <Marker

--- a/tools/apps/bricklayer/src/viewport/GameObjectMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/GameObjectMarkers.tsx
@@ -3,7 +3,7 @@ import { Html } from '@react-three/drei';
 import { useSceneStore } from '../store/useSceneStore.js';
 import { PlyPointCloud } from './PlyPointCloud.js';
 
-function Marker({ id, name, position, rotation, scale, plyFile, hasComponents, isSelected, showObjectPly, projectHandle, onSelect }: {
+function Marker({ id, name, position, rotation, scale, plyFile, hasComponents, hasCollider, colliderActive, isSelected, showObjectPly, projectHandle, onSelect }: {
   id: string;
   name: string;
   position: [number, number, number];
@@ -11,6 +11,8 @@ function Marker({ id, name, position, rotation, scale, plyFile, hasComponents, i
   scale: number;
   plyFile: string;
   hasComponents: boolean;
+  hasCollider: boolean;
+  colliderActive: boolean;
   isSelected: boolean;
   showObjectPly: boolean;
   projectHandle: FileSystemDirectoryHandle | null;
@@ -32,24 +34,29 @@ function Marker({ id, name, position, rotation, scale, plyFile, hasComponents, i
           scale={scale}
         />
       )}
-      {/* Invisible hit box for click detection */}
-      <mesh
-        position={position}
-        onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}
-      >
-        <boxGeometry args={[1.5, 1.5, 1.5]} />
-        <meshBasicMaterial visible={false} />
-      </mesh>
-      {/* Visible wireframe cube */}
-      <mesh position={position}>
-        <boxGeometry args={[1.2, 1.2, 1.2]} />
-        <meshBasicMaterial
-          color={color}
-          wireframe
-          transparent
-          opacity={opacity}
-        />
-      </mesh>
+      {/* Suppress origin cube when ColliderMarkers provides the hit target */}
+      {!colliderActive && (
+        <>
+          {/* Invisible hit box for click detection */}
+          <mesh
+            position={position}
+            onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}
+          >
+            <boxGeometry args={[1.5, 1.5, 1.5]} />
+            <meshBasicMaterial visible={false} />
+          </mesh>
+          {/* Visible wireframe cube */}
+          <mesh position={position}>
+            <boxGeometry args={[1.2, 1.2, 1.2]} />
+            <meshBasicMaterial
+              color={color}
+              wireframe
+              transparent
+              opacity={opacity}
+            />
+          </mesh>
+        </>
+      )}
       {/* Name label when selected */}
       {isSelected && (
         <Html position={[position[0], position[1] + 1.2, position[2]]} center>
@@ -73,6 +80,7 @@ function Marker({ id, name, position, rotation, scale, plyFile, hasComponents, i
 export function GameObjectMarkers() {
   const gameObjects = useSceneStore((s) => s.gameObjects);
   const showGizmos = useSceneStore((s) => s.showGizmos);
+  const showCollision = useSceneStore((s) => s.showCollision);
   const showObjectPly = useSceneStore((s) => s.showObjectPly);
   const projectHandle = useSceneStore((s) => s.projectHandle);
   const selectedEntity = useSceneStore((s) => s.selectedEntity);
@@ -82,22 +90,30 @@ export function GameObjectMarkers() {
 
   return (
     <group>
-      {gameObjects.map((obj, idx) => (
-        <Marker
-          key={`${obj.id}_${idx}`}
-          id={obj.id}
-          name={obj.name}
-          position={obj.position}
-          rotation={obj.rotation}
-          scale={obj.scale}
-          plyFile={obj.ply_file}
-          hasComponents={Object.keys(obj.components).length > 0}
-          isSelected={selectedEntity?.type === 'game_object' && selectedEntity.id === obj.id}
-          showObjectPly={showObjectPly}
-          projectHandle={projectHandle}
-          onSelect={() => setSelectedEntity({ type: 'game_object', id: obj.id })}
-        />
-      ))}
+      {gameObjects.map((obj, idx) => {
+        const hasCollider = 'ColliderComponent' in obj.components;
+        const isSelected = selectedEntity?.type === 'game_object' && selectedEntity.id === obj.id;
+        // Collider hit mesh is active when the collider wireframe is visible
+        const colliderActive = hasCollider && (showCollision || isSelected);
+        return (
+          <Marker
+            key={`${obj.id}_${idx}`}
+            id={obj.id}
+            name={obj.name}
+            position={obj.position}
+            rotation={obj.rotation}
+            scale={obj.scale}
+            plyFile={obj.ply_file}
+            hasComponents={Object.keys(obj.components).length > 0}
+            hasCollider={hasCollider}
+            colliderActive={colliderActive}
+            isSelected={isSelected}
+            showObjectPly={showObjectPly}
+            projectHandle={projectHandle}
+            onSelect={() => setSelectedEntity({ type: 'game_object', id: obj.id })}
+          />
+        );
+      })}
     </group>
   );
 }


### PR DESCRIPTION
## Summary
Fixes three issues found during exploratory QA testing of the ColliderMarkers viewport feature:

- **P0: Dual hit mesh conflict** — `GameObjectMarkers` now suppresses its 1.5-unit origin cube when `ColliderMarkers` provides a shape-matched hit target (when `showCollision` is ON, or when a collider object is selected). Eliminates raycaster competition so click targets always match visible geometry.
- **P1: useMemo array reference thrashing** — `ColliderWireframe` now destructures `shape.half_extents` into scalar dependencies (`hx, hy, hz`) instead of depending on the array reference. Prevents unnecessary `EdgesGeometry` reconstruction on unrelated Zustand store updates.
- **P2: EdgesGeometry memory leak** — Added explicit `.dispose()` on shape change and component unmount via `useRef` + `useEffect` cleanup. Prevents GPU memory accumulation in long editing sessions with frequent shape changes.

## Test plan
- [ ] With showCollision OFF, click near a collider object origin — the 1.5-unit cube hit mesh works normally
- [ ] Toggle showCollision ON — origin cubes disappear for collider objects, wireframe hit meshes take over
- [ ] Click on a large box wireframe edge — selects parent game object (no competing cube)
- [ ] Objects without ColliderComponent still show origin cubes normally
- [ ] Rapidly switch shape types (Box -> Sphere -> Capsule) — no console warnings about disposed geometry
- [ ] Type-check passes: `pnpm --filter bricklayer exec tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)