### PR TITLE
feat(debug-dump): add store domain and panel-id coverage

### DIFF
--- a/tools/apps/bricklayer/src/App.tsx
+++ b/tools/apps/bricklayer/src/App.tsx
@@ -16,6 +16,7 @@ import {
 } from '@gseurat/debug-dump';
 import { connectBridgeToPath } from './lib/bridgeConnection.js';
 import { BricklayerEyesDumper } from './lib/debugDumper.js';
+import { BricklayerStoreDumper } from './lib/storeDumper.js';
 import { ScenePropertiesPanel } from './panels/ScenePropertiesPanel.js';
 import { SettingsRightPanel } from './panels/SettingsRightPanel.js';
 import { WorldPropertiesPanel } from './panels/WorldPropertiesPanel.js';
@@ -227,15 +228,17 @@ export function App() {
     setRightWidth((w) => Math.max(200, Math.min(600, w + delta)));
   }, []);
 
-  // Debug dump: register eyes dumper + install triggers (Ctrl+Shift+D / console)
+  // Debug dump: register eyes + store dumpers + install triggers (Ctrl+Shift+D / console)
   useEffect(() => {
     const registry = DebugDumpRegistry.getInstance();
     registry.setSource('bricklayer');
-    const dumper = new BricklayerEyesDumper();
-    registry.register(dumper);
+    const eyesDumper = new BricklayerEyesDumper();
+    const storeDumper = new BricklayerStoreDumper();
+    registry.register(eyesDumper);
+    registry.register(storeDumper);
     installDebugDumpGlobal();
     installDebugDumpKeyboard();
-    return () => { registry.unregister(dumper); };
+    return () => { registry.unregister(eyesDumper); registry.unregister(storeDumper); };
   }, []);
 
   // Bootstrap (Phase 0.1 #2): on first load, restore the previously-used

--- a/tools/apps/bricklayer/src/lib/storeDumper.ts
+++ b/tools/apps/bricklayer/src/lib/storeDumper.ts
@@ -1,0 +1,88 @@
+import type { IDebugDumpable, StoreDump } from '@gseurat/debug-dump';
+import { useSceneStore } from '../store/useSceneStore.js';
+import { useWorldStore } from '../store/useWorldStore.js';
+
+/**
+ * Bricklayer "store" domain dumper — snapshots SceneStore + WorldStore state.
+ * Excludes non-serializable fields (FileSystemDirectoryHandle, Blob maps).
+ * Zero cost until triggered via Ctrl+Shift+D or console.
+ */
+export class BricklayerStoreDumper implements IDebugDumpable {
+  readonly debugDomain = 'store' as const;
+  readonly debugName = 'BricklayerStores';
+
+  dumpDebugState(): StoreDump {
+    const scene = useSceneStore.getState();
+    const world = useWorldStore.getState();
+
+    const warnings: string[] = [];
+    if (scene.isDirty) warnings.push('scene_dirty_unsaved');
+    if (world.dirty) warnings.push('world_dirty_unsaved');
+    if (!scene.bridgeConnectedPath) warnings.push('bridge_disconnected');
+
+    return {
+      store_name: 'BricklayerStores',
+      state: {
+        scene: {
+          projectName: scene.projectName,
+          bridgeConnectedPath: scene.bridgeConnectedPath,
+          isDirty: scene.isDirty,
+          lastSavedAt: scene.lastSavedAt,
+          activeNode: scene.activeNode,
+          selectedEntity: scene.selectedEntity,
+          inspectorTab: scene.inspectorTab,
+          selectedSettingsCategory: scene.selectedSettingsCategory,
+          gridWidth: scene.gridWidth,
+          gridDepth: scene.gridDepth,
+          grabMode: scene.grabMode,
+          grabAxisLock: scene.grabAxisLock,
+          orbitLocked: scene.orbitLocked,
+          editingSpline: scene.editingSpline,
+          showGrid: scene.showGrid,
+          showCollision: scene.showCollision,
+          showGizmos: scene.showGizmos,
+          showTerrainPly: scene.showTerrainPly,
+          showObjectPly: scene.showObjectPly,
+          stagingAutoSync: scene.stagingAutoSync,
+          stagingCameraLock: scene.stagingCameraLock,
+          cameraShowDebugVolumes: scene.cameraShowDebugVolumes,
+          // Entity counts (not full arrays — avoids multi-KB dumps)
+          counts: {
+            gameObjects: scene.gameObjects.length,
+            staticLights: scene.staticLights.length,
+            gsParticleEmitters: scene.gsParticleEmitters.length,
+            gsAnimations: scene.gsAnimations.length,
+            vfxInstances: scene.vfxInstances.length,
+            cameraVolumes: scene.cameraVolumes.length,
+            cameraTriggers: scene.cameraTriggers.length,
+            cameraRails: scene.cameraRails.length,
+            audioZones: scene.audioZones.length,
+            backgroundLayers: scene.backgroundLayers.length,
+            assets: scene.assets.length,
+            navZoneNames: scene.navZoneNames.length,
+          },
+          player: scene.player,
+          ambientColor: scene.ambientColor,
+          godRaysIntensity: scene.godRaysIntensity,
+          terrainPlyFile: scene.terrainPlyFile,
+          weather: { enabled: scene.weather.enabled, type: scene.weather.type },
+          dayNight: { enabled: scene.dayNight.enabled },
+        },
+        world: {
+          loaded: world.loaded,
+          dirty: world.dirty,
+          selectedEntity: world.selectedEntity,
+          editingChunkGrid: world.editingChunkGrid,
+          editingContext: world.editingContext,
+          counts: {
+            chunks: world.manifest.chunks.length,
+            streamingVolumes: world.manifest.streaming_volumes?.length ?? 0,
+            instances: world.manifest.instances?.length ?? 0,
+            portals: world.manifest.portals?.length ?? 0,
+          },
+        },
+      },
+      warnings,
+    };
+  }
+}

