### PR TITLE
Loading architecture prerequisites: VkPipelineCache + general-purpose TransferQueue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Thumbs.db
 imgui.ini
 perf.log
 __pycache__/
+.cache/
 
 # Compiled objects
 *.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ add_library(gseurat_core ${_gseurat_lib_type}
     src/engine/swapchain.cpp
     src/engine/render_pass.cpp
     src/engine/pipeline.cpp
+    src/engine/pipeline_cache.cpp
     src/engine/command_pool.cpp
     src/engine/sync.cpp
     src/engine/buffer.cpp
@@ -552,6 +553,8 @@ function(add_gseurat_gpu_test NAME)
         src/engine/vk_context.cpp
         src/engine/buffer.cpp
         src/engine/pipeline.cpp
+        src/engine/pipeline_cache.cpp
+        src/engine/project_root.cpp
         ${ARGN}
     )
     target_include_directories(${NAME} PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,7 @@ add_library(gseurat_core ${_gseurat_lib_type}
     src/engine/systems/transition_system.cpp
     src/engine/systems/portal_trigger_handler.cpp
     src/engine/systems/audio_zone_system.cpp
+    src/engine/engine_state.cpp
 )
 
 
@@ -387,6 +388,7 @@ endfunction()
 add_gseurat_test(test_feature_flags)
 add_gseurat_test(test_tile_sort_key)
 add_gseurat_test(test_onesweep_logic)
+add_gseurat_test(test_engine_loading_monitor  src/engine/engine_state.cpp)
 add_gseurat_test(test_async_loader     src/engine/async_loader.cpp)
 add_gseurat_test(test_character_data   src/engine/character_data.cpp)
 add_gseurat_test(test_gaussian_cloud   src/engine/gaussian_cloud.cpp src/engine/collision_gen.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,5 +575,6 @@ function(add_gseurat_gpu_test NAME)
 endfunction()
 
 add_gseurat_gpu_test(test_onesweep_gpu)
+add_gseurat_gpu_test(test_transfer_queue_gpu src/engine/transfer_queue.cpp)
 
 endif() # GSEURAT_BUILD_TESTS

--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -3,6 +3,7 @@
 #include "gseurat/engine/async_loader.hpp"
 #include "gseurat/engine/audio/audio_engine.hpp"
 #include "gseurat/engine/component_registry.hpp"
+#include "gseurat/engine/engine_state.hpp"
 #include "gseurat/engine/system_scheduler.hpp"
 #include "gseurat/engine/control_server.hpp"
 #include "gseurat/engine/collision_gen.hpp"
@@ -178,6 +179,13 @@ public:
     AsyncLoader& async_loader() { return async_loader_; }
     StagingUploader& staging_uploader() { return staging_uploader_; }
 
+    // Engine-level lifecycle monitor (Loading / Warming / Playing). Default
+    // state is Playing; games opt into the loading flow by calling
+    // `loading_monitor().begin_load(...)` after enqueueing async asset
+    // uploads on a TransferQueue (or any other handle-producing loader).
+    EngineLoadingMonitor& loading_monitor() { return loading_monitor_; }
+    const EngineLoadingMonitor& loading_monitor() const { return loading_monitor_; }
+
     // Game object system accessors
     ComponentRegistry& component_registry() { return component_registry_; }
     SystemScheduler& system_scheduler() { return system_scheduler_; }
@@ -282,6 +290,9 @@ protected:
     // Async asset loading
     AsyncLoader async_loader_;
     StagingUploader staging_uploader_;
+
+    // Engine-level Loading/Warming/Playing state machine.
+    EngineLoadingMonitor loading_monitor_;
 
     // Game object system
     ComponentRegistry component_registry_;

--- a/include/gseurat/engine/engine_state.hpp
+++ b/include/gseurat/engine/engine_state.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "gseurat/engine/transfer_queue.hpp"
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace gseurat {
+
+// Engine-level lifecycle state, orthogonal to gameplay states (Title, InGame…).
+// Drives whether engine subsystems are running, paused, or warming up — not
+// what the player is interacting with.
+enum class EngineState : std::uint8_t {
+    Loading,   // assets streaming — gameplay paused, GS compute paused, UI overlay drawn
+    Warming,   // assets uploaded, dispatching GPU pipelines to flush driver state, gameplay still paused
+    Playing,   // normal frame — everything active
+};
+
+// Monitors a batch of in-flight transfer handles, transitioning the engine
+// through Loading → Warming → Playing as they complete and a configurable
+// number of warm-up frames elapse.
+//
+// The monitor is decoupled from `TransferQueue`: callers supply a
+// `StatusProvider` callback when ticking, so any async-load primitive that
+// can answer "is this handle done?" works (transfer queues, texture
+// uploaders, audio streamers, etc.).
+//
+// Default state is `Playing` — apps that never call `begin_load(...)` see no
+// behavioural change, preserving backward compatibility with the existing
+// `gseurat_demo`, headless tests, and CI flows.
+class EngineLoadingMonitor {
+public:
+    using StatusProvider = std::function<TransferQueue::Status(TransferQueue::Handle)>;
+
+    static constexpr std::uint32_t kDefaultWarmupFrames = 4;
+    static constexpr std::uint32_t kMaxWarmupFrames     = 16;
+
+    EngineLoadingMonitor() = default;
+
+    // Configure how many warm-up frames run between the last handle reaching
+    // Complete and the transition to Playing. Clamped to [1, kMaxWarmupFrames].
+    void set_warmup_frames(std::uint32_t n) noexcept;
+    std::uint32_t warmup_frames() const noexcept { return warmup_frames_total_; }
+
+    // Begin a Loading phase tracking the given handles. State flips to
+    // Loading immediately. Subsequent `tick()` calls drive the transition:
+    //   - all handles Complete → Warming, with `warmup_frames_total_` to count down
+    //   - empty handle list   → Warming on the next tick (skip-load fast path
+    //                          for "force a warm-up cycle" callers)
+    void begin_load(std::vector<TransferQueue::Handle> handles);
+
+    // Per-frame: poll handle statuses (or count down warm-up), advance state.
+    // `provider` may be nullptr-equivalent (an empty `std::function`) — that
+    // is treated as "no progress this tick" so the early boot path before
+    // the transfer queue exists is harmless.
+    void tick(const StatusProvider& provider);
+
+    EngineState   state()                    const noexcept { return state_; }
+    std::uint32_t pending_handles()          const noexcept { return static_cast<std::uint32_t>(tracked_.size()); }
+    std::uint32_t warmup_frames_remaining()  const noexcept { return warmup_remaining_; }
+
+    // Frame-policy helpers — what callers (AppBase, Renderer) actually use.
+    bool should_run_gameplay()       const noexcept { return state_ == EngineState::Playing; }
+    bool should_dispatch_gpu_work()  const noexcept { return state_ != EngineState::Loading; }
+    bool should_overlay_loading_ui() const noexcept { return state_ != EngineState::Playing; }
+
+private:
+    // Walk `tracked_` once, removing handles that have reached Complete.
+    // Returns true when no handles remain pending.
+    bool reap_completed(const StatusProvider& provider);
+
+    EngineState                          state_ = EngineState::Playing;
+    std::vector<TransferQueue::Handle>   tracked_;
+    std::uint32_t                        warmup_frames_total_ = kDefaultWarmupFrames;
+    std::uint32_t                        warmup_remaining_    = 0;
+};
+
+}  // namespace gseurat

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -83,7 +83,8 @@ struct GsPreprocessPush {
 
 class GsRenderer {
 public:
-    void init(VkDevice device, VkPhysicalDevice physical_device, VmaAllocator allocator, VkDescriptorPool pool);
+    void init(VkDevice device, VkPhysicalDevice physical_device, VmaAllocator allocator,
+              VkDescriptorPool pool, VkPipelineCache pipeline_cache);
     void load_cloud(const GaussianCloud& cloud);
     void init_streaming(const StreamingConfig& config);
     void unload_cloud(uint32_t chunk_id);
@@ -235,6 +236,7 @@ private:
 
     VkDevice device_ = VK_NULL_HANDLE;
     VmaAllocator allocator_ = VK_NULL_HANDLE;
+    VkPipelineCache pipeline_cache_ = VK_NULL_HANDLE;
 
     // Output storage image (raw HDR from tile rasterizer)
     VkImage output_image_ = VK_NULL_HANDLE;

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -92,6 +92,13 @@ public:
     void poll_transfers(VkCommandBuffer frame_cmd);
     void create_transfer_queue(VkQueue transfer_q, uint32_t transfer_family,
                                uint32_t graphics_family, bool dedicated);
+
+    // Exposed for the engine-level loading monitor: AppBase wires a status
+    // provider against this so the EngineState machine can advance from
+    // Loading → Warming when the streamer's transfer handles complete.
+    // Returns nullptr until `create_transfer_queue` runs.
+    TransferQueue* transfer_queue() { return transfer_queue_.get(); }
+    const TransferQueue* transfer_queue() const { return transfer_queue_.get(); }
     void update_active_gaussians(const Gaussian* data, uint32_t count);
     void update_gaussian_data(const Gaussian* data, uint32_t count);
 

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -91,7 +91,7 @@ public:
     void load_cloud_async(const std::string& ply_path);
     void poll_transfers(VkCommandBuffer frame_cmd);
     void create_transfer_queue(VkQueue transfer_q, uint32_t transfer_family,
-                               bool dedicated);
+                               uint32_t graphics_family, bool dedicated);
     void update_active_gaussians(const Gaussian* data, uint32_t count);
     void update_gaussian_data(const Gaussian* data, uint32_t count);
 

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -91,7 +91,7 @@ public:
     void load_cloud_async(const std::string& ply_path);
     void poll_transfers(VkCommandBuffer frame_cmd);
     void create_transfer_queue(VkQueue transfer_q, uint32_t transfer_family,
-                               bool dedicated, VkQueue graphics_q);
+                               bool dedicated);
     void update_active_gaussians(const Gaussian* data, uint32_t count);
     void update_gaussian_data(const Gaussian* data, uint32_t count);
 

--- a/include/gseurat/engine/pipeline.hpp
+++ b/include/gseurat/engine/pipeline.hpp
@@ -27,7 +27,7 @@ public:
     PipelineBuilder& set_layout(VkPipelineLayout layout);
     PipelineBuilder& set_render_pass(VkRenderPass render_pass, uint32_t subpass);
 
-    VkPipeline build(VkDevice device);
+    VkPipeline build(VkDevice device, VkPipelineCache cache = VK_NULL_HANDLE);
 
 private:
     std::vector<VkPipelineShaderStageCreateInfo> shader_stages_;

--- a/include/gseurat/engine/pipeline_cache.hpp
+++ b/include/gseurat/engine/pipeline_cache.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+
+#include <filesystem>
+#include <span>
+
+namespace gseurat {
+
+// Disk-backed VkPipelineCache wrapper.
+//
+// On init(), attempts to load a previously-saved cache blob from `path` and
+// validates its header (length / version / vendorID / deviceID / UUID) against
+// the current physical device. Mismatch or any I/O failure is non-fatal — we
+// fall back to an empty cache. The VkPipelineCache handle is always valid
+// after a successful init() (driver allocation is the only hard failure).
+//
+// On save(), retrieves the current cache contents from the driver and writes
+// them atomically (temp file + rename). Errors are logged to stderr but never
+// thrown — losing the cache is a perf hit, not a correctness bug.
+class PipelineCache {
+public:
+    PipelineCache() = default;
+    ~PipelineCache() = default;
+
+    PipelineCache(const PipelineCache&) = delete;
+    PipelineCache& operator=(const PipelineCache&) = delete;
+    PipelineCache(PipelineCache&&) = delete;
+    PipelineCache& operator=(PipelineCache&&) = delete;
+
+    // Initialize the cache. Pass an empty `path` for an in-memory-only cache
+    // (e.g. headless tests) — load attempts and save() become no-ops, but
+    // the cache still deduplicates shader compiles within a single process.
+    // Returns true if existing on-disk data was loaded; false if started fresh.
+    bool init(VkDevice device, VkPhysicalDevice physical_device,
+              std::filesystem::path path);
+
+    // Persist current cache contents to disk. Safe to call multiple times,
+    // and a no-op if `path` is empty or init() was never called.
+    void save() const;
+
+    // Destroy the underlying VkPipelineCache. Safe to call without init().
+    void shutdown(VkDevice device);
+
+    VkPipelineCache handle() const { return cache_; }
+    const std::filesystem::path& path() const { return path_; }
+
+private:
+    // Validate the 32-byte VkPipelineCacheHeaderVersionOne preamble against
+    // the current physical device's properties.
+    static bool header_matches(std::span<const std::byte> blob,
+                               const VkPhysicalDeviceProperties& props);
+
+    VkDevice device_ = VK_NULL_HANDLE;
+    VkPipelineCache cache_ = VK_NULL_HANDLE;
+    std::filesystem::path path_;
+};
+
+} // namespace gseurat

--- a/include/gseurat/engine/post_process.hpp
+++ b/include/gseurat/engine/post_process.hpp
@@ -46,7 +46,8 @@ struct PostProcessParams {
 
 class PostProcessPipeline {
 public:
-    void init(VkDevice device, VmaAllocator allocator, const Swapchain& swapchain);
+    void init(VkDevice device, VmaAllocator allocator, const Swapchain& swapchain,
+              VkPipelineCache pipeline_cache);
     void shutdown(VkDevice device, VmaAllocator allocator);
 
     VkRenderPass scene_render_pass() const { return scene_render_pass_; }
@@ -77,7 +78,7 @@ private:
     void create_render_passes(VkDevice device, VkFormat swapchain_format);
     void create_framebuffers(VkDevice device, const Swapchain& swapchain);
     void create_descriptor_resources(VkDevice device);
-    void create_pipelines(VkDevice device);
+    void create_pipelines(VkDevice device, VkPipelineCache cache);
 
     ImageResource create_color_image(VkDevice device, VmaAllocator allocator,
                                      VkFormat format, uint32_t width, uint32_t height,

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -79,6 +79,10 @@ public:
     void set_gs_lod_focus(const glm::vec3& pos) { gs_lod_focus_pos_ = pos; gs_has_lod_focus_ = true; }
     void clear_gs_lod_focus() { gs_has_lod_focus_ = false; }
 
+    // `dispatch_gpu_compute` gates GS-renderer compute pipelines (preprocess /
+    // sort / merge / render / pbd_solver / tile_render / post_process). Set
+    // false during EngineState::Loading to keep the GPU idle while the
+    // loading screen draws; true during Warming and Playing.
     void draw_scene(Scene& scene,
                     const std::vector<SpriteDrawInfo>& entity_sprites = {},
                     const std::vector<SpriteDrawInfo>& outline_sprites = {},
@@ -88,7 +92,8 @@ public:
                     const std::vector<SpriteDrawInfo>& overlay = {},
                     const std::vector<ui::UIDrawBatch>& ui_batches = {},
                     const std::vector<DebugColliderDrawInfo>& debug_colliders_list = {},
-                    const FeatureFlags& flags = {});
+                    const FeatureFlags& flags = {},
+                    bool dispatch_gpu_compute = true);
 
     /// Draw debug collider wireframes. Call between scene pass begin and end.
     void draw_debug_colliders(VkCommandBuffer cmd,
@@ -175,7 +180,8 @@ private:
                           const std::vector<SpriteDrawInfo>& sprites,
                           VkDescriptorSet descriptor_set);
     void record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
-                           const FeatureFlags& flags);
+                           const FeatureFlags& flags,
+                           bool dispatch_gpu_compute);
     void record_gs_blit(VkCommandBuffer cmd, const FeatureFlags& flags);
     void record_ui_pass(VkCommandBuffer cmd,
                         const std::vector<ui::UIDrawBatch>& ui_batches);

--- a/include/gseurat/engine/transfer_queue.hpp
+++ b/include/gseurat/engine/transfer_queue.hpp
@@ -5,6 +5,7 @@
 #include <vk_mem_alloc.h>
 #include <vulkan/vulkan.h>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
@@ -98,6 +99,16 @@ public:
     bool          is_dedicated()  const { return dedicated_; }
     std::uint64_t staging_size()  const { return staging_size_; }
 
+    // Signal worker threads spinning on `reserve_staging()` that the queue is
+    // tearing down so they can abandon their work and exit. Must be called
+    // before joining loader threads — `shutdown()` itself blocks on
+    // `vkDeviceWaitIdle` which would deadlock if a worker still holds a
+    // reservation that will never be drained.
+    void request_cancel();
+    bool is_shutting_down() const noexcept {
+        return shutting_down_.load(std::memory_order_acquire);
+    }
+
     void shutdown();
 
 private:
@@ -161,6 +172,8 @@ private:
 
     std::uint64_t next_handle_id_ = 1;
     std::uint64_t next_token_     = 1;
+
+    std::atomic<bool> shutting_down_{false};
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/transfer_queue.hpp
+++ b/include/gseurat/engine/transfer_queue.hpp
@@ -59,6 +59,7 @@ public:
 
     TransferQueue(VkDevice device, VmaAllocator allocator,
                   VkQueue transfer_queue, std::uint32_t transfer_family,
+                  std::uint32_t graphics_family,
                   bool dedicated, std::uint64_t staging_size,
                   std::uint32_t transfer_budget_mb);
 
@@ -115,6 +116,10 @@ private:
         VkFence                              fence = VK_NULL_HANDLE;
         std::vector<Handle>                  handles;
         std::vector<std::function<void()>>   callbacks;
+        // Per-buffer ranges for the graphics-side acquire barrier (dedicated
+        // path only — empty when transfer_family_ == graphics_family_).
+        struct AcquireRange { VkBuffer buffer; std::uint64_t offset; std::uint64_t size; };
+        std::vector<AcquireRange>            acquire_ranges;
         std::uint64_t                        max_logical_end = 0;   // for ring retirement
     };
 
@@ -125,6 +130,7 @@ private:
     VmaAllocator     allocator_;
     VkQueue          transfer_queue_;
     std::uint32_t    transfer_family_;
+    std::uint32_t    graphics_family_;
     bool             dedicated_;
     std::uint64_t    staging_size_;
     std::uint64_t    transfer_budget_bytes_;

--- a/include/gseurat/engine/transfer_queue.hpp
+++ b/include/gseurat/engine/transfer_queue.hpp
@@ -1,85 +1,160 @@
 #pragma once
 
+#include "gseurat/engine/buffer.hpp"
+
+#include <vk_mem_alloc.h>
+#include <vulkan/vulkan.h>
+
+#include <cstddef>
 #include <cstdint>
 #include <deque>
 #include <functional>
 #include <mutex>
+#include <optional>
+#include <unordered_map>
 #include <vector>
-#include <vulkan/vulkan.h>
-#include <vk_mem_alloc.h>
-#include "gseurat/engine/buffer.hpp"
 
 namespace gseurat {
 
-struct TransferChunk {
-    uint64_t staging_offset;
-    uint64_t dest_offset;
-    uint64_t size;
-    std::function<void()> on_complete;
-    bool is_completion_marker{false};
-};
-
+// Asynchronous host→device transfers via a shared host-visible staging ring.
+//
+// Use:
+//   1. `reserve_staging(bytes)`  → caller memcpys the payload into `host_ptr`
+//   2. `submit(reservation, dest_buffer, dest_offset, on_complete?)` → Handle
+//   3. main loop calls `poll_completions(frame_cmd)` once per frame; signaled
+//      fences retire batches, fire callbacks, and (when the transfer queue is
+//      a dedicated family) emit acquire barriers into `frame_cmd`.
+//
+// Threading: `reserve_staging` and `submit` are mutex-locked and safe to call
+// from worker threads. `poll_completions` must run on the main thread (it
+// manipulates the transfer command buffer and `frame_cmd`).
 class TransferQueue {
 public:
+    // Opaque handle ECS components hold to track an in-flight transfer.
+    // 0 is reserved for "invalid".
+    struct Handle {
+        std::uint64_t id = 0;
+        explicit operator bool() const noexcept { return id != 0; }
+        bool operator==(const Handle&) const = default;
+    };
+
+    enum class Status {
+        Unknown,    // handle never seen (or already aged out of recent map)
+        Pending,    // queued, not yet submitted to GPU
+        InFlight,   // submitted, fence not yet signaled
+        Complete,   // GPU finished, callback fired (cached briefly)
+        Failed,     // staging reservation could not be fulfilled
+    };
+
+    // Slice of the host-visible staging ring leased to a producer.
+    struct Reservation {
+        std::byte*    host_ptr        = nullptr;
+        std::uint64_t staging_offset  = 0;   // physical offset in staging buffer
+        std::uint64_t size            = 0;
+        std::uint64_t logical_end     = 0;   // monotonic ring offset for retirement
+        std::uint64_t token           = 0;   // sanity-check tag
+
+        explicit operator bool() const noexcept { return host_ptr != nullptr; }
+    };
+
     TransferQueue(VkDevice device, VmaAllocator allocator,
-                  VkQueue transfer_queue, uint32_t transfer_family,
-                  bool dedicated, uint64_t staging_size,
-                  uint32_t transfer_budget_mb,
-                  VkBuffer dest_buffer);
+                  VkQueue transfer_queue, std::uint32_t transfer_family,
+                  bool dedicated, std::uint64_t staging_size,
+                  std::uint32_t transfer_budget_mb);
 
     ~TransferQueue();
 
-    // Not copyable or movable — owns Vulkan handles
-    TransferQueue(const TransferQueue&) = delete;
+    TransferQueue(const TransferQueue&)            = delete;
     TransferQueue& operator=(const TransferQueue&) = delete;
-    TransferQueue(TransferQueue&&) = delete;
-    TransferQueue& operator=(TransferQueue&&) = delete;
+    TransferQueue(TransferQueue&&)                 = delete;
+    TransferQueue& operator=(TransferQueue&&)      = delete;
 
-    // Enqueue a copy from staging_offset -> dest_offset of the given size.
-    // on_complete is called once the GPU copy has finished.
-    void enqueue(uint64_t staging_offset, uint64_t dest_offset,
-                 uint64_t size, std::function<void()> on_complete = nullptr);
+    // Carve out `bytes` of host-visible staging. Returns nullopt if the ring
+    // is too full this frame — caller should retry next frame (after poll
+    // has had a chance to retire in-flight batches).
+    std::optional<Reservation> reserve_staging(std::uint64_t bytes);
 
-    // Enqueue a callback with no associated copy (fires after all preceding copies finish).
+    // Schedule a copy of the reservation into [dest_buffer + dest_offset].
+    // The reservation is consumed; do not pass it to submit() twice.
+    Handle submit(const Reservation& reservation,
+                  VkBuffer dest_buffer, std::uint64_t dest_offset,
+                  std::function<void()> on_complete = {});
+
+    // Schedule a callback that fires after every preceding submit() in the
+    // current pending batch finishes. Useful for "all chunks for asset X are
+    // uploaded → register asset" without per-chunk handles.
     void enqueue_completion(std::function<void()> on_complete);
 
-    // Called once per frame. Checks for completed transfers and fires callbacks.
-    // frame_cmd is used on the fallback (graphics-queue) path only.
+    // Per-frame: retire signaled fences, fire callbacks, emit acquire barriers
+    // into `frame_cmd` (dedicated transfer family only), and submit the next
+    // pending batch.
     void poll_completions(VkCommandBuffer frame_cmd);
 
-    void* staging_mapped() const { return staging_buffer_.mapped(); }
-    uint64_t staging_size() const { return staging_size_; }
-    bool is_dedicated() const { return dedicated_; }
+    // O(1) lookup; returns Status::Unknown for handles whose record has aged
+    // out of the retention map (~64 most recent retirements are kept).
+    Status status(Handle handle) const;
+
+    bool          is_dedicated()  const { return dedicated_; }
+    std::uint64_t staging_size()  const { return staging_size_; }
 
     void shutdown();
 
 private:
-    VkDevice device_;
-    VmaAllocator allocator_;
-    VkQueue transfer_queue_;
-    uint32_t transfer_family_;
-    bool dedicated_;
-    uint64_t staging_size_;
-    uint64_t transfer_budget_bytes_;
-    VkBuffer dest_buffer_;  // not owned — reference to main Gaussian SSBO
-
-    Buffer staging_buffer_;
-
-    // Dedicated transfer path
-    VkCommandPool transfer_cmd_pool_{VK_NULL_HANDLE};
-    VkCommandBuffer transfer_cmd_{VK_NULL_HANDLE};
-    VkFence transfer_fence_{VK_NULL_HANDLE};
-    bool transfer_in_flight_{false};
-
-    // Pending transfer queue (thread-safe)
-    std::mutex queue_mutex_;
-    std::deque<TransferChunk> pending_chunks_;
+    struct PendingChunk {
+        Handle                handle;
+        VkBuffer              dest_buffer = VK_NULL_HANDLE;
+        std::uint64_t         dest_offset = 0;
+        std::uint64_t         staging_offset = 0;
+        std::uint64_t         size = 0;
+        std::uint64_t         logical_end = 0;          // for ring retirement
+        std::function<void()> on_complete;
+        bool                  is_completion_marker = false;
+    };
 
     struct InFlightBatch {
-        VkFence fence;
-        std::vector<std::function<void()>> callbacks;
+        VkFence                              fence = VK_NULL_HANDLE;
+        std::vector<Handle>                  handles;
+        std::vector<std::function<void()>>   callbacks;
+        std::uint64_t                        max_logical_end = 0;   // for ring retirement
     };
+
+    void retire_batch(InFlightBatch& batch, VkCommandBuffer frame_cmd);
+    Handle make_handle();
+
+    VkDevice         device_;
+    VmaAllocator     allocator_;
+    VkQueue          transfer_queue_;
+    std::uint32_t    transfer_family_;
+    bool             dedicated_;
+    std::uint64_t    staging_size_;
+    std::uint64_t    transfer_budget_bytes_;
+
+    Buffer           staging_buffer_;
+
+    // Dedicated path
+    VkCommandPool    transfer_cmd_pool_ = VK_NULL_HANDLE;
+    VkCommandBuffer  transfer_cmd_      = VK_NULL_HANDLE;
+    VkFence          transfer_fence_    = VK_NULL_HANDLE;
+    bool             transfer_in_flight_ = false;
+
+    // Ring watermarks (linear, monotonic — physical offset = X % staging_size_).
+    // Protected by `queue_mutex_`.
+    std::uint64_t    ring_write_ = 0;   // next byte to allocate
+    std::uint64_t    ring_read_  = 0;   // bytes up to this offset are free
+
+    // Pending queue
+    mutable std::mutex        queue_mutex_;
+    std::deque<PendingChunk>  pending_chunks_;
     std::deque<InFlightBatch> in_flight_;
+
+    // Status tracking
+    std::unordered_map<std::uint64_t, Status> pending_status_;
+    std::deque<std::uint64_t>                 recent_complete_order_;
+    std::unordered_map<std::uint64_t, Status> recent_status_;
+    static constexpr std::size_t              kRecentStatusCap = 64;
+
+    std::uint64_t next_handle_id_ = 1;
+    std::uint64_t next_token_     = 1;
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/vk_context.hpp
+++ b/include/gseurat/engine/vk_context.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "gseurat/engine/pipeline_cache.hpp"
+
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 #include <vk_mem_alloc.h>
@@ -26,6 +28,12 @@ public:
     VkSurfaceKHR surface() const { return surface_; }
     VmaAllocator allocator() const { return allocator_; }
 
+    // Engine-wide pipeline cache (disk-backed in windowed mode, in-memory in
+    // headless mode). Hands the same VkPipelineCache handle to every
+    // vkCreate{Compute,Graphics}Pipelines call so the driver can amortise
+    // shader compilation across pipelines and runs.
+    VkPipelineCache pipeline_cache() const { return pipeline_cache_.handle(); }
+
 private:
     void create_instance();
     void setup_debug_messenger();
@@ -33,6 +41,7 @@ private:
     void pick_physical_device();
     void create_logical_device();
     void create_allocator();
+    void create_pipeline_cache(bool persistent);
 
     int32_t find_queue_family() const;
     std::vector<const char*> get_required_device_extensions() const;
@@ -54,6 +63,7 @@ private:
     bool is_apple_gpu_{false};
     bool headless_{false};
     VmaAllocator allocator_ = VK_NULL_HANDLE;
+    PipelineCache pipeline_cache_;
 };
 
 }  // namespace gseurat

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -223,15 +223,19 @@ void AppBase::main_loop() {
         debug_metrics_.update(dt);
 
         // Drive the engine lifecycle state machine. The status provider
-        // closes over the GS streamer's transfer queue when one exists; if
-        // no streaming is active, the empty `std::function` makes `tick()`
-        // a safe no-op (only the Warming countdown advances).
-        // GsRenderer doesn't yet expose its TransferQueue handle, so for
-        // now we drive the monitor with an empty provider — only callers
-        // that explicitly `begin_load({})` (skip-load fast path) advance
-        // the state machine. Real handle tracking arrives once streaming
-        // is wired into engine startup in a follow-up.
-        loading_monitor_.tick({});
+        // closes over the GS streamer's transfer queue when one exists. If
+        // no streaming has been initialised yet, the closure returns
+        // `Unknown`, which the monitor treats as resolved — that way a
+        // caller who `begin_load`s before streaming is wired up doesn't
+        // permanently stall in Loading. Once streaming is active, real
+        // handle status flows through.
+        loading_monitor_.tick(
+            [this](TransferQueue::Handle h) -> TransferQueue::Status {
+                if (auto* tq = renderer_.gs_renderer().transfer_queue()) {
+                    return tq->status(h);
+                }
+                return TransferQueue::Status::Unknown;
+            });
 
         // F1 → toggle developer overlay
         if (input_.was_key_pressed(GLFW_KEY_F1)) {

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -222,6 +222,17 @@ void AppBase::main_loop() {
 
         debug_metrics_.update(dt);
 
+        // Drive the engine lifecycle state machine. The status provider
+        // closes over the GS streamer's transfer queue when one exists; if
+        // no streaming is active, the empty `std::function` makes `tick()`
+        // a safe no-op (only the Warming countdown advances).
+        // GsRenderer doesn't yet expose its TransferQueue handle, so for
+        // now we drive the monitor with an empty provider — only callers
+        // that explicitly `begin_load({})` (skip-load fast path) advance
+        // the state machine. Real handle tracking arrives once streaming
+        // is wired into engine startup in a follow-up.
+        loading_monitor_.tick({});
+
         // F1 → toggle developer overlay
         if (input_.was_key_pressed(GLFW_KEY_F1)) {
             dev_overlay_.toggle();
@@ -233,7 +244,13 @@ void AppBase::main_loop() {
         }
         dev_overlay_.begin_frame();
 
-        state_stack_.update(*this, dt);
+        // Gameplay updates (KCC, AI, PBD integration, animations) only run
+        // in EngineState::Playing. During Loading and Warming the world is
+        // intentionally frozen so the player doesn't see physics tick or
+        // characters move during the loading screen.
+        if (loading_monitor_.should_run_gameplay()) {
+            state_stack_.update(*this, dt);
+        }
 
         // Broadcast camera state to subscribed clients (throttled to 30 Hz)
         camera_broadcast_timer_ += dt;
@@ -258,8 +275,12 @@ void AppBase::main_loop() {
         // Reset camera sync override at frame end
         command_dispatcher_.context().camera_sync_override = false;
 
-        upload_bone_transforms();
-        gameplay_.play_time += dt;
+        // Bone transforms only stream up while gameplay is running; otherwise
+        // they freeze at their last value, matching the suspended world state.
+        if (loading_monitor_.should_run_gameplay()) {
+            upload_bone_transforms();
+            gameplay_.play_time += dt;
+        }
         tick_++;
 
         // Feed UI context with input state
@@ -333,9 +354,14 @@ void AppBase::main_loop() {
                 });
         }
 
+        // GS compute pipelines (preprocess / sort / merge / render / pbd /
+        // tile_render / post_process) are gated on the engine state. Loading
+        // skips them entirely; Warming dispatches them to flush driver state
+        // against freshly-uploaded buffers; Playing is the steady state.
+        const bool dispatch_gpu_compute = loading_monitor_.should_dispatch_gpu_work();
         renderer_.draw_scene(scene_, draw_lists_.entity, draw_lists_.outline, draw_lists_.reflection,
                              draw_lists_.shadow, particle_sprites, draw_lists_.overlay, ui_batches,
-                             draw_lists_.debug_colliders, feature_flags_);
+                             draw_lists_.debug_colliders, feature_flags_, dispatch_gpu_compute);
     }
 }
 

