### PR TITLE
docs: update READMEs with KCC heightfield and ply2heightmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ GSeurat is designed to be embedded in external game projects as a **Git submodul
 - **Sprite overlay** — Sprite-based entities over GS backgrounds with bloom, depth-of-field, and tone mapping
 - **Game Object System** — Unified entity model with component composition. Developers define C++ component structs + JSON schemas; level designers compose objects in Bricklayer
 - **Component Registry** — Type-erased component registration with JSON attach/serialize. SystemScheduler with read/write dependency declarations (parallel-ready)
-- **3D Collision System** — Primitive colliders (Box, Sphere, Capsule) with static BVH broadphase, capsule sweep queries, and a Kinematic Character Controller with continuous gravity and wall sliding
+- **3D Collision System** — Primitive colliders (Box, Sphere, Capsule) with static BVH broadphase, capsule sweep queries, heightfield terrain colliders (16-bit PNG), and a Kinematic Character Controller with depenetration recovery, continuous gravity, and wall sliding
 - **Camera Pipeline** — 5-mode camera system (free_look, rail_follow, cinematic_rail, fixed_point, side_scroll) with zone priority resolution, smooth blending, spline paths, easing curves, and cinematic playback modes
 - **Entity Component System** — Header-only ECS with archetype storage, typed views, and system functions
 - **[Scene transitions](docs/scene-transitions.md)** — Transient-entity state machine (`SceneOut → Loading → SceneIn`) fully decoupled from presentation. Portals are authored in Bricklayer via `ProximityTrigger + PortalTarget`; the post-process shader supports solid fade, left-to-right wipe, and iris wipe effects
@@ -51,6 +51,7 @@ GSeurat/
 │       └── world.json         #   World manifest (chunks, portals, streaming volumes)
 ├── tests/                     # C++ unit and GPU tests
 ├── scripts/                   # Python utilities (Game Director, asset generation)
+├── src/tools/                 # Offline CLI utilities (ply2heightmap)
 ├── tools/                     # TypeScript/React monorepo (pnpm)
 │   ├── apps/                  #   Web apps (Bricklayer, Echidna, Melies, Bridge)
 │   └── packages/              #   Shared packages (engine-client, asset-types, ui-kit)
@@ -185,6 +186,7 @@ One demo executable and one staging tool are produced:
 |---|---|
 | `gseurat_demo` | Island demo with visual effects, scene layers, and chunk streaming |
 | `gseurat_staging` | ImGui-based rendering review with live scene preview and gizmos |
+| `ply2heightmap` | Convert Gaussian-splat PLY point clouds to 16-bit heightmap PNGs |
 
 ```bash
 # Run with default island scene
@@ -192,6 +194,9 @@ One demo executable and one staging tool are produced:
 
 # Run with a custom scene
 ./build/macos-release/gseurat_demo --scene examples/island_demo/assets/scenes/my_scene.json
+
+# Generate a heightmap from a PLY point cloud
+./build/macos-release/ply2heightmap assets/maps/map.ply terrain_heightmap.png --ppu 2.0
 ```
 
 ## Architecture
@@ -337,15 +342,18 @@ Primitive collider system backed by a static BVH, replacing the legacy 2D Collis
 - `BoxData` — axis-aligned box with half-extents
 - `SphereData` — sphere with radius
 - `CapsuleData` — capsule with radius + half-height (oriented along Y axis)
+- `HeightfieldComponent` — 16-bit PNG grayscale terrain with bilinear sampling and triangle-based sweep
 
-**Architecture:** Hybrid ECS + cached CollisionWorld. `ColliderComponent` is an ECS component for serialization and inspector support. `CollisionSystem` maintains packed `ColliderInstance` caches (static and dynamic) and rebuilds a static BVH for broadphase acceleration.
+**Architecture:** Hybrid ECS + cached CollisionWorld. `ColliderComponent` is an ECS component for serialization and inspector support. `CollisionSystem` maintains packed `ColliderInstance` caches (static and dynamic), a `HeightfieldInstance` cache, and rebuilds a static BVH for broadphase acceleration.
 
 **Queries:**