--- a/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/ScenePropertiesPanel.tsx
@@ -28,63 +28,71 @@ export function ScenePropertiesPanel() {
   const cameraRails = useSceneStore((s) => s.cameraRails);
   const audioZones = useSceneStore((s) => s.audioZones);
 
-  if (!selectedEntity) {
-    return <div style={styles.empty}>Select an entity in the scene tree</div>;
-  }
+  const content = (() => {
+    if (!selectedEntity) {
+      return <div style={styles.empty}>Select an entity in the scene tree</div>;
+    }
 
-  if (selectedEntity.type === 'game_object') {
-    const obj = gameObjects.find((o) => o.id === selectedEntity.id);
-    if (!obj) return <div style={styles.empty}>Game object not found</div>;
-    return <GameObjectProperties obj={obj} />;
-  }
+    if (selectedEntity.type === 'game_object') {
+      const obj = gameObjects.find((o) => o.id === selectedEntity.id);
+      if (!obj) return <div style={styles.empty}>Game object not found</div>;
+      return <GameObjectProperties obj={obj} />;
+    }
 
-  if (selectedEntity.type === 'light') {
-    const light = staticLights.find((l) => l.id === selectedEntity.id);
-    if (!light) return <div style={styles.empty}>Light not found</div>;
-    return <LightProperties light={light} />;
-  }
+    if (selectedEntity.type === 'light') {
+      const light = staticLights.find((l) => l.id === selectedEntity.id);
+      if (!light) return <div style={styles.empty}>Light not found</div>;
+      return <LightProperties light={light} />;
+    }
 
-  if (selectedEntity.type === 'gs_emitter') {
-    const emitter = gsParticleEmitters.find((e) => e.id === selectedEntity.id);
-    if (!emitter) return <div style={styles.empty}>Emitter not found</div>;
-    return <GsEmitterProperties emitter={emitter} />;
-  }
+    if (selectedEntity.type === 'gs_emitter') {
+      const emitter = gsParticleEmitters.find((e) => e.id === selectedEntity.id);
+      if (!emitter) return <div style={styles.empty}>Emitter not found</div>;
+      return <GsEmitterProperties emitter={emitter} />;
+    }
 
-  if (selectedEntity.type === 'gs_animation') {
-    const anim = gsAnimations.find((a) => a.id === selectedEntity.id);
-    if (!anim) return <div style={styles.empty}>Animation not found</div>;
-    return <GsAnimationProperties anim={anim} />;
-  }
+    if (selectedEntity.type === 'gs_animation') {
+      const anim = gsAnimations.find((a) => a.id === selectedEntity.id);
+      if (!anim) return <div style={styles.empty}>Animation not found</div>;
+      return <GsAnimationProperties anim={anim} />;
+    }
 
-  if (selectedEntity.type === 'vfx_instance') {
-    const vfx = vfxInstances.find((v) => v.id === selectedEntity.id);
-    if (!vfx) return <div style={styles.empty}>VFX instance not found</div>;
-    return <VfxInstanceProperties vfx={vfx} />;
-  }
+    if (selectedEntity.type === 'vfx_instance') {
+      const vfx = vfxInstances.find((v) => v.id === selectedEntity.id);
+      if (!vfx) return <div style={styles.empty}>VFX instance not found</div>;
+      return <VfxInstanceProperties vfx={vfx} />;
+    }
 
-  if (selectedEntity.type === 'camera_volume') {
-    const vol = cameraVolumes.find((v) => v.id === selectedEntity.id);
-    if (!vol) return <div style={styles.empty}>Camera volume not found</div>;
-    return <CameraVolumeEditor volume={vol} />;
-  }
+    if (selectedEntity.type === 'camera_volume') {
+      const vol = cameraVolumes.find((v) => v.id === selectedEntity.id);
+      if (!vol) return <div style={styles.empty}>Camera volume not found</div>;
+      return <CameraVolumeEditor volume={vol} />;
+    }
 
-  if (selectedEntity.type === 'camera_trigger') {
-    const trig = cameraTriggers.find((t) => t.id === selectedEntity.id);
-    if (!trig) return <div style={styles.empty}>Camera trigger not found</div>;
-    return <CameraTriggerEditor trigger={trig} />;
-  }
+    if (selectedEntity.type === 'camera_trigger') {
+      const trig = cameraTriggers.find((t) => t.id === selectedEntity.id);
+      if (!trig) return <div style={styles.empty}>Camera trigger not found</div>;
+      return <CameraTriggerEditor trigger={trig} />;
+    }
 
-  if (selectedEntity.type === 'camera_rail') {
-    const rail = cameraRails.find((r) => r.id === selectedEntity.id);
-    if (!rail) return <div style={styles.empty}>Camera rail not found</div>;
-    return <CameraRailEditor rail={rail} />;
-  }
+    if (selectedEntity.type === 'camera_rail') {
+      const rail = cameraRails.find((r) => r.id === selectedEntity.id);
+      if (!rail) return <div style={styles.empty}>Camera rail not found</div>;
+      return <CameraRailEditor rail={rail} />;
+    }
 
-  if (selectedEntity.type === 'audio_zone') {
-    const zone = audioZones.find((z) => z.id === selectedEntity.id);
-    if (!zone) return <div style={styles.empty}>Audio zone not found</div>;
-    return <AudioZoneProperties zone={zone} />;
-  }
+    if (selectedEntity.type === 'audio_zone') {
+      const zone = audioZones.find((z) => z.id === selectedEntity.id);
+      if (!zone) return <div style={styles.empty}>Audio zone not found</div>;
+      return <AudioZoneProperties zone={zone} />;
+    }
 
-  return <div style={styles.empty}>Unknown entity type</div>;
+    return <div style={styles.empty}>Unknown entity type</div>;
+  })();
+
+  return (
+    <div data-panel-id="scene-properties-panel">
+      {content}
+    </div>
+  );
 }