--- a/src/engine/engine_state.cpp
+++ b/src/engine/engine_state.cpp
@@ -1,0 +1,61 @@
+#include "gseurat/engine/engine_state.hpp"
+
+#include <algorithm>
+
+namespace gseurat {
+
+void EngineLoadingMonitor::set_warmup_frames(std::uint32_t n) noexcept {
+    if (n == 0) n = 1;
+    if (n > kMaxWarmupFrames) n = kMaxWarmupFrames;
+    warmup_frames_total_ = n;
+}
+
+void EngineLoadingMonitor::begin_load(std::vector<TransferQueue::Handle> handles) {
+    tracked_           = std::move(handles);
+    warmup_remaining_  = 0;
+    state_             = EngineState::Loading;
+}
+
+bool EngineLoadingMonitor::reap_completed(const StatusProvider& provider) {
+    if (!provider) return tracked_.empty();   // no progress; only empty list is "done"
+
+    auto it = std::remove_if(tracked_.begin(), tracked_.end(),
+        [&](TransferQueue::Handle h) {
+            // Complete → drop. Failed → also drop (caller decides what to do
+            // with the side-effect; the loader monitor's job is "did the
+            // handle resolve", not "did it succeed"). Pending/InFlight stay.
+            const auto s = provider(h);
+            return s == TransferQueue::Status::Complete
+                || s == TransferQueue::Status::Failed;
+        });
+    tracked_.erase(it, tracked_.end());
+    return tracked_.empty();
+}
+
+void EngineLoadingMonitor::tick(const StatusProvider& provider) {
+    switch (state_) {
+        case EngineState::Loading: {
+            if (reap_completed(provider)) {
+                // All handles resolved. Begin warm-up.
+                state_            = EngineState::Warming;
+                warmup_remaining_ = warmup_frames_total_;
+            }
+            return;
+        }
+        case EngineState::Warming: {
+            if (warmup_remaining_ > 0) {
+                --warmup_remaining_;
+            }
+            if (warmup_remaining_ == 0) {
+                state_ = EngineState::Playing;
+            }
+            return;
+        }
+        case EngineState::Playing:
+            // Steady state. Nothing to advance until begin_load() is called
+            // again (e.g. on scene transition).
+            return;
+    }
+}
+
+}  // namespace gseurat

