### PR TITLE
fix(bricklayer): zone gizmo occlusion fix + collider validation test

### DIFF
--- a/scripts/test_collider_validation.py
+++ b/scripts/test_collider_validation.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Integration test: verify Staging engine handles degenerate collider values.
+
+Connects to the running Staging engine via Unix socket and sends
+update_scene_data commands with game objects containing degenerate collider
+values (zero, negative, extreme). Asserts that the engine does not crash
+and continues responding after each payload.
+
+Prerequisites:
+  - Staging engine running (gseurat_staging / island_demo)
+  - Any scene loaded
+
+Usage:
+  python scripts/test_collider_validation.py
+"""
+
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import game_director as gd
+
+
+class TestResult:
+    def __init__(self):
+        self.steps: list[tuple[str, bool, str]] = []
+
+    def step(self, description: str, passed: bool, detail: str = ""):
+        self.steps.append((description, passed, detail))
+        status = "\033[32mPASS\033[0m" if passed else "\033[31mFAIL\033[0m"
+        msg = f"  {status}  {description}"
+        if detail:
+            msg += f" -- {detail}"
+        print(msg)
+
+    @property
+    def passed(self) -> bool:
+        return all(s[1] for s in self.steps)
+
+    def summary(self) -> str:
+        p = sum(1 for s in self.steps if s[1])
+        total = len(self.steps)
+        color = "\033[32m" if self.passed else "\033[31m"
+        return f"{color}{'PASS' if self.passed else 'FAIL'}\033[0m ({p}/{total} steps)"
+
+
+def send_cmd(cmd: dict) -> dict:
+    return gd._conn.send(cmd)
+
+
+def make_scene(game_objects: list[dict]) -> dict:
+    """Build a minimal scene JSON with the given game objects."""
+    return {
+        "ambient_color": [0.3, 0.3, 0.4],
+        "static_lights": [],
+        "game_objects": game_objects,
+        "gs_particle_emitters": [],
+        "gs_animations": [],
+        "vfx_instances": [],
+        "camera_zones": {"volumes": [], "triggers": []},
+    }
+
+
+def make_game_object(obj_id: str, shape: dict) -> dict:
+    """Build a game object with a ColliderComponent."""
+    return {
+        "id": obj_id,
+        "name": f"Test {obj_id}",
+        "position": [10, 0, 10],
+        "rotation": [0, 0, 0],
+        "scale": 1,
+        "components": {
+            "ColliderComponent": {
+                "shape": shape,
+                "offset": [0, 0, 0],
+                "is_trigger": False,
+                "is_dynamic": False,
+            }
+        },
+    }
+
+
+def send_scene_with_collider(obj_id: str, shape: dict) -> dict:
+    """Send update_scene_data with a single game object containing the shape."""
+    scene = make_scene([make_game_object(obj_id, shape)])
+    return send_cmd({"cmd": "update_scene_data", "json": json.dumps(scene)})
+
+
+def verify_engine_alive() -> bool:
+    """Verify the engine responds to a harmless command."""
+    try:
+        resp = send_cmd({"cmd": "list_colliders"})
+        return resp.get("type") == "ok"
+    except Exception:
+        return False
+
+
+def run_tests() -> TestResult:
+    result = TestResult()
+
+    # ── Connect ──
+    try:
+        gd._conn = gd.GameConnection()
+        gd._conn.connect()
+        result.step("Connected to Staging engine", True)
+    except Exception as e:
+        result.step("Connected to Staging engine", False, str(e))
+        return result
+
+    # ── Baseline: valid sphere ──
+    resp = send_scene_with_collider("valid_sphere", {"type": "sphere", "radius": 1.0})
+    result.step("Baseline: valid sphere (radius=1.0)", resp.get("type") == "ok")
+
+    # ── Test 1: Sphere with radius=0 ──
+    resp = send_scene_with_collider("sphere_r0", {"type": "sphere", "radius": 0})
+    result.step("Sphere radius=0 accepted", resp.get("type") == "ok")
+    result.step("Engine alive after radius=0", verify_engine_alive())
+
+    # ── Test 2: Sphere with negative radius ──
+    resp = send_scene_with_collider("sphere_neg", {"type": "sphere", "radius": -5.0})
+    result.step("Sphere radius=-5 accepted", resp.get("type") == "ok")
+    result.step("Engine alive after radius=-5", verify_engine_alive())
+
+    # ── Test 3: Box with zero half_extents ──
+    resp = send_scene_with_collider("box_zero", {"type": "box", "half_extents": [0, 0, 0]})
+    result.step("Box half_extents=[0,0,0] accepted", resp.get("type") == "ok")
+    result.step("Engine alive after zero extents", verify_engine_alive())
+
+    # ── Test 4: Box with negative half_extents ──
+    resp = send_scene_with_collider("box_neg", {"type": "box", "half_extents": [-5, -5, -5]})
+    result.step("Box half_extents=[-5,-5,-5] accepted", resp.get("type") == "ok")
+    result.step("Engine alive after negative extents", verify_engine_alive())
+
+    # ── Test 5: Capsule with zero dimensions ──
+    resp = send_scene_with_collider("capsule_zero", {"type": "capsule", "radius": 0, "half_height": 0})
+    result.step("Capsule radius=0 half_height=0 accepted", resp.get("type") == "ok")
+    result.step("Engine alive after zero capsule", verify_engine_alive())
+
+    # ── Test 6: Capsule with negative values ──
+    resp = send_scene_with_collider("capsule_neg", {"type": "capsule", "radius": -2.0, "half_height": -3.0})
+    result.step("Capsule radius=-2 half_height=-3 accepted", resp.get("type") == "ok")
+    result.step("Engine alive after negative capsule", verify_engine_alive())
+
+    # ── Test 7: Extremely large radius ──
+    resp = send_scene_with_collider("sphere_huge", {"type": "sphere", "radius": 1e6})
+    result.step("Sphere radius=1e6 accepted", resp.get("type") == "ok")
+    result.step("Engine alive after huge radius", verify_engine_alive())
+
+    # ── Test 8: Missing shape fields (default fallback) ──
+    resp = send_scene_with_collider("sphere_default", {"type": "sphere"})
+    result.step("Sphere with no radius (uses default 0.5)", resp.get("type") == "ok")
+    result.step("Engine alive after missing radius", verify_engine_alive())
+
+    # ── Test 9: Unknown shape type (falls back to sphere) ──
+    resp = send_scene_with_collider("unknown", {"type": "cylinder", "radius": 1.0})
+    result.step("Unknown shape 'cylinder' accepted (fallback to sphere)", resp.get("type") == "ok")
+    result.step("Engine alive after unknown type", verify_engine_alive())
+
+    # ── Test 10: Empty shape object ──
+    resp = send_scene_with_collider("empty_shape", {})
+    result.step("Empty shape object accepted", resp.get("type") == "ok")
+    result.step("Engine alive after empty shape", verify_engine_alive())
+
+    # ── Test 11: Multiple degenerate colliders in one scene ──
+    scene = make_scene([
+        make_game_object("multi_1", {"type": "sphere", "radius": 0}),
+        make_game_object("multi_2", {"type": "box", "half_extents": [-1, -1, -1]}),
+        make_game_object("multi_3", {"type": "capsule", "radius": 0, "half_height": 0}),
+        make_game_object("multi_4", {"type": "sphere", "radius": 1e6}),
+        make_game_object("multi_5", {"type": "box", "half_extents": [0, 0, 0]}),
+    ])
+    resp = send_cmd({"cmd": "update_scene_data", "json": json.dumps(scene)})
+    result.step("5 degenerate colliders in one scene accepted", resp.get("type") == "ok")
+    result.step("Engine alive after multi-degenerate scene", verify_engine_alive())
+
+    # ── Restore: send empty scene to clean up ──
+    resp = send_cmd({"cmd": "update_scene_data", "json": json.dumps(make_scene([]))})
+    result.step("Cleanup: empty scene accepted", resp.get("type") == "ok")
+    result.step("Engine alive after cleanup", verify_engine_alive())
+
+    gd._conn.close()
+    return result
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Collider Validation Integration Test")
+    print("=" * 60)
+    print()
+
+    result = run_tests()
+
+    print()
+    print("-" * 60)
+    print(f"Result: {result.summary()}")
+    print("-" * 60)
+
+    sys.exit(0 if result.passed else 1)

--- a/tools/apps/bricklayer/src/viewport/AudioZoneMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/AudioZoneMarkers.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo } from 'react';
+import * as THREE from 'three';
+import { Html } from '@react-three/drei';
+import { useSceneStore } from '../store/useSceneStore.js';
+import type { AudioZoneData } from '../store/types.js';
+
+function AudioZoneMarker({ zone, isSelected, onSelect }: {
+  zone: AudioZoneData;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  const edgeColor = isSelected ? '#4488ff' : '#2255aa';
+  const edgeOpacity = isSelected ? 1.0 : 0.5;
+
+  const { center, halfExtents } = useMemo(() => {
+    const mn = zone.bounds.min;
+    const mx = zone.bounds.max;
+    return {
+      center: [
+        (mn[0] + mx[0]) / 2,
+        (mn[1] + mx[1]) / 2,
+        (mn[2] + mx[2]) / 2,
+      ] as [number, number, number],
+      halfExtents: [
+        (mx[0] - mn[0]) / 2,
+        (mx[1] - mn[1]) / 2,
+        (mx[2] - mn[2]) / 2,
+      ] as [number, number, number],
+    };
+  }, [zone.bounds.min, zone.bounds.max]);
+
+  const edgesGeo = useMemo(() => {
+    return new THREE.EdgesGeometry(
+      new THREE.BoxGeometry(2 * halfExtents[0], 2 * halfExtents[1], 2 * halfExtents[2])
+    );
+  }, [halfExtents]);
+
+  const labelY = Math.max(...halfExtents) + 1.2;
+
+  return (
+    <group position={center}>
+      {/* Center gizmo — visible solid cube as click target */}
+      <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
+        <boxGeometry args={[1.5, 1.5, 1.5]} />
+        <meshBasicMaterial color={edgeColor} />
+      </mesh>
+      {/* Wireframe edges */}
+      <lineSegments geometry={edgesGeo}>
+        <lineBasicMaterial color={edgeColor} transparent opacity={edgeOpacity} />
+      </lineSegments>
+      {/* Semi-transparent fill */}
+      <mesh>
+        <boxGeometry args={[2 * halfExtents[0], 2 * halfExtents[1], 2 * halfExtents[2]]} />
+        <meshBasicMaterial color="#4488ff" opacity={0.06} transparent side={THREE.DoubleSide} />
+      </mesh>
+      {/* Label when selected */}
+      {isSelected && (
+        <Html position={[0, labelY, 0]} center>
+          <div style={{
+            background: 'rgba(0,0,0,0.7)', color: '#4488ff',
+            padding: '1px 5px', borderRadius: 3, fontSize: 10, whiteSpace: 'nowrap',
+          }}>
+            {zone.name}
+          </div>
+        </Html>
+      )}
+    </group>
+  );
+}
+
+export function AudioZoneMarkers() {
+  const audioZones = useSceneStore((s) => s.audioZones);
+  const showGizmos = useSceneStore((s) => s.showGizmos);
+  const selectedEntity = useSceneStore((s) => s.selectedEntity);
+  const setSelectedEntity = useSceneStore((s) => s.setSelectedEntity);
+
+  if (!showGizmos) return null;
+
+  return (
+    <group>
+      {audioZones.map((zone) => (
+        <AudioZoneMarker
+          key={zone.id}
+          zone={zone}
+          isSelected={selectedEntity?.type === 'audio_zone' && selectedEntity.id === zone.id}
+          onSelect={() => setSelectedEntity({ type: 'audio_zone', id: zone.id })}
+        />
+      ))}
+    </group>
+  );
+}

--- a/tools/apps/bricklayer/src/viewport/AudioZoneMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/AudioZoneMarkers.tsx
@@ -13,8 +13,9 @@ function AudioZoneMarker({ zone, isSelected, onSelect }: {
   const edgeOpacity = isSelected ? 1.0 : 0.5;
 
   const { center, halfExtents } = useMemo(() => {
-    const mn = zone.bounds.min;
-    const mx = zone.bounds.max;
+    const mn = zone.bounds?.min;
+    const mx = zone.bounds?.max;
+    if (!mn || !mx) return { center: [0, 0, 0] as [number, number, number], halfExtents: [1, 1, 1] as [number, number, number] };
     return {
       center: [
         (mn[0] + mx[0]) / 2,
@@ -27,7 +28,7 @@ function AudioZoneMarker({ zone, isSelected, onSelect }: {
         (mx[2] - mn[2]) / 2,
       ] as [number, number, number],
     };
-  }, [zone.bounds.min, zone.bounds.max]);
+  }, [zone.bounds?.min, zone.bounds?.max]);
 
   const edgesGeo = useMemo(() => {
     return new THREE.EdgesGeometry(
@@ -44,8 +45,8 @@ function AudioZoneMarker({ zone, isSelected, onSelect }: {
         <boxGeometry args={[1.5, 1.5, 1.5]} />
         <meshBasicMaterial color={edgeColor} />
       </mesh>
-      {/* Wireframe edges */}
-      <lineSegments geometry={edgesGeo}>
+      {/* Wireframe edges — raycast disabled to avoid interfering with teleport */}
+      <lineSegments geometry={edgesGeo} raycast={() => null}>
         <lineBasicMaterial color={edgeColor} transparent opacity={edgeOpacity} />
       </lineSegments>
       {/* Semi-transparent fill — raycast disabled to avoid interfering with teleport */}

--- a/tools/apps/bricklayer/src/viewport/AudioZoneMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/AudioZoneMarkers.tsx
@@ -48,8 +48,8 @@ function AudioZoneMarker({ zone, isSelected, onSelect }: {
       <lineSegments geometry={edgesGeo}>
         <lineBasicMaterial color={edgeColor} transparent opacity={edgeOpacity} />
       </lineSegments>
-      {/* Semi-transparent fill */}
-      <mesh>
+      {/* Semi-transparent fill — raycast disabled to avoid interfering with teleport */}
+      <mesh raycast={() => null}>
         <boxGeometry args={[2 * halfExtents[0], 2 * halfExtents[1], 2 * halfExtents[2]]} />
         <meshBasicMaterial color="#4488ff" opacity={0.06} transparent side={THREE.DoubleSide} />
       </mesh>

--- a/tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx
@@ -26,7 +26,7 @@ function ShapeFill({ shape }: { shape: CameraShape }) {
   if (shape.type === 'aabb') {
     const [hx, hy, hz] = shape.half_extents ?? [2, 2, 2];
     return (
-      <mesh>
+      <mesh raycast={() => null}>
         <boxGeometry args={[2 * hx, 2 * hy, 2 * hz]} />
         <meshBasicMaterial color="#00ccff" opacity={0.08} transparent side={THREE.DoubleSide} />
       </mesh>
@@ -34,7 +34,7 @@ function ShapeFill({ shape }: { shape: CameraShape }) {
   } else {
     const r = shape.radius ?? 2;
     return (
-      <mesh>
+      <mesh raycast={() => null}>
         <sphereGeometry args={[r, 24, 16]} />
         <meshBasicMaterial color="#00ccff" opacity={0.08} transparent side={THREE.DoubleSide} />
       </mesh>
@@ -138,8 +138,8 @@ function TriggerMarker({ trigger, isSelected, onSelect, onMove }: {
         </mesh>
         {/* Wireframe edges */}
         <ShapeWireframe shape={shape} color={edgeColor} opacity={edgeOpacity} />
-        {/* Semi-transparent fill */}
-        <mesh>
+        {/* Semi-transparent fill — raycast disabled to avoid interfering with teleport */}
+        <mesh raycast={() => null}>
           {fillGeo}
           <meshBasicMaterial color="#ff00ff" opacity={0.08} transparent side={THREE.DoubleSide} />
         </mesh>

--- a/tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx
@@ -64,10 +64,10 @@ function VolumeMarker({ volume, isSelected, onSelect, onMove }: {
   return (
     <>
       <group ref={groupRef} position={[center[0], center[1], center[2]]}>
-        {/* Invisible hit mesh */}
+        {/* Center gizmo — visible solid cube as click target */}
         <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
-          <sphereGeometry args={[Math.max(hitSize, 1.5), 12, 12]} />
-          <meshBasicMaterial visible={false} />
+          <boxGeometry args={[1.5, 1.5, 1.5]} />
+          <meshBasicMaterial color={edgeColor} />
         </mesh>
         {/* Wireframe edges */}
         <ShapeWireframe shape={shape} color={edgeColor} opacity={edgeOpacity} />
@@ -131,10 +131,10 @@ function TriggerMarker({ trigger, isSelected, onSelect, onMove }: {
   return (
     <>
       <group ref={groupRef} position={[center[0], center[1], center[2]]}>
-        {/* Invisible hit mesh */}
+        {/* Center gizmo — visible solid cube as click target */}
         <mesh onPointerDown={(e) => { e.stopPropagation(); onSelect(); }}>
-          <sphereGeometry args={[Math.max(hitSize, 1.5), 12, 12]} />
-          <meshBasicMaterial visible={false} />
+          <boxGeometry args={[1.5, 1.5, 1.5]} />
+          <meshBasicMaterial color={edgeColor} />
         </mesh>
         {/* Wireframe edges */}
         <ShapeWireframe shape={shape} color={edgeColor} opacity={edgeOpacity} />

--- a/tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx
+++ b/tools/apps/bricklayer/src/viewport/CameraZoneMarkers.tsx
@@ -16,7 +16,7 @@ function ShapeWireframe({ shape, color, opacity = 1 }: { shape: CameraShape; col
   }, [shape]);
 
   return (
-    <lineSegments geometry={edgesGeo}>
+    <lineSegments geometry={edgesGeo} raycast={() => null}>
       <lineBasicMaterial color={color} transparent opacity={opacity} />
     </lineSegments>
   );

--- a/tools/apps/bricklayer/src/viewport/Viewport.tsx
+++ b/tools/apps/bricklayer/src/viewport/Viewport.tsx
@@ -14,6 +14,7 @@ import { VfxInstanceMarkers } from './VfxInstanceMarkers.js';
 import { VfxRenderer } from './VfxRenderer.js';
 import { PlayerMarker } from './PlayerMarker.js';
 import { CameraZoneMarkers } from './CameraZoneMarkers.js';
+import { AudioZoneMarkers } from './AudioZoneMarkers.js';
 import { CameraRailMarkers } from './CameraRailMarkers.js';
 import { CameraFrustumGizmo } from './CameraFrustumGizmo.js';
 import { ChunkWireframes } from './ChunkWireframes.js';
@@ -318,6 +319,7 @@ function SceneContent() {
       <VfxRenderer />
       <PlayerMarker />
       <CameraZoneMarkers />
+      <AudioZoneMarkers />
       <CameraRailMarkers />
       <CameraFrustumGizmo />
       <ChunkWireframes />


### PR DESCRIPTION
## Summary
- **P0 fix:** Camera volume/trigger invisible hit meshes used full-extent spheres (up to radius 50), swallowing clicks on game objects inside them (e.g., Boulder A inside `dungeon_approach` r=12). Replaced with fixed-size visible solid cubes (1.5x1.5x1.5) at zone centers — standard editor gizmo UX.
- **UX enhancement:** Added visible cyan/magenta center gizmos so designers can see where to click to select environmental zones.
- **New component:** `AudioZoneMarkers.tsx` with blue AABB wireframes + center gizmo, wired into Viewport.
- **P1 integration test:** `test_collider_validation.py` — 26-step test proving Staging engine survives degenerate collider values (radius=0, negative extents, radius=1e6, empty shape, unknown type).

## Test plan
- [x] Type check passes (`pnpm --filter bricklayer exec tsc --noEmit`)
- [x] Manual verification: Boulder A now selectable via viewport click (was blocked by camera volume)
- [x] Manual verification: Wall A selectable at far edge of collider box
- [x] Camera zone center gizmos visible as solid cubes in viewport
- [x] Integration test: `python scripts/test_collider_validation.py` — 26/26 PASS
- [ ] Verify no regressions in camera zone selection (click center cube to select)
- [ ] Verify AudioZoneMarkers render correctly when audio zones are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)