### PR TITLE
fix(engine,bricklayer): reset terrain state on scene switch

### DIFF
--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -358,6 +358,7 @@ void AppBase::init_scene(const std::string& /*scene_path*/) {}
 void AppBase::clear_scene() {
     world_.clear();
     bone_anim_registry_.clear();
+    gs_terrain_.reset();
 }
 
 // ITransitionHost default: clear, load, then move PlayerTag (if any) into place.

--- a/tools/apps/bricklayer/src/store/useSceneStore.ts
+++ b/tools/apps/bricklayer/src/store/useSceneStore.ts
@@ -863,6 +863,7 @@ export const useSceneStore = create<SceneStoreState>((set, get) => ({
     });
     set({
       terrainAabb: null,  // Reset before new PLY loads to avoid stale offset
+      terrainPlyFile: '',  // Clear old PLY path to force PlyPointCloud reload
       gridWidth: data.gridWidth,
       gridDepth: data.gridDepth,
       collisionGridData: data.collisionGridData ?? null,


### PR DESCRIPTION
## Summary
- **Engine**: Call `gs_terrain_.reset()` in `AppBase::clear_scene()` — the method existed but was never invoked, leaving `terrain_aabb`, parallax state, PBD anchors, and bone allocations stale across scene switches
- **Bricklayer**: Clear `terrainPlyFile` in `loadProject()` alongside `terrainAabb` to force `PlyPointCloud` to fully reload on scene switch

## Root Cause
`GsTerrainState::reset()` (defined at `gs_terrain_state.hpp:46-48`) was never called anywhere in the codebase. When switching scenes via `clear_scene()` → `init_scene()`, the old `terrain_aabb` persisted. The `update_scene_data` command then used the stale AABB for `coord::to_world()` transforms, placing game objects, lights, and emitters at incorrect world positions.

## Test plan
- [ ] `cmake --build --preset macos-debug` — 514 targets, 0 errors
- [ ] Load Seurat Island in Bricklayer → terrain aligns correctly
- [ ] Switch to dungeon scene → terrain updates
- [ ] Return to Seurat Island → terrain aligns correctly (previously misaligned)
- [ ] Verify parallax/PBD state doesn't leak between scenes

🤖 Generated with [Claude Code](https://claude.com/claude-code)