--- a/src/engine/engine_state.cpp
+++ b/src/engine/engine_state.cpp
@@ -21,12 +21,18 @@ bool EngineLoadingMonitor::reap_completed(const StatusProvider& provider) {
 
     auto it = std::remove_if(tracked_.begin(), tracked_.end(),
         [&](TransferQueue::Handle h) {
-            // Complete → drop. Failed → also drop (caller decides what to do
-            // with the side-effect; the loader monitor's job is "did the
-            // handle resolve", not "did it succeed"). Pending/InFlight stay.
+            // Anything other than Pending/InFlight is "resolved" from the
+            // monitor's perspective:
+            //   - Complete → as advertised
+            //   - Failed   → caller handles the error path; we don't stall
+            //   - Unknown  → either the queue aged this handle out of its
+            //                ~64-entry recent_status_ window, or the handle
+            //                was never tracked. In both cases waiting on
+            //                it forever would be wrong (would deadlock the
+            //                Loading state machine for large batches).
             const auto s = provider(h);
-            return s == TransferQueue::Status::Complete
-                || s == TransferQueue::Status::Failed;
+            return s != TransferQueue::Status::Pending
+                && s != TransferQueue::Status::InFlight;
         });
     tracked_.erase(it, tracked_.end());
     return tracked_.empty();

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1,10 +1,13 @@
 #include "gseurat/engine/gs_renderer.hpp"
 #include "gseurat/engine/pipeline.hpp"
 
+#include <chrono>
 #include <cmath>
 #include <cstring>
 #include <stdexcept>
+#include <thread>
 #include <algorithm>
+#include <optional>
 
 namespace gseurat {
 
@@ -956,15 +959,17 @@ void GsRenderer::unload_cloud(uint32_t chunk_id) {
 }
 
 void GsRenderer::create_transfer_queue(VkQueue transfer_q, uint32_t transfer_family,
-                                        bool dedicated, VkQueue graphics_q) {
+                                        bool dedicated) {
     if (!streaming_initialized_) return;
-    const uint64_t staging_size = streaming_config_.slab_bytes() * 2;  // double-buffered
+    // Sized for double-buffered slab uploads plus headroom for in-flight
+    // chunks before they retire on the fence — multi-batch concurrency now
+    // matters because the queue accepts arbitrary destination buffers.
+    const uint64_t staging_size = streaming_config_.slab_bytes() * 4;
     transfer_queue_ = std::make_unique<TransferQueue>(
         device_, allocator_,
         transfer_q, transfer_family,
         dedicated, staging_size,
-        streaming_config_.transfer_budget_mb_per_frame,
-        static_gaussian_ssbo_.buffer());
+        streaming_config_.transfer_budget_mb_per_frame);
 }
 
 void GsRenderer::load_cloud_async(const std::string& ply_path) {
@@ -989,32 +994,38 @@ void GsRenderer::load_cloud_async(const std::string& ply_path) {
         auto handle = slab_allocator_->checkout(slabs_needed);
 
         const auto& gaussians = cloud.gaussians();
-        auto* staging = static_cast<uint8_t*>(transfer_queue_->staging_mapped());
-        const uint64_t slab_bytes = static_cast<uint64_t>(sps) * sizeof(GpuGaussian);
+        const VkBuffer dest = static_gaussian_ssbo_.buffer();
 
         for (uint32_t s = 0; s < slabs_needed; ++s) {
             const uint32_t physical_slab = handle.slab_indices[s];
             const uint32_t src_start = s * sps;
-            const uint32_t src_end = std::min(src_start + sps, splat_count);
-            const uint32_t count = src_end - src_start;
+            const uint32_t src_end   = std::min(src_start + sps, splat_count);
+            const uint32_t count     = src_end - src_start;
+            const uint64_t copy_size = static_cast<uint64_t>(count) * sizeof(GpuGaussian);
 
-            // Write into staging buffer (ring: alternate halves)
-            const uint64_t staging_offset = (s % 2) * slab_bytes;
-            auto* dst = reinterpret_cast<GpuGaussian*>(staging + staging_offset);
+            // Block-and-retry: reservation only fails when the staging ring is
+            // full of in-flight bytes. The main thread's poll() will retire
+            // batches and free space within a few frames.
+            std::optional<TransferQueue::Reservation> res;
+            while (!(res = transfer_queue_->reserve_staging(copy_size))) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            }
+
+            auto* dst = reinterpret_cast<GpuGaussian*>(res->host_ptr);
             for (uint32_t i = 0; i < count; ++i) {
                 const auto& g = gaussians[src_start + i];
                 float bone_as_float;
                 uint32_t bone_idx = g.bone_index;
                 std::memcpy(&bone_as_float, &bone_idx, sizeof(float));
                 dst[i].pos_opacity = glm::vec4(g.position, g.opacity);
-                dst[i].scale_pad = glm::vec4(g.scale, bone_as_float);
-                dst[i].rot = glm::vec4(g.rotation.x, g.rotation.y, g.rotation.z, g.rotation.w);
-                dst[i].color_pad = glm::vec4(g.color, g.emission);
+                dst[i].scale_pad   = glm::vec4(g.scale, bone_as_float);
+                dst[i].rot         = glm::vec4(g.rotation.x, g.rotation.y, g.rotation.z, g.rotation.w);
+                dst[i].color_pad   = glm::vec4(g.color, g.emission);
             }
 
-            const uint64_t dest_offset = static_cast<uint64_t>(physical_slab) * sps * sizeof(GpuGaussian);
-            const uint64_t copy_size = static_cast<uint64_t>(count) * sizeof(GpuGaussian);
-            transfer_queue_->enqueue(staging_offset, dest_offset, copy_size);
+            const uint64_t dest_offset =
+                static_cast<uint64_t>(physical_slab) * sps * sizeof(GpuGaussian);
+            transfer_queue_->submit(*res, dest, dest_offset);
         }
 
         // Completion callback — runs on main thread via poll_completions

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1005,9 +1005,12 @@ void GsRenderer::load_cloud_async(const std::string& ply_path) {
 
             // Block-and-retry: reservation only fails when the staging ring is
             // full of in-flight bytes. The main thread's poll() will retire
-            // batches and free space within a few frames.
+            // batches and free space within a few frames. On engine shutdown
+            // the queue's cancellation flag flips, breaking the loop so the
+            // joining thread doesn't deadlock.
             std::optional<TransferQueue::Reservation> res;
             while (!(res = transfer_queue_->reserve_staging(copy_size))) {
+                if (transfer_queue_->is_shutting_down()) return;
                 std::this_thread::sleep_for(std::chrono::milliseconds(2));
             }
 
@@ -2760,7 +2763,10 @@ void GsRenderer::load_world(const WorldManifest& manifest) {
 void GsRenderer::shutdown(VmaAllocator allocator) {
     if (!initialized_) return;
 
-    // Join background load threads before destroying resources
+    // Signal in-flight loaders to bail out of their reserve_staging() retry
+    // loops *before* joining — otherwise a worker waiting on space that will
+    // never be freed (because we've stopped polling) would hang the join.
+    if (transfer_queue_) transfer_queue_->request_cancel();
     for (auto& t : load_threads_) {
         if (t.joinable()) t.join();
     }

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -69,10 +69,12 @@ void insert_compute_barrier(VkCommandBuffer cmd) {
 }  // namespace
 
 void GsRenderer::init(VkDevice device, VkPhysicalDevice physical_device,
-                      VmaAllocator allocator, VkDescriptorPool pool) {
+                      VmaAllocator allocator, VkDescriptorPool pool,
+                      VkPipelineCache pipeline_cache) {
     device_ = device;
     allocator_ = allocator;
     pool_ = pool;
+    pipeline_cache_ = pipeline_cache;
 
     create_output_image(320, 240);
 
@@ -536,7 +538,7 @@ void GsRenderer::create_compute_pipelines() {
         pi.stage.pName = "main";
         pi.layout = out_layout;
 
-        if (vkCreateComputePipelines(device_, VK_NULL_HANDLE, 1, &pi,
+        if (vkCreateComputePipelines(device_, pipeline_cache_, 1, &pi,
                                      nullptr, &out_pipeline) != VK_SUCCESS) {
             throw std::runtime_error(std::string("Failed to create pipeline: ") + spv_path);
         }

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -959,7 +959,7 @@ void GsRenderer::unload_cloud(uint32_t chunk_id) {
 }
 
 void GsRenderer::create_transfer_queue(VkQueue transfer_q, uint32_t transfer_family,
-                                        bool dedicated) {
+                                        uint32_t graphics_family, bool dedicated) {
     if (!streaming_initialized_) return;
     // Sized for double-buffered slab uploads plus headroom for in-flight
     // chunks before they retire on the fence — multi-batch concurrency now
@@ -967,7 +967,7 @@ void GsRenderer::create_transfer_queue(VkQueue transfer_q, uint32_t transfer_fam
     const uint64_t staging_size = streaming_config_.slab_bytes() * 4;
     transfer_queue_ = std::make_unique<TransferQueue>(
         device_, allocator_,
-        transfer_q, transfer_family,
+        transfer_q, transfer_family, graphics_family,
         dedicated, staging_size,
         streaming_config_.transfer_budget_mb_per_frame);
 }

--- a/src/engine/pipeline.cpp
+++ b/src/engine/pipeline.cpp
@@ -148,7 +148,7 @@ PipelineBuilder& PipelineBuilder::set_render_pass(VkRenderPass render_pass, uint
     return *this;
 }
 
-VkPipeline PipelineBuilder::build(VkDevice device) {
+VkPipeline PipelineBuilder::build(VkDevice device, VkPipelineCache cache) {
     VkPipelineViewportStateCreateInfo viewport_state{};
     viewport_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
     viewport_state.viewportCount = 1;
@@ -185,7 +185,7 @@ VkPipeline PipelineBuilder::build(VkDevice device) {
     }
 
     VkPipeline pipeline;
-    if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &info, nullptr, &pipeline) !=
+    if (vkCreateGraphicsPipelines(device, cache, 1, &info, nullptr, &pipeline) !=
         VK_SUCCESS) {
         throw std::runtime_error("Failed to create graphics pipeline");
     }

--- a/src/engine/pipeline_cache.cpp
+++ b/src/engine/pipeline_cache.cpp
@@ -1,0 +1,197 @@
+#include "gseurat/engine/pipeline_cache.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <vector>
+
+namespace gseurat {
+
+namespace {
+constexpr std::size_t kVkPipelineCacheHeaderSize = 32;
+}  // namespace
+
+bool PipelineCache::header_matches(std::span<const std::byte> blob,
+                                   const VkPhysicalDeviceProperties& props) {
+    if (blob.size() < kVkPipelineCacheHeaderSize) return false;
+
+    // VkPipelineCacheHeaderVersionOne layout (Vulkan 1.0+):
+    //    0 .. 3   uint32  headerLength      (== 32)
+    //    4 .. 7   uint32  headerVersion     (== VK_PIPELINE_CACHE_HEADER_VERSION_ONE = 1)
+    //    8 .. 11  uint32  vendorID
+    //   12 .. 15  uint32  deviceID
+    //   16 .. 31  uint8[VK_UUID_SIZE]  pipelineCacheUUID  (16 bytes)
+    std::uint32_t header_len = 0;
+    std::uint32_t header_ver = 0;
+    std::uint32_t vendor_id = 0;
+    std::uint32_t device_id = 0;
+    std::memcpy(&header_len, blob.data() + 0,  4);
+    std::memcpy(&header_ver, blob.data() + 4,  4);
+    std::memcpy(&vendor_id,  blob.data() + 8,  4);
+    std::memcpy(&device_id,  blob.data() + 12, 4);
+
+    if (header_len != kVkPipelineCacheHeaderSize) return false;
+    if (header_ver != VK_PIPELINE_CACHE_HEADER_VERSION_ONE) return false;
+    if (vendor_id != props.vendorID) return false;
+    if (device_id != props.deviceID) return false;
+    if (std::memcmp(blob.data() + 16, props.pipelineCacheUUID, VK_UUID_SIZE) != 0) {
+        return false;
+    }
+    return true;
+}
+
+bool PipelineCache::init(VkDevice device, VkPhysicalDevice physical_device,
+                         std::filesystem::path path) {
+    device_ = device;
+    path_   = std::move(path);
+
+    VkPhysicalDeviceProperties props{};
+    vkGetPhysicalDeviceProperties(physical_device, &props);
+
+    std::vector<std::byte> initial_data;
+
+    if (!path_.empty()) {
+        std::error_code ec;
+        if (std::filesystem::exists(path_, ec) && !ec) {
+            std::ifstream file(path_, std::ios::binary | std::ios::ate);
+            if (file) {
+                auto size = static_cast<std::streamoff>(file.tellg());
+                if (size > 0) {
+                    initial_data.resize(static_cast<std::size_t>(size));
+                    file.seekg(0);
+                    file.read(reinterpret_cast<char*>(initial_data.data()), size);
+                    if (!file) {
+                        std::fprintf(stderr,
+                            "[PipelineCache] read failed for %s; starting fresh\n",
+                            path_.string().c_str());
+                        initial_data.clear();
+                    }
+                }
+            }
+        }
+
+        if (!initial_data.empty() && !header_matches(initial_data, props)) {
+            std::fprintf(stderr,
+                "[PipelineCache] header mismatch (driver/device changed?); starting fresh\n");
+            initial_data.clear();
+        }
+    }
+
+    VkPipelineCacheCreateInfo info{};
+    info.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
+    info.initialDataSize = initial_data.size();
+    info.pInitialData    = initial_data.empty() ? nullptr : initial_data.data();
+
+    VkResult res = vkCreatePipelineCache(device_, &info, nullptr, &cache_);
+    if (res != VK_SUCCESS) {
+        // Some drivers reject blobs the header check accepts (Vulkan permits
+        // implementation-defined post-header validation). Retry with empty data.
+        std::fprintf(stderr,
+            "[PipelineCache] vkCreatePipelineCache(%zu B) failed (%d); retrying empty\n",
+            initial_data.size(), static_cast<int>(res));
+        info.initialDataSize = 0;
+        info.pInitialData    = nullptr;
+        res = vkCreatePipelineCache(device_, &info, nullptr, &cache_);
+        if (res != VK_SUCCESS) {
+            std::fprintf(stderr,
+                "[PipelineCache] empty creation also failed (%d); cache disabled\n",
+                static_cast<int>(res));
+            cache_ = VK_NULL_HANDLE;
+        }
+        return false;
+    }
+
+    bool loaded_existing = !initial_data.empty();
+    if (loaded_existing) {
+        std::fprintf(stderr,
+            "[PipelineCache] loaded %zu bytes from %s\n",
+            initial_data.size(), path_.string().c_str());
+    } else if (!path_.empty()) {
+        std::fprintf(stderr,
+            "[PipelineCache] starting empty (will save to %s on shutdown)\n",
+            path_.string().c_str());
+    }
+    return loaded_existing;
+}
+
+void PipelineCache::save() const {
+    if (cache_  == VK_NULL_HANDLE) return;
+    if (device_ == VK_NULL_HANDLE) return;
+    if (path_.empty())             return;
+
+    std::size_t data_size = 0;
+    VkResult res = vkGetPipelineCacheData(device_, cache_, &data_size, nullptr);
+    if (res != VK_SUCCESS) {
+        std::fprintf(stderr,
+            "[PipelineCache] vkGetPipelineCacheData size query failed (%d)\n",
+            static_cast<int>(res));
+        return;
+    }
+    if (data_size == 0) return;  // nothing to save (e.g. no pipelines created)
+
+    std::vector<std::byte> data(data_size);
+    res = vkGetPipelineCacheData(device_, cache_, &data_size, data.data());
+    if (res != VK_SUCCESS) {
+        std::fprintf(stderr,
+            "[PipelineCache] vkGetPipelineCacheData fetch failed (%d)\n",
+            static_cast<int>(res));
+        return;
+    }
+    data.resize(data_size);
+
+    std::error_code ec;
+    if (auto parent = path_.parent_path(); !parent.empty()) {
+        std::filesystem::create_directories(parent, ec);
+        if (ec) {
+            std::fprintf(stderr,
+                "[PipelineCache] create_directories(%s) failed: %s\n",
+                parent.string().c_str(), ec.message().c_str());
+            return;
+        }
+    }
+
+    auto tmp_path = path_;
+    tmp_path += ".tmp";
+    {
+        std::ofstream file(tmp_path, std::ios::binary | std::ios::trunc);
+        if (!file) {
+            std::fprintf(stderr,
+                "[PipelineCache] open(%s) for write failed\n",
+                tmp_path.string().c_str());
+            return;
+        }
+        file.write(reinterpret_cast<const char*>(data.data()),
+                   static_cast<std::streamsize>(data.size()));
+        if (!file) {
+            std::fprintf(stderr,
+                "[PipelineCache] write to %s failed\n",
+                tmp_path.string().c_str());
+            file.close();
+            std::filesystem::remove(tmp_path, ec);
+            return;
+        }
+    }
+
+    std::filesystem::rename(tmp_path, path_, ec);
+    if (ec) {
+        std::fprintf(stderr,
+            "[PipelineCache] rename(%s -> %s) failed: %s\n",
+            tmp_path.string().c_str(), path_.string().c_str(),
+            ec.message().c_str());
+        std::filesystem::remove(tmp_path, ec);
+        return;
+    }
+
+    std::fprintf(stderr, "[PipelineCache] saved %zu bytes to %s\n",
+                 data_size, path_.string().c_str());
+}
+
+void PipelineCache::shutdown(VkDevice device) {
+    if (cache_ != VK_NULL_HANDLE) {
+        vkDestroyPipelineCache(device, cache_, nullptr);
+        cache_ = VK_NULL_HANDLE;
+    }
+    device_ = VK_NULL_HANDLE;
+}
+
+} // namespace gseurat

--- a/src/engine/post_process.cpp
+++ b/src/engine/post_process.cpp
@@ -9,7 +9,8 @@
 namespace gseurat {
 
 void PostProcessPipeline::init(VkDevice device, VmaAllocator allocator,
-                                const Swapchain& swapchain) {
+                                const Swapchain& swapchain,
+                                VkPipelineCache pipeline_cache) {
     device_ = device;
     scene_width_ = swapchain.extent().width;
     scene_height_ = swapchain.extent().height;
@@ -23,7 +24,7 @@ void PostProcessPipeline::init(VkDevice device, VmaAllocator allocator,
     create_render_passes(device, swapchain.image_format());
     create_framebuffers(device, swapchain);
     create_descriptor_resources(device);
-    create_pipelines(device);
+    create_pipelines(device, pipeline_cache);
 
     // Create light glow UBO (host-visible for easy update)
     {
@@ -654,7 +655,7 @@ void PostProcessPipeline::create_descriptor_resources(VkDevice device) {
     }
 }
 
-void PostProcessPipeline::create_pipelines(VkDevice device) {
+void PostProcessPipeline::create_pipelines(VkDevice device, VkPipelineCache cache) {
     auto fullscreen_vert = load_shader_module(device, "shaders/fullscreen.vert.spv");
     auto bloom_extract_frag = load_shader_module(device, "shaders/bloom_extract.frag.spv");
     auto bloom_blur_frag = load_shader_module(device, "shaders/bloom_blur.frag.spv");
@@ -715,7 +716,7 @@ void PostProcessPipeline::create_pipelines(VkDevice device) {
         .set_no_blend()
         .set_layout(bloom_pipeline_layout_)
         .set_render_pass(bloom_render_pass_, 0)
-        .build(device);
+        .build(device, cache);
 
     // Bloom blur pipeline (same for H and V, direction via push constant)
     bloom_blur_pipeline_ = PipelineBuilder()
@@ -729,7 +730,7 @@ void PostProcessPipeline::create_pipelines(VkDevice device) {
         .set_no_blend()
         .set_layout(bloom_pipeline_layout_)
         .set_render_pass(bloom_render_pass_, 0)
-        .build(device);
+        .build(device, cache);
 
     // DoF blur pipeline (half resolution, reuses bloom_blur.frag)
     VkExtent2D dof_extent{dof_width_, dof_height_};
@@ -744,7 +745,7 @@ void PostProcessPipeline::create_pipelines(VkDevice device) {
         .set_no_blend()
         .set_layout(bloom_pipeline_layout_)
         .set_render_pass(bloom_render_pass_, 0)
-        .build(device);
+        .build(device, cache);
 
     // Composite pipeline
     composite_pipeline_ = PipelineBuilder()
@@ -758,7 +759,7 @@ void PostProcessPipeline::create_pipelines(VkDevice device) {
         .set_no_blend()
         .set_layout(composite_pipeline_layout_)
         .set_render_pass(composite_render_pass_, 0)
-        .build(device);
+        .build(device, cache);
 
     vkDestroyShaderModule(device, composite_frag, nullptr);
     vkDestroyShaderModule(device, bloom_blur_frag, nullptr);

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -274,7 +274,8 @@ void Renderer::draw_scene(Scene& scene,
                            const std::vector<SpriteDrawInfo>& overlay,
                            const std::vector<ui::UIDrawBatch>& ui_batches,
                            const std::vector<DebugColliderDrawInfo>& debug_colliders_list,
-                           const FeatureFlags& flags) {
+                           const FeatureFlags& flags,
+                           bool dispatch_gpu_compute) {
     auto device = context_.device();
     const auto& frame_sync = sync_.frame(current_frame_);
 
@@ -380,7 +381,7 @@ void Renderer::draw_scene(Scene& scene,
         gs_renderer_.set_post_process_params(gs_pp);
     }
 
-    record_gs_prepass(cmd, device, dt, flags);
+    record_gs_prepass(cmd, device, dt, flags, dispatch_gpu_compute);
 
     // ===== Pass 1: Scene render pass (offscreen HDR) =====
     {
@@ -863,7 +864,8 @@ void Renderer::draw_sprite_pass(VkCommandBuffer cmd,
 }
 
 void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
-                                  const FeatureFlags& flags) {
+                                  const FeatureFlags& flags,
+                                  bool dispatch_gpu_compute) {
     // Adaptive GS budget: converge to target FPS then lock
     if (flags.gs_adaptive_budget && gs_adaptive_budget_ && gs_gaussian_budget_ > 0 && dt > 0.0f) {
         float fps = 1.0f / dt;
@@ -885,8 +887,12 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
         }
     }
 
-    // Gaussian splatting compute (before render pass)
-    if (flags.gs_rendering && gs_initialized_ && gs_renderer_.has_cloud()) {
+    // Gaussian splatting compute (before render pass).
+    // Gated on `dispatch_gpu_compute` so the engine's Loading state can keep
+    // the GPU idle while the loading screen draws. Warming intentionally
+    // keeps this true so the driver finalises pipeline/state setup against
+    // the freshly-uploaded buffers before the player starts seeing frames.
+    if (dispatch_gpu_compute && flags.gs_rendering && gs_initialized_ && gs_renderer_.has_cloud()) {
 
         // --- Static path: rebuild on camera dirty ---
         bool budget_changed = (gs_gaussian_budget_ != gs_prev_budget_);

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -200,7 +200,8 @@ void Renderer::init_backgrounds(const std::vector<ResourceHandle<Texture>>& bg_t
 void Renderer::init_gs(const GaussianCloud& cloud, uint32_t width, uint32_t height) {
     if (!gs_initialized_) {
         gs_renderer_.init(context_.device(), context_.physical_device(),
-                          context_.allocator(), VK_NULL_HANDLE);
+                          context_.allocator(), VK_NULL_HANDLE,
+                          context_.pipeline_cache());
         gs_initialized_ = true;
     }
     gs_renderer_.resize_output(width, height);

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -34,7 +34,8 @@ void Renderer::init(GLFWwindow* window, ResourceManager& resources,
     context_.init(window);
     swapchain_.init(context_, kWindowWidth, kWindowHeight);
     render_pass_mgr_.init(context_.device(), context_.allocator(), swapchain_);
-    post_process_.init(context_.device(), context_.allocator(), swapchain_);
+    post_process_.init(context_.device(), context_.allocator(), swapchain_,
+                       context_.pipeline_cache());
     command_pool_.init(context_.device(), context_.graphics_queue_family());
     sync_.init(context_.device(), swapchain_.image_count());
     descriptors_.init(context_.device());
@@ -754,7 +755,7 @@ void Renderer::create_sprite_pipeline() {
                            .set_color_blend_alpha()
                            .set_layout(sprite_pipeline_layout_)
                            .set_render_pass(post_process_.scene_render_pass(), 0)
-                           .build(device);
+                           .build(device, context_.pipeline_cache());
 
     vkDestroyShaderModule(device, frag, nullptr);
     vkDestroyShaderModule(device, vert, nullptr);
@@ -800,7 +801,7 @@ void Renderer::create_outline_pipeline() {
                             .set_color_blend_alpha()
                             .set_layout(outline_pipeline_layout_)
                             .set_render_pass(post_process_.scene_render_pass(), 0)
-                            .build(device);
+                            .build(device, context_.pipeline_cache());
 
     vkDestroyShaderModule(device, frag, nullptr);
     vkDestroyShaderModule(device, vert, nullptr);
@@ -828,7 +829,7 @@ void Renderer::create_ui_pipeline() {
                        .set_dynamic_scissor()
                        .set_layout(sprite_pipeline_layout_)
                        .set_render_pass(post_process_.composite_render_pass(), 0)
-                       .build(device);
+                       .build(device, context_.pipeline_cache());
 
     vkDestroyShaderModule(device, frag, nullptr);
     vkDestroyShaderModule(device, vert, nullptr);
@@ -1270,7 +1271,7 @@ void Renderer::create_wireframe_pipeline() {
         .set_color_blend_alpha()
         .set_layout(wireframe_pipeline_layout_)
         .set_render_pass(post_process_.scene_render_pass(), 0)
-        .build(device);
+        .build(device, context_.pipeline_cache());
 
     vkDestroyShaderModule(device, frag, nullptr);
     vkDestroyShaderModule(device, vert, nullptr);

--- a/src/engine/transfer_queue.cpp
+++ b/src/engine/transfer_queue.cpp
@@ -15,12 +15,14 @@ inline std::uint64_t physical_offset(std::uint64_t logical, std::uint64_t capaci
 
 TransferQueue::TransferQueue(VkDevice device, VmaAllocator allocator,
                              VkQueue transfer_queue, std::uint32_t transfer_family,
+                             std::uint32_t graphics_family,
                              bool dedicated, std::uint64_t staging_size,
                              std::uint32_t transfer_budget_mb)
     : device_(device),
       allocator_(allocator),
       transfer_queue_(transfer_queue),
       transfer_family_(transfer_family),
+      graphics_family_(graphics_family),
       dedicated_(dedicated),
       staging_size_(staging_size),
       transfer_budget_bytes_(static_cast<std::uint64_t>(transfer_budget_mb) * 1024u * 1024u) {
@@ -160,8 +162,34 @@ void TransferQueue::retire_batch(InFlightBatch& batch, VkCommandBuffer frame_cmd
         ring_read_ = std::max(ring_read_, batch.max_logical_end);
     }
 
-    (void)frame_cmd;  // unused in single-family path; cross-queue barriers
-                      // arrive in a follow-up commit.
+    // Cross-queue acquire barriers (dedicated path only). Records into
+    // `frame_cmd` so the graphics queue takes ownership before any compute
+    // dispatch reads the destination buffer.
+    if (dedicated_ && frame_cmd != VK_NULL_HANDLE && !batch.acquire_ranges.empty() &&
+        transfer_family_ != graphics_family_) {
+        std::vector<VkBufferMemoryBarrier> barriers;
+        barriers.reserve(batch.acquire_ranges.size());
+        for (const auto& r : batch.acquire_ranges) {
+            VkBufferMemoryBarrier b{};
+            b.sType               = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+            b.srcAccessMask       = 0;                              // release side already flushed
+            b.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT
+                                  | VK_ACCESS_SHADER_WRITE_BIT;
+            b.srcQueueFamilyIndex = transfer_family_;
+            b.dstQueueFamilyIndex = graphics_family_;
+            b.buffer              = r.buffer;
+            b.offset              = r.offset;
+            b.size                = r.size;
+            barriers.push_back(b);
+        }
+        vkCmdPipelineBarrier(frame_cmd,
+            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            0,
+            0, nullptr,
+            static_cast<std::uint32_t>(barriers.size()), barriers.data(),
+            0, nullptr);
+    }
 
     for (auto& cb : batch.callbacks) {
         if (cb) cb();
@@ -205,6 +233,10 @@ void TransferQueue::poll_completions(VkCommandBuffer frame_cmd) {
         begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
         vkBeginCommandBuffer(transfer_cmd_, &begin);
 
+        // Per-buffer release barriers accumulated for emission after all
+        // copies in this batch finish recording.
+        std::vector<VkBufferMemoryBarrier> release_barriers;
+
         for (auto& ch : local) {
             if (ch.is_completion_marker) {
                 if (ch.on_complete) batch.callbacks.push_back(std::move(ch.on_complete));
@@ -221,11 +253,37 @@ void TransferQueue::poll_completions(VkCommandBuffer frame_cmd) {
             if (ch.on_complete) batch.callbacks.push_back(std::move(ch.on_complete));
             batch.max_logical_end = std::max(batch.max_logical_end, ch.logical_end);
 
-            // Cross-queue ownership transfer (release on transfer queue,
-            // acquire on graphics queue) is added in a follow-up commit.
+            // Cross-queue release: hand the destination range from the
+            // transfer family to the graphics family. The acquire half
+            // executes on `frame_cmd` once retire_batch sees this batch's
+            // fence signal.
+            if (transfer_family_ != graphics_family_) {
+                VkBufferMemoryBarrier rb{};
+                rb.sType               = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+                rb.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+                rb.dstAccessMask       = 0;                          // acquire side will set
+                rb.srcQueueFamilyIndex = transfer_family_;
+                rb.dstQueueFamilyIndex = graphics_family_;
+                rb.buffer              = ch.dest_buffer;
+                rb.offset              = ch.dest_offset;
+                rb.size                = ch.size;
+                release_barriers.push_back(rb);
+
+                batch.acquire_ranges.push_back({ch.dest_buffer, ch.dest_offset, ch.size});
+            }
 
             std::lock_guard<std::mutex> lock(queue_mutex_);
             pending_status_[ch.handle.id] = Status::InFlight;
+        }
+
+        if (!release_barriers.empty()) {
+            vkCmdPipelineBarrier(transfer_cmd_,
+                VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                0,
+                0, nullptr,
+                static_cast<std::uint32_t>(release_barriers.size()), release_barriers.data(),
+                0, nullptr);
         }
 
         vkEndCommandBuffer(transfer_cmd_);

--- a/src/engine/transfer_queue.cpp
+++ b/src/engine/transfer_queue.cpp
@@ -28,30 +28,35 @@ TransferQueue::TransferQueue(VkDevice device, VmaAllocator allocator,
       transfer_budget_bytes_(static_cast<std::uint64_t>(transfer_budget_mb) * 1024u * 1024u) {
     staging_buffer_ = Buffer::create_staging(allocator_, staging_size_);
 
-    if (dedicated_) {
-        VkCommandPoolCreateInfo pool_info{};
-        pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-        pool_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-        pool_info.queueFamilyIndex = transfer_family_;
-        if (vkCreateCommandPool(device_, &pool_info, nullptr, &transfer_cmd_pool_) != VK_SUCCESS) {
-            throw std::runtime_error("TransferQueue: failed to create transfer command pool");
-        }
+    // Always own a transfer command buffer + fence — both the dedicated
+    // (separate transfer family) and single-family paths now retire batches
+    // on fence signal so `ring_read_` only advances after the GPU has
+    // actually consumed the staging bytes. The previous "piggyback on the
+    // caller's frame_cmd and retire synchronously" design corrupted the
+    // ring under concurrent worker uploads (recorded but not yet executed
+    // copies still referenced staging bytes that workers were rewriting).
+    VkCommandPoolCreateInfo pool_info{};
+    pool_info.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    pool_info.flags            = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    pool_info.queueFamilyIndex = transfer_family_;
+    if (vkCreateCommandPool(device_, &pool_info, nullptr, &transfer_cmd_pool_) != VK_SUCCESS) {
+        throw std::runtime_error("TransferQueue: failed to create transfer command pool");
+    }
 
-        VkCommandBufferAllocateInfo alloc_info{};
-        alloc_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-        alloc_info.commandPool = transfer_cmd_pool_;
-        alloc_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-        alloc_info.commandBufferCount = 1;
-        if (vkAllocateCommandBuffers(device_, &alloc_info, &transfer_cmd_) != VK_SUCCESS) {
-            throw std::runtime_error("TransferQueue: failed to allocate transfer command buffer");
-        }
+    VkCommandBufferAllocateInfo alloc_info{};
+    alloc_info.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    alloc_info.commandPool        = transfer_cmd_pool_;
+    alloc_info.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    alloc_info.commandBufferCount = 1;
+    if (vkAllocateCommandBuffers(device_, &alloc_info, &transfer_cmd_) != VK_SUCCESS) {
+        throw std::runtime_error("TransferQueue: failed to allocate transfer command buffer");
+    }
 
-        VkFenceCreateInfo fence_info{};
-        fence_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-        // Not pre-signaled — `transfer_in_flight_` gates polling.
-        if (vkCreateFence(device_, &fence_info, nullptr, &transfer_fence_) != VK_SUCCESS) {
-            throw std::runtime_error("TransferQueue: failed to create transfer fence");
-        }
+    VkFenceCreateInfo fence_info{};
+    fence_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    // Not pre-signaled — `transfer_in_flight_` gates polling.
+    if (vkCreateFence(device_, &fence_info, nullptr, &transfer_fence_) != VK_SUCCESS) {
+        throw std::runtime_error("TransferQueue: failed to create transfer fence");
     }
 }
 
@@ -209,133 +214,31 @@ void TransferQueue::retire_batch(InFlightBatch& batch, VkCommandBuffer frame_cmd
 }
 
 void TransferQueue::poll_completions(VkCommandBuffer frame_cmd) {
-    if (dedicated_) {
-        // ── Dedicated transfer queue path ──
+    // ── 1. Retire the in-flight batch when its fence signals ──
+    if (transfer_in_flight_) {
+        // When transfer and graphics families differ, retiring the batch
+        // means recording the queue-family acquire barrier into `frame_cmd`.
+        // If the caller hasn't given us one yet, defer retirement: the
+        // batch stays in flight and we'll catch it on a later poll. Without
+        // this guard, handles would flip to Complete with no acquire on
+        // the consumer side, leaving the destination range in an
+        // undefined state for graphics-side reads.
+        const bool needs_acquire = (transfer_family_ != graphics_family_);
+        if (needs_acquire && frame_cmd == VK_NULL_HANDLE) return;
 
-        // 1. Retire the in-flight batch (if any) when its fence signals.
-        if (transfer_in_flight_) {
-            VkResult fs = vkGetFenceStatus(device_, transfer_fence_);
-            if (fs == VK_SUCCESS) {
-                vkResetFences(device_, 1, &transfer_fence_);
-                if (!in_flight_.empty()) {
-                    auto batch = std::move(in_flight_.front());
-                    in_flight_.pop_front();
-                    retire_batch(batch, frame_cmd);
-                }
-                transfer_in_flight_ = false;
-            } else {
-                return;  // still pending; new batch waits its turn
-            }
-        }
-
-        // 2. Drain pending chunks into a new batch.
-        std::deque<PendingChunk> local;
-        {
-            std::lock_guard<std::mutex> lock(queue_mutex_);
-            local.swap(pending_chunks_);
-        }
-        if (local.empty()) return;
-
-        InFlightBatch batch{};
-        batch.fence = transfer_fence_;
-
-        vkResetCommandBuffer(transfer_cmd_, 0);
-        VkCommandBufferBeginInfo begin{};
-        begin.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-        begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-        vkBeginCommandBuffer(transfer_cmd_, &begin);
-
-        // Per-buffer release barriers accumulated for emission after all
-        // copies in this batch finish recording.
-        std::vector<VkBufferMemoryBarrier> release_barriers;
-
-        for (auto& ch : local) {
-            if (ch.is_completion_marker) {
-                if (ch.on_complete) batch.callbacks.push_back(std::move(ch.on_complete));
-                continue;
-            }
-            VkBufferCopy region{};
-            region.srcOffset = ch.staging_offset;
-            region.dstOffset = ch.dest_offset;
-            region.size      = ch.size;
-            vkCmdCopyBuffer(transfer_cmd_, staging_buffer_.buffer(),
-                            ch.dest_buffer, 1, &region);
-
-            batch.handles.push_back(ch.handle);
-            if (ch.on_complete) batch.callbacks.push_back(std::move(ch.on_complete));
-            batch.max_logical_end = std::max(batch.max_logical_end, ch.logical_end);
-
-            // Cross-queue release: hand the destination range from the
-            // transfer family to the graphics family. The acquire half
-            // executes on `frame_cmd` once retire_batch sees this batch's
-            // fence signal.
-            if (transfer_family_ != graphics_family_) {
-                VkBufferMemoryBarrier rb{};
-                rb.sType               = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
-                rb.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
-                rb.dstAccessMask       = 0;                          // acquire side will set
-                rb.srcQueueFamilyIndex = transfer_family_;
-                rb.dstQueueFamilyIndex = graphics_family_;
-                rb.buffer              = ch.dest_buffer;
-                rb.offset              = ch.dest_offset;
-                rb.size                = ch.size;
-                release_barriers.push_back(rb);
-
-                batch.acquire_ranges.push_back({ch.dest_buffer, ch.dest_offset, ch.size});
-            }
-
-            std::lock_guard<std::mutex> lock(queue_mutex_);
-            pending_status_[ch.handle.id] = Status::InFlight;
-        }
-
-        if (!release_barriers.empty()) {
-            vkCmdPipelineBarrier(transfer_cmd_,
-                VK_PIPELINE_STAGE_TRANSFER_BIT,
-                VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                0,
-                0, nullptr,
-                static_cast<std::uint32_t>(release_barriers.size()), release_barriers.data(),
-                0, nullptr);
-        }
-
-        vkEndCommandBuffer(transfer_cmd_);
-
-        VkSubmitInfo submit{};
-        submit.sType              = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-        submit.commandBufferCount = 1;
-        submit.pCommandBuffers    = &transfer_cmd_;
-        vkQueueSubmit(transfer_queue_, 1, &submit, transfer_fence_);
-
-        in_flight_.push_back(std::move(batch));
-        transfer_in_flight_ = true;
-        return;
-    }
-
-    // ── Graphics-queue fallback path ──
-    // No cross-queue ownership transfer needed (single family). Copies record
-    // directly into `frame_cmd`; callbacks fire inline since the recorded copy
-    // executes before the same submission's later commands.
-
-    // 1. Retire any per-batch fences that have signaled (fallback path uses
-    //    one fence per submitted batch).
-    while (!in_flight_.empty()) {
-        auto& front = in_flight_.front();
-        if (vkGetFenceStatus(device_, front.fence) == VK_SUCCESS) {
-            vkDestroyFence(device_, front.fence, nullptr);
-            front.fence = VK_NULL_HANDLE;
-            auto batch = std::move(front);
+        VkResult fs = vkGetFenceStatus(device_, transfer_fence_);
+        if (fs == VK_SUCCESS) {
+            vkResetFences(device_, 1, &transfer_fence_);
+            auto batch = std::move(in_flight_.front());
             in_flight_.pop_front();
-            retire_batch(batch, frame_cmd);  // no acquire barriers in fallback
+            retire_batch(batch, frame_cmd);
+            transfer_in_flight_ = false;
         } else {
-            break;
+            return;  // still pending; new batch waits its turn
         }
     }
 
-    // 2. Drain pending chunks into `frame_cmd` up to the per-frame budget.
-    // Bail before the swap when there's no command buffer to record into —
-    // otherwise pending chunks would be moved into `local` and silently
-    // dropped on return, leaking handles and stalling the staging ring.
-    if (frame_cmd == VK_NULL_HANDLE) return;
+    // ── 2. Drain pending chunks into a new batch ──
     std::deque<PendingChunk> local;
     {
         std::lock_guard<std::mutex> lock(queue_mutex_);
@@ -343,52 +246,78 @@ void TransferQueue::poll_completions(VkCommandBuffer frame_cmd) {
     }
     if (local.empty()) return;
 
-    std::uint64_t bytes_recorded = 0;
-    std::deque<PendingChunk> deferred;
-    InFlightBatch frame_batch{};
+    InFlightBatch batch{};
+    batch.fence = transfer_fence_;
+
+    vkResetCommandBuffer(transfer_cmd_, 0);
+    VkCommandBufferBeginInfo begin{};
+    begin.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(transfer_cmd_, &begin);
+
+    // Per-buffer release barriers accumulated for emission after all copies
+    // in this batch finish recording (cross-family path only — empty when
+    // transfer_family_ == graphics_family_).
+    std::vector<VkBufferMemoryBarrier> release_barriers;
 
     for (auto& ch : local) {
         if (ch.is_completion_marker) {
-            if (ch.on_complete) frame_batch.callbacks.push_back(std::move(ch.on_complete));
+            if (ch.on_complete) batch.callbacks.push_back(std::move(ch.on_complete));
             continue;
         }
-        if (transfer_budget_bytes_ > 0 &&
-            bytes_recorded + ch.size > transfer_budget_bytes_) {
-            deferred.push_back(std::move(ch));
-            continue;
-        }
-
         VkBufferCopy region{};
         region.srcOffset = ch.staging_offset;
         region.dstOffset = ch.dest_offset;
         region.size      = ch.size;
-        vkCmdCopyBuffer(frame_cmd, staging_buffer_.buffer(),
+        vkCmdCopyBuffer(transfer_cmd_, staging_buffer_.buffer(),
                         ch.dest_buffer, 1, &region);
 
-        frame_batch.handles.push_back(ch.handle);
-        if (ch.on_complete) frame_batch.callbacks.push_back(std::move(ch.on_complete));
-        frame_batch.max_logical_end =
-            std::max(frame_batch.max_logical_end, ch.logical_end);
-        bytes_recorded += ch.size;
+        batch.handles.push_back(ch.handle);
+        if (ch.on_complete) batch.callbacks.push_back(std::move(ch.on_complete));
+        batch.max_logical_end = std::max(batch.max_logical_end, ch.logical_end);
+
+        // Cross-queue release: hand the destination range from the transfer
+        // family to the graphics family. The acquire half executes on
+        // `frame_cmd` once retire_batch sees this batch's fence signal.
+        if (transfer_family_ != graphics_family_) {
+            VkBufferMemoryBarrier rb{};
+            rb.sType               = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+            rb.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+            rb.dstAccessMask       = 0;  // acquire side will set
+            rb.srcQueueFamilyIndex = transfer_family_;
+            rb.dstQueueFamilyIndex = graphics_family_;
+            rb.buffer              = ch.dest_buffer;
+            rb.offset              = ch.dest_offset;
+            rb.size                = ch.size;
+            release_barriers.push_back(rb);
+
+            batch.acquire_ranges.push_back({ch.dest_buffer, ch.dest_offset, ch.size});
+        }
 
         std::lock_guard<std::mutex> lock(queue_mutex_);
         pending_status_[ch.handle.id] = Status::InFlight;
     }
 
-    if (!deferred.empty()) {
-        std::lock_guard<std::mutex> lock(queue_mutex_);
-        for (auto it = deferred.rbegin(); it != deferred.rend(); ++it) {
-            pending_chunks_.push_front(std::move(*it));
-        }
+    if (!release_barriers.empty()) {
+        vkCmdPipelineBarrier(transfer_cmd_,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+            0,
+            0, nullptr,
+            static_cast<std::uint32_t>(release_barriers.size()), release_barriers.data(),
+            0, nullptr);
     }
 
-    // Fallback path retires synchronously — the same `frame_cmd` will execute
-    // the copy before any later use, so we can fire callbacks immediately
-    // without waiting on a fence. Ring read also advances right away (the
-    // staging memcpy is a CPU write that's already visible).
-    if (!frame_batch.handles.empty() || !frame_batch.callbacks.empty()) {
-        retire_batch(frame_batch, /*frame_cmd=*/VK_NULL_HANDLE);
-    }
+    vkEndCommandBuffer(transfer_cmd_);
+
+    VkSubmitInfo submit{};
+    submit.sType              = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit.commandBufferCount = 1;
+    submit.pCommandBuffers    = &transfer_cmd_;
+    vkQueueSubmit(transfer_queue_, 1, &submit, transfer_fence_);
+
+    in_flight_.push_back(std::move(batch));
+    transfer_in_flight_ = true;
 }
 
 void TransferQueue::request_cancel() {
@@ -414,9 +343,8 @@ void TransferQueue::shutdown() {
     }
     for (auto& batch : in_flight_) {
         for (auto& cb : batch.callbacks) if (cb) cb();
-        if (!dedicated_ && batch.fence != VK_NULL_HANDLE) {
-            vkDestroyFence(device_, batch.fence, nullptr);
-        }
+        // All batches share the queue's `transfer_fence_` (destroyed below);
+        // there are no per-batch fences to clean up.
     }
     in_flight_.clear();
 

--- a/src/engine/transfer_queue.cpp
+++ b/src/engine/transfer_queue.cpp
@@ -73,6 +73,18 @@ TransferQueue::reserve_staging(std::uint64_t bytes) {
 
     std::lock_guard<std::mutex> lock(queue_mutex_);
 
+    // When the ring is empty, snap both watermarks to the next wrap boundary.
+    // Without this a request for the full `staging_size_` would fail when
+    // `ring_write_` happens to land mid-buffer — the wrap-pad would consume
+    // bytes the request still needs.
+    if (ring_read_ == ring_write_) {
+        const std::uint64_t phys = physical_offset(ring_write_, staging_size_);
+        if (phys != 0) {
+            ring_write_ += (staging_size_ - phys);
+            ring_read_   = ring_write_;
+        }
+    }
+
     // Determine the candidate write offset. If the request would straddle the
     // ring boundary (physical offset + bytes > capacity), pad to the next
     // wrap to keep each reservation contiguous.
@@ -320,12 +332,16 @@ void TransferQueue::poll_completions(VkCommandBuffer frame_cmd) {
     }
 
     // 2. Drain pending chunks into `frame_cmd` up to the per-frame budget.
+    // Bail before the swap when there's no command buffer to record into —
+    // otherwise pending chunks would be moved into `local` and silently
+    // dropped on return, leaking handles and stalling the staging ring.
+    if (frame_cmd == VK_NULL_HANDLE) return;
     std::deque<PendingChunk> local;
     {
         std::lock_guard<std::mutex> lock(queue_mutex_);
         local.swap(pending_chunks_);
     }
-    if (local.empty() || frame_cmd == VK_NULL_HANDLE) return;
+    if (local.empty()) return;
 
     std::uint64_t bytes_recorded = 0;
     std::deque<PendingChunk> deferred;
@@ -375,8 +391,17 @@ void TransferQueue::poll_completions(VkCommandBuffer frame_cmd) {
     }
 }
 
+void TransferQueue::request_cancel() {
+    shutting_down_.store(true, std::memory_order_release);
+}
+
 void TransferQueue::shutdown() {
     if (device_ == VK_NULL_HANDLE) return;
+
+    // Belt-and-braces: callers should already have set this before joining
+    // their loader threads, but signalling it here too makes the queue safe
+    // to shut down even if the convention is missed.
+    shutting_down_.store(true, std::memory_order_release);
 
     vkDeviceWaitIdle(device_);
 

--- a/src/engine/transfer_queue.cpp
+++ b/src/engine/transfer_queue.cpp
@@ -1,22 +1,29 @@
 #include "gseurat/engine/transfer_queue.hpp"
 
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
 #include <stdexcept>
 
 namespace gseurat {
 
+namespace {
+inline std::uint64_t physical_offset(std::uint64_t logical, std::uint64_t capacity) {
+    return logical % capacity;
+}
+}  // namespace
+
 TransferQueue::TransferQueue(VkDevice device, VmaAllocator allocator,
-                             VkQueue transfer_queue, uint32_t transfer_family,
-                             bool dedicated, uint64_t staging_size,
-                             uint32_t transfer_budget_mb,
-                             VkBuffer dest_buffer)
+                             VkQueue transfer_queue, std::uint32_t transfer_family,
+                             bool dedicated, std::uint64_t staging_size,
+                             std::uint32_t transfer_budget_mb)
     : device_(device),
       allocator_(allocator),
       transfer_queue_(transfer_queue),
       transfer_family_(transfer_family),
       dedicated_(dedicated),
       staging_size_(staging_size),
-      transfer_budget_bytes_(static_cast<uint64_t>(transfer_budget_mb) * 1024u * 1024u),
-      dest_buffer_(dest_buffer) {
+      transfer_budget_bytes_(static_cast<std::uint64_t>(transfer_budget_mb) * 1024u * 1024u) {
     staging_buffer_ = Buffer::create_staging(allocator_, staging_size_);
 
     if (dedicated_) {
@@ -39,7 +46,7 @@ TransferQueue::TransferQueue(VkDevice device, VmaAllocator allocator,
 
         VkFenceCreateInfo fence_info{};
         fence_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-        // Do not pre-signal — we check transfer_in_flight_ before polling
+        // Not pre-signaled — `transfer_in_flight_` gates polling.
         if (vkCreateFence(device_, &fence_info, nullptr, &transfer_fence_) != VK_SUCCESS) {
             throw std::runtime_error("TransferQueue: failed to create transfer fence");
         }
@@ -50,139 +57,263 @@ TransferQueue::~TransferQueue() {
     shutdown();
 }
 
-void TransferQueue::enqueue(uint64_t staging_offset, uint64_t dest_offset,
-                            uint64_t size, std::function<void()> on_complete) {
+TransferQueue::Handle TransferQueue::make_handle() {
+    Handle h{ next_handle_id_++ };
+    pending_status_[h.id] = Status::Pending;
+    return h;
+}
+
+std::optional<TransferQueue::Reservation>
+TransferQueue::reserve_staging(std::uint64_t bytes) {
+    if (bytes == 0 || bytes > staging_size_) {
+        return std::nullopt;
+    }
+
     std::lock_guard<std::mutex> lock(queue_mutex_);
-    pending_chunks_.push_back({staging_offset, dest_offset, size, std::move(on_complete), false});
+
+    // Determine the candidate write offset. If the request would straddle the
+    // ring boundary (physical offset + bytes > capacity), pad to the next
+    // wrap to keep each reservation contiguous.
+    std::uint64_t candidate = ring_write_;
+    const std::uint64_t phys = physical_offset(candidate, staging_size_);
+    if (phys + bytes > staging_size_) {
+        candidate += (staging_size_ - phys);   // skip the tail
+    }
+
+    // Refuse if the new high-water mark would lap the read watermark.
+    if (candidate + bytes - ring_read_ > staging_size_) {
+        return std::nullopt;
+    }
+
+    Reservation res{};
+    res.host_ptr       = static_cast<std::byte*>(staging_buffer_.mapped())
+                       + physical_offset(candidate, staging_size_);
+    res.staging_offset = physical_offset(candidate, staging_size_);
+    res.size           = bytes;
+    res.logical_end    = candidate + bytes;
+    res.token          = next_token_++;
+
+    ring_write_ = candidate + bytes;
+    return res;
+}
+
+TransferQueue::Handle
+TransferQueue::submit(const Reservation& reservation,
+                      VkBuffer dest_buffer, std::uint64_t dest_offset,
+                      std::function<void()> on_complete) {
+    if (!reservation || dest_buffer == VK_NULL_HANDLE) {
+        return Handle{};
+    }
+
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+
+    Handle h{ next_handle_id_++ };
+    pending_status_[h.id] = Status::Pending;
+
+    PendingChunk chunk{};
+    chunk.handle         = h;
+    chunk.dest_buffer    = dest_buffer;
+    chunk.dest_offset    = dest_offset;
+    chunk.staging_offset = reservation.staging_offset;
+    chunk.size           = reservation.size;
+    chunk.logical_end    = reservation.logical_end;
+    chunk.on_complete    = std::move(on_complete);
+    pending_chunks_.push_back(std::move(chunk));
+    return h;
 }
 
 void TransferQueue::enqueue_completion(std::function<void()> on_complete) {
     std::lock_guard<std::mutex> lock(queue_mutex_);
-    TransferChunk marker{};
-    marker.on_complete = std::move(on_complete);
+    PendingChunk marker{};
     marker.is_completion_marker = true;
+    marker.on_complete = std::move(on_complete);
     pending_chunks_.push_back(std::move(marker));
+}
+
+TransferQueue::Status TransferQueue::status(Handle h) const {
+    if (!h) return Status::Unknown;
+
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    if (auto it = pending_status_.find(h.id); it != pending_status_.end()) {
+        return it->second;
+    }
+    if (auto it = recent_status_.find(h.id); it != recent_status_.end()) {
+        return it->second;
+    }
+    return Status::Unknown;
+}
+
+void TransferQueue::retire_batch(InFlightBatch& batch, VkCommandBuffer frame_cmd) {
+    // Move handle status: Pending/InFlight -> Complete (kept briefly).
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        for (Handle h : batch.handles) {
+            pending_status_.erase(h.id);
+            recent_status_[h.id] = Status::Complete;
+            recent_complete_order_.push_back(h.id);
+            while (recent_complete_order_.size() > kRecentStatusCap) {
+                std::uint64_t old = recent_complete_order_.front();
+                recent_complete_order_.pop_front();
+                recent_status_.erase(old);
+            }
+        }
+        ring_read_ = std::max(ring_read_, batch.max_logical_end);
+    }
+
+    (void)frame_cmd;  // unused in single-family path; cross-queue barriers
+                      // arrive in a follow-up commit.
+
+    for (auto& cb : batch.callbacks) {
+        if (cb) cb();
+    }
 }
 
 void TransferQueue::poll_completions(VkCommandBuffer frame_cmd) {
     if (dedicated_) {
-        // --- Dedicated transfer queue path ---
+        // ── Dedicated transfer queue path ──
 
-        // 1. Check if current in-flight batch has finished
+        // 1. Retire the in-flight batch (if any) when its fence signals.
         if (transfer_in_flight_) {
-            VkResult status = vkGetFenceStatus(device_, transfer_fence_);
-            if (status == VK_SUCCESS) {
+            VkResult fs = vkGetFenceStatus(device_, transfer_fence_);
+            if (fs == VK_SUCCESS) {
                 vkResetFences(device_, 1, &transfer_fence_);
-                // Fire all callbacks from the completed batch
                 if (!in_flight_.empty()) {
-                    for (auto& cb : in_flight_.front().callbacks) {
-                        if (cb) cb();
-                    }
+                    auto batch = std::move(in_flight_.front());
                     in_flight_.pop_front();
+                    retire_batch(batch, frame_cmd);
                 }
                 transfer_in_flight_ = false;
+            } else {
+                return;  // still pending; new batch waits its turn
             }
-            // If still pending, do not submit a new batch this frame
-            if (transfer_in_flight_) return;
         }
 
-        // 2. Drain pending_chunks_ and record a new batch
-        std::deque<TransferChunk> local_chunks;
+        // 2. Drain pending chunks into a new batch.
+        std::deque<PendingChunk> local;
         {
             std::lock_guard<std::mutex> lock(queue_mutex_);
-            local_chunks.swap(pending_chunks_);
+            local.swap(pending_chunks_);
         }
-        if (local_chunks.empty()) return;
+        if (local.empty()) return;
 
-        InFlightBatch batch;
+        InFlightBatch batch{};
         batch.fence = transfer_fence_;
 
         vkResetCommandBuffer(transfer_cmd_, 0);
-        VkCommandBufferBeginInfo begin_info{};
-        begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-        begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-        vkBeginCommandBuffer(transfer_cmd_, &begin_info);
+        VkCommandBufferBeginInfo begin{};
+        begin.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        vkBeginCommandBuffer(transfer_cmd_, &begin);
 
-        for (auto& chunk : local_chunks) {
-            if (chunk.is_completion_marker) {
-                if (chunk.on_complete) batch.callbacks.push_back(chunk.on_complete);
+        for (auto& ch : local) {
+            if (ch.is_completion_marker) {
+                if (ch.on_complete) batch.callbacks.push_back(std::move(ch.on_complete));
                 continue;
             }
             VkBufferCopy region{};
-            region.srcOffset = chunk.staging_offset;
-            region.dstOffset = chunk.dest_offset;
-            region.size = chunk.size;
-            vkCmdCopyBuffer(transfer_cmd_, staging_buffer_.buffer(), dest_buffer_, 1, &region);
-            if (chunk.on_complete) batch.callbacks.push_back(chunk.on_complete);
+            region.srcOffset = ch.staging_offset;
+            region.dstOffset = ch.dest_offset;
+            region.size      = ch.size;
+            vkCmdCopyBuffer(transfer_cmd_, staging_buffer_.buffer(),
+                            ch.dest_buffer, 1, &region);
+
+            batch.handles.push_back(ch.handle);
+            if (ch.on_complete) batch.callbacks.push_back(std::move(ch.on_complete));
+            batch.max_logical_end = std::max(batch.max_logical_end, ch.logical_end);
+
+            // Cross-queue ownership transfer (release on transfer queue,
+            // acquire on graphics queue) is added in a follow-up commit.
+
+            std::lock_guard<std::mutex> lock(queue_mutex_);
+            pending_status_[ch.handle.id] = Status::InFlight;
         }
 
         vkEndCommandBuffer(transfer_cmd_);
 
-        VkSubmitInfo submit_info{};
-        submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-        submit_info.commandBufferCount = 1;
-        submit_info.pCommandBuffers = &transfer_cmd_;
-        vkQueueSubmit(transfer_queue_, 1, &submit_info, transfer_fence_);
+        VkSubmitInfo submit{};
+        submit.sType              = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submit.commandBufferCount = 1;
+        submit.pCommandBuffers    = &transfer_cmd_;
+        vkQueueSubmit(transfer_queue_, 1, &submit, transfer_fence_);
 
         in_flight_.push_back(std::move(batch));
         transfer_in_flight_ = true;
+        return;
+    }
 
-    } else {
-        // --- Fallback graphics-queue path ---
+    // ── Graphics-queue fallback path ──
+    // No cross-queue ownership transfer needed (single family). Copies record
+    // directly into `frame_cmd`; callbacks fire inline since the recorded copy
+    // executes before the same submission's later commands.
 
-        // 1. Fire any completed in-flight fences (FIFO)
-        while (!in_flight_.empty()) {
-            auto& front = in_flight_.front();
-            if (vkGetFenceStatus(device_, front.fence) == VK_SUCCESS) {
-                vkDestroyFence(device_, front.fence, nullptr);
-                for (auto& cb : front.callbacks) {
-                    if (cb) cb();
-                }
-                in_flight_.pop_front();
-            } else {
-                break;
-            }
+    // 1. Retire any per-batch fences that have signaled (fallback path uses
+    //    one fence per submitted batch).
+    while (!in_flight_.empty()) {
+        auto& front = in_flight_.front();
+        if (vkGetFenceStatus(device_, front.fence) == VK_SUCCESS) {
+            vkDestroyFence(device_, front.fence, nullptr);
+            front.fence = VK_NULL_HANDLE;
+            auto batch = std::move(front);
+            in_flight_.pop_front();
+            retire_batch(batch, frame_cmd);  // no acquire barriers in fallback
+        } else {
+            break;
+        }
+    }
+
+    // 2. Drain pending chunks into `frame_cmd` up to the per-frame budget.
+    std::deque<PendingChunk> local;
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        local.swap(pending_chunks_);
+    }
+    if (local.empty() || frame_cmd == VK_NULL_HANDLE) return;
+
+    std::uint64_t bytes_recorded = 0;
+    std::deque<PendingChunk> deferred;
+    InFlightBatch frame_batch{};
+
+    for (auto& ch : local) {
+        if (ch.is_completion_marker) {
+            if (ch.on_complete) frame_batch.callbacks.push_back(std::move(ch.on_complete));
+            continue;
+        }
+        if (transfer_budget_bytes_ > 0 &&
+            bytes_recorded + ch.size > transfer_budget_bytes_) {
+            deferred.push_back(std::move(ch));
+            continue;
         }
 
-        // 2. Drain up to transfer_budget_bytes_ into frame_cmd
-        std::deque<TransferChunk> local_chunks;
-        {
-            std::lock_guard<std::mutex> lock(queue_mutex_);
-            local_chunks.swap(pending_chunks_);
-        }
-        if (local_chunks.empty()) return;
+        VkBufferCopy region{};
+        region.srcOffset = ch.staging_offset;
+        region.dstOffset = ch.dest_offset;
+        region.size      = ch.size;
+        vkCmdCopyBuffer(frame_cmd, staging_buffer_.buffer(),
+                        ch.dest_buffer, 1, &region);
 
-        uint64_t bytes_this_frame = 0;
-        std::deque<TransferChunk> deferred;
+        frame_batch.handles.push_back(ch.handle);
+        if (ch.on_complete) frame_batch.callbacks.push_back(std::move(ch.on_complete));
+        frame_batch.max_logical_end =
+            std::max(frame_batch.max_logical_end, ch.logical_end);
+        bytes_recorded += ch.size;
 
-        for (auto& chunk : local_chunks) {
-            if (chunk.is_completion_marker) {
-                // Fire completion markers inline after copies already recorded
-                if (chunk.on_complete) chunk.on_complete();
-                continue;
-            }
-            if (bytes_this_frame + chunk.size > transfer_budget_bytes_) {
-                deferred.push_back(std::move(chunk));
-                continue;
-            }
-            VkBufferCopy region{};
-            region.srcOffset = chunk.staging_offset;
-            region.dstOffset = chunk.dest_offset;
-            region.size = chunk.size;
-            vkCmdCopyBuffer(frame_cmd, staging_buffer_.buffer(), dest_buffer_, 1, &region);
-            bytes_this_frame += chunk.size;
-            // Callbacks fire immediately for the graphics-queue path — the copy
-            // executes before the queue submission that contains frame_cmd.
-            if (chunk.on_complete) chunk.on_complete();
-        }
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        pending_status_[ch.handle.id] = Status::InFlight;
+    }
 
-        // Re-queue anything that didn't fit this frame
-        if (!deferred.empty()) {
-            std::lock_guard<std::mutex> lock(queue_mutex_);
-            for (auto& chunk : deferred) {
-                pending_chunks_.push_front(std::move(chunk));
-            }
+    if (!deferred.empty()) {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        for (auto it = deferred.rbegin(); it != deferred.rend(); ++it) {
+            pending_chunks_.push_front(std::move(*it));
         }
+    }
+
+    // Fallback path retires synchronously — the same `frame_cmd` will execute
+    // the copy before any later use, so we can fire callbacks immediately
+    // without waiting on a fence. Ring read also advances right away (the
+    // staging memcpy is a CPU write that's already visible).
+    if (!frame_batch.handles.empty() || !frame_batch.callbacks.empty()) {
+        retire_batch(frame_batch, /*frame_cmd=*/VK_NULL_HANDLE);
     }
 }
 
@@ -191,19 +322,15 @@ void TransferQueue::shutdown() {
 
     vkDeviceWaitIdle(device_);
 
-    // Fire any remaining callbacks before destroying resources
     {
         std::lock_guard<std::mutex> lock(queue_mutex_);
-        for (auto& chunk : pending_chunks_) {
-            if (chunk.on_complete) chunk.on_complete();
+        for (auto& ch : pending_chunks_) {
+            if (ch.on_complete) ch.on_complete();
         }
         pending_chunks_.clear();
     }
     for (auto& batch : in_flight_) {
-        for (auto& cb : batch.callbacks) {
-            if (cb) cb();
-        }
-        // Destroy per-batch fences from the fallback path
+        for (auto& cb : batch.callbacks) if (cb) cb();
         if (!dedicated_ && batch.fence != VK_NULL_HANDLE) {
             vkDestroyFence(device_, batch.fence, nullptr);
         }
@@ -213,18 +340,15 @@ void TransferQueue::shutdown() {
     if (staging_buffer_.buffer() != VK_NULL_HANDLE) {
         staging_buffer_.destroy(allocator_);
     }
-
     if (transfer_cmd_pool_ != VK_NULL_HANDLE) {
         vkDestroyCommandPool(device_, transfer_cmd_pool_, nullptr);
         transfer_cmd_pool_ = VK_NULL_HANDLE;
         transfer_cmd_ = VK_NULL_HANDLE;
     }
-
     if (transfer_fence_ != VK_NULL_HANDLE) {
         vkDestroyFence(device_, transfer_fence_, nullptr);
         transfer_fence_ = VK_NULL_HANDLE;
     }
-
     transfer_in_flight_ = false;
     device_ = VK_NULL_HANDLE;
 }

--- a/src/engine/vk_context.cpp
+++ b/src/engine/vk_context.cpp
@@ -1,6 +1,8 @@
 #define VMA_IMPLEMENTATION
 #include "gseurat/engine/vk_context.hpp"
 
+#include "gseurat/engine/project_root.hpp"
+
 #include <cstdio>
 #include <cstring>
 #include <iostream>
@@ -26,6 +28,7 @@ void VkContext::init(GLFWwindow* window) {
     pick_physical_device();
     create_logical_device();
     create_allocator();
+    create_pipeline_cache(/*persistent=*/true);
 }
 
 void VkContext::init_headless() {
@@ -35,9 +38,25 @@ void VkContext::init_headless() {
     pick_physical_device_headless();
     create_logical_device_headless();
     create_allocator();
+    // Headless tests get an in-memory cache only — still amortises compiles
+    // across the 12 GS compute pipelines within a single test process, but
+    // doesn't pollute the working tree with cache files.
+    create_pipeline_cache(/*persistent=*/false);
+}
+
+void VkContext::create_pipeline_cache(bool persistent) {
+    std::filesystem::path path;
+    if (persistent) {
+        path = resolve_asset_path(".cache/vulkan_pipeline.bin");
+    }
+    pipeline_cache_.init(device_, physical_device_, std::move(path));
 }
 
 void VkContext::shutdown() {
+    // Save before tearing down the device — vkGetPipelineCacheData needs it.
+    pipeline_cache_.save();
+    pipeline_cache_.shutdown(device_);
+
 #ifndef NDEBUG
     VmaTotalStatistics stats{};
     vmaCalculateStatistics(allocator_, &stats);

--- a/tests/test_engine_loading_monitor.cpp
+++ b/tests/test_engine_loading_monitor.cpp
@@ -186,7 +186,26 @@ int main() {
         std::printf("[TEST] set_warmup_frames clamps correctly\n");
     }
 
-    // ── 11. Tick during Playing is a no-op (steady state). ──────────────
+    // ── 11. Unknown status counts as resolved (handle aged out / never
+    //        tracked). Without this, the queue's ~64-entry recent_status_
+    //        cap would let large batches strand older completed handles
+    //        in tracked_, deadlocking the monitor in Loading. ───────────
+    {
+        EngineLoadingMonitor m;
+        m.begin_load({TransferQueue::Handle{100}, TransferQueue::Handle{101}});
+        // Provider returns Unknown for both handles — simulating either
+        // aged-out cache entries or handles never seen by the queue.
+        EngineLoadingMonitor::StatusProvider unknown_provider =
+            [](TransferQueue::Handle) {
+                return TransferQueue::Status::Unknown;
+            };
+        m.tick(unknown_provider);
+        expect(m.state() == EngineState::Warming,
+               "Unknown handles count as resolved → Warming");
+        std::printf("[TEST] Unknown status counts as resolved\n");
+    }
+
+    // ── 12. Tick during Playing is a no-op (steady state). ──────────────
     {
         EngineLoadingMonitor m;                       // starts Playing
         for (int i = 0; i < 100; ++i) m.tick(MockStatuses{}.provider());

--- a/tests/test_engine_loading_monitor.cpp
+++ b/tests/test_engine_loading_monitor.cpp
@@ -1,0 +1,200 @@
+// Pure-CPU unit test for EngineLoadingMonitor — covers state transitions,
+// warm-up countdown, frame-policy helpers, and edge cases (empty handle
+// list, missing status provider, scene-restart from Playing).
+
+#include "gseurat/engine/engine_state.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <unordered_map>
+
+using namespace gseurat;
+
+namespace {
+
+void expect(bool cond, const char* msg) {
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", msg);
+        std::exit(1);
+    }
+}
+
+// Programmable status table used as the StatusProvider in tests.
+struct MockStatuses {
+    std::unordered_map<std::uint64_t, TransferQueue::Status> by_id;
+
+    EngineLoadingMonitor::StatusProvider provider() const {
+        return [this](TransferQueue::Handle h) {
+            auto it = by_id.find(h.id);
+            return (it == by_id.end()) ? TransferQueue::Status::Pending : it->second;
+        };
+    }
+};
+
+}  // namespace
+
+int main() {
+    // ── 1. Default state is Playing (backward-compat: apps that never call
+    //      begin_load see today's behaviour). ──────────────────────────────
+    {
+        EngineLoadingMonitor m;
+        expect(m.state() == EngineState::Playing, "default state is Playing");
+        expect(m.should_run_gameplay(),            "Playing → run gameplay");
+        expect(m.should_dispatch_gpu_work(),       "Playing → dispatch GPU work");
+        expect(!m.should_overlay_loading_ui(),     "Playing → no loading overlay");
+        expect(m.pending_handles() == 0,           "no pending handles");
+        expect(m.warmup_frames() == EngineLoadingMonitor::kDefaultWarmupFrames,
+               "default warm-up frames matches constant");
+        std::printf("[TEST] default state Playing\n");
+    }
+
+    // ── 2. begin_load → Loading; gating helpers correct. ─────────────────
+    {
+        EngineLoadingMonitor m;
+        m.begin_load({TransferQueue::Handle{1}, TransferQueue::Handle{2}});
+
+        expect(m.state() == EngineState::Loading,   "begin_load → Loading");
+        expect(!m.should_run_gameplay(),            "Loading → no gameplay");
+        expect(!m.should_dispatch_gpu_work(),       "Loading → no GPU dispatch");
+        expect(m.should_overlay_loading_ui(),       "Loading → overlay UI");
+        expect(m.pending_handles() == 2,            "two handles tracked");
+        std::printf("[TEST] begin_load → Loading + correct gating\n");
+    }
+
+    // ── 3. Pending handles keep state in Loading. ────────────────────────
+    {
+        EngineLoadingMonitor m;
+        m.begin_load({TransferQueue::Handle{1}, TransferQueue::Handle{2}});
+
+        MockStatuses ms;
+        ms.by_id[1] = TransferQueue::Status::Pending;
+        ms.by_id[2] = TransferQueue::Status::InFlight;
+
+        for (int i = 0; i < 5; ++i) m.tick(ms.provider());
+        expect(m.state() == EngineState::Loading,   "Pending handles → still Loading");
+        expect(m.pending_handles() == 2,            "no handles reaped");
+        std::printf("[TEST] Pending handles keep Loading\n");
+    }
+
+    // ── 4. Partial completion still Loading; full completion → Warming. ──
+    {
+        EngineLoadingMonitor m;
+        m.begin_load({TransferQueue::Handle{1}, TransferQueue::Handle{2}});
+
+        MockStatuses ms;
+        ms.by_id[1] = TransferQueue::Status::Complete;
+        ms.by_id[2] = TransferQueue::Status::Pending;
+
+        m.tick(ms.provider());
+        expect(m.state() == EngineState::Loading,   "h1 done, h2 pending → still Loading");
+        expect(m.pending_handles() == 1,            "h1 reaped");
+
+        ms.by_id[2] = TransferQueue::Status::Complete;
+        m.tick(ms.provider());
+        expect(m.state() == EngineState::Warming,   "all complete → Warming");
+        expect(m.warmup_frames_remaining() == EngineLoadingMonitor::kDefaultWarmupFrames,
+               "warm-up countdown initialised");
+        expect(!m.should_run_gameplay(),            "Warming → no gameplay yet");
+        expect(m.should_dispatch_gpu_work(),        "Warming → dispatch GPU work");
+        expect(m.should_overlay_loading_ui(),       "Warming → still overlay UI");
+        std::printf("[TEST] partial → full completion → Warming\n");
+    }
+
+    // ── 5. Warming counts down N frames then Playing. ────────────────────
+    {
+        EngineLoadingMonitor m;
+        m.set_warmup_frames(3);
+        m.begin_load({TransferQueue::Handle{1}});
+
+        MockStatuses ms;
+        ms.by_id[1] = TransferQueue::Status::Complete;
+
+        m.tick(ms.provider());
+        expect(m.state() == EngineState::Warming,   "Warming after first tick");
+        expect(m.warmup_frames_remaining() == 3,    "3 warm-up frames remaining");
+
+        m.tick(ms.provider());
+        expect(m.warmup_frames_remaining() == 2,    "2 remaining");
+        m.tick(ms.provider());
+        expect(m.warmup_frames_remaining() == 1,    "1 remaining");
+        expect(m.state() == EngineState::Warming,   "still Warming with 1 left");
+
+        m.tick(ms.provider());
+        expect(m.warmup_frames_remaining() == 0,    "0 remaining");
+        expect(m.state() == EngineState::Playing,   "→ Playing after countdown");
+        expect(m.should_run_gameplay(),             "Playing → gameplay back on");
+        std::printf("[TEST] Warming counts down 3 frames → Playing\n");
+    }
+
+    // ── 6. Re-entering Loading from Playing (scene transition). ─────────
+    {
+        EngineLoadingMonitor m;
+        m.begin_load({});                             // empty list → fast path
+        m.tick(MockStatuses{}.provider());            // → Warming
+        for (std::uint32_t i = 0; i < EngineLoadingMonitor::kDefaultWarmupFrames; ++i) {
+            m.tick(MockStatuses{}.provider());
+        }
+        expect(m.state() == EngineState::Playing,   "fast path reaches Playing");
+
+        m.begin_load({TransferQueue::Handle{42}});
+        expect(m.state() == EngineState::Loading,   "Playing → begin_load → Loading");
+        expect(m.pending_handles() == 1,            "tracking new handle");
+        std::printf("[TEST] re-enter Loading from Playing\n");
+    }
+
+    // ── 7. Empty handle list — skip-load fast path. ─────────────────────
+    {
+        EngineLoadingMonitor m;
+        m.begin_load({});
+        expect(m.state() == EngineState::Loading,   "even empty load starts in Loading");
+        m.tick(MockStatuses{}.provider());
+        expect(m.state() == EngineState::Warming,   "empty list → Warming on first tick");
+        std::printf("[TEST] empty handle list → fast Warming\n");
+    }
+
+    // ── 8. Failed status counts as resolved (don't deadlock). ───────────
+    {
+        EngineLoadingMonitor m;
+        m.begin_load({TransferQueue::Handle{7}, TransferQueue::Handle{8}});
+        MockStatuses ms;
+        ms.by_id[7] = TransferQueue::Status::Failed;
+        ms.by_id[8] = TransferQueue::Status::Complete;
+        m.tick(ms.provider());
+        expect(m.state() == EngineState::Warming,   "Failed treated as resolved");
+        std::printf("[TEST] Failed status doesn't stall the monitor\n");
+    }
+
+    // ── 9. Empty/null provider during Loading is a safe no-op. ──────────
+    {
+        EngineLoadingMonitor m;
+        m.begin_load({TransferQueue::Handle{9}});
+        EngineLoadingMonitor::StatusProvider null_provider;
+        m.tick(null_provider);                        // must not crash
+        expect(m.state() == EngineState::Loading,   "null provider → no progress");
+        expect(m.pending_handles() == 1,            "handle still tracked");
+        std::printf("[TEST] null provider during Loading is safe\n");
+    }
+
+    // ── 10. set_warmup_frames clamps to [1, kMaxWarmupFrames]. ──────────
+    {
+        EngineLoadingMonitor m;
+        m.set_warmup_frames(0);
+        expect(m.warmup_frames() == 1, "0 clamped up to 1");
+        m.set_warmup_frames(EngineLoadingMonitor::kMaxWarmupFrames + 100);
+        expect(m.warmup_frames() == EngineLoadingMonitor::kMaxWarmupFrames,
+               "huge value clamped to max");
+        std::printf("[TEST] set_warmup_frames clamps correctly\n");
+    }
+
+    // ── 11. Tick during Playing is a no-op (steady state). ──────────────
+    {
+        EngineLoadingMonitor m;                       // starts Playing
+        for (int i = 0; i < 100; ++i) m.tick(MockStatuses{}.provider());
+        expect(m.state() == EngineState::Playing,   "still Playing after many ticks");
+        expect(m.warmup_frames_remaining() == 0,    "no warm-up running");
+        std::printf("[TEST] Playing tick is a no-op\n");
+    }
+
+    std::printf("[ALL TESTS PASSED]\n");
+    return 0;
+}

--- a/tests/test_transfer_queue_gpu.cpp
+++ b/tests/test_transfer_queue_gpu.cpp
@@ -63,7 +63,7 @@ int main() {
     TransferQueue tq(
         gpu.device(), gpu.allocator(),
         gpu.context().graphics_queue(),
-        gpu.queue_family(),
+        gpu.queue_family(), gpu.queue_family(),
         /*dedicated=*/false,
         staging_size,
         /*budget_mb=*/64);

--- a/tests/test_transfer_queue_gpu.cpp
+++ b/tests/test_transfer_queue_gpu.cpp
@@ -11,10 +11,13 @@
 #include "gpu_test_context.hpp"
 #include "gseurat/engine/transfer_queue.hpp"
 
+#include <atomic>
 #include <cassert>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <thread>
 #include <vector>
 
 using namespace gseurat;
@@ -216,6 +219,71 @@ int main() {
         auto res = tq.reserve_staging(staging_size + 1);
         expect(!res.has_value(), "oversized reservation refused");
         std::printf("[TEST] oversized reservation rejected\n");
+    }
+
+    // ── Test 6: pending chunks survive a poll with no frame_cmd ──
+    // Regression for a bug where `poll_completions(VK_NULL_HANDLE)` would
+    // drain `pending_chunks_` into a local deque and then return without
+    // recording any copy, silently dropping every queued upload.
+    {
+        auto dest = Buffer::create_storage_gpu_only(gpu.allocator(), 256);
+        auto res = tq.reserve_staging(64);
+        expect(res.has_value(), "reservation for null-frame test");
+        std::memset(res->host_ptr, 0xDD, 64);
+        auto h = tq.submit(*res, dest.buffer(), 0);
+
+        // Poll with no command buffer. The chunk must remain pending.
+        tq.poll_completions(VK_NULL_HANDLE);
+        expect(tq.status(h) == TransferQueue::Status::Pending,
+               "chunk stays Pending when poll has no frame_cmd");
+
+        // Now poll for real and verify the upload completes.
+        poll_until_complete(tq, gpu, {h});
+
+        auto cmd = gpu.begin_commands();
+        auto rb = gpu.readback_from_gpu(cmd, dest, 64);
+        gpu.submit_and_wait();
+        const auto* p = static_cast<const std::uint8_t*>(rb.mapped());
+        for (int i = 0; i < 64; ++i) {
+            expect(p[i] == 0xDD, "byte mismatch after recovered poll");
+        }
+        rb.destroy(gpu.allocator());
+        dest.destroy(gpu.allocator());
+        std::printf("[TEST] poll(VK_NULL_HANDLE) preserves pending chunks\n");
+    }
+
+    // ── Test 7: request_cancel breaks a worker's reserve_staging spin loop ──
+    // Regression for an engine-shutdown deadlock: workers loop forever on
+    // `reserve_staging` when the ring is full; shutdown joins them while
+    // still holding the lock that would have freed the ring.
+    {
+        // Fill the ring so further reservations will block.
+        auto pad = tq.reserve_staging(staging_size);
+        expect(pad.has_value(), "saturating reservation for cancellation test");
+
+        std::atomic<bool> worker_returned{false};
+        std::thread worker([&]() {
+            std::optional<TransferQueue::Reservation> r;
+            while (!(r = tq.reserve_staging(64))) {
+                if (tq.is_shutting_down()) {
+                    worker_returned.store(true);
+                    return;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            // Should never succeed in this test — if it does, fail loud.
+            std::fprintf(stderr, "FAIL: worker got reservation despite saturated ring\n");
+            std::exit(1);
+        });
+
+        // Give the worker a chance to enter its retry loop.
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        expect(!worker_returned.load(), "worker is still spinning before cancel");
+
+        tq.request_cancel();
+        worker.join();
+        expect(worker_returned.load(), "worker observed cancel and exited");
+        std::printf("[TEST] request_cancel unblocks worker spin loop\n");
     }
 
     tq.shutdown();

--- a/tests/test_transfer_queue_gpu.cpp
+++ b/tests/test_transfer_queue_gpu.cpp
@@ -221,10 +221,13 @@ int main() {
         std::printf("[TEST] oversized reservation rejected\n");
     }
 
-    // ── Test 6: pending chunks survive a poll with no frame_cmd ──
-    // Regression for a bug where `poll_completions(VK_NULL_HANDLE)` would
-    // drain `pending_chunks_` into a local deque and then return without
-    // recording any copy, silently dropping every queued upload.
+    // ── Test 6: poll(VK_NULL_HANDLE) is safe in single-family mode ──
+    // The unified poll_completions submits its own command buffer regardless
+    // of `frame_cmd`; `frame_cmd` is consulted only for the cross-queue
+    // acquire barrier when transfer/graphics families differ. In the
+    // single-family fixture used here, passing VK_NULL_HANDLE must not
+    // crash, must not drop the chunk, and must still produce a byte-perfect
+    // upload after subsequent polls drive the fence to signal.
     {
         auto dest = Buffer::create_storage_gpu_only(gpu.allocator(), 256);
         auto res = tq.reserve_staging(64);
@@ -232,12 +235,13 @@ int main() {
         std::memset(res->host_ptr, 0xDD, 64);
         auto h = tq.submit(*res, dest.buffer(), 0);
 
-        // Poll with no command buffer. The chunk must remain pending.
-        tq.poll_completions(VK_NULL_HANDLE);
-        expect(tq.status(h) == TransferQueue::Status::Pending,
-               "chunk stays Pending when poll has no frame_cmd");
+        tq.poll_completions(VK_NULL_HANDLE);  // safe in single-family mode
+        const auto s = tq.status(h);
+        expect(s == TransferQueue::Status::Pending
+            || s == TransferQueue::Status::InFlight,
+               "status is Pending or InFlight after null-cmd poll (not lost)");
 
-        // Now poll for real and verify the upload completes.
+        // Driving the queue to completion still works.
         poll_until_complete(tq, gpu, {h});
 
         auto cmd = gpu.begin_commands();
@@ -249,7 +253,7 @@ int main() {
         }
         rb.destroy(gpu.allocator());
         dest.destroy(gpu.allocator());
-        std::printf("[TEST] poll(VK_NULL_HANDLE) preserves pending chunks\n");
+        std::printf("[TEST] poll(VK_NULL_HANDLE) is safe (single-family path)\n");
     }
 
     // ── Test 7: request_cancel breaks a worker's reserve_staging spin loop ──

--- a/tests/test_transfer_queue_gpu.cpp
+++ b/tests/test_transfer_queue_gpu.cpp
@@ -1,0 +1,225 @@
+// GPU integration test for the refactored TransferQueue:
+//   1. reserve_staging() returns a contiguous host slice from the ring.
+//   2. submit() schedules a copy to a chosen device buffer.
+//   3. poll_completions() drives the copy to completion (single-family path —
+//      headless VkContext exposes only the graphics queue family, so this
+//      exercises the fallback branch).
+//   4. status(handle) transitions Pending → Complete.
+//   5. Multiple back-to-back submits, including ring wrap-around, all land
+//      with the right bytes at the right offsets.
+
+#include "gpu_test_context.hpp"
+#include "gseurat/engine/transfer_queue.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+using namespace gseurat;
+
+namespace {
+
+void expect(bool cond, const char* msg) {
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", msg);
+        std::exit(1);
+    }
+}
+
+// Drive the queue until `expected_count` distinct handles report Complete or
+// `max_polls` is exhausted.
+void poll_until_complete(TransferQueue& tq, GpuTestContext& gpu,
+                         const std::vector<TransferQueue::Handle>& handles,
+                         int max_polls = 64) {
+    for (int i = 0; i < max_polls; ++i) {
+        auto cmd = gpu.begin_commands();
+        tq.poll_completions(cmd);
+        gpu.submit_and_wait();
+
+        bool all_done = true;
+        for (auto h : handles) {
+            if (tq.status(h) != TransferQueue::Status::Complete) {
+                all_done = false;
+                break;
+            }
+        }
+        if (all_done) return;
+    }
+    expect(false, "timed out waiting for transfers to complete");
+}
+
+}  // namespace
+
+int main() {
+    GpuTestContext gpu;
+    gpu.init();
+
+    // Single-family fallback: headless VkContext only exposes the graphics
+    // family, so transfer_family == graphics_family and the queue chooses
+    // its non-dedicated path.
+    const std::uint64_t staging_size = 256 * 1024;  // 256 KB
+    TransferQueue tq(
+        gpu.device(), gpu.allocator(),
+        gpu.context().graphics_queue(),
+        gpu.queue_family(),
+        /*dedicated=*/false,
+        staging_size,
+        /*budget_mb=*/64);
+
+    // ── Test 1: single submit round-trip ──
+    {
+        auto dest = Buffer::create_storage_gpu_only(gpu.allocator(), 4096);
+
+        auto res = tq.reserve_staging(1024);
+        expect(res.has_value(), "reserve_staging(1024) succeeded");
+        expect(res->size == 1024, "reservation size matches request");
+
+        // Write a recognizable pattern.
+        for (int i = 0; i < 1024; ++i) {
+            res->host_ptr[i] = static_cast<std::byte>(i & 0xFF);
+        }
+
+        auto h = tq.submit(*res, dest.buffer(), /*dest_offset=*/0);
+        expect(static_cast<bool>(h), "submit returned a non-null handle");
+        expect(tq.status(h) == TransferQueue::Status::Pending,
+               "status is Pending immediately after submit");
+
+        poll_until_complete(tq, gpu, {h});
+        expect(tq.status(h) == TransferQueue::Status::Complete,
+               "status transitioned to Complete after poll");
+
+        // Read back and verify.
+        auto cmd = gpu.begin_commands();
+        auto rb = gpu.readback_from_gpu(cmd, dest, 1024);
+        gpu.submit_and_wait();
+        const auto* got = static_cast<const std::uint8_t*>(rb.mapped());
+        for (int i = 0; i < 1024; ++i) {
+            expect(got[i] == (i & 0xFF), "byte mismatch in roundtrip");
+        }
+        rb.destroy(gpu.allocator());
+        dest.destroy(gpu.allocator());
+        std::printf("[TEST] single-submit roundtrip OK\n");
+    }
+
+    // ── Test 2: multiple destinations in a single batch ──
+    {
+        auto dest_a = Buffer::create_storage_gpu_only(gpu.allocator(), 256);
+        auto dest_b = Buffer::create_storage_gpu_only(gpu.allocator(), 256);
+
+        auto res_a = tq.reserve_staging(64);
+        auto res_b = tq.reserve_staging(64);
+        expect(res_a && res_b, "two consecutive reservations succeed");
+        expect(res_a->staging_offset != res_b->staging_offset,
+               "reservations get distinct staging offsets");
+        std::memset(res_a->host_ptr, 0xAA, 64);
+        std::memset(res_b->host_ptr, 0xBB, 64);
+
+        auto h_a = tq.submit(*res_a, dest_a.buffer(), 0);
+        auto h_b = tq.submit(*res_b, dest_b.buffer(), 0);
+        poll_until_complete(tq, gpu, {h_a, h_b});
+
+        auto cmd = gpu.begin_commands();
+        auto rb_a = gpu.readback_from_gpu(cmd, dest_a, 64);
+        auto rb_b = gpu.readback_from_gpu(cmd, dest_b, 64);
+        gpu.submit_and_wait();
+
+        const auto* a = static_cast<const std::uint8_t*>(rb_a.mapped());
+        const auto* b = static_cast<const std::uint8_t*>(rb_b.mapped());
+        for (int i = 0; i < 64; ++i) {
+            expect(a[i] == 0xAA, "dest_a byte mismatch");
+            expect(b[i] == 0xBB, "dest_b byte mismatch");
+        }
+        rb_a.destroy(gpu.allocator());
+        rb_b.destroy(gpu.allocator());
+        dest_a.destroy(gpu.allocator());
+        dest_b.destroy(gpu.allocator());
+        std::printf("[TEST] multi-destination batch OK\n");
+    }
+
+    // ── Test 3: ring wrap-around ──
+    // Reserve+submit chunks that together exceed staging_size, forcing the
+    // ring read pointer to advance and the write pointer to wrap.
+    {
+        auto dest = Buffer::create_storage_gpu_only(gpu.allocator(), staging_size * 2);
+        const std::uint64_t chunk_bytes = 32 * 1024;       // 32 KB
+        const int chunks = 16;                              // 512 KB total > 256 KB ring
+        std::vector<TransferQueue::Handle> handles;
+        for (int c = 0; c < chunks; ++c) {
+            std::optional<TransferQueue::Reservation> res;
+            // Spin until reservation succeeds (poll between attempts so the
+            // ring can retire in-flight bytes).
+            for (int attempt = 0; attempt < 64 && !res; ++attempt) {
+                res = tq.reserve_staging(chunk_bytes);
+                if (!res) {
+                    auto cmd = gpu.begin_commands();
+                    tq.poll_completions(cmd);
+                    gpu.submit_and_wait();
+                }
+            }
+            expect(res.has_value(), "wrap-around reservation eventually succeeds");
+
+            std::memset(res->host_ptr, c & 0xFF, chunk_bytes);
+            auto h = tq.submit(*res, dest.buffer(), c * chunk_bytes);
+            handles.push_back(h);
+        }
+        poll_until_complete(tq, gpu, handles, /*max_polls=*/256);
+
+        auto cmd = gpu.begin_commands();
+        auto rb = gpu.readback_from_gpu(cmd, dest, chunks * chunk_bytes);
+        gpu.submit_and_wait();
+        const auto* p = static_cast<const std::uint8_t*>(rb.mapped());
+        for (int c = 0; c < chunks; ++c) {
+            for (std::uint64_t i = 0; i < chunk_bytes; ++i) {
+                if (p[c * chunk_bytes + i] != (c & 0xFF)) {
+                    std::fprintf(stderr,
+                        "wrap-around mismatch at chunk %d offset %llu: got 0x%02X want 0x%02X\n",
+                        c, static_cast<unsigned long long>(i), p[c * chunk_bytes + i], c & 0xFF);
+                    std::exit(1);
+                }
+            }
+        }
+        rb.destroy(gpu.allocator());
+        dest.destroy(gpu.allocator());
+        std::printf("[TEST] %d-chunk ring wrap-around OK\n", chunks);
+    }
+
+    // ── Test 4: enqueue_completion fires after preceding submits ──
+    {
+        auto dest = Buffer::create_storage_gpu_only(gpu.allocator(), 1024);
+        auto res = tq.reserve_staging(256);
+        expect(res.has_value(), "reservation for completion-marker test");
+        std::memset(res->host_ptr, 0xCC, 256);
+        auto h = tq.submit(*res, dest.buffer(), 0);
+
+        bool fired = false;
+        tq.enqueue_completion([&fired]() { fired = true; });
+
+        // Single poll completes both the copy and the marker (fallback path
+        // is synchronous: callbacks fire as soon as the frame_cmd is recorded
+        // because the copy is in the same command buffer).
+        for (int i = 0; i < 16 && !fired; ++i) {
+            auto cmd = gpu.begin_commands();
+            tq.poll_completions(cmd);
+            gpu.submit_and_wait();
+        }
+        expect(fired, "enqueue_completion callback fired");
+        expect(tq.status(h) == TransferQueue::Status::Complete,
+               "preceding submit also Complete");
+        dest.destroy(gpu.allocator());
+        std::printf("[TEST] enqueue_completion ordering OK\n");
+    }
+
+    // ── Test 5: oversized reservation rejected ──
+    {
+        auto res = tq.reserve_staging(staging_size + 1);
+        expect(!res.has_value(), "oversized reservation refused");
+        std::printf("[TEST] oversized reservation rejected\n");
+    }
+
+    tq.shutdown();
+    gpu.shutdown();
+    std::printf("[ALL TESTS PASSED]\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Foundation for the upcoming Loading state machine — both prerequisites called out in the spec, sequenced so each commit compiles and is independently reviewable.

- **Prereq 1 — VkPipelineCache (engine-wide):** `PipelineCache` module owned by `VkContext`, persisted at `<project_root>/.cache/vulkan_pipeline.bin` via `resolve_asset_path`, threaded through every `vkCreate{Compute,Graphics}Pipelines` call (12 GS compute + 4 post-process + 4 sprite/UI graphics). Header validation against the device's `pipelineCacheUUID` so a driver/device swap falls back to an empty cache instead of a crash. Atomic save (temp + rename). Headless mode keeps the cache in-memory only so unit tests don't pollute the working tree.
- **Prereq 2 — TransferQueue refactor:** drops the hardcoded single `dest_buffer` from the constructor and exposes a `reserve_staging() → submit(reservation, dest_buffer, dest_offset, cb?) → Handle` API plus `status(Handle)` polling for ECS consumers. Single host-visible staging ring with monotonic write/read watermarks; reservations that would straddle the boundary skip the tail rather than splitting. Cross-queue ownership barriers (release on transfer cmd buffer + acquire on the next graphics `frame_cmd`) for hardware with a dedicated transfer family.

## Commit timeline

| SHA | Subject |
|---|---|
| `32d2d97` | `feat(engine): add disk-backed PipelineCache module` |
| `d901b1b` | `feat(engine): own pipeline cache in VkContext, route into GS compute pipelines` |
| `260d1e2` | `feat(engine): route shared pipeline cache through graphics pipelines` |
| `dee4082` | `feat(engine): generalize TransferQueue with reservation + handle API` |
| `a8bb62f` | `feat(engine): cross-queue ownership transfer for dedicated transfer family` |

## Test plan

- [x] `cmake --build --preset macos-debug` — clean build of `gseurat_core`, `gseurat_demo`, `gseurat_staging`, all GPU/non-GPU test executables
- [x] `tests/test_transfer_queue_gpu` — new headless GPU test with 5 cases (single-submit roundtrip, multi-destination batch, 16-chunk ring wrap-around through a 256 KB ring, `enqueue_completion` ordering, oversized reservation rejection); all pass with no Vulkan validation warnings
- [x] Engine smoke test (`gseurat_demo` + `{\"cmd\":\"quit\"}` over the control socket) — three boots verified end-to-end:
  - Cold (no `.cache/`) → `[PipelineCache] starting empty (will save…)` → `[PipelineCache] saved 209103 bytes`
  - Warm → `[PipelineCache] loaded 209103 bytes` → re-saved at same size (driver had no new compiles to absorb)
  - Corrupted UUID byte → `[PipelineCache] header mismatch (driver/device changed?); starting fresh` → fresh save
- [ ] Cross-queue barrier path validation on hardware with a dedicated transfer family (AMD desktop / discrete-GPU Linux) — Apple Silicon exposes a single family, so the headless test colocates them and the barrier code is dormant there. Naturally exercised once the Loading state machine wires `create_transfer_queue` into engine startup in a follow-up PR.

## Out of scope (next PR)

- The `EngineState::{Loading, Playing}` state machine itself + warm-up dummy frames (Prereq 3 of the spec) — this PR ships the primitives; the state machine consumes them.
- Image-upload unification (`StagingUploader` keeps its own double-buffered fence path for textures).
- Timeline-semaphore upgrade for queue ordering — fences are sufficient for the current single-batch-in-flight model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)