--- a/tools/apps/bricklayer/src/panels/SettingsLeftPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/SettingsLeftPanel.tsx
@@ -36,7 +36,7 @@ export function SettingsLeftPanel() {
   const setSelected = useSceneStore((s) => s.setSelectedSettingsCategory);
 
   return (
-    <div>
+    <div data-panel-id="settings-left-panel">
       {categories.map((cat) => (
         <button
           key={cat.id}

--- a/tools/apps/bricklayer/src/panels/SettingsRightPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/SettingsRightPanel.tsx
@@ -25,7 +25,7 @@ export function SettingsRightPanel() {
   const category = useSceneStore((s) => s.selectedSettingsCategory);
 
   return (
-    <div>
+    <div data-panel-id="settings-right-panel">
       {category === 'gs_camera' && (
         <>
           <div style={styles.heading}>GS Camera & Render</div>

--- a/tools/apps/bricklayer/src/panels/WorldPropertiesPanel.tsx
+++ b/tools/apps/bricklayer/src/panels/WorldPropertiesPanel.tsx
@@ -478,7 +478,7 @@ export function WorldPropertiesPanel() {
   const selectedEntity = useWorldStore((s) => s.selectedEntity);
 
   return (
-    <div style={{ color: '#ccc', fontSize: 12 }}>
+    <div data-panel-id="world-properties-panel" style={{ color: '#ccc', fontSize: 12 }}>
       <WorldSettingsEditor />
 
       {selectedEntity?.type === 'chunk' && (

--- a/tools/apps/bricklayer/src/panels/WorldTree.tsx
+++ b/tools/apps/bricklayer/src/panels/WorldTree.tsx
@@ -106,7 +106,7 @@ export function WorldTree() {
   };
 
   return (
-    <div style={styles.root}>
+    <div data-panel-id="world-tree" style={styles.root}>
       {/* Chunks */}
       <div style={styles.section}>
         <div style={styles.sectionHeader}>

--- a/tools/apps/echidna/src/App.tsx
+++ b/tools/apps/echidna/src/App.tsx
@@ -19,6 +19,7 @@ import {
   installDebugDumpKeyboard,
 } from '@gseurat/debug-dump';
 import { EchidnaEyesDumper } from './lib/debugDumper.js';
+import { EchidnaStoreDumper } from './lib/storeDumper.js';
 
 const styles: Record<string, React.CSSProperties> = {
   root: {
@@ -163,15 +164,17 @@ export function App() {
     }
   }, []);
 
-  // Debug dump: register eyes dumper + install triggers (Ctrl+Shift+D / console)
+  // Debug dump: register eyes + store dumpers + install triggers (Ctrl+Shift+D / console)
   useEffect(() => {
     const registry = DebugDumpRegistry.getInstance();
     registry.setSource('echidna');
-    const dumper = new EchidnaEyesDumper();
-    registry.register(dumper);
+    const eyesDumper = new EchidnaEyesDumper();
+    const storeDumper = new EchidnaStoreDumper();
+    registry.register(eyesDumper);
+    registry.register(storeDumper);
     installDebugDumpGlobal();
     installDebugDumpKeyboard();
-    return () => { registry.unregister(dumper); };
+    return () => { registry.unregister(eyesDumper); registry.unregister(storeDumper); };
   }, []);
 
   // Bootstrap: restore project root handle from IDB on startup

--- a/tools/apps/echidna/src/lib/storeDumper.ts
+++ b/tools/apps/echidna/src/lib/storeDumper.ts
@@ -1,0 +1,75 @@
+import type { IDebugDumpable, StoreDump } from '@gseurat/debug-dump';
+import { useCharacterStore } from '../store/useCharacterStore.js';
+
+/**
+ * Echidna "store" domain dumper — snapshots CharacterStore state.
+ * Excludes non-serializable fields (FileSystemDirectoryHandle, undo/redo stacks).
+ * Zero cost until triggered via Ctrl+Shift+D or console.
+ */
+export class EchidnaStoreDumper implements IDebugDumpable {
+  readonly debugDomain = 'store' as const;
+  readonly debugName = 'EchidnaCharacterStore';
+
+  dumpDebugState(): StoreDump {
+    const s = useCharacterStore.getState();
+
+    const warnings: string[] = [];
+    if (s.dirty) warnings.push('dirty_unsaved');
+    if (s.undoStack.length > 50) warnings.push('undo_stack_deep');
+    if (!s.asset) warnings.push('no_asset_loaded');
+
+    return {
+      store_name: 'CharacterStore',
+      state: {
+        mode: s.mode,
+        dirty: s.dirty,
+        activeTool: s.activeTool,
+        activeColor: s.activeColor,
+        brushSize: s.brushSize,
+        activePaletteIndex: s.activePaletteIndex,
+        selectedPart: s.selectedPart,
+        selectedPose: s.selectedPose,
+        previewPose: s.previewPose,
+        showGrid: s.showGrid,
+        showGizmos: s.showGizmos,
+        yClip: s.yClip,
+        mirrorAxis: s.mirrorAxis,
+        colorByPart: s.colorByPart,
+        xrayMode: s.xrayMode,
+        yLevelLock: s.yLevelLock,
+        onionSkinning: s.onionSkinning,
+        selectedAnimation: s.selectedAnimation,
+        playbackTime: s.playbackTime,
+        isPlaying: s.isPlaying,
+        playbackSpeed: s.playbackSpeed,
+        playbackMode: s.playbackMode,
+        hasClipboard: s.clipboard !== null,
+        hasBoxSelection: s.boxSelection !== null,
+        hasLassoSelection: s.lassoSelection !== null,
+        counts: {
+          knownAssets: s.knownAssets.length,
+          undoStack: s.undoStack.length,
+          redoStack: s.redoStack.length,
+          parts: s.asset?.characterParts?.length ?? 0,
+          poses: Object.keys(s.asset?.characterPoses ?? {}).length,
+          animations: Object.keys(s.asset?.animations ?? {}).length,
+          voxels: s.asset?.voxels?.size ?? 0,
+        },
+        asset: s.asset
+          ? {
+              id: s.asset.id,
+              kind: s.asset.kind,
+              name: s.asset.characterName,
+              gridWidth: s.asset.gridWidth,
+              gridDepth: s.asset.gridDepth,
+              partCount: s.asset.characterParts?.length ?? 0,
+              poseCount: Object.keys(s.asset.characterPoses ?? {}).length,
+              animationCount: Object.keys(s.asset.animations ?? {}).length,
+              voxelCount: s.asset.voxels?.size ?? 0,
+            }
+          : null,
+      },
+      warnings,
+    };
+  }
+}

--- a/tools/apps/melies/src/App.tsx
+++ b/tools/apps/melies/src/App.tsx
@@ -6,6 +6,7 @@ import {
   installDebugDumpKeyboard,
 } from '@gseurat/debug-dump';
 import { MeliesEyesDumper } from './lib/debugDumper.js';
+import { MeliesStoreDumper } from './lib/storeDumper.js';
 import { useVfxStore, playbackTimeRef } from './store/useVfxStore.js';
 import type { VfxPreset, VfxElement, ElementType } from './store/types.js';
 type VfxLayer = VfxElement;
@@ -842,15 +843,17 @@ export function App() {
   const scenePoints = useVfxStore((s) => s.scenePoints);
   const storeSetScenePoints = useVfxStore((s) => s.setScenePoints);
 
-  // Debug dump: register eyes dumper + install triggers (Ctrl+Shift+D / console)
+  // Debug dump: register eyes + store dumpers + install triggers (Ctrl+Shift+D / console)
   useEffect(() => {
     const registry = DebugDumpRegistry.getInstance();
     registry.setSource('melies');
-    const dumper = new MeliesEyesDumper();
-    registry.register(dumper);
+    const eyesDumper = new MeliesEyesDumper();
+    const storeDumper = new MeliesStoreDumper();
+    registry.register(eyesDumper);
+    registry.register(storeDumper);
     installDebugDumpGlobal();
     installDebugDumpKeyboard();
-    return () => { registry.unregister(dumper); };
+    return () => { registry.unregister(eyesDumper); registry.unregister(storeDumper); };
   }, []);
 
   const handleImportScene = useCallback(() => {

--- a/tools/apps/melies/src/lib/storeDumper.ts
+++ b/tools/apps/melies/src/lib/storeDumper.ts
@@ -1,0 +1,49 @@
+import type { IDebugDumpable, StoreDump } from '@gseurat/debug-dump';
+import { useVfxStore } from '../store/useVfxStore.js';
+
+/**
+ * Melies "store" domain dumper — snapshots VfxStore state.
+ * Excludes non-serializable fields (FileSystemDirectoryHandle, PlyPoint arrays).
+ * Zero cost until triggered via Ctrl+Shift+D or console.
+ */
+export class MeliesStoreDumper implements IDebugDumpable {
+  readonly debugDomain = 'store' as const;
+  readonly debugName = 'MeliesVfxStore';
+
+  dumpDebugState(): StoreDump {
+    const s = useVfxStore.getState();
+
+    const warnings: string[] = [];
+    if (s.isDirty) warnings.push('dirty_unsaved');
+    if (s.soloLayerIds.length > 0) warnings.push('solo_active');
+    if (s.presets.length === 0) warnings.push('no_presets');
+
+    return {
+      store_name: 'VfxStore',
+      state: {
+        projectName: s.projectName,
+        isDirty: s.isDirty,
+        selectedPresetId: s.selectedPresetId,
+        selectedLayerId: s.selectedLayerId,
+        selectedView: s.selectedView,
+        showGizmos: s.showGizmos,
+        showPointCloud: s.showPointCloud,
+        stagingAutoSync: s.stagingAutoSync,
+        playing: s.playing,
+        playbackTime: s.playbackTime,
+        mutedLayerIds: s.mutedLayerIds,
+        soloLayerIds: s.soloLayerIds,
+        activeSceneId: s.activeSceneId,
+        counts: {
+          presets: s.presets.length,
+          layers: s.selectedPresetId
+            ? (s.presets.find((p) => p.id === s.selectedPresetId)?.elements?.length ?? 0)
+            : 0,
+          scenes: s.scenes.length,
+          scenePoints: s.scenePoints.length,
+        },
+      },
+      warnings,
+    };
+  }
+}

--- a/tools/packages/debug-dump/src/index.ts
+++ b/tools/packages/debug-dump/src/index.ts
@@ -17,6 +17,7 @@ export type {
   EyesState,
   EyesWarning,
   IDebugDumpable,
+  StoreDump,
   TrackGroupStatus,
 } from "./types.js";
 

--- a/tools/packages/debug-dump/src/registry.ts
+++ b/tools/packages/debug-dump/src/registry.ts
@@ -9,6 +9,7 @@ import type {
   EyesComponentNode,
   EyesDump,
   IDebugDumpable,
+  StoreDump,
 } from "./types.js";
 
 // Empty sentinel objects — avoids allocations when a domain has no registrants.
@@ -67,6 +68,7 @@ export class DebugDumpRegistry {
   collectAll(): DebugDumpEnvelope {
     const eyesComponents: EyesComponentNode[] = [];
     let earsDump: EarsDump | null = null;
+    const storeDumps: StoreDump[] = [];
 
     for (const mod of this.modules) {
       const state = mod.dumpDebugState();
@@ -74,7 +76,7 @@ export class DebugDumpRegistry {
       if (mod.debugDomain === "eyes") {
         // Eyes modules return EyesComponentNode[]
         eyesComponents.push(...(state as EyesComponentNode[]));
-      } else {
+      } else if (mod.debugDomain === "ears") {
         // Ears modules return EarsDump — merge if multiple
         const dump = state as EarsDump;
         if (!earsDump) {
@@ -85,6 +87,9 @@ export class DebugDumpRegistry {
           earsDump.warnings.push(...dump.warnings);
           // Keep the first global state (primary audio module wins)
         }
+      } else {
+        // Store modules return StoreDump
+        storeDumps.push(state as StoreDump);
       }
     }
 
@@ -94,6 +99,7 @@ export class DebugDumpRegistry {
       source: this.source,
       eyes: eyesComponents.length > 0 ? { components: eyesComponents } : EMPTY_EYES,
       ears: earsDump ?? EMPTY_EARS,
+      store: storeDumps,
     };
   }
 
@@ -101,7 +107,7 @@ export class DebugDumpRegistry {
    * Collect from a single domain only.
    * Useful when debugging just UI or just audio.
    */
-  collectDomain(domain: DebugDomain): EyesDump | EarsDump {
+  collectDomain(domain: DebugDomain): EyesDump | EarsDump | StoreDump[] {
     if (domain === "eyes") {
       const components: EyesComponentNode[] = [];
       for (const mod of this.modules) {
@@ -110,6 +116,16 @@ export class DebugDumpRegistry {
         }
       }
       return { components };
+    }
+
+    if (domain === "store") {
+      const stores: StoreDump[] = [];
+      for (const mod of this.modules) {
+        if (mod.debugDomain === "store") {
+          stores.push(mod.dumpDebugState() as StoreDump);
+        }
+      }
+      return stores;
     }
 
     // ears

--- a/tools/packages/debug-dump/src/types.ts
+++ b/tools/packages/debug-dump/src/types.ts
@@ -5,7 +5,7 @@
 // Domain tag — partitions the dump into "eyes" (UI/layout) and "ears" (audio)
 // ---------------------------------------------------------------------------
 
-export type DebugDomain = "eyes" | "ears";
+export type DebugDomain = "eyes" | "ears" | "store";
 
 // ---------------------------------------------------------------------------
 // Eyes (UI / Layout) schema
@@ -111,6 +111,19 @@ export interface EarsDump {
 }
 
 // ---------------------------------------------------------------------------
+// Store (Application State) schema
+// ---------------------------------------------------------------------------
+
+export interface StoreDump {
+  /** Name of the store (e.g. "SceneStore", "VfxStore"). */
+  store_name: string;
+  /** JSON-serializable snapshot of the store's state fields. */
+  state: Record<string, unknown>;
+  /** Optional warnings (e.g. "undo_stack_deep", "dirty_unsaved"). */
+  warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
 // Core interface — every dumpable module implements this
 // ---------------------------------------------------------------------------
 
@@ -123,9 +136,9 @@ export interface IDebugDumpable {
 
   /**
    * Gather current state. Called ONLY on explicit request — never on a hot path.
-   * Return the domain-specific payload (EyesComponentNode[] or EarsDump).
+   * Return the domain-specific payload.
    */
-  dumpDebugState(): EyesComponentNode[] | EarsDump;
+  dumpDebugState(): EyesComponentNode[] | EarsDump | StoreDump;
 }
 
 // ---------------------------------------------------------------------------
@@ -146,4 +159,5 @@ export interface DebugDumpEnvelope {
   source: DebugDumpSource;
   eyes: EyesDump;
   ears: EarsDump;
+  store: StoreDump[];
 }


### PR DESCRIPTION
## Summary
- **New `store` domain** in `@gseurat/debug-dump` schema — adds `StoreDump` type and `store: StoreDump[]` to the envelope, alongside existing `eyes` and `ears`
- **Bricklayer panel coverage** — added `data-panel-id` to 5 panels (ScenePropertiesPanel, WorldPropertiesPanel, SettingsLeftPanel, SettingsRightPanel, WorldTree), bringing tracked panels from 5 to 10
- **Store dumpers** for Bricklayer (SceneStore + WorldStore), Melies (VfxStore), and Echidna (CharacterStore) — registered in each App.tsx with proper cleanup

## Design
- Store snapshots use **counts, not full arrays** to keep dumps clipboard-friendly
- Non-serializable fields (FileSystemDirectoryHandle, Map, Blob) are excluded
- Warnings surface actionable state: `dirty_unsaved`, `bridge_disconnected`, `undo_stack_deep`, `solo_active`, `no_asset_loaded`

## Test plan
- [ ] `pnpm tsc --noEmit` passes for debug-dump, bricklayer, melies, echidna
- [ ] `pnpm --filter bricklayer build` / `--filter melies` / `--filter echidna` all succeed
- [ ] Ctrl+Shift+D in Bricklayer produces JSON with `eyes.components` containing 10 panels and `store[0]` containing scene/world state
- [ ] Ctrl+Shift+D in Melies produces `store[0]` with VfxStore snapshot
- [ ] Ctrl+Shift+D in Echidna produces `store[0]` with CharacterStore snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)