-- `sweep()` — capsule sweep against static geometry (continuous collision detection for KCC)
+- `sweep()` — capsule sweep against static geometry and heightfields (continuous collision detection for KCC)
 - `overlap_aabb()` — broadphase AABB overlap query
 - `raycast()` — ray intersection with distance-sorted results
 
-**Kinematic Character Controller (KCC):** Per-frame `run_kcc()` applies continuous gravity, capsule sweeps for movement, ground probing for slope detection, and iterative wall sliding. Configurable ground angle threshold, skin width, and slide iterations.
+**Kinematic Character Controller (KCC):** 7-step per-frame pipeline: depenetration → gravity → horizontal sweep → wall slide → vertical sweep → ground probe → write-back. The depenetration step resolves capsule-terrain overlap on spawn/teleport (prevents the "stuck player" bug when authored Y coordinates don't account for capsule dimensions). Configurable ground angle threshold, skin width, and slide iterations.
+
+**Heightmap pipeline:** The `ply2heightmap` CLI converts Gaussian-splat PLY point clouds to 16-bit heightmaps via AABB splatting — each splat's oriented bounding box is projected onto an XZ grid with conservative max-Y fill. Output PNGs plug directly into `HeightfieldComponent`.
 
 ### Camera Pipeline
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -341,6 +341,37 @@ c++ -std=c++23 -I include \
     -o build/test_character_data
 ```
 
+### test_kcc_integration
+
+Headless KCC (Kinematic Character Controller) integration tests. Exercises the full physics pipeline (CollisionSystem + heightfield terrain) without GPU or display.
+
+**Run:** `ctest -R test_kcc_integration -V`
+
+**Tests (18 assertions across 5 charters):**
+| Charter | Test | What it verifies |
+|---------|------|------------------|
+| 1+4 | Slope tracking | 14° ramp, grounded for 20 frames, Y monotonically non-decreasing |
+| 2 | Zero tunneling | Gravity fall from Y=45, player never passes through Y=5 terrain |
+| 3 | Primitive transition | Walk from heightfield onto flush box collider, grounded throughout |
+| 5 | Depenetration recovery | Spawn embedded 0.8u in terrain, recovers within 3 frames |
+| 6 | Flat terrain baseline | v*t displacement matches expected, constant Y |
+
+### test_ply2heightmap
+
+Tests for the `ply2heightmap` CLI tool's core rasterizer functions. Headless — no GPU required.
+
+**Run:** `ctest -R test_ply2heightmap -V`
+
+**Tests (17 assertions):**
+| # | Test | What it verifies |
+|---|------|------------------|
+| 1 | Flat plane | 4 splats at Y=5 → center cells filled at ~6.0 (pos + half_y) |
+| 2 | Gap fill | 5x5 grid with center hole → dilation fills to neighbor max |
+| 3 | Flat-world guard | All cells identical Y → no NaN, guard sets range to 1.0 |
+| 4 | Opacity filter | Low-opacity splat excluded, high-opacity passes |
+| 5 | AABB footprint | Non-uniform scale splat covers expected cell count (~24) |
+| 6 | PNG round-trip | write_png_16 produces valid non-empty file |
+
 ## TypeScript Tool Tests
 
 All tool tests run via the QA test runner which uses headless Chrome + WebSocket to manipulate Zustand stores.


### PR DESCRIPTION
## Summary
- **README.md**: Add `HeightfieldComponent` to collider types, document 7-step KCC pipeline with depenetration recovery, add `ply2heightmap` CLI to executable table and project structure, add heightmap pipeline section
- **tests/README.md**: Add `test_kcc_integration` (18 assertions, 5 charters) and `test_ply2heightmap` (17 assertions, 6 test groups)

## Test plan
- [ ] No code changes — docs only
- [ ] Build succeeds (all platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)