### PR TITLE
feat(tools): add ply2heightmap CLI for PLY-to-heightmap conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,15 @@ add_custom_target(sync_assets ALL
     DEPENDS shaders
 )
 
+add_executable(ply2heightmap src/tools/ply2heightmap.cpp
+    src/engine/gaussian_cloud.cpp
+    src/engine/project_root.cpp)
+target_include_directories(ply2heightmap PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR})
+target_compile_definitions(ply2heightmap PRIVATE GLM_FORCE_DEPTH_ZERO_TO_ONE)
+target_link_libraries(ply2heightmap PRIVATE glm::glm nlohmann_json::nlohmann_json)
+
 endif() # GSEURAT_BUILD_EXAMPLES
 
 # --- Tests ------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,6 +538,10 @@ add_gseurat_test(test_audio_effect_chain
     ${AUDIO_ENGINE_TEST_SOURCES})
 target_include_directories(test_audio_effect_chain PRIVATE ${PROJECT_SOURCE_DIR}/src/engine/audio)
 
+add_gseurat_test(test_ply2heightmap
+    src/engine/gaussian_cloud.cpp
+    src/engine/project_root.cpp)
+
 # --- GPU Tests (require actual GPU, link engine sources directly) ----------
 
 function(add_gseurat_gpu_test NAME)

