### PR TITLE
fix(transfer_queue): honor per-frame upload budget

### DIFF
--- a/src/engine/transfer_queue.cpp
+++ b/src/engine/transfer_queue.cpp
@@ -260,9 +260,34 @@ void TransferQueue::poll_completions(VkCommandBuffer frame_cmd) {
     // transfer_family_ == graphics_family_).
     std::vector<VkBufferMemoryBarrier> release_barriers;
 
+    // Per-frame upload budget: stop recording new copies once we've hit the
+    // configured byte cap, and push the remaining chunks back onto
+    // `pending_chunks_` for the next poll. `transfer_budget_bytes_ == 0`
+    // means "no cap" (caller passed budget_mb == 0). Once we defer the
+    // first chunk, every subsequent chunk and completion marker is also
+    // deferred so callbacks fire in the right order relative to the work
+    // they're meant to gate on.
+    std::uint64_t  bytes_recorded = 0;
+    bool           defer_rest     = false;
+    std::deque<PendingChunk> deferred;
+
     for (auto& ch : local) {
+        if (defer_rest) {
+            deferred.push_back(std::move(ch));
+            continue;
+        }
         if (ch.is_completion_marker) {
             if (ch.on_complete) batch.callbacks.push_back(std::move(ch.on_complete));
+            continue;
+        }
+        if (transfer_budget_bytes_ > 0 &&
+            bytes_recorded + ch.size > transfer_budget_bytes_ &&
+            bytes_recorded > 0) {
+            // Out of budget. Defer this chunk and every later one. Allow at
+            // least one chunk per poll regardless of budget so a single
+            // oversized payload can still make progress.
+            defer_rest = true;
+            deferred.push_back(std::move(ch));
             continue;
         }
         VkBufferCopy region{};
@@ -272,6 +297,7 @@ void TransferQueue::poll_completions(VkCommandBuffer frame_cmd) {
         vkCmdCopyBuffer(transfer_cmd_, staging_buffer_.buffer(),
                         ch.dest_buffer, 1, &region);
 
+        bytes_recorded += ch.size;
         batch.handles.push_back(ch.handle);
         if (ch.on_complete) batch.callbacks.push_back(std::move(ch.on_complete));
         batch.max_logical_end = std::max(batch.max_logical_end, ch.logical_end);
@@ -298,6 +324,15 @@ void TransferQueue::poll_completions(VkCommandBuffer frame_cmd) {
         pending_status_[ch.handle.id] = Status::InFlight;
     }
 
+    // Re-queue deferred chunks at the front of pending_chunks_ so they keep
+    // their original FIFO order on the next poll.
+    if (!deferred.empty()) {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        for (auto it = deferred.rbegin(); it != deferred.rend(); ++it) {
+            pending_chunks_.push_front(std::move(*it));
+        }
+    }
+
     if (!release_barriers.empty()) {
         vkCmdPipelineBarrier(transfer_cmd_,
             VK_PIPELINE_STAGE_TRANSFER_BIT,
@@ -309,6 +344,13 @@ void TransferQueue::poll_completions(VkCommandBuffer frame_cmd) {
     }
 
     vkEndCommandBuffer(transfer_cmd_);
+
+    // If everything was deferred (budget exhausted before the first chunk
+    // could record) and no markers piggybacked on this poll, skip the
+    // submit — there's no GPU work to fence on. Standalone markers (no
+    // recorded copies) still fire via the in_flight retirement path so
+    // they observe their preceding chunks.
+    if (batch.handles.empty() && batch.callbacks.empty()) return;
 
     VkSubmitInfo submit{};
     submit.sType              = VK_STRUCTURE_TYPE_SUBMIT_INFO;

--- a/tests/test_transfer_queue_gpu.cpp
+++ b/tests/test_transfer_queue_gpu.cpp
@@ -326,18 +326,31 @@ int main() {
         }
 
         // First poll: budget allows 2 × 384 KB = 768 KB before the third
-        // chunk would push us over 1 MB. Three chunks must remain Pending.
+        // chunk would push us over 1 MB. The split must be exact —
+        // recording a third chunk (1.125 MB) would exceed the budget and
+        // reintroduce the frame-time spikes this fix is meant to prevent.
+        // Recording fewer than two would mean the "always allow at least
+        // one chunk" allowance ate into the cap unnecessarily.
         {
             auto cmd = gpu.begin_commands();
             tiny.poll_completions(cmd);
             gpu.submit_and_wait();
 
-            int still_pending = 0;
+            int pending = 0;
+            int inflight = 0;
+            int complete = 0;
             for (auto h : handles) {
-                if (tiny.status(h) == TransferQueue::Status::Pending) still_pending++;
+                switch (tiny.status(h)) {
+                    case TransferQueue::Status::Pending:  pending++;  break;
+                    case TransferQueue::Status::InFlight: inflight++; break;
+                    case TransferQueue::Status::Complete: complete++; break;
+                    default:                                          break;
+                }
             }
-            expect(still_pending >= 2,
-                   "first poll deferred at least the budget-exceeding tail");
+            expect(pending == 3,
+                   "exactly 3 of 5 chunks deferred to next poll");
+            expect(inflight + complete == 2,
+                   "exactly 2 chunks recorded into the first batch");
         }
 
         // Drive the rest to completion across multiple polls.

--- a/tests/test_transfer_queue_gpu.cpp
+++ b/tests/test_transfer_queue_gpu.cpp
@@ -291,6 +291,97 @@ int main() {
     }
 
     tq.shutdown();
+
+    // ── Test 8: per-frame transfer budget spreads work across polls ─────
+    // Build a separate TransferQueue with a small budget and a ring large
+    // enough to hold every reservation in flight, then verify that chunks
+    // exceeding the budget get deferred to subsequent polls (instead of
+    // recording into one giant submission). Allowance: a single chunk is
+    // always permitted even if it alone exceeds the budget — otherwise
+    // oversize payloads would never make progress.
+    {
+        constexpr std::uint64_t kRing       = 4ull * 1024 * 1024;  // 4 MB ring
+        constexpr std::uint64_t kChunkBytes = 384ull * 1024;       // 384 KB each
+        constexpr int           kChunks     = 5;                    // 5 × 384 KB = 1.875 MB
+        constexpr std::uint32_t kBudgetMB   = 1;                    // 1 MB → 2 chunks/poll
+
+        TransferQueue tiny(
+            gpu.device(), gpu.allocator(),
+            gpu.context().graphics_queue(),
+            gpu.queue_family(), gpu.queue_family(),
+            /*dedicated=*/false,
+            kRing,
+            kBudgetMB);
+
+        auto dest = Buffer::create_storage_gpu_only(gpu.allocator(),
+                                                     kChunks * kChunkBytes);
+
+        std::vector<TransferQueue::Handle> handles;
+        for (int c = 0; c < kChunks; ++c) {
+            auto res = tiny.reserve_staging(kChunkBytes);
+            expect(res.has_value(), "tiny-budget reservation succeeded");
+            std::memset(res->host_ptr, 0xE0 + c, kChunkBytes);
+            handles.push_back(tiny.submit(*res, dest.buffer(),
+                                          static_cast<std::uint64_t>(c) * kChunkBytes));
+        }
+
+        // First poll: budget allows 2 × 384 KB = 768 KB before the third
+        // chunk would push us over 1 MB. Three chunks must remain Pending.
+        {
+            auto cmd = gpu.begin_commands();
+            tiny.poll_completions(cmd);
+            gpu.submit_and_wait();
+
+            int still_pending = 0;
+            for (auto h : handles) {
+                if (tiny.status(h) == TransferQueue::Status::Pending) still_pending++;
+            }
+            expect(still_pending >= 2,
+                   "first poll deferred at least the budget-exceeding tail");
+        }
+
+        // Drive the rest to completion across multiple polls.
+        for (int i = 0; i < 32; ++i) {
+            auto cmd = gpu.begin_commands();
+            tiny.poll_completions(cmd);
+            gpu.submit_and_wait();
+            bool all_done = true;
+            for (auto h : handles) {
+                if (tiny.status(h) != TransferQueue::Status::Complete) {
+                    all_done = false;
+                    break;
+                }
+            }
+            if (all_done) break;
+        }
+        for (auto h : handles) {
+            expect(tiny.status(h) == TransferQueue::Status::Complete,
+                   "all budgeted chunks eventually complete");
+        }
+
+        // Verify bytes landed correctly across the destination buffer.
+        auto cmd = gpu.begin_commands();
+        auto rb = gpu.readback_from_gpu(cmd, dest, kChunks * kChunkBytes);
+        gpu.submit_and_wait();
+        const auto* p = static_cast<const std::uint8_t*>(rb.mapped());
+        for (int c = 0; c < kChunks; ++c) {
+            const auto expected = static_cast<std::uint8_t>(0xE0 + c);
+            for (std::uint64_t i = 0; i < kChunkBytes; ++i) {
+                if (p[c * kChunkBytes + i] != expected) {
+                    std::fprintf(stderr,
+                        "byte mismatch chunk %d offset %llu: got 0x%02X want 0x%02X\n",
+                        c, static_cast<unsigned long long>(i),
+                        p[c * kChunkBytes + i], expected);
+                    std::exit(1);
+                }
+            }
+        }
+        rb.destroy(gpu.allocator());
+        dest.destroy(gpu.allocator());
+        tiny.shutdown();
+        std::printf("[TEST] per-frame budget defers excess across polls\n");
+    }
+
     gpu.shutdown();
     std::printf("[ALL TESTS PASSED]\n");
     return 0;


### PR DESCRIPTION
## Summary

Post-merge follow-up to #376. Codex reviewer flagged a P2: the unified `poll_completions` path I introduced kept the `transfer_budget_mb` knob in the API but stopped honoring it — every pending chunk was drained into one submission per poll, producing potentially huge command buffers and frame-time hitches under sustained streaming load.

Restored the per-frame byte cap inside the drain loop:

- Track `bytes_recorded` while iterating; once recording the next chunk would cross `transfer_budget_bytes_`, defer it (and every later item, including completion markers, so callbacks fire only after the work they gate on).
- Deferred chunks go back to the front of `pending_chunks_` to preserve FIFO order.
- Always allow at least one chunk per poll so an oversized payload can still make progress.
- Skip `vkQueueSubmit` when budget exhaustion leaves the batch empty — otherwise we'd burn the shared `transfer_fence_` cycle on a no-op.
- `transfer_budget_mb == 0` opts out of the cap entirely (drain everything in one batch).

## Test plan

- [x] `tests/test_transfer_queue_gpu` test 8 (new) — `[TEST] per-frame budget defers excess across polls`. 4 MB ring, 1 MB budget, 5 × 384 KB chunks (= 1.875 MB total). First poll records 2 chunks (768 KB, fits the 1 MB cap) and defers 3. Subsequent polls drive the deferred chunks to completion. Readback verifies byte-perfect placement at the right offsets.
- [x] All 8 GPU tests pass — no Vulkan validation warnings.
- [x] Existing 7 cases (single-submit roundtrip, multi-destination batch, 16-chunk wrap-around, completion ordering, oversized rejection, null-cmd safety, cancel-unblock) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)