--- a/docs/superpowers/plans/2026-04-27-ply2heightmap.md
+++ b/docs/superpowers/plans/2026-04-27-ply2heightmap.md
@@ -1,0 +1,960 @@
+# ply2heightmap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a CLI tool that converts Gaussian-splat PLY point clouds to 16-bit grayscale PNG heightmaps for the KCC collision pipeline.
+
+**Architecture:** Single-file CLI (`src/tools/ply2heightmap.cpp`) with free functions for rasterization, dilation, normalization, and 16-bit PNG writing. Reuses `GaussianCloud::load_ply()` for input. Tests exercise the core functions directly.
+
+**Tech Stack:** C++23, GLM, stb_image_write (zlib compress only), GaussianCloud
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `src/tools/ply2heightmap.cpp` | CLI entry point + all rasterizer functions |
+| `tests/test_ply2heightmap.cpp` | Headless unit tests for core functions |
+| `CMakeLists.txt` | Build targets for executable and test |
+
+---
+
+### Task 1: Scaffold the executable and build target
+
+**Files:**
+- Create: `src/tools/ply2heightmap.cpp`
+- Modify: `CMakeLists.txt:348` (before `endif() # GSEURAT_BUILD_EXAMPLES`)
+
+- [ ] **Step 1: Create the source file with a minimal main**
+
+```cpp
+// src/tools/ply2heightmap.cpp
+// ply2heightmap — Convert Gaussian-splat PLY to 16-bit heightmap PNG.
+
+#include "gseurat/engine/gaussian_cloud.hpp"
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include <algorithm>
+#include <cfloat>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace gseurat;
+
+// ── Forward declarations ─────────────────────────────────────────────────────
+
+struct HeightmapParams {
+    float ppu         = 2.0f;
+    float padding     = 1.0f;
+    float min_opacity = 0.1f;
+    bool  z_up        = false;
+};
+
+struct HeightmapResult {
+    std::vector<float> grid;    // height per cell (-FLT_MAX = no data)
+    uint32_t width  = 0;       // pixels (X axis)
+    uint32_t height = 0;       // pixels (Z axis)
+    float cell_size = 0.0f;
+    AABB  padded_aabb;
+};
+
+HeightmapResult rasterize_splats(const std::vector<Gaussian>& splats,
+                                  const AABB& bounds,
+                                  const HeightmapParams& params);
+
+void dilate_gaps(const std::vector<float>& src, std::vector<float>& dst,
+                 uint32_t w, uint32_t h);
+
+struct NormResult {
+    std::vector<uint16_t> pixels;
+    float min_height;
+    float max_height;
+};
+
+NormResult normalize_to_uint16(const std::vector<float>& grid,
+                                uint32_t w, uint32_t h);
+
+bool write_png_16(const char* path, const uint16_t* data,
+                  uint32_t w, uint32_t h);
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+int main(int argc, char* argv[]) {
+    if (argc < 3) {
+        std::fprintf(stderr,
+            "Usage: ply2heightmap <input.ply> <output.png> [options]\n"
+            "\n"
+            "Options:\n"
+            "  --ppu <float>          Pixels per world-unit (default: 2.0)\n"
+            "  --padding <float>      Extra world-units around AABB (default: 1.0)\n"
+            "  --min-opacity <float>  Skip splats below this opacity (default: 0.1)\n"
+            "  --z-up                 Interpret Z as height (default: Y-up)\n");
+        return 1;
+    }
+
+    const char* input_path  = argv[1];
+    const char* output_path = argv[2];
+
+    HeightmapParams params;
+    for (int i = 3; i < argc; ++i) {
+        std::string_view arg(argv[i]);
+        if (arg == "--ppu" && i + 1 < argc)         params.ppu = std::atof(argv[++i]);
+        else if (arg == "--padding" && i + 1 < argc) params.padding = std::atof(argv[++i]);
+        else if (arg == "--min-opacity" && i + 1 < argc) params.min_opacity = std::atof(argv[++i]);
+        else if (arg == "--z-up")                     params.z_up = true;
+        else {
+            std::fprintf(stderr, "Unknown option: %s\n", argv[i]);
+            return 1;
+        }
+    }
+
+    // Load PLY
+    GaussianCloud cloud;
+    try {
+        cloud = GaussianCloud::load_ply(input_path);
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "Error loading PLY: %s\n", e.what());
+        return 1;
+    }
+
+    if (cloud.empty()) {
+        std::fprintf(stderr, "Error: PLY contains no splats.\n");
+        return 1;
+    }
+
+    // Filter by opacity
+    std::vector<Gaussian> filtered;
+    filtered.reserve(cloud.count());
+    for (const auto& g : cloud.gaussians()) {
+        if (g.opacity >= params.min_opacity) {
+            filtered.push_back(g);
+        }
+    }
+
+    uint32_t skipped = cloud.count() - static_cast<uint32_t>(filtered.size());
+    if (filtered.empty()) {
+        std::fprintf(stderr, "Error: All %u splats filtered below opacity %.2f.\n",
+                     cloud.count(), params.min_opacity);
+        return 1;
+    }
+
+    // Z-up swap: rotate positions and scales so Y becomes height
+    if (params.z_up) {
+        for (auto& g : filtered) {
+            std::swap(g.position.y, g.position.z);
+            std::swap(g.scale.y, g.scale.z);
+            // Swap quaternion components to match axis swap
+            std::swap(g.rotation.y, g.rotation.z);
+        }
+    }
+
+    // Compute bounds from filtered splats
+    AABB bounds;
+    for (const auto& g : filtered) bounds.expand(g.position);
+
+    // Rasterize
+    auto result = rasterize_splats(filtered, bounds, params);
+
+    // Dilate gaps (double-buffered)
+    std::vector<float> dilated(result.grid.size());
+    dilate_gaps(result.grid, dilated, result.width, result.height);
+
+    // Normalize to uint16
+    auto norm = normalize_to_uint16(dilated, result.width, result.height);
+
+    // Write PNG
+    if (!write_png_16(output_path, norm.pixels.data(), result.width, result.height)) {
+        std::fprintf(stderr, "Error: Failed to write PNG to %s\n", output_path);
+        return 1;
+    }
+
+    // Print summary to stdout
+    const auto& aabb = result.padded_aabb;
+    float world_w = aabb.max.x - aabb.min.x;
+    float world_l = aabb.max.z - aabb.min.z;
+
+    std::printf("Loaded %u splats from %s (filtered %u below opacity %.2f)\n",
+                static_cast<uint32_t>(filtered.size()) + skipped,
+                input_path, skipped, params.min_opacity);
+    std::printf("AABB: (%.1f, %.1f, %.1f) -> (%.1f, %.1f, %.1f)\n",
+                aabb.min.x, aabb.min.y, aabb.min.z,
+                aabb.max.x, aabb.max.y, aabb.max.z);
+    std::printf("Grid: %ux%u, cell_size=%.3f, ppu=%.1f\n",
+                result.width, result.height, result.cell_size, params.ppu);
+    std::printf("Height range: %.3f -> %.3f\n", norm.min_height, norm.max_height);
+    std::printf("Wrote: %s\n\n", output_path);
+    std::printf("# HeightfieldComponent values:\n");
+    std::printf("  \"width\": %.1f\n", world_w);
+    std::printf("  \"length\": %.1f\n", world_l);
+    std::printf("  \"min_height\": %.3f\n", norm.min_height);
+    std::printf("  \"max_height\": %.3f\n", norm.max_height);
+
+    return 0;
+}
+```
+
+- [ ] **Step 2: Add CMake targets**
+
+Insert before `endif() # GSEURAT_BUILD_EXAMPLES` in `CMakeLists.txt` (around line 348):
+
+```cmake
+add_executable(ply2heightmap src/tools/ply2heightmap.cpp
+    src/engine/gaussian_cloud.cpp)
+target_include_directories(ply2heightmap PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR})
+target_compile_definitions(ply2heightmap PRIVATE GLM_FORCE_DEPTH_ZERO_TO_ONE)
+target_link_libraries(ply2heightmap PRIVATE glm::glm nlohmann_json::nlohmann_json)
+```
+
+- [ ] **Step 3: Create the src/tools directory**
+
+```bash
+mkdir -p src/tools
+```
+
+- [ ] **Step 4: Build to verify it compiles (link errors expected for unimplemented functions)**
+
+```bash
+cmake --build --preset macos-debug --target ply2heightmap -j8 2>&1 | tail -10
+```
+
+Expected: Linker errors for `rasterize_splats`, `dilate_gaps`, `normalize_to_uint16`, `write_png_16`. This confirms the scaffold is correct.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/ply2heightmap.cpp CMakeLists.txt
+git commit -m "feat(tools): scaffold ply2heightmap CLI with arg parsing and pipeline"
+```
+
+---
+
+### Task 2: Implement the AABB splat rasterizer
+
+**Files:**
+- Modify: `src/tools/ply2heightmap.cpp`
+
+- [ ] **Step 1: Implement `rasterize_splats`**
+
+Add after the forward declarations, before `main()`:
+
+```cpp
+// ── Rasterizer ───────────────────────────────────────────────────────────────
+
+HeightmapResult rasterize_splats(const std::vector<Gaussian>& splats,
+                                  const AABB& bounds,
+                                  const HeightmapParams& params) {
+    HeightmapResult result;
+
+    // Pad the AABB
+    result.padded_aabb.min = bounds.min - glm::vec3(params.padding);
+    result.padded_aabb.max = bounds.max + glm::vec3(params.padding);
+    const auto& aabb = result.padded_aabb;
+
+    // Compute grid dimensions (uniform square cells)
+    float ppu = params.ppu;
+    result.cell_size = 1.0f / ppu;
+    result.width  = static_cast<uint32_t>(
+        std::ceil((aabb.max.x - aabb.min.x) * ppu));
+    result.height = static_cast<uint32_t>(
+        std::ceil((aabb.max.z - aabb.min.z) * ppu));
+
+    // Clamp to at least 1x1
+    if (result.width  == 0) result.width  = 1;
+    if (result.height == 0) result.height = 1;
+
+    // Allocate grid, sentinel = no data
+    result.grid.assign(
+        static_cast<size_t>(result.width) * result.height, -FLT_MAX);
+
+    int w = static_cast<int>(result.width);
+    int h = static_cast<int>(result.height);
+
+    for (const auto& g : splats) {
+        // 1. Rotate scale axes by quaternion
+        glm::vec3 ax = g.rotation * glm::vec3(g.scale.x, 0.0f, 0.0f);
+        glm::vec3 ay = g.rotation * glm::vec3(0.0f, g.scale.y, 0.0f);
+        glm::vec3 az = g.rotation * glm::vec3(0.0f, 0.0f, g.scale.z);
+
+        // 2. AABB half-extents (sum of absolute components)
+        float half_x = std::abs(ax.x) + std::abs(ay.x) + std::abs(az.x);
+        float half_y = std::abs(ax.y) + std::abs(ay.y) + std::abs(az.y);
+        float half_z = std::abs(ax.z) + std::abs(ay.z) + std::abs(az.z);
+
+        // 3. Conservative top-of-splat Y
+        float top_y = g.position.y + half_y;
+
+        // 4. Map to grid cells
+        int x_min = static_cast<int>(
+            std::floor((g.position.x - half_x - aabb.min.x) * ppu));
+        int x_max = static_cast<int>(
+            std::floor((g.position.x + half_x - aabb.min.x) * ppu));
+        int z_min = static_cast<int>(
+            std::floor((g.position.z - half_z - aabb.min.z) * ppu));
+        int z_max = static_cast<int>(
+            std::floor((g.position.z + half_z - aabb.min.z) * ppu));
+
+        x_min = std::max(x_min, 0);
+        x_max = std::min(x_max, w - 1);
+        z_min = std::max(z_min, 0);
+        z_max = std::min(z_max, h - 1);
+
+        // 5. Fill cells with max Y
+        for (int z = z_min; z <= z_max; ++z) {
+            for (int x = x_min; x <= x_max; ++x) {
+                float& cell = result.grid[static_cast<size_t>(z) * w + x];
+                cell = std::max(cell, top_y);
+            }
+        }
+    }
+
+    return result;
+}
+```
+
+- [ ] **Step 2: Build to verify compilation**
+
+```bash
+cmake --build --preset macos-debug --target ply2heightmap -j8 2>&1 | tail -5
+```
+
+Expected: Linker errors only for `dilate_gaps`, `normalize_to_uint16`, `write_png_16`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tools/ply2heightmap.cpp
+git commit -m "feat(tools): implement AABB splat rasterizer for ply2heightmap"
+```
+
+---
+
+### Task 3: Implement dilation and normalization
+
+**Files:**
+- Modify: `src/tools/ply2heightmap.cpp`
+
+- [ ] **Step 1: Implement `dilate_gaps`**
+
+Add after `rasterize_splats`:
+
+```cpp
+// ── Gap fill (double-buffered 3x3 max dilation) ─────────────────────────────
+
+void dilate_gaps(const std::vector<float>& src, std::vector<float>& dst,
+                 uint32_t w, uint32_t h) {
+    dst = src;  // copy all valid cells
+
+    for (uint32_t z = 0; z < h; ++z) {
+        for (uint32_t x = 0; x < w; ++x) {
+            size_t idx = static_cast<size_t>(z) * w + x;
+            if (src[idx] != -FLT_MAX) continue;  // already filled
+
+            // 3x3 max of neighbors (read from src only)
+            float best = -FLT_MAX;
+            for (int dz = -1; dz <= 1; ++dz) {
+                for (int dx = -1; dx <= 1; ++dx) {
+                    int nx = static_cast<int>(x) + dx;
+                    int nz = static_cast<int>(z) + dz;
+                    if (nx < 0 || nx >= static_cast<int>(w)) continue;
+                    if (nz < 0 || nz >= static_cast<int>(h)) continue;
+                    float v = src[static_cast<size_t>(nz) * w + nx];
+                    if (v > best) best = v;
+                }
+            }
+            dst[idx] = best;  // may still be -FLT_MAX if no neighbors had data
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Implement `normalize_to_uint16`**
+
+Add after `dilate_gaps`:
+
+```cpp
+// ── Normalize to uint16 ─────────────────────────────────────────────────────
+
+NormResult normalize_to_uint16(const std::vector<float>& grid,
+                                uint32_t w, uint32_t h) {
+    NormResult result;
+    size_t total = static_cast<size_t>(w) * h;
+    result.pixels.resize(total);
+
+    // Find min/max of filled cells
+    float lo =  FLT_MAX;
+    float hi = -FLT_MAX;
+    for (size_t i = 0; i < total; ++i) {
+        if (grid[i] == -FLT_MAX) continue;
+        lo = std::min(lo, grid[i]);
+        hi = std::max(hi, grid[i]);
+    }
+
+    // Flat-world guard
+    if (hi - lo < 1e-5f) {
+        hi = lo + 1.0f;
+    }
+
+    // If no cells were filled at all, set sensible defaults
+    if (lo == FLT_MAX) {
+        lo = 0.0f;
+        hi = 1.0f;
+    }
+
+    result.min_height = lo;
+    result.max_height = hi;
+
+    float range = hi - lo;
+    for (size_t i = 0; i < total; ++i) {
+        if (grid[i] == -FLT_MAX) {
+            result.pixels[i] = 0;  // maps to min_height
+        } else {
+            float normalized = (grid[i] - lo) / range;
+            long val = std::lround(normalized * 65535.0f);
+            result.pixels[i] = static_cast<uint16_t>(
+                std::clamp(val, 0L, 65535L));
+        }
+    }
+
+    return result;
+}
+```
+
+- [ ] **Step 3: Build (should still have linker error for `write_png_16` only)**
+
+```bash
+cmake --build --preset macos-debug --target ply2heightmap -j8 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tools/ply2heightmap.cpp
+git commit -m "feat(tools): add gap dilation and uint16 normalization"
+```
+
+---
+
+### Task 4: Implement 16-bit PNG writer
+
+**Files:**
+- Modify: `src/tools/ply2heightmap.cpp`
+
+**Note:** `stbi_write_png` only supports 8-bit per channel. PNG format natively supports 16-bit grayscale. We write the PNG manually using `stbi_zlib_compress` (exposed by stb_image_write) for IDAT compression.
+
+- [ ] **Step 1: Implement `write_png_16`**
+
+Add after `normalize_to_uint16`:
+
+```cpp
+// ── 16-bit grayscale PNG writer ─────────────────────────────────────────────
+// PNG spec: 16-bit grayscale = color_type 0, bit_depth 16.
+// stb_image_write only supports 8-bit, so we construct the PNG manually
+// using stbi_zlib_compress for the IDAT payload.
+
+static void png_write_u32be(uint8_t* p, uint32_t v) {
+    p[0] = static_cast<uint8_t>((v >> 24) & 0xFF);
+    p[1] = static_cast<uint8_t>((v >> 16) & 0xFF);
+    p[2] = static_cast<uint8_t>((v >>  8) & 0xFF);
+    p[3] = static_cast<uint8_t>((v      ) & 0xFF);
+}
+
+static uint32_t png_crc32(const uint8_t* data, size_t len) {
+    // CRC-32 used by PNG (polynomial 0xEDB88320)
+    uint32_t crc = 0xFFFFFFFF;
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (int b = 0; b < 8; ++b) {
+            crc = (crc >> 1) ^ (0xEDB88320 & (-(crc & 1)));
+        }
+    }
+    return crc ^ 0xFFFFFFFF;
+}
+
+static bool png_write_chunk(FILE* f, const char type[4],
+                             const uint8_t* data, uint32_t len) {
+    uint8_t header[8];
+    png_write_u32be(header, len);
+    std::memcpy(header + 4, type, 4);
+
+    // CRC covers type + data
+    uint32_t crc_buf_len = 4 + len;
+    std::vector<uint8_t> crc_data(crc_buf_len);
+    std::memcpy(crc_data.data(), type, 4);
+    if (len > 0) std::memcpy(crc_data.data() + 4, data, len);
+    uint32_t crc = png_crc32(crc_data.data(), crc_buf_len);
+
+    uint8_t crc_bytes[4];
+    png_write_u32be(crc_bytes, crc);
+
+    if (std::fwrite(header, 1, 8, f) != 8) return false;
+    if (len > 0 && std::fwrite(data, 1, len, f) != len) return false;
+    if (std::fwrite(crc_bytes, 1, 4, f) != 4) return false;
+    return true;
+}
+
+bool write_png_16(const char* path, const uint16_t* data,
+                  uint32_t w, uint32_t h) {
+    FILE* f = std::fopen(path, "wb");
+    if (!f) return false;
+
+    // PNG signature
+    static const uint8_t sig[8] = {137, 80, 78, 71, 13, 10, 26, 10};
+    std::fwrite(sig, 1, 8, f);
+
+    // IHDR: 13 bytes — width, height, bit_depth=16, color_type=0 (grayscale)
+    uint8_t ihdr[13];
+    png_write_u32be(ihdr + 0, w);
+    png_write_u32be(ihdr + 4, h);
+    ihdr[8]  = 16;  // bit depth
+    ihdr[9]  = 0;   // color type: grayscale
+    ihdr[10] = 0;   // compression: deflate
+    ihdr[11] = 0;   // filter: adaptive
+    ihdr[12] = 0;   // interlace: none
+    if (!png_write_chunk(f, "IHDR", ihdr, 13)) { std::fclose(f); return false; }
+
+    // Build raw scanlines: each row = 1 filter byte + w * 2 bytes (big-endian)
+    size_t row_bytes = 1 + static_cast<size_t>(w) * 2;
+    std::vector<uint8_t> raw(row_bytes * h);
+    for (uint32_t y = 0; y < h; ++y) {
+        size_t row_off = y * row_bytes;
+        raw[row_off] = 0;  // filter: None
+        for (uint32_t x = 0; x < w; ++x) {
+            uint16_t val = data[y * w + x];
+            size_t px_off = row_off + 1 + static_cast<size_t>(x) * 2;
+            raw[px_off + 0] = static_cast<uint8_t>(val >> 8);    // big-endian
+            raw[px_off + 1] = static_cast<uint8_t>(val & 0xFF);
+        }
+    }
+
+    // Compress with stb's zlib
+    int zlen = 0;
+    unsigned char* zdata = stbi_zlib_compress(
+        raw.data(), static_cast<int>(raw.size()), &zlen,
+        stbi_write_png_compression_level);
+    if (!zdata) { std::fclose(f); return false; }
+
+    // IDAT
+    bool ok = png_write_chunk(f, "IDAT", zdata, static_cast<uint32_t>(zlen));
+    STBIW_FREE(zdata);
+    if (!ok) { std::fclose(f); return false; }
+
+    // IEND
+    png_write_chunk(f, "IEND", nullptr, 0);
+
+    std::fclose(f);
+    return true;
+}
+```
+
+- [ ] **Step 2: Build and verify full link succeeds**
+
+```bash
+cmake --build --preset macos-debug --target ply2heightmap -j8 2>&1 | tail -5
+```
+
+Expected: Clean build, no errors.
+
+- [ ] **Step 3: Smoke test with a real PLY file**
+
+```bash
+cd build/macos-debug
+./ply2heightmap ../../examples/island_demo/assets/maps/map.ply /tmp/test_heightmap.png --ppu 1.0
+```
+
+Expected: Prints summary with AABB, grid dimensions, HeightfieldComponent values. Creates a PNG file.
+
+- [ ] **Step 4: Verify the PNG is readable by stb**
+
+```bash
+# Quick check: file should exist and be non-empty
+ls -la /tmp/test_heightmap.png
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/ply2heightmap.cpp
+git commit -m "feat(tools): add 16-bit PNG writer using stb zlib compression"
+```
+
+---
+
+### Task 5: Write the test suite
+
+**Files:**
+- Create: `tests/test_ply2heightmap.cpp`
+- Modify: `CMakeLists.txt` (add test target)
+
+- [ ] **Step 1: Add test target to CMakeLists.txt**
+
+Add after the existing `add_gseurat_test` entries (around line 525):
+
+```cmake
+add_gseurat_test(test_ply2heightmap
+    src/engine/gaussian_cloud.cpp)
+```
+
+- [ ] **Step 2: Create the test file**
+
+```cpp
+// tests/test_ply2heightmap.cpp
+// Headless tests for ply2heightmap rasterizer functions.
+
+#include "gseurat/engine/gaussian_cloud.hpp"
+
+// Pull in the implementation directly (same pattern as other GSeurat tests).
+// We need the free functions but not main().
+#define PLY2HEIGHTMAP_NO_MAIN
+#include "../src/tools/ply2heightmap.cpp"
+
+#include <cassert>
+#include <cfloat>
+#include <cmath>
+#include <cstdio>
+
+static int passed = 0;
+static int failed = 0;
+
+static void check(bool cond, const char* msg) {
+    if (cond) { std::printf("  PASS: %s\n", msg); passed++; }
+    else      { std::printf("  FAIL: %s\n", msg); failed++; }
+}
+
+static bool approx(float a, float b, float eps = 0.1f) {
+    return std::abs(a - b) < eps;
+}
+
+// ── Helper: create a Gaussian at a given position with uniform scale ────────
+
+static Gaussian make_splat(float x, float y, float z,
+                            float scale = 0.5f, float opacity = 1.0f) {
+    Gaussian g{};
+    g.position = glm::vec3(x, y, z);
+    g.scale = glm::vec3(scale);
+    g.rotation = glm::quat(1, 0, 0, 0);  // identity
+    g.opacity = opacity;
+    g.importance = opacity * scale;
+    return g;
+}
+
+// ── Test 1: Flat plane ──────────────────────────────────────────────────────
+
+static void test_flat_plane() {
+    std::printf("\n-- Test 1: Flat plane --\n");
+
+    // 4 splats at Y=5.0 arranged in a 2x2 grid, scale=1.0 to cover the area
+    std::vector<Gaussian> splats = {
+        make_splat(1.0f, 5.0f, 1.0f, 1.0f),
+        make_splat(3.0f, 5.0f, 1.0f, 1.0f),
+        make_splat(1.0f, 5.0f, 3.0f, 1.0f),
+        make_splat(3.0f, 5.0f, 3.0f, 1.0f),
+    };
+
+    AABB bounds;
+    for (const auto& g : splats) bounds.expand(g.position);
+
+    HeightmapParams params;
+    params.ppu = 2.0f;
+    params.padding = 0.5f;
+
+    auto result = rasterize_splats(splats, bounds, params);
+
+    // Check that center cells have height data (not -FLT_MAX)
+    // The center of the grid corresponds to the splat region
+    uint32_t cx = result.width / 2;
+    uint32_t cz = result.height / 2;
+    float center_val = result.grid[static_cast<size_t>(cz) * result.width + cx];
+
+    check(center_val != -FLT_MAX, "center cell has data");
+    // Scale=1.0, identity rotation → half_y = 1.0 → top_y = 5.0 + 1.0 = 6.0
+    check(approx(center_val, 6.0f, 0.5f),
+          "center cell Y ≈ 6.0 (position.y + half_y)");
+
+    // Grid dimensions should be roughly (4+1)*2 = 10 x 10
+    check(result.width > 0 && result.height > 0, "grid has non-zero dimensions");
+}
+
+// ── Test 2: Gap fill ────────────────────────────────────────────────────────
+
+static void test_gap_fill() {
+    std::printf("\n-- Test 2: Gap fill (dilation) --\n");
+
+    // Create a 5x5 grid with one hole in the center
+    uint32_t w = 5, h = 5;
+    std::vector<float> grid(25, 10.0f);
+    grid[12] = -FLT_MAX;  // center cell = hole
+
+    std::vector<float> dilated(25);
+    dilate_gaps(grid, dilated, w, h);
+
+    check(dilated[12] != -FLT_MAX, "center hole was filled by dilation");
+    check(approx(dilated[12], 10.0f), "filled value = max of neighbors (10.0)");
+
+    // Verify non-hole cells are unchanged
+    check(approx(dilated[0], 10.0f), "corner cell unchanged after dilation");
+}
+
+// ── Test 3: Flat-world guard (no NaN) ───────────────────────────────────────
+
+static void test_flat_world() {
+    std::printf("\n-- Test 3: Flat-world guard --\n");
+
+    // All cells at exactly the same height
+    uint32_t w = 4, h = 4;
+    std::vector<float> grid(16, 42.0f);
+
+    auto norm = normalize_to_uint16(grid, w, h);
+
+    check(norm.max_height > norm.min_height,
+          "max_height > min_height (guard applied)");
+    check(norm.max_height - norm.min_height >= 0.9f,
+          "height range >= 1.0 (flat-world fallback)");
+
+    // No NaN in output
+    bool has_nan = false;
+    for (auto px : norm.pixels) {
+        if (px != px) has_nan = true;  // NaN check for uint16 is always false, but check the float path
+    }
+    check(!has_nan, "no NaN in output pixels");
+
+    // All pixels should be the same value (flat surface)
+    uint16_t first = norm.pixels[0];
+    bool all_same = true;
+    for (auto px : norm.pixels) {
+        if (px != first) all_same = false;
+    }
+    check(all_same, "all pixels identical for flat input");
+}
+
+// ── Test 4: Opacity filter ──────────────────────────────────────────────────
+
+static void test_opacity_filter() {
+    std::printf("\n-- Test 4: Opacity filter --\n");
+
+    // Two splats: one visible (opacity=1.0 at Y=5), one ghostly (opacity=0.01 at Y=100)
+    std::vector<Gaussian> all_splats = {
+        make_splat(2.0f, 5.0f, 2.0f, 1.0f, 1.0f),    // visible floor
+        make_splat(2.0f, 100.0f, 2.0f, 1.0f, 0.01f),  // ghost ceiling
+    };
+
+    // Filter manually (same as main() does)
+    std::vector<Gaussian> filtered;
+    float min_opacity = 0.1f;
+    for (const auto& g : all_splats) {
+        if (g.opacity >= min_opacity) filtered.push_back(g);
+    }
+
+    check(filtered.size() == 1, "ghost splat filtered out");
+    check(approx(filtered[0].position.y, 5.0f), "remaining splat is the floor");
+}
+
+// ── Test 5: AABB footprint ──────────────────────────────────────────────────
+
+static void test_aabb_footprint() {
+    std::printf("\n-- Test 5: AABB footprint --\n");
+
+    // Single large splat at origin, scale = (2, 1, 3), identity rotation
+    // Expected half_x = 2.0, half_z = 3.0 → covers 4x6 world units
+    // At ppu=1.0 with padding=0: grid should be ~4x6 pixels
+    Gaussian g{};
+    g.position = glm::vec3(0.0f);
+    g.scale = glm::vec3(2.0f, 1.0f, 3.0f);
+    g.rotation = glm::quat(1, 0, 0, 0);
+    g.opacity = 1.0f;
+
+    std::vector<Gaussian> splats = {g};
+    AABB bounds;
+    bounds.expand(g.position);
+
+    HeightmapParams params;
+    params.ppu = 1.0f;
+    params.padding = 0.0f;
+
+    auto result = rasterize_splats(splats, bounds, params);
+
+    // With padding=0, AABB is (0,0,0)→(0,0,0), grid is 1x1.
+    // But the splat's footprint extends ±2 in X and ±3 in Z from position (0,0,0).
+    // The grid only covers [aabb.min.x, aabb.max.x], so cells outside are clamped.
+    // With padding=0 on a single point, the grid is tiny.
+    // Let's test with padding that captures the footprint:
+    params.padding = 3.5f;  // captures the full ±3 Z extent
+    result = rasterize_splats(splats, bounds, params);
+
+    // Count filled cells
+    uint32_t filled = 0;
+    for (float v : result.grid) {
+        if (v != -FLT_MAX) filled++;
+    }
+
+    // Expected: the splat covers a 4x6 area (half_x=2 → 4 wide, half_z=3 → 6 tall)
+    // At ppu=1.0 that's roughly 4*6 = 24 cells, but with rounding it may be ±2
+    check(filled >= 20 && filled <= 35,
+          "splat covers approximately 24 cells (±5 for rounding)");
+
+    // Top Y should be position.y + half_y = 0 + 1 = 1.0
+    for (size_t i = 0; i < result.grid.size(); ++i) {
+        if (result.grid[i] != -FLT_MAX) {
+            check(approx(result.grid[i], 1.0f),
+                  "filled cell Y ≈ 1.0 (position.y + half_y)");
+            break;
+        }
+    }
+}
+
+// ── Test 6: 16-bit PNG round-trip ───────────────────────────────────────────
+
+static void test_png_roundtrip() {
+    std::printf("\n-- Test 6: 16-bit PNG round-trip --\n");
+
+    // Write a small 4x4 16-bit PNG, then verify file exists and is non-empty
+    uint32_t w = 4, h = 4;
+    std::vector<uint16_t> pixels(16);
+    for (uint32_t i = 0; i < 16; ++i) {
+        pixels[i] = static_cast<uint16_t>(i * 4096);  // 0, 4096, 8192, ...
+    }
+
+    const char* path = "/tmp/test_ply2hm_roundtrip.png";
+    bool ok = write_png_16(path, pixels.data(), w, h);
+    check(ok, "write_png_16 succeeded");
+
+    // Verify file exists and has reasonable size (PNG header alone is ~8 bytes)
+    FILE* f = std::fopen(path, "rb");
+    check(f != nullptr, "output PNG file exists");
+    if (f) {
+        std::fseek(f, 0, SEEK_END);
+        long size = std::ftell(f);
+        std::fclose(f);
+        check(size > 50, "output PNG has reasonable size (> 50 bytes)");
+    }
+
+    // Clean up
+    std::remove(path);
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+int main() {
+    std::printf("=== test_ply2heightmap ===\n");
+
+    test_flat_plane();
+    test_gap_fill();
+    test_flat_world();
+    test_opacity_filter();
+    test_aabb_footprint();
+    test_png_roundtrip();
+
+    std::printf("\n=== Results: %d passed, %d failed ===\n", passed, failed);
+    return failed > 0 ? 1 : 0;
+}
+```
+
+- [ ] **Step 3: Guard main() in ply2heightmap.cpp for test inclusion**
+
+Add at the top of `main()` in `src/tools/ply2heightmap.cpp`, wrap the main function:
+
+```cpp
+#ifndef PLY2HEIGHTMAP_NO_MAIN
+int main(int argc, char* argv[]) {
+    // ... existing main code ...
+}
+#endif // PLY2HEIGHTMAP_NO_MAIN
+```
+
+- [ ] **Step 4: Build and run tests**
+
+```bash
+cmake --build --preset macos-debug --target test_ply2heightmap -j8
+cd build/macos-debug && ./test_ply2heightmap
+```
+
+Expected: All 6 test groups pass.
+
+- [ ] **Step 5: Run via ctest**
+
+```bash
+ctest --test-dir build/macos-debug -R test_ply2heightmap -V
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_ply2heightmap.cpp src/tools/ply2heightmap.cpp CMakeLists.txt
+git commit -m "test(tools): add headless test suite for ply2heightmap rasterizer"
+```
+
+---
+
+### Task 6: End-to-end validation with real PLY data
+
+**Files:** None modified — this is a validation step.
+
+- [ ] **Step 1: Run ply2heightmap on the island demo map**
+
+```bash
+cd build/macos-debug
+./ply2heightmap ../../examples/island_demo/assets/maps/map.ply /tmp/island_heightmap.png --ppu 2.0
+```
+
+Expected: Prints summary. Record the HeightfieldComponent values from stdout.
+
+- [ ] **Step 2: Verify the heightmap is loadable by stbi_load_16**
+
+The existing `test_heightfield_system` uses `HeightfieldData` with manually constructed samples. A quick sanity check: the PNG should be loadable by the same stb_image path used by `heightfield_loader.cpp`:
+
+```bash
+# File should exist and be non-trivial
+ls -la /tmp/island_heightmap.png
+file /tmp/island_heightmap.png
+```
+
+Expected: PNG image file, non-zero size.
+
+- [ ] **Step 3: Run the full test suite to verify no regressions**
+
+```bash
+ctest --test-dir build/macos-debug -j8 2>&1 | tail -5
+```
+
+Expected: Same pass rate as before (no regressions).
+
+- [ ] **Step 4: Commit (no code changes — just a validation checkpoint)**
+
+No commit needed. If all checks pass, the tool is ready.
+
+---
+
+## Self-Review Checklist
+
+**1. Spec coverage:**
+- CLI interface (--ppu, --padding, --min-opacity, --z-up) → Task 1 ✓
+- AABB splatting rasterizer → Task 2 ✓
+- Double-buffered dilation → Task 3 ✓
+- Normalization with flat-world guard → Task 3 ✓
+- 16-bit PNG writer → Task 4 ✓
+- Build integration (GSEURAT_BUILD_EXAMPLES) → Task 1 ✓
+- Headless tests (flat plane, gap fill, flat-world, opacity, footprint) → Task 5 ✓
+- Error handling (empty PLY, all filtered, etc.) → Task 1 (main) ✓
+- Stdout HeightfieldComponent output → Task 1 (main) ✓
+
+**2. Placeholder scan:** No TBD/TODO. All code blocks are complete.
+
+**3. Type consistency:**
+- `HeightmapParams` used consistently across Task 1 (definition), Task 2 (rasterizer), Task 5 (tests)
+- `HeightmapResult` returned from `rasterize_splats`, consumed by `dilate_gaps` and `normalize_to_uint16`
+- `NormResult` returned from `normalize_to_uint16`, consumed by `write_png_16` and main stdout
+- `write_png_16` signature matches declaration and usage

--- a/docs/superpowers/specs/2026-04-27-ply2heightmap-design.md
+++ b/docs/superpowers/specs/2026-04-27-ply2heightmap-design.md
@@ -1,0 +1,172 @@
+# ply2heightmap — PLY Point Cloud to 16-bit Heightmap Converter
+
+## Goal
+
+Provide an offline CLI tool that converts GSeurat's Gaussian-splat PLY files (vertex-only point clouds) into 16-bit grayscale PNG heightmaps, ready to drop into `HeightfieldComponent` for KCC collision.
+
+## Context
+
+- GSeurat's PLY files are **point clouds** (`element vertex` only, no `element face`). Triangle rasterization is not applicable.
+- Each vertex is a Gaussian splat with `position`, `scale` (3-axis, world-space after `exp()`), and `rotation` (quaternion).
+- The existing `GaussianCloud::load_ply()` parser handles all PLY format variants used in the project.
+- `HeightfieldComponent` expects a 16-bit grayscale PNG where pixel 0 maps to `min_height` and pixel 65535 maps to `max_height`.
+- `stb_image_write` is already available in the build.
+
+## CLI Interface
+
+```
+ply2heightmap <input.ply> <output.png> [options]
+
+Options:
+  --ppu <float>          Pixels per world-unit. Default: 2.0
+  --padding <float>      Extra world-units around AABB. Default: 1.0
+  --min-opacity <float>  Skip splats below this opacity. Default: 0.1
+  --z-up                 Interpret Z as height (for Blender exports). Default: Y-up.
+```
+
+### Stdout Output
+
+```
+Loaded 87687 splats from map.ply (filtered 2340 below opacity 0.1)
+AABB: (-128.0, -5.0, -64.0) -> (128.0, 45.0, 64.0)
+Grid: 512x256, cell_size=0.500, ppu=2.0
+Height range: -5.000 -> 45.000
+Wrote: map_heightmap.png
+
+# HeightfieldComponent values:
+  "width": 256.0
+  "length": 128.0
+  "min_height": -5.000
+  "max_height": 45.000
+```
+
+Errors go to stderr. Structured output goes to stdout so it can be piped.
+
+## Architecture
+
+### Rasterization: AABB Splatting
+
+Each Gaussian splat has a 3D oriented ellipsoid defined by its scale and rotation. Rather than computing the exact 2D covariance or performing OBB scanline rasterization, we project each splat's oriented bounding box down to an axis-aligned bounding box in the XZ plane and fill covered cells with the maximum Y value.
+
+This is conservative (overestimates footprint by ~40% for diagonal splats) which is desirable for collision — it guarantees a watertight surface with no holes.
+
+#### Grid Setup
+
+```
+ppu = pixels_per_unit (e.g., 2.0)
+aabb = cloud.bounds(), padded by --padding on all sides
+width_px  = ceil((aabb.max.x - aabb.min.x) * ppu)
+height_px = ceil((aabb.max.z - aabb.min.z) * ppu)
+cell_size = 1.0 / ppu  (uniform — square cells guaranteed)
+```
+
+Grid buffer: `std::vector<float>` of size `width_px * height_px`, initialized to `-FLT_MAX` (sentinel for "no data").
+
+#### Per-Splat Loop
+
+```
+For each Gaussian g where g.opacity >= min_opacity:
+
+  1. Rotate scale axes by quaternion:
+     ax = g.rotation * vec3(g.scale.x, 0, 0)
+     ay = g.rotation * vec3(0, g.scale.y, 0)
+     az = g.rotation * vec3(0, 0, g.scale.z)
+
+  2. AABB half-extents (sum of absolute components per axis):
+     half_x = |ax.x| + |ay.x| + |az.x|
+     half_y = |ax.y| + |ay.y| + |az.y|
+     half_z = |ax.z| + |ay.z| + |az.z|
+
+  3. Splat top Y (conservative — top of the ellipsoid, not center):
+     top_y = g.position.y + half_y
+
+  4. Map to grid cells:
+     x_min = floor((g.position.x - half_x - aabb.min.x) * ppu)
+     x_max = floor((g.position.x + half_x - aabb.min.x) * ppu)
+     z_min = floor((g.position.z - half_z - aabb.min.z) * ppu)
+     z_max = floor((g.position.z + half_z - aabb.min.z) * ppu)
+     Clamp all to [0, dimension - 1].
+
+  5. Fill:
+     for z in [z_min, z_max]:
+       for x in [x_min, x_max]:
+         grid[z * width_px + x] = max(grid[z * width_px + x], top_y)
+```
+
+### Post-Processing
+
+#### Gap Fill (Double-Buffered Dilation)
+
+After the splat pass, cells still at `-FLT_MAX` have no coverage. One pass of 3x3 max-neighbor dilation fills isolated single-pixel gaps.
+
+**Critical:** Dilation must be double-buffered. Read from `grid`, write to `dilated_grid`. In-place mutation causes a "streak" bug where a single valid pixel propagates across the entire grid due to iteration-order dependency.
+
+Cells still at `-FLT_MAX` after dilation are clamped to `min_height`.
+
+#### Normalization to uint16
+
+```
+min_height = min of all filled cells
+max_height = max of all filled cells
+
+// Flat-world guard: prevent divide-by-zero when all splats are at the same Y
+if (max_height - min_height < 1e-5f) {
+    max_height = min_height + 1.0f;
+}
+
+For each cell:
+  if cell == -FLT_MAX: sample = 0  (maps to min_height)
+  else: sample = lround((cell - min_height) / (max_height - min_height) * 65535.0f)
+```
+
+`std::lround()` prevents truncation artifacts (65534.999 → 65535, not 65534).
+
+## Build Integration
+
+```cmake
+if(GSEURAT_BUILD_EXAMPLES)
+    add_executable(ply2heightmap src/tools/ply2heightmap.cpp
+        src/engine/gaussian_cloud.cpp)
+    target_include_directories(ply2heightmap PRIVATE
+        ${PROJECT_SOURCE_DIR}/include  ${stb_SOURCE_DIR})
+    target_link_libraries(ply2heightmap PRIVATE glm::glm nlohmann_json::nlohmann_json)
+endif()
+```
+
+Gated behind `GSEURAT_BUILD_EXAMPLES` — developer tool, not core library. Reuses `gaussian_cloud.cpp` for PLY parsing (no external PLY library needed).
+
+## File Structure
+
+```
+src/tools/ply2heightmap.cpp     — CLI entry point + rasterizer functions
+tests/test_ply2heightmap.cpp    — headless unit tests
+```
+
+Rasterizer logic lives as free functions in the source file. Tests compile the source directly via `add_gseurat_test` (same pattern as existing collision tests).
+
+## Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Missing/unreadable PLY | stderr error, exit 1 |
+| Zero splats after opacity filter | stderr warning, exit 1 |
+| Output directory doesn't exist | stderr error, exit 1 |
+| Flat world (all same Y) | Guard: set range to 1.0, continue |
+| Corrupt PLY (bad header) | Caught by `load_ply()` exception, exit 1 |
+
+## Testing
+
+`test_ply2heightmap` — headless CI test that exercises the rasterizer functions directly (not via CLI):
+
+1. **Flat plane:** Generate splats at Y=5.0 across a grid. Assert all cells approximately 5.0.
+2. **Gap fill:** Leave one cell uncovered. Assert dilation fills it from neighbors.
+3. **Flat-world guard:** All splats at identical Y. Assert no NaN in output, valid uint16 values.
+4. **Opacity filter:** Mix high and low opacity splats. Assert low-opacity splats are excluded.
+5. **AABB footprint:** Single large splat with known scale. Assert correct number of cells covered.
+
+## Non-Goals
+
+- Interactive/real-time heightmap editing (future Bricklayer feature)
+- Triangle mesh rasterization (PLY files have no face data)
+- Multi-channel output (normal maps, AO, etc.)
+- GPU acceleration

--- a/src/tools/ply2heightmap.cpp
+++ b/src/tools/ply2heightmap.cpp
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -226,14 +227,14 @@ uint32_t png_crc32(const uint8_t* data, size_t len) {
 }
 
 // Write a PNG chunk: length(4) + type(4) + data(length) + crc(4)
-void png_write_chunk(FILE* fp, const char type[4],
+bool png_write_chunk(FILE* fp, const char type[4],
                      const uint8_t* data, uint32_t length) {
     uint8_t buf[4];
     png_write_u32be(buf, length);
-    fwrite(buf, 1, 4, fp);
-    fwrite(type, 1, 4, fp);
+    if (fwrite(buf, 1, 4, fp) != 4) return false;
+    if (fwrite(type, 1, 4, fp) != 4) return false;
     if (length > 0 && data) {
-        fwrite(data, 1, length, fp);
+        if (fwrite(data, 1, length, fp) != length) return false;
     }
     // CRC covers type + data
     std::vector<uint8_t> crc_buf(4 + length);
@@ -243,7 +244,8 @@ void png_write_chunk(FILE* fp, const char type[4],
     }
     uint32_t crc = png_crc32(crc_buf.data(), crc_buf.size());
     png_write_u32be(buf, crc);
-    fwrite(buf, 1, 4, fp);
+    if (fwrite(buf, 1, 4, fp) != 4) return false;
+    return true;
 }
 
 } // anonymous namespace
@@ -266,7 +268,7 @@ bool write_png_16(const char* path, const uint16_t* data,
     ihdr[10] = 0;  // compression method
     ihdr[11] = 0;  // filter method
     ihdr[12] = 0;  // interlace method
-    png_write_chunk(fp, "IHDR", ihdr, 13);
+    if (!png_write_chunk(fp, "IHDR", ihdr, 13)) { fclose(fp); return false; }
 
     // Build raw image data: for each row, 1 filter byte + w*2 bytes (big-endian)
     size_t row_bytes = 1 + static_cast<size_t>(w) * 2;
@@ -294,12 +296,13 @@ bool write_png_16(const char* path, const uint16_t* data,
         return false;
     }
 
-    png_write_chunk(fp, "IDAT", compressed,
-                    static_cast<uint32_t>(compressed_len));
+    bool idat_ok = png_write_chunk(fp, "IDAT", compressed,
+                                    static_cast<uint32_t>(compressed_len));
     STBIW_FREE(compressed);
+    if (!idat_ok) { fclose(fp); return false; }
 
     // IEND
-    png_write_chunk(fp, "IEND", nullptr, 0);
+    if (!png_write_chunk(fp, "IEND", nullptr, 0)) { fclose(fp); return false; }
 
     fclose(fp);
     return true;
@@ -343,8 +346,24 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    // Validate parameters
+    if (params.ppu <= 0.0f) {
+        fprintf(stderr, "Error: --ppu must be positive (got %.4f)\n", params.ppu);
+        return 1;
+    }
+    if (params.padding < 0.0f) {
+        fprintf(stderr, "Error: --padding must be non-negative (got %.4f)\n", params.padding);
+        return 1;
+    }
+
     // Load PLY
-    GaussianCloud cloud = GaussianCloud::load_ply(input_path);
+    GaussianCloud cloud;
+    try {
+        cloud = GaussianCloud::load_ply(input_path);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "Error loading PLY: %s\n", e.what());
+        return 1;
+    }
     if (cloud.empty()) {
         fprintf(stderr, "Error: failed to load PLY or file is empty: %s\n",
                 input_path);

--- a/src/tools/ply2heightmap.cpp
+++ b/src/tools/ply2heightmap.cpp
@@ -1,0 +1,431 @@
+// ply2heightmap — Convert Gaussian-splat PLY point clouds to 16-bit grayscale
+// PNG heightmaps for GSeurat's HeightfieldComponent.
+//
+// Usage: ply2heightmap <input.ply> <output.png> [--ppu N] [--padding N]
+//                      [--min-opacity N] [--z-up]
+
+#include "gseurat/engine/gaussian_cloud.hpp"
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include <algorithm>
+#include <cfloat>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using gseurat::AABB;
+using gseurat::Gaussian;
+using gseurat::GaussianCloud;
+
+// ---------------------------------------------------------------------------
+// Structs
+// ---------------------------------------------------------------------------
+
+struct HeightmapParams {
+    float ppu = 2.0f;         // pixels per unit
+    float padding = 1.0f;     // padding around AABB
+    float min_opacity = 0.1f; // opacity filter threshold
+    bool z_up = false;        // swap Y/Z on load
+};
+
+struct HeightmapResult {
+    std::vector<float> grid;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    float cell_size = 0.0f;
+    AABB padded_aabb;
+};
+
+struct NormResult {
+    std::vector<uint16_t> pixels;
+    float min_height = 0.0f;
+    float max_height = 0.0f;
+};
+
+// ---------------------------------------------------------------------------
+// rasterize_splats
+// ---------------------------------------------------------------------------
+
+HeightmapResult rasterize_splats(const std::vector<Gaussian>& splats,
+                                 const AABB& bounds,
+                                 const HeightmapParams& params) {
+    HeightmapResult result;
+
+    // Pad AABB
+    AABB padded = bounds;
+    glm::vec3 pad(params.padding);
+    padded.min -= pad;
+    padded.max += pad;
+    result.padded_aabb = padded;
+
+    float range_x = padded.max.x - padded.min.x;
+    float range_z = padded.max.z - padded.min.z;
+
+    result.width = static_cast<uint32_t>(std::ceil(range_x * params.ppu));
+    result.height = static_cast<uint32_t>(std::ceil(range_z * params.ppu));
+    result.cell_size = 1.0f / params.ppu;
+
+    if (result.width == 0) result.width = 1;
+    if (result.height == 0) result.height = 1;
+
+    result.grid.assign(static_cast<size_t>(result.width) * result.height, -FLT_MAX);
+
+    for (const auto& g : splats) {
+        // Rotate scale axes by quaternion to get oriented half-extents
+        glm::vec3 ax = g.rotation * glm::vec3(g.scale.x, 0.0f, 0.0f);
+        glm::vec3 ay = g.rotation * glm::vec3(0.0f, g.scale.y, 0.0f);
+        glm::vec3 az = g.rotation * glm::vec3(0.0f, 0.0f, g.scale.z);
+
+        // AABB half-extents from rotated axes
+        float half_x = std::abs(ax.x) + std::abs(ay.x) + std::abs(az.x);
+        float half_y = std::abs(ax.y) + std::abs(ay.y) + std::abs(az.y);
+        float half_z = std::abs(ax.z) + std::abs(ay.z) + std::abs(az.z);
+
+        float top_y = g.position.y + half_y;
+
+        // Map splat AABB to grid cells
+        float min_gx = (g.position.x - half_x - padded.min.x) * params.ppu;
+        float max_gx = (g.position.x + half_x - padded.min.x) * params.ppu;
+        float min_gz = (g.position.z - half_z - padded.min.z) * params.ppu;
+        float max_gz = (g.position.z + half_z - padded.min.z) * params.ppu;
+
+        int ix0 = std::max(0, static_cast<int>(std::floor(min_gx)));
+        int ix1 = std::min(static_cast<int>(result.width) - 1,
+                           static_cast<int>(std::floor(max_gx)));
+        int iz0 = std::max(0, static_cast<int>(std::floor(min_gz)));
+        int iz1 = std::min(static_cast<int>(result.height) - 1,
+                           static_cast<int>(std::floor(max_gz)));
+
+        for (int iz = iz0; iz <= iz1; ++iz) {
+            for (int ix = ix0; ix <= ix1; ++ix) {
+                size_t idx = static_cast<size_t>(iz) * result.width + ix;
+                result.grid[idx] = std::max(result.grid[idx], top_y);
+            }
+        }
+    }
+
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// dilate_gaps — double-buffered 3x3 max dilation
+// ---------------------------------------------------------------------------
+
+void dilate_gaps(const std::vector<float>& src,
+                 std::vector<float>& dst,
+                 uint32_t w, uint32_t h) {
+    dst = src; // copy so filled cells stay unchanged
+
+    for (uint32_t y = 0; y < h; ++y) {
+        for (uint32_t x = 0; x < w; ++x) {
+            size_t idx = static_cast<size_t>(y) * w + x;
+            if (src[idx] != -FLT_MAX) continue; // already filled in src
+
+            float best = -FLT_MAX;
+            for (int dy = -1; dy <= 1; ++dy) {
+                for (int dx = -1; dx <= 1; ++dx) {
+                    int nx = static_cast<int>(x) + dx;
+                    int ny = static_cast<int>(y) + dy;
+                    if (nx < 0 || nx >= static_cast<int>(w) ||
+                        ny < 0 || ny >= static_cast<int>(h))
+                        continue;
+                    size_t nidx = static_cast<size_t>(ny) * w + nx;
+                    best = std::max(best, src[nidx]);
+                }
+            }
+            dst[idx] = best;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// normalize_to_uint16
+// ---------------------------------------------------------------------------
+
+NormResult normalize_to_uint16(const std::vector<float>& grid,
+                               uint32_t w, uint32_t h) {
+    NormResult result;
+
+    float lo = FLT_MAX;
+    float hi = -FLT_MAX;
+
+    for (size_t i = 0; i < static_cast<size_t>(w) * h; ++i) {
+        if (grid[i] == -FLT_MAX) continue;
+        lo = std::min(lo, grid[i]);
+        hi = std::max(hi, grid[i]);
+    }
+
+    // Flat-world guard
+    if (hi - lo < 1e-5f) {
+        hi = lo + 1.0f;
+    }
+
+    result.min_height = lo;
+    result.max_height = hi;
+
+    float range = hi - lo;
+    result.pixels.resize(static_cast<size_t>(w) * h);
+
+    for (size_t i = 0; i < static_cast<size_t>(w) * h; ++i) {
+        if (grid[i] == -FLT_MAX) {
+            result.pixels[i] = 0;
+        } else {
+            float t = (grid[i] - lo) / range;
+            result.pixels[i] = static_cast<uint16_t>(
+                std::lround(t * 65535.0));
+        }
+    }
+
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// write_png_16 — manual 16-bit grayscale PNG writer
+// ---------------------------------------------------------------------------
+
+namespace {
+
+void png_write_u32be(uint8_t* buf, uint32_t val) {
+    buf[0] = static_cast<uint8_t>((val >> 24) & 0xFF);
+    buf[1] = static_cast<uint8_t>((val >> 16) & 0xFF);
+    buf[2] = static_cast<uint8_t>((val >> 8) & 0xFF);
+    buf[3] = static_cast<uint8_t>(val & 0xFF);
+}
+
+uint32_t png_crc32(const uint8_t* data, size_t len) {
+    // CRC-32/ISO-HDLC (PNG uses this polynomial)
+    static uint32_t table[256] = {};
+    static bool table_init = false;
+    if (!table_init) {
+        for (uint32_t i = 0; i < 256; ++i) {
+            uint32_t c = i;
+            for (int j = 0; j < 8; ++j) {
+                if (c & 1)
+                    c = 0xEDB88320u ^ (c >> 1);
+                else
+                    c >>= 1;
+            }
+            table[i] = c;
+        }
+        table_init = true;
+    }
+    uint32_t crc = 0xFFFFFFFFu;
+    for (size_t i = 0; i < len; ++i) {
+        crc = table[(crc ^ data[i]) & 0xFF] ^ (crc >> 8);
+    }
+    return crc ^ 0xFFFFFFFFu;
+}
+
+// Write a PNG chunk: length(4) + type(4) + data(length) + crc(4)
+void png_write_chunk(FILE* fp, const char type[4],
+                     const uint8_t* data, uint32_t length) {
+    uint8_t buf[4];
+    png_write_u32be(buf, length);
+    fwrite(buf, 1, 4, fp);
+    fwrite(type, 1, 4, fp);
+    if (length > 0 && data) {
+        fwrite(data, 1, length, fp);
+    }
+    // CRC covers type + data
+    std::vector<uint8_t> crc_buf(4 + length);
+    std::memcpy(crc_buf.data(), type, 4);
+    if (length > 0 && data) {
+        std::memcpy(crc_buf.data() + 4, data, length);
+    }
+    uint32_t crc = png_crc32(crc_buf.data(), crc_buf.size());
+    png_write_u32be(buf, crc);
+    fwrite(buf, 1, 4, fp);
+}
+
+} // anonymous namespace
+
+bool write_png_16(const char* path, const uint16_t* data,
+                  uint32_t w, uint32_t h) {
+    FILE* fp = fopen(path, "wb");
+    if (!fp) return false;
+
+    // PNG signature
+    static const uint8_t sig[8] = {137, 80, 78, 71, 13, 10, 26, 10};
+    fwrite(sig, 1, 8, fp);
+
+    // IHDR: width(4) height(4) bitdepth(1) colortype(1) compress(1) filter(1) interlace(1)
+    uint8_t ihdr[13];
+    png_write_u32be(ihdr, w);
+    png_write_u32be(ihdr + 4, h);
+    ihdr[8] = 16;  // bit depth
+    ihdr[9] = 0;   // color type: grayscale
+    ihdr[10] = 0;  // compression method
+    ihdr[11] = 0;  // filter method
+    ihdr[12] = 0;  // interlace method
+    png_write_chunk(fp, "IHDR", ihdr, 13);
+
+    // Build raw image data: for each row, 1 filter byte + w*2 bytes (big-endian)
+    size_t row_bytes = 1 + static_cast<size_t>(w) * 2;
+    std::vector<uint8_t> raw(row_bytes * h);
+    for (uint32_t y = 0; y < h; ++y) {
+        size_t row_off = y * row_bytes;
+        raw[row_off] = 0; // filter byte: None
+        for (uint32_t x = 0; x < w; ++x) {
+            uint16_t val = data[static_cast<size_t>(y) * w + x];
+            size_t px_off = row_off + 1 + static_cast<size_t>(x) * 2;
+            raw[px_off] = static_cast<uint8_t>((val >> 8) & 0xFF);
+            raw[px_off + 1] = static_cast<uint8_t>(val & 0xFF);
+        }
+    }
+
+    // Compress with stbi_zlib_compress
+    int compressed_len = 0;
+    stbi_write_png_compression_level = 8;
+    uint8_t* compressed = reinterpret_cast<uint8_t*>(
+        stbi_zlib_compress(raw.data(),
+                           static_cast<int>(raw.size()),
+                           &compressed_len, 8));
+    if (!compressed) {
+        fclose(fp);
+        return false;
+    }
+
+    png_write_chunk(fp, "IDAT", compressed,
+                    static_cast<uint32_t>(compressed_len));
+    STBIW_FREE(compressed);
+
+    // IEND
+    png_write_chunk(fp, "IEND", nullptr, 0);
+
+    fclose(fp);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+#ifndef PLY2HEIGHTMAP_NO_MAIN
+
+int main(int argc, char* argv[]) {
+    if (argc < 3) {
+        fprintf(stderr,
+                "Usage: ply2heightmap <input.ply> <output.png> [options]\n"
+                "Options:\n"
+                "  --ppu N          Pixels per unit (default: 2.0)\n"
+                "  --padding N      AABB padding in units (default: 1.0)\n"
+                "  --min-opacity N  Minimum opacity threshold (default: 0.1)\n"
+                "  --z-up           Swap Y/Z axes (input is Z-up)\n");
+        return 1;
+    }
+
+    const char* input_path = argv[1];
+    const char* output_path = argv[2];
+
+    HeightmapParams params;
+
+    for (int i = 3; i < argc; ++i) {
+        if (strcmp(argv[i], "--ppu") == 0 && i + 1 < argc) {
+            params.ppu = static_cast<float>(atof(argv[++i]));
+        } else if (strcmp(argv[i], "--padding") == 0 && i + 1 < argc) {
+            params.padding = static_cast<float>(atof(argv[++i]));
+        } else if (strcmp(argv[i], "--min-opacity") == 0 && i + 1 < argc) {
+            params.min_opacity = static_cast<float>(atof(argv[++i]));
+        } else if (strcmp(argv[i], "--z-up") == 0) {
+            params.z_up = true;
+        } else {
+            fprintf(stderr, "Unknown option: %s\n", argv[i]);
+            return 1;
+        }
+    }
+
+    // Load PLY
+    GaussianCloud cloud = GaussianCloud::load_ply(input_path);
+    if (cloud.empty()) {
+        fprintf(stderr, "Error: failed to load PLY or file is empty: %s\n",
+                input_path);
+        return 1;
+    }
+
+    fprintf(stderr, "Loaded %u Gaussians from %s\n", cloud.count(), input_path);
+
+    // Filter by opacity and optionally swap Y/Z
+    const auto& all = cloud.gaussians();
+    std::vector<Gaussian> filtered;
+    filtered.reserve(all.size());
+    AABB bounds;
+
+    for (const auto& g : all) {
+        if (g.opacity < params.min_opacity) continue;
+
+        Gaussian out = g;
+        if (params.z_up) {
+            // Swap Y and Z
+            std::swap(out.position.y, out.position.z);
+            std::swap(out.scale.y, out.scale.z);
+            // Swap quaternion components for Y/Z swap
+            out.rotation = glm::quat(g.rotation.w, g.rotation.x,
+                                     g.rotation.z, g.rotation.y);
+        }
+        bounds.expand(out.position);
+        filtered.push_back(out);
+    }
+
+    if (filtered.empty()) {
+        fprintf(stderr, "Error: no Gaussians passed opacity filter (>= %.3f)\n",
+                params.min_opacity);
+        return 1;
+    }
+
+    fprintf(stderr, "Filtered to %zu Gaussians (opacity >= %.3f)\n",
+            filtered.size(), params.min_opacity);
+
+    // Rasterize
+    HeightmapResult hm = rasterize_splats(filtered, bounds, params);
+    fprintf(stderr, "Grid: %u x %u (cell_size=%.4f)\n",
+            hm.width, hm.height, hm.cell_size);
+
+    // Dilate gaps
+    std::vector<float> dilated;
+    dilate_gaps(hm.grid, dilated, hm.width, hm.height);
+
+    // Normalize
+    NormResult norm = normalize_to_uint16(dilated, hm.width, hm.height);
+
+    // Write PNG
+    if (!write_png_16(output_path, norm.pixels.data(), hm.width, hm.height)) {
+        fprintf(stderr, "Error: failed to write PNG: %s\n", output_path);
+        return 1;
+    }
+
+    // Print summary (HeightfieldComponent values)
+    const AABB& pa = hm.padded_aabb;
+    printf("=== ply2heightmap summary ===\n");
+    printf("  input:      %s\n", input_path);
+    printf("  output:     %s\n", output_path);
+    printf("  dimensions: %u x %u\n", hm.width, hm.height);
+    printf("  cell_size:  %.4f\n", hm.cell_size);
+    printf("  min_height: %.4f\n", norm.min_height);
+    printf("  max_height: %.4f\n", norm.max_height);
+    printf("  padded_aabb.min: (%.4f, %.4f, %.4f)\n",
+           pa.min.x, pa.min.y, pa.min.z);
+    printf("  padded_aabb.max: (%.4f, %.4f, %.4f)\n",
+           pa.max.x, pa.max.y, pa.max.z);
+    printf("\nHeightfieldComponent JSON:\n");
+    printf("  {\n");
+    printf("    \"heightmap\": \"%s\",\n", output_path);
+    printf("    \"offset\": [%.4f, %.4f, %.4f],\n",
+           pa.min.x, norm.min_height, pa.min.z);
+    printf("    \"scale\": [%.4f, %.4f, %.4f]\n",
+           pa.max.x - pa.min.x, norm.max_height - norm.min_height,
+           pa.max.z - pa.min.z);
+    printf("  }\n");
+
+    return 0;
+}
+
+#endif // PLY2HEIGHTMAP_NO_MAIN

--- a/tests/test_ply2heightmap.cpp
+++ b/tests/test_ply2heightmap.cpp
@@ -1,0 +1,233 @@
+// Unit test: ply2heightmap — headless tests for rasterize_splats, dilate_gaps,
+// normalize_to_uint16, and write_png_16.
+//
+// Build:
+//   cmake --build --preset macos-debug --target test_ply2heightmap -j8
+//
+// Run: cd build/macos-debug && ./test_ply2heightmap
+
+#define PLY2HEIGHTMAP_NO_MAIN
+#include "../src/tools/ply2heightmap.cpp"
+
+#include <cfloat>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+static int passed = 0, failed = 0;
+static void check(bool cond, const char* msg) {
+    if (cond) { std::printf("  PASS: %s\n", msg); passed++; }
+    else { std::printf("  FAIL: %s\n", msg); failed++; }
+}
+static bool approx(float a, float b, float eps = 0.1f) {
+    return std::abs(a - b) < eps;
+}
+
+// Helper: create a Gaussian with common defaults
+static Gaussian make_splat(glm::vec3 pos, glm::vec3 scale, float opacity = 1.0f) {
+    Gaussian g{};
+    g.position = pos;
+    g.scale = scale;
+    g.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f); // identity
+    g.color = glm::vec3(1.0f);
+    g.opacity = opacity;
+    g.importance = opacity * glm::max(scale.x, glm::max(scale.y, scale.z));
+    g.bone_index = 0;
+    g.emission = 0.0f;
+    return g;
+}
+
+// ---------------------------------------------------------------------------
+// test_flat_plane
+// ---------------------------------------------------------------------------
+void test_flat_plane() {
+    std::printf("test_flat_plane:\n");
+
+    // 4 splats at Y=5.0 in a 2x2 pattern, scale=1.0 uniform
+    std::vector<Gaussian> splats = {
+        make_splat({1.0f, 5.0f, 1.0f}, {1.0f, 1.0f, 1.0f}),
+        make_splat({3.0f, 5.0f, 1.0f}, {1.0f, 1.0f, 1.0f}),
+        make_splat({1.0f, 5.0f, 3.0f}, {1.0f, 1.0f, 1.0f}),
+        make_splat({3.0f, 5.0f, 3.0f}, {1.0f, 1.0f, 1.0f}),
+    };
+
+    AABB bounds;
+    for (const auto& g : splats) bounds.expand(g.position);
+
+    HeightmapParams params;
+    params.ppu = 2.0f;
+    params.padding = 0.5f;
+
+    HeightmapResult hm = rasterize_splats(splats, bounds, params);
+
+    check(hm.width > 0 && hm.height > 0, "grid dimensions are positive");
+    check(hm.cell_size > 0.0f, "cell_size is positive");
+
+    // Check that center cells are filled (not -FLT_MAX)
+    // The center of the grid should be covered by the splats
+    uint32_t cx = hm.width / 2;
+    uint32_t cz = hm.height / 2;
+    size_t center_idx = static_cast<size_t>(cz) * hm.width + cx;
+    float center_val = hm.grid[center_idx];
+
+    check(center_val != -FLT_MAX, "center cell is filled");
+    // position.y=5 + half_y=1 (scale.y=1, identity rotation) = 6.0
+    check(approx(center_val, 6.0f), "center cell value ~6.0 (pos.y + half_y)");
+}
+
+// ---------------------------------------------------------------------------
+// test_gap_fill
+// ---------------------------------------------------------------------------
+void test_gap_fill() {
+    std::printf("test_gap_fill:\n");
+
+    // 5x5 grid filled with 10.0, center cell is a hole
+    const uint32_t w = 5, h = 5;
+    std::vector<float> src(w * h, 10.0f);
+    src[12] = -FLT_MAX; // center cell (2,2) = index 12
+
+    std::vector<float> dst;
+    dilate_gaps(src, dst, w, h);
+
+    check(dst[12] == 10.0f, "center hole filled to 10.0");
+    check(dst[0] == 10.0f, "corner cell unchanged");
+    check(dst[6] == 10.0f, "non-hole cell unchanged");
+}
+
+// ---------------------------------------------------------------------------
+// test_flat_world
+// ---------------------------------------------------------------------------
+void test_flat_world() {
+    std::printf("test_flat_world:\n");
+
+    const uint32_t w = 4, h = 4;
+    std::vector<float> grid(w * h, 42.0f);
+
+    NormResult norm = normalize_to_uint16(grid, w, h);
+
+    check(norm.max_height > norm.min_height, "flat-world guard: max > min");
+
+    // All pixels should be identical (all same input value)
+    bool all_same = true;
+    uint16_t first = norm.pixels[0];
+    for (size_t i = 1; i < norm.pixels.size(); ++i) {
+        if (norm.pixels[i] != first) { all_same = false; break; }
+    }
+    check(all_same, "all pixels identical for flat input");
+
+    // No NaN in float outputs
+    check(!std::isnan(norm.min_height), "min_height is not NaN");
+    check(!std::isnan(norm.max_height), "max_height is not NaN");
+}
+
+// ---------------------------------------------------------------------------
+// test_opacity_filter
+// ---------------------------------------------------------------------------
+void test_opacity_filter() {
+    std::printf("test_opacity_filter:\n");
+
+    // Two Gaussians: one visible, one below threshold
+    std::vector<Gaussian> all = {
+        make_splat({0.0f, 5.0f, 0.0f}, {1.0f, 1.0f, 1.0f}, 1.0f),
+        make_splat({0.0f, 100.0f, 0.0f}, {1.0f, 1.0f, 1.0f}, 0.01f),
+    };
+
+    float min_opacity = 0.1f;
+    std::vector<Gaussian> filtered;
+    for (const auto& g : all) {
+        if (g.opacity >= min_opacity) filtered.push_back(g);
+    }
+
+    check(filtered.size() == 1, "only one Gaussian passes opacity filter");
+    check(approx(filtered[0].position.y, 5.0f), "surviving Gaussian is the visible one");
+}
+
+// ---------------------------------------------------------------------------
+// test_aabb_footprint
+// ---------------------------------------------------------------------------
+void test_aabb_footprint() {
+    std::printf("test_aabb_footprint:\n");
+
+    // Single splat at origin, scale=(2,1,3), identity rotation
+    std::vector<Gaussian> splats = {
+        make_splat({0.0f, 0.0f, 0.0f}, {2.0f, 1.0f, 3.0f}),
+    };
+
+    AABB bounds;
+    bounds.expand(splats[0].position);
+
+    HeightmapParams params;
+    params.ppu = 1.0f;
+    params.padding = 3.5f;
+
+    HeightmapResult hm = rasterize_splats(splats, bounds, params);
+
+    // Count filled cells
+    int filled = 0;
+    for (size_t i = 0; i < hm.grid.size(); ++i) {
+        if (hm.grid[i] != -FLT_MAX) ++filled;
+    }
+
+    // Splat covers ~4x6 world units (half_x=2, half_z=3 → 4 wide, 6 tall)
+    // At ppu=1.0 that's roughly 24 cells
+    check(filled >= 20 && filled <= 35,
+          "filled cell count in expected range (20-35)");
+
+    // Filled cells should have value ~1.0 (position.y=0 + half_y=1)
+    bool values_ok = true;
+    for (size_t i = 0; i < hm.grid.size(); ++i) {
+        if (hm.grid[i] != -FLT_MAX && !approx(hm.grid[i], 1.0f)) {
+            values_ok = false;
+            break;
+        }
+    }
+    check(values_ok, "filled cell values ~1.0 (pos.y=0 + half_y=1)");
+}
+
+// ---------------------------------------------------------------------------
+// test_png_roundtrip
+// ---------------------------------------------------------------------------
+void test_png_roundtrip() {
+    std::printf("test_png_roundtrip:\n");
+
+    const uint32_t w = 4, h = 4;
+    std::vector<uint16_t> data(w * h);
+    for (uint32_t i = 0; i < w * h; ++i) {
+        data[i] = static_cast<uint16_t>(i * 4096);
+    }
+
+    // Build path in TMPDIR
+    const char* tmpdir = std::getenv("TMPDIR");
+    std::string path = tmpdir ? std::string(tmpdir) : std::string("/tmp");
+    if (!path.empty() && path.back() != '/') path += '/';
+    path += "test_ply2heightmap_roundtrip.png";
+
+    bool ok = write_png_16(path.c_str(), data.data(), w, h);
+    check(ok, "write_png_16 returns true");
+
+    // Check file exists and has reasonable size
+    auto fsize = std::filesystem::file_size(path);
+    check(fsize > 50, "PNG file size > 50 bytes");
+
+    // Clean up
+    std::filesystem::remove(path);
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+int main() {
+    std::printf("=== test_ply2heightmap ===\n");
+
+    test_flat_plane();
+    test_gap_fill();
+    test_flat_world();
+    test_opacity_filter();
+    test_aabb_footprint();
+    test_png_roundtrip();
+
+    std::printf("\n%d passed, %d failed\n", passed, failed);
+    return failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- New CLI tool `ply2heightmap` converts Gaussian-splat PLY point clouds to 16-bit grayscale PNG heightmaps for `HeightfieldComponent`
- Uses AABB splatting: rotates each splat's scale by its quaternion, projects conservative footprint onto XZ grid, stores max Y
- Double-buffered 3x3 max dilation fills single-pixel gaps
- Custom 16-bit PNG writer using stb's zlib compression (stbi_write_png only supports 8-bit)
- Prints HeightfieldComponent values to stdout for direct use in Bricklayer

## Usage
```
ply2heightmap input.ply output.png --ppu 2.0 --padding 1.0 --min-opacity 0.1
```

## Test plan
- [ ] 17/17 headless unit test assertions pass (flat plane, gap fill, flat-world guard, opacity filter, AABB footprint, PNG round-trip)
- [ ] Smoke test on island demo PLY produces valid 16-bit grayscale PNG
- [ ] Full ctest passes (no regressions)
- [ ] Build succeeds on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)