### PR TITLE
fix: portal regressions — async PLY parse, per-frame GS images, fade pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ Everything in the scene is a **Game Object** — a unified entity with position,
 
 Portals and cross-scene transitions are driven by a **transient-entity state machine** on the existing ECS. When a `ProximityTrigger + PortalTarget` pair fires, `portal_trigger_handler` spawns an entity with `SceneTransition + ScreenFade` components. `transition_system` advances `SceneOut → Loading → SceneIn`, issues a single atomic `host.transition_scene()` call under a fully-opaque overlay, and destroys the entity on completion.
 
+PLY parsing for the destination scene runs on a worker thread (`std::async`) via `AppBase::begin_async_load_gs_scene`; the main thread keeps rendering the loading overlay while `tick_async_load_gs_scene` non-blockingly polls the future, then performs the GPU/ECS finalize. `ITransitionHost::is_async_loading()` lets the state machine pin the SceneIn fade at alpha=1.0 until the load completes, so the fade-in only starts once the new scene is fully ready.
+
 Visuals are decoupled from the state machine — the post-process compute shader branches on `effect_type` to select between solid fade, left-to-right wipe, and iris wipe (aspect-corrected circle). Adding a new effect is a single-file shader change plus a schema bump.
 
 See [docs/scene-transitions.md](docs/scene-transitions.md) for the full architecture, components, effects reference, authoring workflow, and extension guide.

--- a/docs/gpu-compute-pipeline.md
+++ b/docs/gpu-compute-pipeline.md
@@ -94,28 +94,28 @@ Shader: `gs_sort.comp` | Push constants: 8 bytes
 
 ### Render (`render_layout_`)
 
-Full-screen Gaussian rasterization (non-tiled path).
+Full-screen Gaussian rasterization (non-tiled path). Allocated per-frame as `render_sets_[kMaxFramesInFlight]` — each frame's set binds the frame's matching `output_image[frame]` / `depth_image[frame]`.
 
 | Binding | Type | Resource |
 |---|---|---|
 | 0 | `STORAGE_BUFFER` | projected |
 | 1 | `STORAGE_BUFFER` | sort_keys |
 | 2 | `UNIFORM_BUFFER` | uniforms |
-| 3 | `STORAGE_IMAGE` | output_image |
+| 3 | `STORAGE_IMAGE` | output_image (per frame) |
 | 4 | `STORAGE_BUFFER` | visible_count |
-| 5 | `STORAGE_IMAGE` | depth_image |
+| 5 | `STORAGE_IMAGE` | depth_image (per frame) |
 
 Shader: `gs_render.comp`
 
 ### Post-Process (`post_process_layout_`)
 
-Fog, tone mapping, vignette, bloom, DoF, chromatic aberration.
+Fog, tone mapping, vignette, bloom, DoF, chromatic aberration. Allocated per-frame as `post_process_sets_[kMaxFramesInFlight]` — each frame's set reads / writes the frame's matching images.
 
 | Binding | Type | Resource |
 |---|---|---|
-| 0 | `STORAGE_IMAGE` | input (readonly) |
-| 1 | `STORAGE_IMAGE` | depth (readonly) |
-| 2 | `STORAGE_IMAGE` | output (writeonly) |
+| 0 | `STORAGE_IMAGE` | input (readonly, per frame = output_image[frame]) |
+| 1 | `STORAGE_IMAGE` | depth (readonly, per frame = depth_image[frame]) |
+| 2 | `STORAGE_IMAGE` | output (writeonly, per frame = processed_image[frame]) |
 | 3 | `UNIFORM_BUFFER` | UBO |
 
 Shader: `gs_post_process.comp`
@@ -202,16 +202,16 @@ Shader: `gs_tile_prepare_indirect.comp` | Push constants: 4 bytes (max_entries)
 
 ### Tile Render (`tile_render_layout_`)
 
-Per-tile Gaussian rasterization (production path, ~3x faster than full-screen).
+Per-tile Gaussian rasterization (production path, ~3x faster than full-screen). Allocated per-frame as `tile_render_sets_[kMaxFramesInFlight]` — each frame's set binds the frame's matching `output_image[frame]` / `depth_image[frame]`.
 
 | Binding | Type | Resource |
 |---|---|---|
 | 0 | `STORAGE_BUFFER` | projected |
 | 1 | `STORAGE_BUFFER` | tile_entries |
 | 2 | `UNIFORM_BUFFER` | uniforms |
-| 3 | `STORAGE_IMAGE` | output_image |
+| 3 | `STORAGE_IMAGE` | output_image (per frame) |
 | 4 | `STORAGE_BUFFER` | tile_ranges |
-| 5 | `STORAGE_IMAGE` | depth_image |
+| 5 | `STORAGE_IMAGE` | depth_image (per frame) |
 
 Shader: `gs_tile_render.comp`
 
@@ -319,6 +319,9 @@ call (`gs_renderer.cpp:439-504`).
 | 25-26 | onesweep_hist | Depth sort histogram A/B (dynamic) |
 | 27-28 | onesweep_scatter | Depth sort scatter (dynamic) |
 | 29 | tile_scan | Deterministic tile-bin prefix-sum |
+| 30 | render | Render set (frame-in-flight 1) — paired with slot 2 |
+| 31 | post_process | Post-process set (frame-in-flight 1) — paired with slot 3 |
+| 32 | tile_render | Tile render set (frame-in-flight 1) — paired with slot 12 |
 
 ---
 
@@ -342,10 +345,29 @@ call (`gs_renderer.cpp:439-504`).
 
 | Resource | Allocated | Pool Limit | Remaining |
 |---|---|---|---|
-| Sets | 30 | 128 | 98 |
+| Sets | 33 | 160 | 127 |
 | `STORAGE_BUFFER` | ~120 | 256 | ~136 |
-| `STORAGE_IMAGE` | 8 | 24 | 16 |
+| `STORAGE_IMAGE` | 14 | 24 | 10 |
 | `UNIFORM_BUFFER` | 9 | 32 | 23 |
+
+The set count grew from 30 to 33 when `output_image_` / `depth_image_` /
+`processed_image_` were promoted to per-frame `std::array<…, kMaxFramesInFlight>`
+arrays — the render, post_process, and tile_render descriptor sets that bind
+those images had to follow, so each gets one set per frame in flight (slots
+2, 3, 12 hold the frame-0 set; slots 30, 31, 32 hold the frame-1 set). The
+storage-image count grew similarly: 3 images × 2 frames = 6, plus one extra
+sampler view per frame, vs. the original 3 single shared images.
+
+**Per-frame intermediates rationale.** With `kMaxFramesInFlight = 2`, a
+single shared `output_image_` / `depth_image_` / `processed_image_` would be
+written by frame N+1's compute dispatch while frame N's composite-blit is
+still sampling it on the GPU — there is no producer/consumer fence between
+adjacent in-flight frames on those images. On Apple/MoltenVK with a 3-image
+swapchain that race manifested as a "first-rendered configuration flashes
+back" ghost. Each frame now writes into its own image and binds its own
+descriptor set; the `Renderer` passes its `current_frame_` index through
+`gs_renderer_.render(cmd, frame, view, proj)` and uses the matching
+`output_views_[frame]` for the swapchain blit (`DescriptorManager::allocate_sprite_sets_per_frame`).
 
 Adding a new compute pass with a typical layout (4 SSBOs + 1 UBO + 1 storage
 image) is well within pool limits without resizing.

--- a/docs/scene-transitions.md
+++ b/docs/scene-transitions.md
@@ -125,19 +125,58 @@ struct ScreenFade {
 
 ### `ITransitionHost`
 
-The system calls one atomic host method on the `SceneOut → Loading` boundary:
+The system calls one atomic host method on the `SceneOut → Loading` boundary, plus a non-blocking query each frame in `SceneIn`:
 
 ```cpp
 struct ITransitionHost {
     virtual void transition_scene(const std::string& target_scene,
                                   const glm::vec3& target_position) = 0;
+    // Optional: defaults to false. When true, transition_system pins the
+    // SceneIn fade overlay at alpha=1.0 and resets its timer each frame,
+    // so the kFadeIn animation only starts once the host reports the new
+    // scene is fully ready. Hosts that load synchronously can leave the
+    // default; hosts using the async load path (see "Async Scene Loading"
+    // below) override to forward their loading state.
+    virtual bool is_async_loading() const { return false; }
     virtual ~ITransitionHost() = default;
 };
 ```
 
-`AppBase` implements this interface by clearing the ECS world + bone registry, loading the destination scene, and placing `PlayerTag` at the target position. Game apps that need extra recovery (collision grids, camera state, audio regions) override `transition_scene` to wrap the base behavior.
+`AppBase` implements this interface by clearing the ECS world + bone registry, loading the destination scene, and placing `PlayerTag` at the target position. Its `is_async_loading()` override forwards `is_async_loading_gs_scene()` so the SceneIn fade stays opaque while a worker thread is parsing PLYs. Game apps that need extra recovery (collision grids, camera state, audio regions) override `transition_scene` to wrap the base behavior.
 
-The single-method design is deliberate: portal transitions are atomic — you cannot "move the player" to an entity that doesn't exist between clear and load. Tests provide a `FakeHost` implementation to exercise the state machine without Vulkan.
+The single-method design for `transition_scene` is deliberate: portal transitions are atomic — you cannot "move the player" to an entity that doesn't exist between clear and load. Tests provide a `FakeHost` implementation to exercise the state machine without Vulkan.
+
+## Async Scene Loading
+
+`AppBase::transition_scene` for the demo's portal path is implemented as a two-phase split that keeps the main thread free of long PLY-parse stalls:
+
+```cpp
+// Phase A — synchronous, fast (<100ms): drain GPU, clear world, kick off
+// worker. `begin_async_load_gs_scene` is non-blocking.
+app.world().clear();
+app.clear_scene();
+app.begin_async_load_gs_scene(SceneLoader::load(target_scene), opts);
+
+pending_portal_post_load_ = [this, target_scene, target_position](AppBase& a) {
+    finish_portal_transition(a, target_scene, target_position);
+};
+
+// Phase B — drained from update() once is_async_loading_gs_scene() is false.
+// Performs collision-grid restore, player respawn, character re-merge, etc.
+```
+
+The supporting API on `AppBase`:
+
+| Method | Phase | Notes |
+|---|---|---|
+| `begin_async_load_gs_scene(SceneData, opts)` | Phase A | Spawns a `std::async(std::launch::async, …)` worker that runs `GsSceneLoader::parse()` (PLY load + Gaussian merge, no Vulkan / ECS access). |
+| `tick_async_load_gs_scene()` | every frame | Called from `main_loop`. Non-blocking poll via `wait_for(0s)`. When the future is ready, runs `GsSceneLoader::finalize_on_main` (Vulkan + ECS) and arms `loading_monitor_` for the streaming-upload phase. |
+| `is_async_loading_gs_scene()` | every frame | True between `begin_…` and the frame `tick_…` consumes the future. |
+| `load_gs_scene(SceneData, opts)` | sync | Convenience wrapper that calls `parse()` then `finalize_on_main()` on the calling thread. Used by the initial scene load where a loading screen is already up. |
+
+`GsSceneLoader::parse(SceneData) → ParsedScene` is the CPU-only contract. It owns no Vulkan / ECS resources and is safe to invoke from a worker thread. `finalize_on_main(ctx, parsed, opts)` is the main-thread half — it performs `init_gs`, ECS entity creation, bone registry population, light upload, VFX instance setup, etc.
+
+While Phase B is pending, `IslandDemoState::update()` checks `app.is_async_loading_gs_scene()` and drains the deferred lambda once it flips false. The SceneIn `ScreenFade` entity is created in Phase A (not Phase B), so the opaque overlay covers the entire async-parse + GPU-upload window — without that earlier creation, the user would see the per-frame `processed_image_` slots from the OLD scene flash through during the parse.
 
 ## Transition Effects
 
@@ -303,7 +342,6 @@ The state machine itself does not need to change.
 
 ### Known out-of-scope items
 
-- **Async scene loading.** `Loading` currently invokes `host.transition_scene` synchronously under a fully-opaque overlay. Upgrading to true async loading is an internal change with no public API impact — component schemas would stay identical.
 - **Transition cancellation / pause.** Transitions run to completion once started.
 - **Non-portal triggers.** `portal_trigger_handler` only handles `ProximityTrigger + PortalTarget` pairs; interact-key triggers, cutscene entries, and save-point respawns are future features that follow the same pattern (new companion component + new handler, same transient-entity machinery).
 - **Per-transition audio hooks.** Sound designers can respond to `ScreenFade` presence from their own system.
@@ -315,7 +353,8 @@ The state machine itself does not need to change.
 |---|---|
 | Components | `include/gseurat/engine/ecs/components/{scene_transition,screen_fade,portal_target}.hpp` |
 | Systems | `include/gseurat/engine/systems/{transition_system,portal_trigger_handler}.hpp`<br>`src/engine/systems/{transition_system,portal_trigger_handler}.cpp` |
-| Registration & host | `src/engine/app_base.cpp` (`register_component<PortalTarget>`, `register_component<ScreenFade>`, `transition_scene` override, system registration order) |
+| Async load | `include/gseurat/engine/app_base.hpp` (`begin_async_load_gs_scene`, `tick_async_load_gs_scene`, `is_async_loading_gs_scene`)<br>`include/gseurat/engine/gs_scene_loader.hpp` (`parse`, `finalize_on_main`, `ParsedScene`)<br>`src/demo/island_demo_state.cpp` (`perform_portal_transition` Phase A, `finish_portal_transition` Phase B) |
+| Registration & host | `src/engine/app_base.cpp` (`register_component<PortalTarget>`, `register_component<ScreenFade>`, `transition_scene` override, `is_async_loading` override, system registration order) |
 | Renderer | `include/gseurat/engine/post_process.hpp`, `include/gseurat/engine/gs_renderer.hpp`, `src/engine/gs_renderer.cpp`, `src/engine/renderer.cpp` |
 | Shader | `shaders/gs_post_process.comp` (UBO `overlay` + `overlay_effect_type`, effect branches) |
 | Schemas | `examples/island_demo/assets/components/{portal_target,screen_fade,scene_transition}.schema.json` |

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -94,6 +94,12 @@ private:
     // World streaming
     std::unique_ptr<WorldStreamer> world_streamer_;
 
+    // Explicit hard-stop for the streamer. TRUE while transitioning OUT
+    // of the overworld and inside any non-overworld scene; FALSE only
+    // after the overworld is fully restored. Replaces the brittle
+    // current_scene_path string-equality gate.
+    bool disable_world_streaming_ = false;
+
     // Async chunk-load worker. PLY parsing is the main cost in
     // load_cloud_async's caller path; running it on the main thread
     // shows up as multi-frame stalls / OS beachballs while walking

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -13,6 +13,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <array>
+#include <functional>
 #include <future>
 #include <memory>
 #include <string>
@@ -34,12 +35,24 @@ public:
 
     /// Perform the demo-specific scene-transition recovery work for a portal.
     /// Invoked by DemoApp::transition_scene via the portal_handler callback.
-    /// Includes: vkDeviceWaitIdle, world clear, scene load, collision-grid restore,
-    /// world-chunk re-merge (overworld only), camera reset, player re-creation,
-    /// character re-merge, bone-animation re-registration, portal entity re-spawn.
+    /// Phase A (this call, fast): drain in-flight chunk parses, wait_idle,
+    /// drop chunks, clear world, kick off async scene load via
+    /// AppBase::begin_async_load_gs_scene, and store `pending_portal_post_load_`
+    /// to do the rest later. Phase B (drained from update() the first frame the
+    /// async scene load reports complete): collision-grid restore, world-chunk
+    /// re-merge, player re-creation, character re-merge, bone-animation
+    /// re-registration.
     void perform_portal_transition(AppBase& app,
                                    const std::string& target_scene,
                                    const glm::vec3& target_position);
+
+private:
+    /// Phase B of perform_portal_transition. Runs once the async scene-load
+    /// future is consumed and the GPU/ECS finalize has happened.
+    void finish_portal_transition(AppBase& app,
+                                  const std::string& target_scene,
+                                  const glm::vec3& target_position);
+public:
 
 private:
     void update_player(AppBase& app, float dt);
@@ -99,6 +112,12 @@ private:
     // after the overworld is fully restored. Replaces the brittle
     // current_scene_path string-equality gate.
     bool disable_world_streaming_ = false;
+
+    // Deferred post-load work for the in-flight portal transition. Populated
+    // by perform_portal_transition (Phase A, runs synchronously); drained
+    // from update() once `app.is_async_loading_gs_scene()` flips back to
+    // false (parse + finalize done). Empty when no portal is in flight.
+    std::function<void(AppBase&)> pending_portal_post_load_;
 
     // Async chunk-load worker. PLY parsing is the main cost in
     // load_cloud_async's caller path; running it on the main thread

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -94,6 +94,15 @@ private:
     // World streaming
     std::unique_ptr<WorldStreamer> world_streamer_;
 
+    // Explicit hard-stop for the streamer. Set TRUE the moment a portal
+    // begins transitioning OUT of the overworld and back to FALSE after
+    // we've successfully restored the overworld and re-marked all chunks
+    // LOADED. While true, world_streamer_->update() is NOT called and
+    // no async chunk parses are kicked off — guarantees zero risk of an
+    // overworld chunk's PLY parse landing in the dungeon's GS buffer.
+    // Replaces the brittle current_scene_path string-equality gate.
+    bool disable_world_streaming_ = false;
+
     // Async chunk-load worker. PLY parsing is the main cost in
     // load_cloud_async's caller path; running it on the main thread
     // shows up as multi-frame stalls / OS beachballs while walking

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -13,8 +13,10 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <array>
+#include <future>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace gseurat {
 
@@ -91,6 +93,20 @@ private:
 
     // World streaming
     std::unique_ptr<WorldStreamer> world_streamer_;
+
+    // Async chunk-load worker. PLY parsing is the main cost in
+    // load_cloud_async's caller path; running it on the main thread
+    // shows up as multi-frame stalls / OS beachballs while walking
+    // toward newly-streaming chunks. We hand the parse to std::async
+    // and let the main thread poll the future once per frame.
+    struct PendingChunkParse {
+        std::string grid_key;
+        std::future<GaussianCloud> future;
+    };
+    std::vector<PendingChunkParse> pending_chunk_parses_;
+    void enqueue_async_chunk_load(const std::string& grid_key,
+                                  const std::string& ply_path);
+    void drain_async_chunk_loads(AppBase& app);
 
     // Orbit camera (third-person around player)
     float azimuth_ = 0.0f;

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -94,15 +94,6 @@ private:
     // World streaming
     std::unique_ptr<WorldStreamer> world_streamer_;
 
-    // Explicit hard-stop for the streamer. Set TRUE the moment a portal
-    // begins transitioning OUT of the overworld and back to FALSE after
-    // we've successfully restored the overworld and re-marked all chunks
-    // LOADED. While true, world_streamer_->update() is NOT called and
-    // no async chunk parses are kicked off — guarantees zero risk of an
-    // overworld chunk's PLY parse landing in the dungeon's GS buffer.
-    // Replaces the brittle current_scene_path string-equality gate.
-    bool disable_world_streaming_ = false;
-
     // Async chunk-load worker. PLY parsing is the main cost in
     // load_cloud_async's caller path; running it on the main thread
     // shows up as multi-frame stalls / OS beachballs while walking

--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -138,6 +138,12 @@ public:
     void transition_scene(const std::string& target_scene,
                           const glm::vec3& target_position) override;
 
+    // ITransitionHost: lets the transition system pin the SceneIn fade at
+    // alpha=1.0 while async scene loading is in flight.
+    bool is_async_loading() const override {
+        return is_async_loading_gs_scene();
+    }
+
     // Shared GS scene loading: PLY + placed objects + lights + emitters + animations + VFX
     void load_gs_scene(const SceneData& scene_data, const GsSceneOptions& opts = {});
 

--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -49,7 +49,9 @@
 #include <chrono>
 #include <cstdint>
 #include <functional>
+#include <future>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace gseurat {
@@ -138,6 +140,22 @@ public:
 
     // Shared GS scene loading: PLY + placed objects + lights + emitters + animations + VFX
     void load_gs_scene(const SceneData& scene_data, const GsSceneOptions& opts = {});
+
+    // Async-load API. Pushes the CPU-only PLY parse + Gaussian merge to a worker
+    // thread (`std::async(std::launch::async, …)`), returning immediately. The
+    // main thread is expected to invoke `tick_async_load_gs_scene` once per
+    // frame; once the parse future is ready, that hook performs the GPU/ECS
+    // finalize phase synchronously and then arms `loading_monitor_` to track
+    // the streaming-upload phase. While the parse is in flight,
+    // `is_async_loading_gs_scene` returns true so callers can render a
+    // loading overlay or otherwise gate input.
+    void begin_async_load_gs_scene(SceneData scene_data,
+                                   const GsSceneOptions& opts = {});
+    void tick_async_load_gs_scene();
+    bool is_async_loading_gs_scene() const {
+        return pending_async_scene_.has_value();
+    }
+
     virtual void update_game(float dt);
     void upload_bone_transforms();
     virtual void update_audio(float dt);
@@ -305,6 +323,18 @@ protected:
     ComponentRegistry component_registry_;
     SystemScheduler system_scheduler_;
     void init_game_object_system();
+
+    // In-flight async scene load. The future runs `GsSceneLoader::parse` on a
+    // worker thread; the main thread polls it from `tick_async_load_gs_scene`
+    // and, when it is ready, performs the Vulkan / ECS finalize phase on the
+    // calling (main) thread. `scene_data` and `opts` are owned here so they
+    // outlive the worker.
+    struct PendingAsyncScene {
+        std::future<ParsedScene> parse_future;
+        SceneData scene_data;
+        GsSceneOptions opts;
+    };
+    std::optional<PendingAsyncScene> pending_async_scene_;
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/debug_dump_renderer.hpp
+++ b/include/gseurat/engine/debug_dump_renderer.hpp
@@ -9,7 +9,10 @@
 #include "gseurat/engine/renderer.hpp"
 
 #include <cstdint>
+#include <functional>
+#include <string>
 #include <string_view>
+#include <vector>
 
 namespace gseurat {
 
@@ -57,6 +60,17 @@ public:
         uint32_t streaming_active_chunks = 0;
         uint32_t streaming_active_splats = 0;
         bool     streaming_initialized   = false;
+        uint32_t streaming_pending_loads = 0;
+
+        // Per-chunk detail (proves which scene's content is currently
+        // resident in VRAM — empty after a clean scene transition).
+        struct ChunkRow {
+            std::string status;
+            uint32_t page_table_offset = 0;
+            uint32_t splat_count       = 0;
+            uint32_t slab_count        = 0;
+        };
+        std::vector<ChunkRow> chunks;
 
         // Render distance
         float max_render_distance   = 0.0f;
@@ -116,6 +130,19 @@ public:
                     {"initialized",   snap.streaming_initialized},
                     {"active_chunks", snap.streaming_active_chunks},
                     {"active_splats", snap.streaming_active_splats},
+                    {"pending_loads", snap.streaming_pending_loads},
+                    {"chunks",        [&]() {
+                        nlohmann::json arr = nlohmann::json::array();
+                        for (const auto& c : snap.chunks) {
+                            arr.push_back({
+                                {"status",            c.status},
+                                {"page_table_offset", c.page_table_offset},
+                                {"splat_count",       c.splat_count},
+                                {"slab_count",        c.slab_count},
+                            });
+                        }
+                        return arr;
+                    }()},
                 }},
                 {"max_render_distance", snap.max_render_distance},
             }},

--- a/include/gseurat/engine/descriptor.hpp
+++ b/include/gseurat/engine/descriptor.hpp
@@ -25,6 +25,18 @@ public:
         VkImageView normal_view = VK_NULL_HANDLE,
         VkSampler normal_sampler = VK_NULL_HANDLE);
 
+    // Per-frame view variant: descriptor set `i` is bound to `texture_views[i]`.
+    // Used for sampling per-frame intermediate images (e.g. the GS post-processed
+    // image) where a single shared view would race between frames in flight.
+    std::array<VkDescriptorSet, kMaxFramesInFlight> allocate_sprite_sets_per_frame(
+        VkDevice device,
+        const std::array<VkBuffer, kMaxFramesInFlight>& uniform_buffers,
+        VkDeviceSize ubo_size,
+        const std::array<VkImageView, kMaxFramesInFlight>& texture_views,
+        VkSampler sampler,
+        VkImageView normal_view = VK_NULL_HANDLE,
+        VkSampler normal_sampler = VK_NULL_HANDLE);
+
     void free_sprite_sets(VkDevice device,
                           std::array<VkDescriptorSet, kMaxFramesInFlight>& sets);
 

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -13,6 +13,7 @@
 #include <vulkan/vulkan.h>
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <deque>
@@ -141,20 +142,43 @@ public:
 
     void resize_output(uint32_t width, uint32_t height);
 
-    // Records a one-time barrier+clear that transitions the GS output,
-    // processed, and depth images out of `VK_IMAGE_LAYOUT_UNDEFINED` (their
-    // post-creation state) into `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL`
-    // with their contents cleared to black. The renderer's main pass samples
-    // `processed_view_` every frame; without this seed transition, the very
-    // first frame after `resize_output` while the engine state is `Loading`
-    // (i.e. the GS compute path is gated off) would hit a layout-mismatch
-    // validation error. Caller is responsible for submitting + waiting on
-    // the recorded command buffer.
+    // Records a one-time barrier+clear that transitions every per-frame
+    // GS output, processed, and depth image out of `VK_IMAGE_LAYOUT_UNDEFINED`
+    // (post-creation state) into `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL`
+    // with contents cleared to black. The renderer's main pass samples
+    // `processed_views_[frame]` every frame; without this seed transition,
+    // the very first frame after `resize_output` while the engine state is
+    // `Loading` (i.e. the GS compute path is gated off) would hit a
+    // layout-mismatch validation error. Caller is responsible for submitting
+    // and waiting on the recorded command buffer.
     void init_output_layouts(VkCommandBuffer cmd);
 
-    void render(VkCommandBuffer cmd, const glm::mat4& view, const glm::mat4& proj);
-    VkImageView output_view() const { return processed_view_ ? processed_view_ : output_view_; }
-    VkImageView raw_output_view() const { return output_view_; }
+    // `frame_in_flight` selects which of the kMaxFramesInFlight per-frame
+    // image and descriptor sets to write into / bind. The caller is the
+    // top-level Renderer which already tracks `current_frame_`.
+    void render(VkCommandBuffer cmd, uint32_t frame_in_flight,
+                const glm::mat4& view, const glm::mat4& proj);
+    // Per-frame view consumed by the composite/blit. Caller passes the
+    // same frame index it used to record `render()` so the sampled image
+    // is the one this frame just wrote to.
+    VkImageView output_view(uint32_t frame_in_flight) const {
+        return processed_views_[frame_in_flight] != VK_NULL_HANDLE
+            ? processed_views_[frame_in_flight]
+            : output_views_[frame_in_flight];
+    }
+    VkImageView raw_output_view(uint32_t frame_in_flight) const {
+        return output_views_[frame_in_flight];
+    }
+    // Backwards-compatible accessors returning all per-frame views; the
+    // descriptor allocator binds set i to view i.
+    const std::array<VkImageView, kMaxFramesInFlight>& output_views() const {
+        // Prefer processed if available; callers needing the raw-HDR
+        // version use `raw_output_views()`.
+        return processed_views_[0] != VK_NULL_HANDLE ? processed_views_ : output_views_;
+    }
+    const std::array<VkImageView, kMaxFramesInFlight>& raw_output_views() const {
+        return output_views_;
+    }
     VkSampler output_sampler() const { return output_sampler_; }
     static constexpr uint32_t kParticleHeadroom = 2048;
     static constexpr uint32_t kDynamicHeadroom = 8192;  // particles + character + animated regions
@@ -337,23 +361,24 @@ private:
     VmaAllocator allocator_ = VK_NULL_HANDLE;
     VkPipelineCache pipeline_cache_ = VK_NULL_HANDLE;
 
-    // Output storage image (raw HDR from tile rasterizer)
-    VkImage output_image_ = VK_NULL_HANDLE;
-    VmaAllocation output_allocation_ = VK_NULL_HANDLE;
-    VkImageView output_view_ = VK_NULL_HANDLE;
+    // Per-frame intermediate images. Frame N writes into images_[N % kMaxFramesInFlight];
+    // Frame N+1 begins recording before frame N's GPU work has finished, so a single
+    // shared VkImage would be raced (compute write of frame N+1 vs composite read of
+    // frame N). Indexed by `frame_in_flight` passed into render().
+    std::array<VkImage,        kMaxFramesInFlight> output_images_{};
+    std::array<VmaAllocation,  kMaxFramesInFlight> output_allocations_{};
+    std::array<VkImageView,    kMaxFramesInFlight> output_views_{};
     VkSampler output_sampler_ = VK_NULL_HANDLE;
     uint32_t output_width_ = 0;
     uint32_t output_height_ = 0;
 
-    // Depth storage image (R16F, per-pixel view-space depth from tile rasterizer)
-    VkImage depth_image_ = VK_NULL_HANDLE;
-    VmaAllocation depth_allocation_ = VK_NULL_HANDLE;
-    VkImageView depth_view_ = VK_NULL_HANDLE;
+    std::array<VkImage,        kMaxFramesInFlight> depth_images_{};
+    std::array<VmaAllocation,  kMaxFramesInFlight> depth_allocations_{};
+    std::array<VkImageView,    kMaxFramesInFlight> depth_views_{};
 
-    // Post-processed output image (RGBA16F, final result after effects)
-    VkImage processed_image_ = VK_NULL_HANDLE;
-    VmaAllocation processed_allocation_ = VK_NULL_HANDLE;
-    VkImageView processed_view_ = VK_NULL_HANDLE;
+    std::array<VkImage,        kMaxFramesInFlight> processed_images_{};
+    std::array<VmaAllocation,  kMaxFramesInFlight> processed_allocations_{};
+    std::array<VkImageView,    kMaxFramesInFlight> processed_views_{};
 
     // GPU buffers
     Buffer gaussian_ssbo_;           // Input Gaussians
@@ -448,7 +473,9 @@ private:
     VkDescriptorSetLayout preprocess_layout_ = VK_NULL_HANDLE;
     VkDescriptorSetLayout render_layout_ = VK_NULL_HANDLE;
     VkDescriptorSet preprocess_set_ = VK_NULL_HANDLE;
-    VkDescriptorSet render_set_ = VK_NULL_HANDLE;
+    // render_set_ binds output_image + depth_image — both per-frame —
+    // so the set must also be per-frame to point at the right pair.
+    std::array<VkDescriptorSet, kMaxFramesInFlight> render_sets_{};
 
     // Merge pipeline
     VkDescriptorSetLayout merge_layout_ = VK_NULL_HANDLE;
@@ -477,7 +504,9 @@ private:
     VkDescriptorSetLayout post_process_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout post_process_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline post_process_pipeline_ = VK_NULL_HANDLE;
-    VkDescriptorSet post_process_set_ = VK_NULL_HANDLE;
+    // post_process binds input output_image + depth_image AND output processed_image
+    // — three per-frame images, so the set is per-frame.
+    std::array<VkDescriptorSet, kMaxFramesInFlight> post_process_sets_{};
     Buffer pp_ubo_buffer_;
     GsPostProcessParams gs_pp_params_;
 
@@ -528,7 +557,8 @@ private:
     VkDescriptorSetLayout tile_render_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout tile_render_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline tile_render_pipeline_ = VK_NULL_HANDLE;
-    VkDescriptorSet tile_render_set_ = VK_NULL_HANDLE;
+    // tile_render binds output_image + depth_image — per-frame.
+    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_render_sets_{};
 
     // Onesweep 2-dispatch sort (histogram+lookback → scatter)
     VkDescriptorSetLayout onesweep_hist_layout_ = VK_NULL_HANDLE;

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -131,16 +131,6 @@ public:
 
     // Static/dynamic split API
     void update_static_gaussians(const Gaussian* data, uint32_t count);
-
-    // Re-initialise the static sort buffers in place without re-packing
-    // the gaussian SSBO. The radix-sort's scatter pass leaves
-    // static_sort_a_/static_sort_b_ permuted by the previous frame's
-    // depth ordering; if dynamics exist, those stale keys must be reset
-    // back to {key=0xFFFFFFFF, index=i} or the merge output is wrong.
-    // update_static_gaussians does this AND a 200-300MB Gaussian
-    // re-pack — separating them lets us run the cheap sort reset every
-    // frame and the expensive re-pack only when chunk visibility changes.
-    void reset_static_sort_only();
     void update_dynamic_gaussians(const Gaussian* data, uint32_t count);
     uint32_t max_static_count() const { return max_static_count_; }
     uint32_t max_dynamic_count() const { return max_dynamic_count_; }

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -131,6 +131,16 @@ public:
 
     // Static/dynamic split API
     void update_static_gaussians(const Gaussian* data, uint32_t count);
+
+    // Re-initialise the static sort buffers in place without re-packing
+    // the gaussian SSBO. The radix-sort's scatter pass leaves
+    // static_sort_a_/static_sort_b_ permuted by the previous frame's
+    // depth ordering; if dynamics exist, those stale keys must be reset
+    // back to {key=0xFFFFFFFF, index=i} or the merge output is wrong.
+    // update_static_gaussians does this AND a 200-300MB Gaussian
+    // re-pack — separating them lets us run the cheap sort reset every
+    // frame and the expensive re-pack only when chunk visibility changes.
+    void reset_static_sort_only();
     void update_dynamic_gaussians(const Gaussian* data, uint32_t count);
     uint32_t max_static_count() const { return max_static_count_; }
     uint32_t max_dynamic_count() const { return max_dynamic_count_; }

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -304,6 +304,18 @@ public:
     uint32_t total_active_splats() const { return total_active_splats_; }
     bool streaming_initialized() const { return streaming_initialized_; }
 
+    // Per-chunk inventory for diagnostic dumps. status_str is one of
+    // "loading", "active", "unloading"; splat_count is the splat count
+    // published by the chunk's load completion callback.
+    struct ChunkInventoryEntry {
+        std::string status_str;
+        uint32_t page_table_offset;
+        uint32_t splat_count;
+        uint32_t slab_count;
+    };
+    std::vector<ChunkInventoryEntry> chunk_inventory() const;
+    uint32_t pending_load_count() const { return static_cast<uint32_t>(pending_loads_.size()); }
+
     // World manifest (Phase 3 streaming)
     void load_world(const WorldManifest& manifest);
     const WorldManifest& world_manifest() const { return world_manifest_; }

--- a/include/gseurat/engine/gs_scene_loader.hpp
+++ b/include/gseurat/engine/gs_scene_loader.hpp
@@ -1,6 +1,14 @@
 #pragma once
 
+#include "gseurat/engine/coordinate.hpp"
+#include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/gs_terrain_state.hpp"
 #include "gseurat/engine/scene_loader.hpp"
+#include "gseurat/engine/types.hpp"
+
+#include <glm/glm.hpp>
+#include <cstdint>
+#include <vector>
 
 namespace gseurat {
 
@@ -11,10 +19,43 @@ struct GsSceneOptions {
     bool set_god_rays = false;
 };
 
+// Output of the CPU-only parse phase. Contains everything `GsSceneLoader::load`
+// produced from PLY parsing + merging, ready for the main-thread GPU/ECS phase.
+// Designed to be moved out of a worker thread and consumed once on the main
+// thread.
+struct ParsedScene {
+    GaussianCloud cloud;                                     // merged terrain + game-object Gaussians
+    bool has_terrain = false;
+    float gs_scale_multiplier = 1.0f;
+    AABB terrain_aabb{};
+    glm::vec3 cloud_center{0.0f};
+    float cloud_extent = 0.0f;
+
+    std::vector<GameObjectData> snapped_objects;
+    std::vector<coord::WorldPos> world_positions;
+    std::vector<GsTerrainState::BoneAllocation> bone_allocations;
+    uint32_t bone_slot_counter = 8;
+
+    std::vector<glm::vec3> pbd_anchors;
+    std::vector<PbdConfig> pbd_configs;
+};
+
 class GsSceneLoader {
 public:
+    // Synchronous full load (parse on calling thread, then GPU/ECS finalize).
     void load(SceneLoadContext& ctx, const SceneData& scene_data,
               const GsSceneOptions& opts = {});
+
+    // CPU-only parse phase: PLY parsing, geometry merging, transform of game-object
+    // Gaussians, bone-allocation enumeration, PBD anchor extraction. Safe to call
+    // from a worker thread because it touches no Vulkan/ECS/GPU state. The result
+    // is consumed by `finalize_on_main` to perform the GPU/ECS phase.
+    static ParsedScene parse(const SceneData& scene_data);
+
+    // GPU/ECS finalize phase, must run on the main (Vulkan) thread. Uses the
+    // already-parsed cloud + metadata in `parsed` plus the live `ctx`.
+    void finalize_on_main(SceneLoadContext& ctx, const SceneData& scene_data,
+                          ParsedScene&& parsed, const GsSceneOptions& opts);
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -51,6 +51,13 @@ public:
     void draw_frame();
     void init_gs(const GaussianCloud& cloud, uint32_t width = 320, uint32_t height = 240);
 
+    // Drop every GS chunk currently resident in VRAM. Allocates a transient
+    // command buffer for `gs_renderer_.clear_chunks` so callers don't need
+    // access to the renderer's internal command pool. Used by demo portal
+    // transitions to defend against scene-leak bugs where new scene's
+    // init_gs is skipped or runs after a frame of stale rendering.
+    void drop_all_gs_chunks_now();
+
     // After `init_gs` runs an async upload via the transfer queue, the
     // returned slab Handles are stashed here. The demo `run()` flow takes
     // them after pushing the initial game state and feeds them into

--- a/include/gseurat/engine/scoped_timer.hpp
+++ b/include/gseurat/engine/scoped_timer.hpp
@@ -1,0 +1,48 @@
+#pragma once
+// ── ScopedTimer ──
+// RAII timer that emits a loud `[StallWarn]` log line when the elapsed time
+// exceeds a threshold. Intended for hunting main-thread blocks (sync I/O,
+// PLY parsing, vkDeviceWaitIdle, etc.) that show up to the user as an OS
+// beachball / movement freeze.
+//
+// Zero cost when the threshold isn't tripped: just two `chrono::now()` calls
+// and a subtraction. Enabled at all times — the threshold (default 50ms) is
+// the gate, not a compile flag.
+
+#include <chrono>
+#include <cstdio>
+#include <string_view>
+
+namespace gseurat {
+
+class ScopedStallTimer {
+public:
+    explicit ScopedStallTimer(std::string_view label,
+                              double warn_threshold_ms = 50.0) noexcept
+        : label_(label),
+          warn_threshold_ms_(warn_threshold_ms),
+          start_(std::chrono::steady_clock::now()) {}
+
+    ScopedStallTimer(const ScopedStallTimer&) = delete;
+    ScopedStallTimer& operator=(const ScopedStallTimer&) = delete;
+    ScopedStallTimer(ScopedStallTimer&&) = delete;
+    ScopedStallTimer& operator=(ScopedStallTimer&&) = delete;
+
+    ~ScopedStallTimer() {
+        const auto end = std::chrono::steady_clock::now();
+        const auto ms  = std::chrono::duration<double, std::milli>(end - start_).count();
+        if (ms >= warn_threshold_ms_) {
+            std::fprintf(stderr,
+                "[StallWarn] %.*s blocked main thread for %.1fms (threshold=%.0fms)\n",
+                static_cast<int>(label_.size()), label_.data(),
+                ms, warn_threshold_ms_);
+        }
+    }
+
+private:
+    std::string_view label_;
+    double warn_threshold_ms_;
+    std::chrono::steady_clock::time_point start_;
+};
+
+}  // namespace gseurat

--- a/include/gseurat/engine/systems/transition_system.hpp
+++ b/include/gseurat/engine/systems/transition_system.hpp
@@ -25,6 +25,17 @@ namespace gseurat {
 struct ITransitionHost {
     virtual void transition_scene(const std::string& target_scene,
                                   const glm::vec3& target_position) = 0;
+
+    /// Returns true while an async scene load is in flight (PLY parsing on a
+    /// worker, GPU upload not yet complete). The transition system uses this
+    /// to keep the SceneIn fade pinned at alpha=1.0 until the new scene is
+    /// fully ready — without it, the fade would tick down to 0 after
+    /// `transition_duration` regardless of load progress, exposing whatever
+    /// stale processed-image content was last rendered (the "old initial
+    /// configuration flashes back" ghost). Default returns false for hosts
+    /// that don't use the async-load path.
+    virtual bool is_async_loading() const { return false; }
+
     virtual ~ITransitionHost() = default;
 };
 

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -814,6 +814,19 @@ void IslandDemoState::update(AppBase& app, float dt) {
         return;
     }
 
+    // Drain Phase B of any in-flight portal transition. We can only run the
+    // post-load body once `app.is_async_loading_gs_scene()` has flipped back
+    // to false — that's the signal that `tick_async_load_gs_scene` has
+    // consumed the parse future and run `GsSceneLoader::finalize_on_main`,
+    // so `renderer().has_gs_cloud()` is now true and the new ECS world is
+    // populated. Until then keep waiting; the screen-fade overlay covers
+    // the window.
+    if (pending_portal_post_load_ && !app.is_async_loading_gs_scene()) {
+        auto fn = std::move(pending_portal_post_load_);
+        pending_portal_post_load_ = {};
+        fn(app);
+    }
+
     // Skip keyboard shortcuts when dev overlay has focus
     if (!app.dev_overlay().wants_keyboard()) {
         // Tab → cycle HUD mode: OFF → COMPACT → FULL → OFF
@@ -2116,10 +2129,42 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
     player_entity_ = ecs::kNullEntity;
 
     app.clear_scene();
-    {
-        ScopedStallTimer _t{"perform_portal_transition: init_scene (load_gs_scene + first init_gs)"};
-        app.init_scene(target_scene);
-    }
+
+    // Phase A ends here: kick off PLY parsing on a worker thread and stash
+    // the rest of the transition as a deferred lambda. update() drains it
+    // once `app.is_async_loading_gs_scene()` flips back to false (parse +
+    // GPU/ECS finalize done). The main thread keeps rendering the scene
+    // transition fade overlay while the worker parses.
+    app.scene_objects().current_scene_path = target_scene;
+    auto target_scene_data = SceneLoader::load(target_scene);
+    GsSceneOptions portal_opts{ .add_default_light = true, .set_god_rays = true };
+    app.begin_async_load_gs_scene(std::move(target_scene_data), portal_opts);
+
+    pending_portal_post_load_ =
+        [target_scene, target_position](AppBase& app_in) {
+            // Forward to the (private) member implementation. We need the
+            // `IslandDemoState*` to call `finish_portal_transition`. The
+            // lambda is owned by `IslandDemoState::pending_portal_post_load_`
+            // so `this` is alive for the duration; we capture it via the
+            // surrounding outer-method `this`-pointer below.
+            (void)app_in;
+        };
+    pending_portal_post_load_ =
+        [this, target_scene, target_position](AppBase& app_in) {
+            this->finish_portal_transition(app_in, target_scene, target_position);
+        };
+
+    std::fprintf(stderr, "[IslandDemo] Portal Phase A done; async parse in flight for '%s'\n",
+                 target_scene.c_str());
+}
+
+// Phase B: invoked from `update()` once the async scene-load has finalized.
+// Runs the original synchronous post-load body — collision grid restore,
+// player respawn, world-chunk re-merge, bone registry, etc.
+void IslandDemoState::finish_portal_transition(AppBase& app,
+                                               const std::string& target_scene,
+                                               const glm::vec3& target_position) {
+    ScopedStallTimer _t_total{"finish_portal_transition (Phase B TOTAL)"};
 
     // "Returning to overworld" detection: target matches our base scene path.
     const bool is_overworld = (target_scene == scene_path_);
@@ -2468,12 +2513,10 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
 
     // Recreate a SceneTransition entity in SceneIn state so the next few
     // frames render with a fade-in overlay covering any first-frame GS
-    // pop (slabs streaming in, chunk grid warming up). Without this the
-    // SceneOut entity was destroyed by `app.world().clear()` above and
-    // the new scene appears with NO overlay — the user sees the slab
-    // upload progress and chunk re-tag flicker uncovered. Set alpha=1
-    // so the very first post-transition frame is fully covered, then
-    // transition_system animates it down to 0 over `kFadeIn` seconds.
+    // pop. The SceneOut entity was destroyed by `app.world().clear()`
+    // above; without this recreation the new scene would render
+    // uncovered. alpha=1 fully covers the very first post-transition
+    // frame, then transition_system animates it down to 0 over kFadeIn.
     {
         constexpr float kFadeIn = 0.4f;
         auto e = app.world().create();
@@ -2483,7 +2526,7 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
         st.transition_duration = kFadeIn;
         st.target_scene        = target_scene;
         st.target_position     = target_position;
-        st.load_dispatched     = true;  // already done — we're past Loading
+        st.load_dispatched     = true;
         app.world().add<SceneTransition>(e, st);
 
         ScreenFade fade;

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -988,8 +988,15 @@ void IslandDemoState::update(AppBase& app, float dt) {
     // Camera follow
     update_camera(app, dt);
 
-    // World streaming evaluation
-    if (world_streamer_) {
+    // World streaming evaluation. Gated to the overworld: world_streamer_
+    // is initialised once (in on_enter) with seurat_island/world.json's
+    // manifest, but its update() is purely distance-based — leaving it
+    // ticking inside dungeon.json would distance-check the dungeon player
+    // against overworld chunk AABBs and trigger load_cloud_async for any
+    // chunk that happens to fall within load_radius_, leaking forest
+    // content into the dungeon's GS buffer.
+    const bool in_overworld = (app.scene_objects().current_scene_path == scene_path_);
+    if (world_streamer_ && in_overworld) {
         auto events = world_streamer_->update(character_origin_);
 
         // Process pending loads
@@ -2157,23 +2164,31 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
     character_origin_ = spawn;
     character_spawn_pos_ = spawn;
 
-    // Re-create player entity (old one was destroyed by world.clear())
-    player_entity_ = app.world().create();
-    app.world().add<ecs::Transform>(player_entity_,
-        {coord::WorldPos(spawn), {1.0f, 1.0f}});
-    app.world().add<PlayerController>(player_entity_, {20.0f, 20.0f});
-    app.world().add<PlayerJump>(player_entity_);
-    // PlayerTag is required by proximity_trigger_system — without it, ALL
-    // ECS proximity triggers (portals, lights, emitters) silently no-op
-    // because the system early-returns when it can't find the player.
-    // (Latent bug in the original inline portal code, exposed by the new
-    // ECS-based portal triggers.)
-    app.world().add<PlayerTag>(player_entity_);
+    // The new scene's "player" game_object (when present, e.g. seurat_island)
+    // is already wired up by load_gs_scene during init_scene above: PlayerController,
+    // PlayerTag, BoneAnimated, KinematicBody, ColliderComponent — and its PLY is
+    // merged into the new gs_chunk_grid_ at the *authored* position. Reuse that
+    // entity, teleport it to `spawn`, and skip the manual merge below to avoid
+    // a second PC entity + a second copy of the splats (which appears as a
+    // collision-less ghost at the authored position when target_position
+    // differs from the authored one — the dungeon-return spawn does).
+    //
+    // For scenes without a player game_object (interior instances etc.), fall
+    // back to creating one manually — same shape as the on_enter legacy path.
+    player_entity_ = ecs::kNullEntity;
+    app.world().view<PlayerController, PlayerTag, ecs::Transform>().each(
+        [&](ecs::Entity e, PlayerController&, PlayerTag&, ecs::Transform& t) {
+            player_entity_ = e;
+            t.position = coord::WorldPos(spawn);
+        });
+    if (!player_entity_.valid()) {
+        player_entity_ = app.world().create();
+        app.world().add<ecs::Transform>(player_entity_,
+            {coord::WorldPos(spawn), {1.0f, 1.0f}});
+        app.world().add<PlayerController>(player_entity_, {20.0f, 20.0f});
+        app.world().add<PlayerJump>(player_entity_);
+        app.world().add<PlayerTag>(player_entity_);
 
-    // KCC components — required for capsule-sweep movement on heightfield terrain.
-    // Without these, run_kcc skips the player and the legacy fallback has no
-    // elevation data (removed in PR #371).
-    {
         KinematicBody kb;
         kb.desired_jump_height = 2.0f;
         kb.time_to_apex = 0.4f;
@@ -2184,6 +2199,16 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
         cc.shape = CapsuleData{0.3f, 0.5f};
         cc.is_dynamic = true;
         app.world().add<ColliderComponent>(player_entity_, cc);
+    }
+
+    // Teleport the load_gs_scene-allocated player bone slot's anchor so the
+    // PLY splats follow the entity to `spawn`. Without this, the splats stay
+    // at the authored bone-allocation world_pos forever (load_gs_scene only
+    // sets it once at scene-load time).
+    for (auto& alloc : app.gs_terrain().bone_allocations) {
+        if (alloc.manifest_path.find("snes_hero") != std::string::npos) {
+            alloc.world_pos = spawn;
+        }
     }
 
     // Re-merge world chunks + player character into the new scene
@@ -2288,37 +2313,82 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
             elevation_ = 0.6f;
         }
 
-        auto char_cloud = GaussianCloud::load_ply(
-            "assets/characters/snes_hero/snes_hero.ply");
-        if (!char_cloud.empty()) {
-            const auto& char_gs = char_cloud.gaussians();
-            for (const auto& g : char_gs) {
-                Gaussian cg = g;
-                glm::vec3 rotated(-cg.position.x, cg.position.y, -cg.position.z);
-                glm::vec3 offset = rotated * kCharScale;
-                offset.y *= gs_scale_;
-                cg.position = spawn + offset + glm::vec3(0, 2.0f, 0);
-                cg.scale *= kCharScale;
-                cg.opacity = std::min(1.0f, cg.opacity * 1.3f);
-                cg.bone_index = cg.bone_index + 1;
-                merged.push_back(cg);
+        // Skip the manual PC PLY merge if load_gs_scene already merged the
+        // player from a "player" game_object — adding it again here would
+        // duplicate the splats (one set at the authored game_object position
+        // via load_gs_scene's PLY merge, one set at `spawn` via this loop)
+        // and produce a side-by-side "ghost PC" whenever target_position
+        // differs from the authored position (every dungeon→overworld
+        // return). Detect via the bone allocation populated by
+        // gs_scene_loader's BoneAnimated pre-scan.
+        bool player_already_merged = false;
+        for (const auto& alloc : app.gs_terrain().bone_allocations) {
+            if (alloc.manifest_path.find("snes_hero") != std::string::npos) {
+                player_already_merged = true;
+                break;
             }
         }
-        std::fprintf(stderr, "[IslandDemo] Portal re-merge: %u total Gaussians\n",
-            static_cast<uint32_t>(merged.size()));
+        if (!player_already_merged) {
+            auto char_cloud = GaussianCloud::load_ply(
+                "assets/characters/snes_hero/snes_hero.ply");
+            if (!char_cloud.empty()) {
+                const auto& char_gs = char_cloud.gaussians();
+                for (const auto& g : char_gs) {
+                    Gaussian cg = g;
+                    glm::vec3 rotated(-cg.position.x, cg.position.y, -cg.position.z);
+                    glm::vec3 offset = rotated * kCharScale;
+                    offset.y *= gs_scale_;
+                    cg.position = spawn + offset + glm::vec3(0, 2.0f, 0);
+                    cg.scale *= kCharScale;
+                    cg.opacity = std::min(1.0f, cg.opacity * 1.3f);
+                    cg.bone_index = cg.bone_index + 1;
+                    merged.push_back(cg);
+                }
+            }
+        }
+        std::fprintf(stderr, "[IslandDemo] Portal re-merge: %u total Gaussians%s\n",
+            static_cast<uint32_t>(merged.size()),
+            player_already_merged ? " (player from game_object)" : "");
 
         auto cloud = GaussianCloud::from_gaussians(std::move(merged));
         uint32_t gs_w = app.renderer().gs_renderer().output_width();
         uint32_t gs_h = app.renderer().gs_renderer().output_height();
         if (gs_w == 0) { gs_w = 320; gs_h = 240; }
         app.renderer().init_gs(cloud, gs_w, gs_h);
+
+        // Returning to overworld merged every world chunk into the new
+        // cloud. Without re-marking them, world_streamer_->update() will
+        // see them as UNLOADED on the next tick and call load_cloud_async
+        // for each — which is append-only — duplicating every tree, NPC,
+        // and ghost-spawn-PC's worth of splats on top of the merged cloud.
+        // Mirror the on_enter loop that does the same for the initial load.
+        if (is_overworld && world_streamer_) {
+            for (const auto& chunk : world_streamer_->manifest().chunks) {
+                std::string key = std::to_string(chunk.grid.x) + "," +
+                                  std::to_string(chunk.grid.y) + "," +
+                                  std::to_string(chunk.grid.z);
+                world_streamer_->on_chunk_loaded(key, 0);
+            }
+        }
     }
 
-    // Re-populate bone animation registry for the new scene
+    // Re-populate bone animation registry for the new scene. When the new
+    // scene has a "player" game_object, this binds the player's bone slot
+    // to player_entity_ — no second register needed below (a second add()
+    // would create a duplicate entry, animating empty bone slots).
     populate_bone_animation_registry(app.bone_animation_registry(), app.world(), app.gs_terrain());
 
-    // Re-register player in BoneAnimationRegistry
-    {
+    // Capture the registry_id populated above (or, fallback path, register
+    // the player manually for scenes that don't author a player game_object).
+    if (auto* existing = app.bone_animation_registry().get_by_entity(player_entity_)) {
+        // populate_bone_animation_registry already wired the player.
+        for (const auto& [id, entry] : app.bone_animation_registry().entries()) {
+            if (&entry == existing) { player_registry_id_ = id; break; }
+        }
+        if (!app.world().has<gseurat::BoneAnimatedTag>(player_entity_)) {
+            app.world().add<gseurat::BoneAnimatedTag>(player_entity_, {player_registry_id_});
+        }
+    } else {
         auto loaded = gseurat::load_character_manifest(
             "assets/characters/snes_hero/snes_hero.manifest.json");
         if (loaded) {

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -991,17 +991,15 @@ void IslandDemoState::update(AppBase& app, float dt) {
     // Camera follow
     update_camera(app, dt);
 
-    // World streaming evaluation. Gated by the explicit `disable_world_streaming_`
-    // flag — set TRUE while transitioning to / inside any non-overworld scene
-    // (dungeon, instanced interiors), FALSE after the overworld is fully
-    // restored. While true the streamer doesn't tick at all: no distance
-    // checks, no pending_loads, no async parses. Replaces the previous
-    // current_scene_path == scene_path_ string check, which was vulnerable
-    // to ordering races (init_scene mutates current_scene_path before the
-    // chunk re-merge runs, so for a few frames after the dungeon's
-    // init_gs the streamer would see "still in overworld" and could
-    // re-trigger forest chunk parses against the dungeon player position).
-    if (world_streamer_ && !disable_world_streaming_) {
+    // World streaming evaluation. Gated to the overworld: world_streamer_
+    // is initialised once (in on_enter) with seurat_island/world.json's
+    // manifest, but its update() is purely distance-based — leaving it
+    // ticking inside dungeon.json would distance-check the dungeon player
+    // against overworld chunk AABBs and trigger load_cloud_async for any
+    // chunk that happens to fall within load_radius_, leaking forest
+    // content into the dungeon's GS buffer.
+    const bool in_overworld = (app.scene_objects().current_scene_path == scene_path_);
+    if (world_streamer_ && in_overworld) {
         ScopedStallTimer _t_streamer{"world_streamer.update+pending_loads"};
         auto events = world_streamer_->update(character_origin_);
 
@@ -2080,14 +2078,6 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
     std::fprintf(stderr, "[IslandDemo] perform_portal_transition -> '%s' at (%.1f,%.1f,%.1f)\n",
         target_scene.c_str(), target_position.x, target_position.y, target_position.z);
 
-    // Hard-stop the world streamer for the entire transition. This must
-    // be set BEFORE any await/clear work so even if a previous frame's
-    // streamer.update() left a parse in flight, we won't kick off any
-    // new parses, and won't drain landed clouds into the wrong scene's
-    // GS buffer. Cleared at the END of the transition only when we've
-    // returned to the overworld AND the merged init_gs has run.
-    disable_world_streaming_ = true;
-
     // Muffle/restore music based on destination
     if (auto* ae = app.audio()) {
         const bool entering_dungeon = target_scene.find("dungeon") != std::string::npos;
@@ -2496,10 +2486,6 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
 
         ScreenFade fade;
         fade.alpha            = 1.0f;
-        // Use scene_color from authored portal data when we still have it
-        // — but at this point the authoring entity is gone. Default to
-        // black, which matches the most common transition_color in the
-        // demo's scene JSONs.
         fade.transition_color = glm::vec3(0.0f, 0.0f, 0.0f);
         fade.effect_type      = 0;
         app.world().add<ScreenFade>(e, fade);

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -998,8 +998,7 @@ void IslandDemoState::update(AppBase& app, float dt) {
     // against overworld chunk AABBs and trigger load_cloud_async for any
     // chunk that happens to fall within load_radius_, leaking forest
     // content into the dungeon's GS buffer.
-    const bool in_overworld = (app.scene_objects().current_scene_path == scene_path_);
-    if (world_streamer_ && in_overworld) {
+    if (world_streamer_ && !disable_world_streaming_) {
         ScopedStallTimer _t_streamer{"world_streamer.update+pending_loads"};
         auto events = world_streamer_->update(character_origin_);
 
@@ -2077,6 +2076,9 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
     ScopedStallTimer _t_total{"perform_portal_transition (TOTAL)"};
     std::fprintf(stderr, "[IslandDemo] perform_portal_transition -> '%s' at (%.1f,%.1f,%.1f)\n",
         target_scene.c_str(), target_position.x, target_position.y, target_position.z);
+
+    // Hard-stop the world streamer for the entire transition.
+    disable_world_streaming_ = true;
 
     // Muffle/restore music based on destination
     if (auto* ae = app.audio()) {

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -2130,6 +2130,35 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
 
     app.clear_scene();
 
+    // The original SceneOut SceneTransition entity was destroyed by the
+    // app.world().clear() above. Recreate one immediately in SceneIn state
+    // with alpha=1.0 so the very next composited frame is fully covered by
+    // an opaque overlay. Without this, the window between Phase A and Phase
+    // B (which spans the async PLY parse + GPU upload — typically several
+    // frames at hundreds of ms) renders against the stale per-frame
+    // `processed_image_` contents, exposing residue from the OLD scene
+    // (the user-reported "old initial-frame configuration flashes back"
+    // ghost). The transition_system holds the alpha at 1.0 until Phase B
+    // completes, then animates it down over kFadeIn seconds.
+    {
+        constexpr float kFadeIn = 0.4f;
+        auto e = app.world().create();
+        SceneTransition st;
+        st.current_state       = SceneTransition::State::SceneIn;
+        st.timer               = 0.0f;
+        st.transition_duration = kFadeIn;
+        st.target_scene        = target_scene;
+        st.target_position     = target_position;
+        st.load_dispatched     = true;  // we are past Loading
+        app.world().add<SceneTransition>(e, st);
+
+        ScreenFade fade;
+        fade.alpha            = 1.0f;
+        fade.transition_color = glm::vec3(0.0f, 0.0f, 0.0f);
+        fade.effect_type      = 0;
+        app.world().add<ScreenFade>(e, fade);
+    }
+
     // Phase A ends here: kick off PLY parsing on a worker thread and stash
     // the rest of the transition as a deferred lambda. update() drains it
     // once `app.is_async_loading_gs_scene()` flips back to false (parse +
@@ -2140,15 +2169,6 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
     GsSceneOptions portal_opts{ .add_default_light = true, .set_god_rays = true };
     app.begin_async_load_gs_scene(std::move(target_scene_data), portal_opts);
 
-    pending_portal_post_load_ =
-        [target_scene, target_position](AppBase& app_in) {
-            // Forward to the (private) member implementation. We need the
-            // `IslandDemoState*` to call `finish_portal_transition`. The
-            // lambda is owned by `IslandDemoState::pending_portal_post_load_`
-            // so `this` is alive for the duration; we capture it via the
-            // surrounding outer-method `this`-pointer below.
-            (void)app_in;
-        };
     pending_portal_post_load_ =
         [this, target_scene, target_position](AppBase& app_in) {
             this->finish_portal_transition(app_in, target_scene, target_position);
@@ -2287,8 +2307,27 @@ void IslandDemoState::finish_portal_transition(AppBase& app,
         }
     }
 
+    // Fast-path detection: when the new scene authors a "player" game_object
+    // pointing at the snes_hero PLY, `GsSceneLoader::parse` already merged
+    // the player Gaussians into the scene cloud on the worker thread.
+    // Phase B's re-merge + 2nd init_gs is redundant for non-overworld
+    // destinations (no streamed chunks to add), and the synchronous
+    // load_ply call below would re-introduce a 100-300ms main-thread
+    // stall after we just spent the entire async-load window avoiding
+    // exactly that. Skip the whole re-merge block when both conditions
+    // hold; the renderer already has everything it needs.
+    bool player_already_merged_fast = false;
+    for (const auto& alloc : app.gs_terrain().bone_allocations) {
+        if (alloc.manifest_path.find("snes_hero") != std::string::npos) {
+            player_already_merged_fast = true;
+            break;
+        }
+    }
+    const bool skip_phase_b_remerge = !is_overworld && player_already_merged_fast
+                                      && app.renderer().has_gs_cloud();
+
     // Re-merge world chunks + player character into the new scene
-    if (app.renderer().has_gs_cloud()) {
+    if (!skip_phase_b_remerge && app.renderer().has_gs_cloud()) {
         const auto& new_map = app.renderer().gs_chunk_grid().all_gaussians();
         map_gaussians_.assign(new_map.begin(), new_map.end());
         std::vector<Gaussian> merged = map_gaussians_;
@@ -2511,30 +2550,11 @@ void IslandDemoState::finish_portal_transition(AppBase& app,
         std::fprintf(stderr, "[IslandDemo] World streaming disabled (non-overworld scene)\n");
     }
 
-    // Recreate a SceneTransition entity in SceneIn state so the next few
-    // frames render with a fade-in overlay covering any first-frame GS
-    // pop. The SceneOut entity was destroyed by `app.world().clear()`
-    // above; without this recreation the new scene would render
-    // uncovered. alpha=1 fully covers the very first post-transition
-    // frame, then transition_system animates it down to 0 over kFadeIn.
-    {
-        constexpr float kFadeIn = 0.4f;
-        auto e = app.world().create();
-        SceneTransition st;
-        st.current_state       = SceneTransition::State::SceneIn;
-        st.timer               = 0.0f;
-        st.transition_duration = kFadeIn;
-        st.target_scene        = target_scene;
-        st.target_position     = target_position;
-        st.load_dispatched     = true;
-        app.world().add<SceneTransition>(e, st);
-
-        ScreenFade fade;
-        fade.alpha            = 1.0f;
-        fade.transition_color = glm::vec3(0.0f, 0.0f, 0.0f);
-        fade.effect_type      = 0;
-        app.world().add<ScreenFade>(e, fade);
-    }
+    // Note: the SceneIn fade entity is created by Phase A
+    // (`perform_portal_transition`) — not here — so the overlay covers the
+    // full async-parse + finalize window, not just the post-finalize tail.
+    // Without that earlier creation the user sees "old initial-frame
+    // configuration flashes back" between Phase A and Phase B.
 
     std::fprintf(stderr, "[IslandDemo] Spawned at (%.1f, %.1f, %.1f)\n",
         spawn.x, spawn.y, spawn.z);

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -989,15 +989,17 @@ void IslandDemoState::update(AppBase& app, float dt) {
     // Camera follow
     update_camera(app, dt);
 
-    // World streaming evaluation. Gated to the overworld: world_streamer_
-    // is initialised once (in on_enter) with seurat_island/world.json's
-    // manifest, but its update() is purely distance-based — leaving it
-    // ticking inside dungeon.json would distance-check the dungeon player
-    // against overworld chunk AABBs and trigger load_cloud_async for any
-    // chunk that happens to fall within load_radius_, leaking forest
-    // content into the dungeon's GS buffer.
-    const bool in_overworld = (app.scene_objects().current_scene_path == scene_path_);
-    if (world_streamer_ && in_overworld) {
+    // World streaming evaluation. Gated by the explicit `disable_world_streaming_`
+    // flag — set TRUE while transitioning to / inside any non-overworld scene
+    // (dungeon, instanced interiors), FALSE after the overworld is fully
+    // restored. While true the streamer doesn't tick at all: no distance
+    // checks, no pending_loads, no async parses. Replaces the previous
+    // current_scene_path == scene_path_ string check, which was vulnerable
+    // to ordering races (init_scene mutates current_scene_path before the
+    // chunk re-merge runs, so for a few frames after the dungeon's
+    // init_gs the streamer would see "still in overworld" and could
+    // re-trigger forest chunk parses against the dungeon player position).
+    if (world_streamer_ && !disable_world_streaming_) {
         ScopedStallTimer _t_streamer{"world_streamer.update+pending_loads"};
         auto events = world_streamer_->update(character_origin_);
 
@@ -2076,6 +2078,14 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
     std::fprintf(stderr, "[IslandDemo] perform_portal_transition -> '%s' at (%.1f,%.1f,%.1f)\n",
         target_scene.c_str(), target_position.x, target_position.y, target_position.z);
 
+    // Hard-stop the world streamer for the entire transition. This must
+    // be set BEFORE any await/clear work so even if a previous frame's
+    // streamer.update() left a parse in flight, we won't kick off any
+    // new parses, and won't drain landed clouds into the wrong scene's
+    // GS buffer. Cleared at the END of the transition only when we've
+    // returned to the overworld AND the merged init_gs has run.
+    disable_world_streaming_ = true;
+
     // Muffle/restore music based on destination
     if (auto* ae = app.audio()) {
         const bool entering_dungeon = target_scene.find("dungeon") != std::string::npos;
@@ -2448,6 +2458,19 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
 
     // Rebuild collision system cache for the new scene
     collision_system_.rebuild_cache(app.world());
+
+    // Re-enable world streaming only when the destination is the overworld
+    // AND we've gotten through the merged init_gs + chunk re-mark. For
+    // any non-overworld destination (dungeon, instanced interiors) the
+    // flag stays TRUE — the dungeon doesn't have streamed chunks, and
+    // leaving the streamer dormant means no rogue parses against the
+    // dungeon player position.
+    if (is_overworld) {
+        disable_world_streaming_ = false;
+        std::fprintf(stderr, "[IslandDemo] World streaming re-enabled (overworld)\n");
+    } else {
+        std::fprintf(stderr, "[IslandDemo] World streaming disabled (non-overworld scene)\n");
+    }
 
     std::fprintf(stderr, "[IslandDemo] Spawned at (%.1f, %.1f, %.1f)\n",
         spawn.x, spawn.y, spawn.z);

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1,6 +1,8 @@
 #include "gseurat/demo/island_demo_state.hpp"
 #include "gseurat/demo/demo_app.hpp"
 #include "gseurat/engine/ecs/components/portal_target.hpp"
+#include "gseurat/engine/ecs/components/scene_transition.hpp"
+#include "gseurat/engine/ecs/components/screen_fade.hpp"
 #include "gseurat/engine/shutdown_auditor.hpp"
 #include "gseurat/character/character_manifest.hpp"
 #include "gseurat/character/bone_animation_player.hpp"
@@ -2470,6 +2472,37 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
         std::fprintf(stderr, "[IslandDemo] World streaming re-enabled (overworld)\n");
     } else {
         std::fprintf(stderr, "[IslandDemo] World streaming disabled (non-overworld scene)\n");
+    }
+
+    // Recreate a SceneTransition entity in SceneIn state so the next few
+    // frames render with a fade-in overlay covering any first-frame GS
+    // pop (slabs streaming in, chunk grid warming up). Without this the
+    // SceneOut entity was destroyed by `app.world().clear()` above and
+    // the new scene appears with NO overlay — the user sees the slab
+    // upload progress and chunk re-tag flicker uncovered. Set alpha=1
+    // so the very first post-transition frame is fully covered, then
+    // transition_system animates it down to 0 over `kFadeIn` seconds.
+    {
+        constexpr float kFadeIn = 0.4f;
+        auto e = app.world().create();
+        SceneTransition st;
+        st.current_state       = SceneTransition::State::SceneIn;
+        st.timer               = 0.0f;
+        st.transition_duration = kFadeIn;
+        st.target_scene        = target_scene;
+        st.target_position     = target_position;
+        st.load_dispatched     = true;  // already done — we're past Loading
+        app.world().add<SceneTransition>(e, st);
+
+        ScreenFade fade;
+        fade.alpha            = 1.0f;
+        // Use scene_color from authored portal data when we still have it
+        // — but at this point the authoring entity is gone. Default to
+        // black, which matches the most common transition_color in the
+        // demo's scene JSONs.
+        fade.transition_color = glm::vec3(0.0f, 0.0f, 0.0f);
+        fade.effect_type      = 0;
+        app.world().add<ScreenFade>(e, fade);
     }
 
     std::fprintf(stderr, "[IslandDemo] Spawned at (%.1f, %.1f, %.1f)\n",

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -8,6 +8,7 @@
 #include "gseurat/engine/app_base.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/gs_chunk_grid.hpp"
+#include "gseurat/engine/scoped_timer.hpp"
 #include "gseurat/demo/island_components.hpp"
 #include "gseurat/engine/trigger_components.hpp"
 #include "gseurat/engine/collision/intersect.hpp"
@@ -997,9 +998,17 @@ void IslandDemoState::update(AppBase& app, float dt) {
     // content into the dungeon's GS buffer.
     const bool in_overworld = (app.scene_objects().current_scene_path == scene_path_);
     if (world_streamer_ && in_overworld) {
+        ScopedStallTimer _t_streamer{"world_streamer.update+pending_loads"};
         auto events = world_streamer_->update(character_origin_);
 
-        // Process pending loads
+        // Drain any worker-thread-completed PLY parses BEFORE kicking off
+        // new ones, so a chunk that finished loading last frame doesn't
+        // wait an extra cycle to reach VRAM.
+        drain_async_chunk_loads(app);
+
+        // Kick off async PLY loads for newly-pending chunks. Parsing runs
+        // on a worker thread; the main thread only enqueues the work and
+        // hands the resulting cloud to load_cloud_async on a later frame.
         for (const auto& grid_key : world_streamer_->pending_loads()) {
             for (const auto& chunk : world_streamer_->manifest().chunks) {
                 std::string key = std::to_string(chunk.grid.x) + "," +
@@ -1007,16 +1016,9 @@ void IslandDemoState::update(AppBase& app, float dt) {
                                   std::to_string(chunk.grid.z);
                 if (key == grid_key && !chunk.ply_file.empty()) {
                     auto resolved = resolve_asset_path(chunk.ply_file);
-                    std::fprintf(stderr, "[IslandDemo] Chunk [%s] Loading: %s\n",
+                    std::fprintf(stderr, "[IslandDemo] Chunk [%s] async parse start: %s\n",
                         grid_key.c_str(), chunk.ply_file.c_str());
-                    // load_cloud_async now expects an in-memory cloud — file
-                    // IO is the caller's responsibility. WorldStreamer load
-                    // happens on the main thread for now; a follow-up could
-                    // hand the PLY parse to a worker thread and queue the
-                    // async upload from a result callback.
-                    GaussianCloud chunk_cloud;
-                    chunk_cloud.load_ply(resolved.string());
-                    app.renderer().gs_renderer().load_cloud_async(std::move(chunk_cloud));
+                    enqueue_async_chunk_load(grid_key, resolved.string());
                     break;
                 }
             }
@@ -2070,6 +2072,7 @@ void IslandDemoState::draw_gizmos(AppBase& app) {
 void IslandDemoState::perform_portal_transition(AppBase& app,
                                                 const std::string& target_scene,
                                                 const glm::vec3& target_position) {
+    ScopedStallTimer _t_total{"perform_portal_transition (TOTAL)"};
     std::fprintf(stderr, "[IslandDemo] perform_portal_transition -> '%s' at (%.1f,%.1f,%.1f)\n",
         target_scene.c_str(), target_position.x, target_position.y, target_position.z);
 
@@ -2079,8 +2082,29 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
         ae->set_rtpc(kRtpcMusicFilter, entering_dungeon ? 0.0f : 1.0f);
     }
 
-    // Wait for GPU to finish before destroying resources
-    vkDeviceWaitIdle(app.renderer().context().device());
+    // Cancel anything we have a worker thread parsing right now — its
+    // result would be a chunk for the SCENE WE'RE LEAVING, which would
+    // otherwise get appended to the new scene's GS buffer once the
+    // future resolves. Wait blocks (the parse is on a worker), so this
+    // is bounded by the longest-in-flight parse, but typically <100ms.
+    {
+        ScopedStallTimer _t{"perform_portal_transition: drain in-flight chunk parses"};
+        for (auto& p : pending_chunk_parses_) {
+            if (p.future.valid()) (void)p.future.wait();
+        }
+        pending_chunk_parses_.clear();
+    }
+
+    // Wait for GPU to finish before destroying resources. Then explicitly
+    // drop any active GS chunks so the new scene starts from a clean
+    // VRAM state — clear_chunks() is also called inside init_gs() but
+    // doing it here too defends against any path where the new scene's
+    // init_gs is skipped (e.g. has_gs_cloud false on the new scene).
+    {
+        ScopedStallTimer _t{"perform_portal_transition: wait_idle + drop_chunks"};
+        vkDeviceWaitIdle(app.renderer().context().device());
+        app.renderer().drop_all_gs_chunks_now();
+    }
 
     // Transition: clear current scene and load instance
     // Clear ECS world first — old game object entities must not persist
@@ -2088,7 +2112,10 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
     player_entity_ = ecs::kNullEntity;
 
     app.clear_scene();
-    app.init_scene(target_scene);
+    {
+        ScopedStallTimer _t{"perform_portal_transition: init_scene (load_gs_scene + first init_gs)"};
+        app.init_scene(target_scene);
+    }
 
     // "Returning to overworld" detection: target matches our base scene path.
     const bool is_overworld = (target_scene == scene_path_);
@@ -2424,6 +2451,65 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
 
     std::fprintf(stderr, "[IslandDemo] Spawned at (%.1f, %.1f, %.1f)\n",
         spawn.x, spawn.y, spawn.z);
+}
+
+// ── Async chunk parsing ───────────────────────────────────────────────
+// PLY parsing is hundreds-of-MB-of-mmap-and-vector-fill expensive. Doing
+// it on the main thread shows up as a 200-800ms beachball whenever a new
+// chunk crosses the streamer's load_radius_. std::async with launch::async
+// pushes it onto a worker thread; drain_async_chunk_loads polls the
+// future once per frame and only touches the GPU once the parse is done.
+
+void IslandDemoState::enqueue_async_chunk_load(const std::string& grid_key,
+                                               const std::string& ply_path) {
+    // Skip if a parse is already in flight for this key (the streamer will
+    // re-emit `pending_loads_` keys until we tell it the chunk is loaded).
+    for (const auto& p : pending_chunk_parses_) {
+        if (p.grid_key == grid_key) return;
+    }
+    pending_chunk_parses_.push_back({
+        grid_key,
+        std::async(std::launch::async, [ply_path]() {
+            GaussianCloud c;
+            c.load_ply(ply_path);
+            return c;
+        })
+    });
+}
+
+void IslandDemoState::drain_async_chunk_loads(AppBase& app) {
+    // Sweep ready futures, consume their clouds, and hand them to the
+    // existing async-upload pipe. Anything still parsing stays in the
+    // queue for next frame.
+    for (auto it = pending_chunk_parses_.begin();
+         it != pending_chunk_parses_.end(); ) {
+        if (it->future.wait_for(std::chrono::seconds(0)) ==
+            std::future_status::ready) {
+            ScopedStallTimer _t{"chunk_parse_drain+load_cloud_async"};
+            GaussianCloud cloud;
+            try {
+                cloud = it->future.get();
+            } catch (const std::exception& e) {
+                std::fprintf(stderr,
+                    "[IslandDemo] Chunk [%s] async parse FAILED: %s\n",
+                    it->grid_key.c_str(), e.what());
+                it = pending_chunk_parses_.erase(it);
+                continue;
+            }
+            if (!cloud.empty()) {
+                app.renderer().gs_renderer().load_cloud_async(std::move(cloud));
+                if (world_streamer_) {
+                    world_streamer_->on_chunk_loaded(it->grid_key, 0);
+                }
+                std::fprintf(stderr,
+                    "[IslandDemo] Chunk [%s] async parse done, queued for VRAM\n",
+                    it->grid_key.c_str());
+            }
+            it = pending_chunk_parses_.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 
 }  // namespace gseurat

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -170,6 +170,15 @@ void AppBase::main_loop() {
         snap.streaming_initialized = gs.streaming_initialized();
         snap.streaming_active_chunks = gs.active_chunk_count();
         snap.streaming_active_splats = gs.total_active_splats();
+        snap.streaming_pending_loads = gs.pending_load_count();
+        for (const auto& c : gs.chunk_inventory()) {
+            snap.chunks.push_back({
+                .status            = c.status_str,
+                .page_table_offset = c.page_table_offset,
+                .splat_count       = c.splat_count,
+                .slab_count        = c.slab_count,
+            });
+        }
         snap.max_render_distance = renderer_.gs_max_render_distance();
 
         if (!gs.has_cloud()) snap.warnings.push_back("no_cloud_loaded");

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -217,6 +217,13 @@ void AppBase::main_loop() {
         resources_.process_async_results(async_loader_, staging_uploader_);
         staging_uploader_.flush();
 
+        // Drive the off-thread GS scene parse (begin_async_load_gs_scene).
+        // When the parse future is ready, this runs the GPU/ECS finalize
+        // synchronously and arms `loading_monitor_` for the upload phase.
+        // Until then the worker keeps parsing PLYs while the main thread
+        // continues to render the loading overlay every frame.
+        tick_async_load_gs_scene();
+
         // Clear draw lists at frame start (states will rebuild them)
         draw_lists_.overlay.clear();
         draw_lists_.ui.clear();
@@ -767,6 +774,61 @@ void AppBase::load_gs_scene(const SceneData& scene_data, const GsSceneOptions& o
 
     // Populate bone animation registry from allocations created by the scene loader
     populate_bone_animation_registry(bone_anim_registry_, world_, gs_terrain_);
+}
+
+void AppBase::begin_async_load_gs_scene(SceneData scene_data,
+                                        const GsSceneOptions& opts) {
+    // Stash everything needed for the finalize phase, then kick the parse off
+    // on a worker. `std::launch::async` forces a real worker thread on every
+    // implementation we ship for (libc++/Apple Clang, MSVC) — the deferred
+    // alternative would silently downgrade to lazy execution, which would
+    // re-introduce the main-thread stall the moment we called `future.get()`.
+    PendingAsyncScene pending;
+    pending.scene_data = std::move(scene_data);
+    pending.opts = opts;
+    SceneData* scene_ref = &pending.scene_data;  // alive until pending is dropped
+    pending.parse_future = std::async(std::launch::async,
+        [scene_ref] { return GsSceneLoader::parse(*scene_ref); });
+    pending_async_scene_.emplace(std::move(pending));
+}
+
+void AppBase::tick_async_load_gs_scene() {
+    if (!pending_async_scene_.has_value()) return;
+    auto& pending = *pending_async_scene_;
+    if (!pending.parse_future.valid()) {
+        pending_async_scene_.reset();
+        return;
+    }
+    // Non-blocking poll. If the worker hasn't finished yet, return — the
+    // calling main loop will tick us again next frame and meanwhile keeps
+    // rendering the loading overlay.
+    auto status = pending.parse_future.wait_for(std::chrono::seconds(0));
+    if (status != std::future_status::ready) return;
+
+    ParsedScene parsed;
+    try {
+        parsed = pending.parse_future.get();
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "[AppBase] async scene parse failed: %s\n", e.what());
+        pending_async_scene_.reset();
+        return;
+    }
+
+    SceneLoadContext ctx{
+        gs_terrain_, scene_objects_, renderer_, scene_,
+        world_, component_registry_, resources_, feature_flags_
+    };
+    GsSceneLoader loader;
+    loader.finalize_on_main(ctx, pending.scene_data, std::move(parsed), pending.opts);
+    populate_bone_animation_registry(bone_anim_registry_, world_, gs_terrain_);
+
+    // After finalize, the renderer has issued any new VRAM uploads via
+    // `load_cloud_async`. Hand the resulting handles to the loading monitor
+    // so the engine state machine waits in `Loading` until streaming
+    // completes, then transitions through `Warming` to `Playing`.
+    loading_monitor_.begin_load(renderer_.take_pending_load_handles());
+
+    pending_async_scene_.reset();
 }
 
 // ── Control Server ──

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -779,17 +779,26 @@ void AppBase::load_gs_scene(const SceneData& scene_data, const GsSceneOptions& o
 void AppBase::begin_async_load_gs_scene(SceneData scene_data,
                                         const GsSceneOptions& opts) {
     // Stash everything needed for the finalize phase, then kick the parse off
-    // on a worker. `std::launch::async` forces a real worker thread on every
-    // implementation we ship for (libc++/Apple Clang, MSVC) — the deferred
-    // alternative would silently downgrade to lazy execution, which would
-    // re-introduce the main-thread stall the moment we called `future.get()`.
-    PendingAsyncScene pending;
-    pending.scene_data = std::move(scene_data);
-    pending.opts = opts;
-    SceneData* scene_ref = &pending.scene_data;  // alive until pending is dropped
-    pending.parse_future = std::async(std::launch::async,
+    // on a worker. The pointer-into-optional must be taken AFTER the
+    // `emplace`, otherwise the move performed by `optional::emplace` would
+    // leave the worker reading from a moved-from `SceneData` (its PLY paths
+    // and scene_objects would be empty strings, the parse would fail with a
+    // bad_alloc / "Failed to open PLY file" cascade, and the post-load body
+    // would silently re-merge the OLD scene's chunks back in — which was
+    // the source of the persistent flashback after #380/#381).
+    //
+    // `std::launch::async` forces a real worker thread on every libc++ /
+    // Apple Clang / MSVC build target; the deferred alternative would
+    // silently downgrade to lazy execution and re-introduce the main-thread
+    // stall the moment `future.get()` was called.
+    PendingAsyncScene initial;
+    initial.scene_data = std::move(scene_data);
+    initial.opts = opts;
+    pending_async_scene_.emplace(std::move(initial));
+
+    SceneData* scene_ref = &pending_async_scene_->scene_data;
+    pending_async_scene_->parse_future = std::async(std::launch::async,
         [scene_ref] { return GsSceneLoader::parse(*scene_ref); });
-    pending_async_scene_.emplace(std::move(pending));
 }
 
 void AppBase::tick_async_load_gs_scene() {

--- a/src/engine/descriptor.cpp
+++ b/src/engine/descriptor.cpp
@@ -124,6 +124,71 @@ std::array<VkDescriptorSet, kMaxFramesInFlight> DescriptorManager::allocate_spri
     return sets;
 }
 
+std::array<VkDescriptorSet, kMaxFramesInFlight>
+DescriptorManager::allocate_sprite_sets_per_frame(
+    VkDevice device, const std::array<VkBuffer, kMaxFramesInFlight>& uniform_buffers,
+    VkDeviceSize ubo_size,
+    const std::array<VkImageView, kMaxFramesInFlight>& texture_views,
+    VkSampler sampler, VkImageView normal_view, VkSampler normal_sampler) {
+    std::array<VkDescriptorSetLayout, kMaxFramesInFlight> layouts;
+    layouts.fill(sprite_layout_);
+
+    VkDescriptorSetAllocateInfo alloc_info{};
+    alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    alloc_info.descriptorPool = pool_;
+    alloc_info.descriptorSetCount = kMaxFramesInFlight;
+    alloc_info.pSetLayouts = layouts.data();
+
+    std::array<VkDescriptorSet, kMaxFramesInFlight> sets;
+    if (vkAllocateDescriptorSets(device, &alloc_info, sets.data()) != VK_SUCCESS) {
+        throw std::runtime_error("Failed to allocate per-frame sprite descriptor sets");
+    }
+
+    for (uint32_t i = 0; i < kMaxFramesInFlight; i++) {
+        VkDescriptorBufferInfo buffer_info{};
+        buffer_info.buffer = uniform_buffers[i];
+        buffer_info.offset = 0;
+        buffer_info.range = ubo_size;
+
+        VkDescriptorImageInfo image_info{};
+        image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        image_info.imageView = texture_views[i];
+        image_info.sampler = sampler;
+
+        VkDescriptorImageInfo normal_info{};
+        normal_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        normal_info.imageView = (normal_view != VK_NULL_HANDLE) ? normal_view : texture_views[i];
+        normal_info.sampler = (normal_sampler != VK_NULL_HANDLE) ? normal_sampler : sampler;
+
+        std::array<VkWriteDescriptorSet, 3> writes{};
+        writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[0].dstSet = sets[i];
+        writes[0].dstBinding = 0;
+        writes[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        writes[0].descriptorCount = 1;
+        writes[0].pBufferInfo = &buffer_info;
+
+        writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[1].dstSet = sets[i];
+        writes[1].dstBinding = 1;
+        writes[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        writes[1].descriptorCount = 1;
+        writes[1].pImageInfo = &image_info;
+
+        writes[2].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[2].dstSet = sets[i];
+        writes[2].dstBinding = 2;
+        writes[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        writes[2].descriptorCount = 1;
+        writes[2].pImageInfo = &normal_info;
+
+        vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0,
+                               nullptr);
+    }
+
+    return sets;
+}
+
 void DescriptorManager::free_sprite_sets(VkDevice device,
                                           std::array<VkDescriptorSet, kMaxFramesInFlight>& sets) {
     std::vector<VkDescriptorSet> valid;

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -121,112 +121,72 @@ void GsRenderer::create_output_image(uint32_t width, uint32_t height) {
     output_width_ = width;
     output_height_ = height;
 
-    VkImageCreateInfo image_info{};
-    image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-    image_info.imageType = VK_IMAGE_TYPE_2D;
-    image_info.format = VK_FORMAT_R16G16B16A16_SFLOAT;
-    image_info.extent = {width, height, 1};
-    image_info.mipLevels = 1;
-    image_info.arrayLayers = 1;
-    image_info.samples = VK_SAMPLE_COUNT_1_BIT;
-    image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
-    image_info.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    // Helper that allocates one VkImage + view at a given index using a
+    // fixed format/usage. Used to build the per-frame arrays for output,
+    // depth, and processed images.
+    auto make_image = [&](VkFormat format, VkImageUsageFlags usage,
+                          VkImage& out_image, VmaAllocation& out_alloc,
+                          VkImageView& out_view, const char* what) {
+        VkImageCreateInfo image_info{};
+        image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        image_info.imageType = VK_IMAGE_TYPE_2D;
+        image_info.format = format;
+        image_info.extent = {width, height, 1};
+        image_info.mipLevels = 1;
+        image_info.arrayLayers = 1;
+        image_info.samples = VK_SAMPLE_COUNT_1_BIT;
+        image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+        image_info.usage = usage;
 
-    VmaAllocationCreateInfo alloc_info{};
-    alloc_info.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+        VmaAllocationCreateInfo alloc_info{};
+        alloc_info.usage = VMA_MEMORY_USAGE_GPU_ONLY;
 
-    if (vmaCreateImage(allocator_, &image_info, &alloc_info,
-                       &output_image_, &output_allocation_, nullptr) != VK_SUCCESS) {
-        throw std::runtime_error("Failed to create GS output image");
-    }
-
-    VkImageViewCreateInfo view_info{};
-    view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-    view_info.image = output_image_;
-    view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    view_info.format = VK_FORMAT_R16G16B16A16_SFLOAT;
-    view_info.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-
-    if (vkCreateImageView(device_, &view_info, nullptr, &output_view_) != VK_SUCCESS) {
-        throw std::runtime_error("Failed to create GS output image view");
-    }
-
-    VkSamplerCreateInfo sampler_info{};
-    sampler_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    sampler_info.magFilter = VK_FILTER_NEAREST;
-    sampler_info.minFilter = VK_FILTER_NEAREST;
-    sampler_info.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-    sampler_info.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-    sampler_info.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-
-    if (vkCreateSampler(device_, &sampler_info, nullptr, &output_sampler_) != VK_SUCCESS) {
-        throw std::runtime_error("Failed to create GS output sampler");
-    }
-
-    // Depth storage image (R16F, per-pixel view-space depth)
-    {
-        VkImageCreateInfo depth_info{};
-        depth_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-        depth_info.imageType = VK_IMAGE_TYPE_2D;
-        depth_info.format = VK_FORMAT_R16_SFLOAT;
-        depth_info.extent = {width, height, 1};
-        depth_info.mipLevels = 1;
-        depth_info.arrayLayers = 1;
-        depth_info.samples = VK_SAMPLE_COUNT_1_BIT;
-        depth_info.tiling = VK_IMAGE_TILING_OPTIMAL;
-        depth_info.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-
-        VmaAllocationCreateInfo depth_alloc{};
-        depth_alloc.usage = VMA_MEMORY_USAGE_GPU_ONLY;
-
-        if (vmaCreateImage(allocator_, &depth_info, &depth_alloc,
-                           &depth_image_, &depth_allocation_, nullptr) != VK_SUCCESS) {
-            throw std::runtime_error("Failed to create GS depth image");
+        if (vmaCreateImage(allocator_, &image_info, &alloc_info,
+                           &out_image, &out_alloc, nullptr) != VK_SUCCESS) {
+            throw std::runtime_error(std::string("Failed to create GS image: ") + what);
         }
 
-        VkImageViewCreateInfo dv_info{};
-        dv_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-        dv_info.image = depth_image_;
-        dv_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
-        dv_info.format = VK_FORMAT_R16_SFLOAT;
-        dv_info.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        VkImageViewCreateInfo view_info{};
+        view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        view_info.image = out_image;
+        view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        view_info.format = format;
+        view_info.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-        if (vkCreateImageView(device_, &dv_info, nullptr, &depth_view_) != VK_SUCCESS) {
-            throw std::runtime_error("Failed to create GS depth image view");
+        if (vkCreateImageView(device_, &view_info, nullptr, &out_view) != VK_SUCCESS) {
+            throw std::runtime_error(std::string("Failed to create GS image view: ") + what);
         }
+    };
+
+    constexpr VkImageUsageFlags kColorUsage =
+        VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+        VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    constexpr VkImageUsageFlags kDepthUsage =
+        VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+
+    for (uint32_t i = 0; i < kMaxFramesInFlight; ++i) {
+        make_image(VK_FORMAT_R16G16B16A16_SFLOAT, kColorUsage,
+                   output_images_[i], output_allocations_[i], output_views_[i],
+                   "output");
+        make_image(VK_FORMAT_R16_SFLOAT, kDepthUsage,
+                   depth_images_[i], depth_allocations_[i], depth_views_[i],
+                   "depth");
+        make_image(VK_FORMAT_R16G16B16A16_SFLOAT, kColorUsage,
+                   processed_images_[i], processed_allocations_[i], processed_views_[i],
+                   "processed");
     }
 
-    // Post-processed output image (RGBA16F, same dimensions)
-    {
-        VkImageCreateInfo proc_info{};
-        proc_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-        proc_info.imageType = VK_IMAGE_TYPE_2D;
-        proc_info.format = VK_FORMAT_R16G16B16A16_SFLOAT;
-        proc_info.extent = {width, height, 1};
-        proc_info.mipLevels = 1;
-        proc_info.arrayLayers = 1;
-        proc_info.samples = VK_SAMPLE_COUNT_1_BIT;
-        proc_info.tiling = VK_IMAGE_TILING_OPTIMAL;
-        proc_info.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT
-                        | VK_IMAGE_USAGE_TRANSFER_DST_BIT;  // for init_output_layouts clear
+    if (output_sampler_ == VK_NULL_HANDLE) {
+        VkSamplerCreateInfo sampler_info{};
+        sampler_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        sampler_info.magFilter = VK_FILTER_NEAREST;
+        sampler_info.minFilter = VK_FILTER_NEAREST;
+        sampler_info.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampler_info.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampler_info.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
 
-        VmaAllocationCreateInfo proc_alloc{};
-        proc_alloc.usage = VMA_MEMORY_USAGE_GPU_ONLY;
-
-        if (vmaCreateImage(allocator_, &proc_info, &proc_alloc,
-                           &processed_image_, &processed_allocation_, nullptr) != VK_SUCCESS) {
-            throw std::runtime_error("Failed to create GS processed image");
-        }
-
-        VkImageViewCreateInfo pv_info{};
-        pv_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-        pv_info.image = processed_image_;
-        pv_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
-        pv_info.format = VK_FORMAT_R16G16B16A16_SFLOAT;
-        pv_info.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-
-        if (vkCreateImageView(device_, &pv_info, nullptr, &processed_view_) != VK_SUCCESS) {
-            throw std::runtime_error("Failed to create GS processed image view");
+        if (vkCreateSampler(device_, &sampler_info, nullptr, &output_sampler_) != VK_SUCCESS) {
+            throw std::runtime_error("Failed to create GS output sampler");
         }
     }
 
@@ -246,7 +206,7 @@ void GsRenderer::create_descriptor_resources() {
 
     VkDescriptorPoolCreateInfo pool_info{};
     pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    pool_info.maxSets = 128;  // expanded for static/dynamic/merge sets
+    pool_info.maxSets = 160;  // expanded for static/dynamic/merge + per-frame sets
     pool_info.poolSizeCount = 3;
     pool_info.pPoolSizes = pool_sizes;
 
@@ -463,9 +423,19 @@ void GsRenderer::create_descriptor_resources() {
     // Reset pool to free previously allocated sets before reallocating
     vkResetDescriptorPool(device_, gs_pool_, 0);
 
+    // Per-frame intermediate images (`output_image_[i]`, `depth_image_[i]`,
+    // `processed_image_[i]`) require per-frame descriptor sets because a
+    // single VkDescriptorSet binds to one VkImageView. The render,
+    // post_process, and tile_render sets all bind at least one of those
+    // images, so we allocate `kMaxFramesInFlight` of each.
+    static_assert(kMaxFramesInFlight == 2,
+                  "Per-frame descriptor allocation below assumes 2 frames in flight; "
+                  "if you change kMaxFramesInFlight, also extend the per-frame slot "
+                  "indices for render/post_process/tile_render at the end of `layouts`.");
+
     VkDescriptorSetLayout layouts[] = {
-        preprocess_layout_, sort_layout_, render_layout_,   // 0-2: legacy
-        post_process_layout_,                               // 3: post-process
+        preprocess_layout_, sort_layout_, render_layout_,   // 0-2: legacy (render_sets_[0])
+        post_process_layout_,                               // 3: post-process (post_process_sets_[0])
         preprocess_layout_, preprocess_layout_,             // 4-5: static + dynamic preprocess
         merge_layout_,                                      // 6: merge
         render_layout_,                                     // 7: merged render
@@ -474,7 +444,7 @@ void GsRenderer::create_descriptor_resources() {
         tile_bin_layout_,                                   // 9: tile bin (count + scatter)
         tile_ranges_layout_,                                // 10: tile range detection
         tile_indirect_layout_,                              // 11: indirect dispatch prep
-        tile_render_layout_,                                // 12: tile render
+        tile_render_layout_,                                // 12: tile render (tile_render_sets_[0])
         onesweep_hist_layout_, onesweep_hist_layout_,       // 13-14: tile onesweep histogram A, B
         onesweep_scatter_layout_, onesweep_scatter_layout_, // 15-16: tile onesweep scatter A→B, B→A
         // Depth sort Onesweep sets (reusing onesweep layouts)
@@ -485,8 +455,12 @@ void GsRenderer::create_descriptor_resources() {
         onesweep_hist_layout_, onesweep_hist_layout_,       // 25-26: dynamic depth hist A, B
         onesweep_scatter_layout_, onesweep_scatter_layout_, // 27-28: dynamic depth scatter AB, BA
         tile_scan_layout_,                                  // 29: deterministic tile-bin scan
+        // Per-frame [1] copies for sets that bind per-frame images:
+        render_layout_,                                     // 30: render_sets_[1]
+        post_process_layout_,                               // 31: post_process_sets_[1]
+        tile_render_layout_,                                // 32: tile_render_sets_[1]
     };
-    constexpr uint32_t kSetCount = 30;
+    constexpr uint32_t kSetCount = 33;
     VkDescriptorSet sets[kSetCount];
     VkDescriptorSetAllocateInfo alloc_info{};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -498,8 +472,10 @@ void GsRenderer::create_descriptor_resources() {
     // Legacy sets
     preprocess_set_ = sets[0];
     sort_set_ = sets[1];
-    render_set_ = sets[2];
-    post_process_set_ = sets[3];
+    render_sets_[0] = sets[2];
+    render_sets_[1] = sets[30];
+    post_process_sets_[0] = sets[3];
+    post_process_sets_[1] = sets[31];
     // Static/dynamic preprocess
     static_preprocess_set_ = sets[4];
     dynamic_preprocess_set_ = sets[5];
@@ -510,7 +486,8 @@ void GsRenderer::create_descriptor_resources() {
     tile_bin_set_ = sets[9];
     tile_ranges_set_ = sets[10];
     tile_indirect_set_ = sets[11];
-    tile_render_set_ = sets[12];
+    tile_render_sets_[0] = sets[12];
+    tile_render_sets_[1] = sets[32];
     onesweep_hist_set_a_ = sets[13];
     onesweep_hist_set_b_ = sets[14];
     onesweep_scatter_set_ab_ = sets[15];
@@ -1804,46 +1781,50 @@ void GsRenderer::update_descriptors() {
     }
 
     // Render set: projected(0), sort_keys_A(1), uniforms(2), output_image(3), visible_count(4), depth_image(5)
-    {
+    // Per-frame: each render_sets_[i] binds output_views_[i] / depth_views_[i].
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
         VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo sort_info{sort_keys_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
-        VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_view_, VK_IMAGE_LAYOUT_GENERAL};
+        VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_views_[f], VK_IMAGE_LAYOUT_GENERAL};
         VkDescriptorBufferInfo visible_count_info{visible_count_ssbo_.buffer(), 0, sizeof(uint32_t)};
-        VkDescriptorImageInfo depth_img_info{VK_NULL_HANDLE, depth_view_, VK_IMAGE_LAYOUT_GENERAL};
+        VkDescriptorImageInfo depth_img_info{VK_NULL_HANDLE, depth_views_[f], VK_IMAGE_LAYOUT_GENERAL};
 
+        VkDescriptorSet set = render_sets_[f];
         VkWriteDescriptorSet writes[] = {
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, render_set_, 0, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &projected_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, render_set_, 1, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &sort_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, render_set_, 2, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, render_set_, 3, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &image_info, nullptr, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, render_set_, 4, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 4, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &visible_count_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, render_set_, 5, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 5, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &depth_img_info, nullptr, nullptr},
         };
         vkUpdateDescriptorSets(device_, 6, writes, 0, nullptr);
     }
 
     // Post-process set: input_image(0), depth_image(1), processed_image(2), pp_ubo(3)
-    {
-        VkDescriptorImageInfo input_info{VK_NULL_HANDLE, output_view_, VK_IMAGE_LAYOUT_GENERAL};
-        VkDescriptorImageInfo depth_info{VK_NULL_HANDLE, depth_view_, VK_IMAGE_LAYOUT_GENERAL};
-        VkDescriptorImageInfo proc_info{VK_NULL_HANDLE, processed_view_, VK_IMAGE_LAYOUT_GENERAL};
+    // Per-frame: each post_process_sets_[i] binds frame i's output, depth, processed views.
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        VkDescriptorImageInfo input_info{VK_NULL_HANDLE, output_views_[f], VK_IMAGE_LAYOUT_GENERAL};
+        VkDescriptorImageInfo depth_info{VK_NULL_HANDLE, depth_views_[f], VK_IMAGE_LAYOUT_GENERAL};
+        VkDescriptorImageInfo proc_info{VK_NULL_HANDLE, processed_views_[f], VK_IMAGE_LAYOUT_GENERAL};
         VkDescriptorBufferInfo ubo_info{pp_ubo_buffer_.buffer(), 0, sizeof(GsPostProcessUbo)};
 
+        VkDescriptorSet set = post_process_sets_[f];
         VkWriteDescriptorSet writes[] = {
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, post_process_set_, 0, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &input_info, nullptr, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, post_process_set_, 1, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &depth_info, nullptr, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, post_process_set_, 2, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &proc_info, nullptr, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, post_process_set_, 3, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &ubo_info, nullptr},
         };
         vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
@@ -2080,27 +2061,31 @@ void GsRenderer::update_descriptors() {
         vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
     }
 
-    // Render set (uses merged_sort and counts)
-    {
+    // Render set (uses merged_sort and counts) — per-frame.
+    // Re-binds render_sets_[i] to point at the merged_sort buffer and
+    // counts_ssbo, replacing the legacy bindings written above. Each
+    // frame's set still references its frame-i image views.
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
         VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo merged_info{merged_sort_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
-        VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_view_, VK_IMAGE_LAYOUT_GENERAL};
+        VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_views_[f], VK_IMAGE_LAYOUT_GENERAL};
         VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorImageInfo depth_img_info{VK_NULL_HANDLE, depth_view_, VK_IMAGE_LAYOUT_GENERAL};
+        VkDescriptorImageInfo depth_img_info{VK_NULL_HANDLE, depth_views_[f], VK_IMAGE_LAYOUT_GENERAL};
 
+        VkDescriptorSet set = render_sets_[f];
         VkWriteDescriptorSet writes[] = {
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, render_set_, 0, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &projected_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, render_set_, 1, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &merged_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, render_set_, 2, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, render_set_, 3, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &image_info, nullptr, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, render_set_, 4, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 4, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &counts_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, render_set_, 5, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 5, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &depth_img_info, nullptr, nullptr},
         };
         vkUpdateDescriptorSets(device_, 6, writes, 0, nullptr);
@@ -2260,26 +2245,28 @@ void GsRenderer::update_descriptors() {
         }
 
         // Tile render set: projected(0), tile_entries(1), uniforms(2), output_image(3), tile_ranges(4), depth_image(5)
-        {
+        // Per-frame: each tile_render_sets_[i] binds frame i's output and depth views.
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
             VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo tile_entries_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
-            VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_view_, VK_IMAGE_LAYOUT_GENERAL};
+            VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_views_[f], VK_IMAGE_LAYOUT_GENERAL};
             VkDescriptorBufferInfo tile_ranges_info{tile_ranges_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorImageInfo depth_img_info{VK_NULL_HANDLE, depth_view_, VK_IMAGE_LAYOUT_GENERAL};
+            VkDescriptorImageInfo depth_img_info{VK_NULL_HANDLE, depth_views_[f], VK_IMAGE_LAYOUT_GENERAL};
 
+            VkDescriptorSet set = tile_render_sets_[f];
             VkWriteDescriptorSet writes[] = {
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_render_set_, 0, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &projected_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_render_set_, 1, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &tile_entries_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_render_set_, 2, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
                  VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_render_set_, 3, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &image_info, nullptr, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_render_set_, 4, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 4, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &tile_ranges_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_render_set_, 5, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 5, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &depth_img_info, nullptr, nullptr},
             };
             vkUpdateDescriptorSets(device_, 6, writes, 0, nullptr);
@@ -2290,13 +2277,36 @@ void GsRenderer::update_descriptors() {
 void GsRenderer::resize_output(uint32_t width, uint32_t height) {
     if (width == output_width_ && height == output_height_) return;
 
-    if (output_sampler_) { vkDestroySampler(device_, output_sampler_, nullptr); output_sampler_ = VK_NULL_HANDLE; }
-    if (output_view_) { vkDestroyImageView(device_, output_view_, nullptr); output_view_ = VK_NULL_HANDLE; }
-    if (output_image_) { vmaDestroyImage(allocator_, output_image_, output_allocation_); output_image_ = VK_NULL_HANDLE; }
-    if (depth_view_) { vkDestroyImageView(device_, depth_view_, nullptr); depth_view_ = VK_NULL_HANDLE; }
-    if (depth_image_) { vmaDestroyImage(allocator_, depth_image_, depth_allocation_); depth_image_ = VK_NULL_HANDLE; }
-    if (processed_view_) { vkDestroyImageView(device_, processed_view_, nullptr); processed_view_ = VK_NULL_HANDLE; }
-    if (processed_image_) { vmaDestroyImage(allocator_, processed_image_, processed_allocation_); processed_image_ = VK_NULL_HANDLE; }
+    // Sampler is resolution-independent — keep it across resizes.
+    for (uint32_t i = 0; i < kMaxFramesInFlight; ++i) {
+        if (output_views_[i]) {
+            vkDestroyImageView(device_, output_views_[i], nullptr);
+            output_views_[i] = VK_NULL_HANDLE;
+        }
+        if (output_images_[i]) {
+            vmaDestroyImage(allocator_, output_images_[i], output_allocations_[i]);
+            output_images_[i] = VK_NULL_HANDLE;
+            output_allocations_[i] = VK_NULL_HANDLE;
+        }
+        if (depth_views_[i]) {
+            vkDestroyImageView(device_, depth_views_[i], nullptr);
+            depth_views_[i] = VK_NULL_HANDLE;
+        }
+        if (depth_images_[i]) {
+            vmaDestroyImage(allocator_, depth_images_[i], depth_allocations_[i]);
+            depth_images_[i] = VK_NULL_HANDLE;
+            depth_allocations_[i] = VK_NULL_HANDLE;
+        }
+        if (processed_views_[i]) {
+            vkDestroyImageView(device_, processed_views_[i], nullptr);
+            processed_views_[i] = VK_NULL_HANDLE;
+        }
+        if (processed_images_[i]) {
+            vmaDestroyImage(allocator_, processed_images_[i], processed_allocations_[i]);
+            processed_images_[i] = VK_NULL_HANDLE;
+            processed_allocations_[i] = VK_NULL_HANDLE;
+        }
+    }
 
     create_output_image(width, height);
 
@@ -2335,32 +2345,42 @@ void GsRenderer::init_output_layouts(VkCommandBuffer cmd) {
         return b;
     };
 
-    // 1. UNDEFINED → TRANSFER_DST_OPTIMAL.
-    VkImageMemoryBarrier to_dst = barrier_for(processed_image_,
-        VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        0, VK_ACCESS_TRANSFER_WRITE_BIT);
-    vkCmdPipelineBarrier(cmd,
-        VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-        VK_PIPELINE_STAGE_TRANSFER_BIT,
-        0, 0, nullptr, 0, nullptr, 1, &to_dst);
-
-    // 2. Clear to opaque black.
     VkClearColorValue clear{};
     clear.float32[0] = clear.float32[1] = clear.float32[2] = 0.0f;
     clear.float32[3] = 1.0f;
     VkImageSubresourceRange range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-    vkCmdClearColorImage(cmd, processed_image_,
-        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear, 1, &range);
 
-    // 3. TRANSFER_DST → SHADER_READ_ONLY_OPTIMAL.
-    VkImageMemoryBarrier to_shader = barrier_for(processed_image_,
-        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-        VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT);
+    std::array<VkImageMemoryBarrier, kMaxFramesInFlight> to_dst{};
+    std::array<VkImageMemoryBarrier, kMaxFramesInFlight> to_shader{};
+    for (uint32_t i = 0; i < kMaxFramesInFlight; ++i) {
+        to_dst[i] = barrier_for(processed_images_[i],
+            VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            0, VK_ACCESS_TRANSFER_WRITE_BIT);
+        to_shader[i] = barrier_for(processed_images_[i],
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+            VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT);
+    }
+
+    // 1. UNDEFINED → TRANSFER_DST_OPTIMAL (all frames).
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        0, 0, nullptr, 0, nullptr,
+        kMaxFramesInFlight, to_dst.data());
+
+    // 2. Clear each per-frame processed image to opaque black.
+    for (uint32_t i = 0; i < kMaxFramesInFlight; ++i) {
+        vkCmdClearColorImage(cmd, processed_images_[i],
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear, 1, &range);
+    }
+
+    // 3. TRANSFER_DST → SHADER_READ_ONLY_OPTIMAL (all frames).
     vkCmdPipelineBarrier(cmd,
         VK_PIPELINE_STAGE_TRANSFER_BIT,
         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-        0, 0, nullptr, 0, nullptr, 1, &to_shader);
+        0, 0, nullptr, 0, nullptr,
+        kMaxFramesInFlight, to_shader.data());
 }
 
 void GsRenderer::dispatch_depth_onesweep(
@@ -2655,8 +2675,20 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd) {
     insert_compute_barrier(cmd);
 }
 
-void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::mat4& proj) {
+void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
+                        const glm::mat4& view, const glm::mat4& proj) {
     if (gaussian_count_ == 0 && static_count_ == 0 && dynamic_count_ == 0) return;
+    if (frame_in_flight >= kMaxFramesInFlight) {
+        std::fprintf(stderr, "[gs_renderer] render(): frame_in_flight=%u out of range\n",
+                     frame_in_flight);
+        return;
+    }
+    const VkImage out_img       = output_images_[frame_in_flight];
+    const VkImage depth_img     = depth_images_[frame_in_flight];
+    const VkImage processed_img = processed_images_[frame_in_flight];
+    VkDescriptorSet render_set       = render_sets_[frame_in_flight];
+    VkDescriptorSet post_process_set = post_process_sets_[frame_in_flight];
+    VkDescriptorSet tile_render_set  = tile_render_sets_[frame_in_flight];
 
     uint32_t width = output_width_;
     uint32_t height = output_height_;
@@ -2747,7 +2779,7 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
     bool skip_gs_compute = skip_sort_ && sort_done_once_;
 
     if (!skip_gs_compute) {
-        // Transition output + depth images to GENERAL layout for compute write
+        // Transition this frame's output + depth images to GENERAL layout for compute write.
         VkImageMemoryBarrier barriers[2]{};
         barriers[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
         barriers[0].srcAccessMask = 0;
@@ -2756,11 +2788,11 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
         barriers[0].newLayout = VK_IMAGE_LAYOUT_GENERAL;
         barriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         barriers[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        barriers[0].image = output_image_;
+        barriers[0].image = out_img;
         barriers[0].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
         barriers[1] = barriers[0];
-        barriers[1].image = depth_image_;
+        barriers[1].image = depth_img;
 
         vkCmdPipelineBarrier(cmd,
             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
@@ -2769,11 +2801,11 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
     }
 
     if (!skip_gs_compute) {
-        // Clear output + depth images to transparent black (prevents ghost artifacts)
+        // Clear this frame's output + depth images to transparent black (prevents ghost artifacts)
         VkClearColorValue clear_color = {{0.0f, 0.0f, 0.0f, 0.0f}};
         VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-        vkCmdClearColorImage(cmd, output_image_, VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &range);
-        vkCmdClearColorImage(cmd, depth_image_, VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &range);
+        vkCmdClearColorImage(cmd, out_img,   VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &range);
+        vkCmdClearColorImage(cmd, depth_img, VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &range);
 
         // === PBD solver dispatch (before any preprocess) ===
         // PBD-tagged Gaussians live in the static buffer but need re-preprocessing
@@ -2927,11 +2959,11 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
                 if (use_tile) {
                     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_render_pipeline_);
                     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                            tile_render_pipeline_layout_, 0, 1, &tile_render_set_, 0, nullptr);
+                                            tile_render_pipeline_layout_, 0, 1, &tile_render_set, 0, nullptr);
                 } else {
                     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, render_pipeline_);
                     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                            render_pipeline_layout_, 0, 1, &render_set_, 0, nullptr);
+                                            render_pipeline_layout_, 0, 1, &render_set, 0, nullptr);
                 }
                 uint32_t tiles_x = (width + 15) / 16;
                 uint32_t tiles_y = (height + 15) / 16;
@@ -2995,10 +3027,10 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
                                    timestamp_pool_, 3);  // tile_sort_end
             }
 
-            // Tile-based rasterization
+            // Tile-based rasterization (legacy path)
             vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, render_pipeline_);
             vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                    render_pipeline_layout_, 0, 1, &render_set_, 0, nullptr);
+                                    render_pipeline_layout_, 0, 1, &render_set, 0, nullptr);
             uint32_t tiles_x = (width + 15) / 16;
             uint32_t tiles_y = (height + 15) / 16;
 
@@ -3057,7 +3089,7 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
         pp_ubo._pad0 = pp_ubo._pad1 = pp_ubo._pad2 = 0;
         std::memcpy(pp_ubo_buffer_.mapped(), &pp_ubo, sizeof(pp_ubo));
 
-        // Transition processed image to GENERAL for compute write
+        // Transition this frame's processed image to GENERAL for compute write
         {
             VkImageMemoryBarrier barrier{};
             barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -3067,7 +3099,7 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
             barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
             barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
             barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            barrier.image = processed_image_;
+            barrier.image = processed_img;
             barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
             vkCmdPipelineBarrier(cmd,
@@ -3079,13 +3111,13 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
         // Dispatch post-process (same tile grid as render)
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, post_process_pipeline_);
         vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                post_process_pipeline_layout_, 0, 1, &post_process_set_, 0, nullptr);
+                                post_process_pipeline_layout_, 0, 1, &post_process_set, 0, nullptr);
         uint32_t tiles_x = (width + 15) / 16;
         uint32_t tiles_y = (height + 15) / 16;
         vkCmdDispatch(cmd, tiles_x, tiles_y, 1);
     }
 
-    // Transition processed image → SHADER_READ_ONLY for fragment sampling (blit)
+    // Transition this frame's processed image → SHADER_READ_ONLY for fragment sampling (blit)
     {
         VkImageMemoryBarrier barrier{};
         barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -3095,7 +3127,7 @@ void GsRenderer::render(VkCommandBuffer cmd, const glm::mat4& view, const glm::m
         barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
         barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        barrier.image = processed_image_;
+        barrier.image = processed_img;
         barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
         vkCmdPipelineBarrier(cmd,
@@ -3235,12 +3267,35 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     pp_ubo_buffer_.destroy(allocator);
 
     if (output_sampler_) { vkDestroySampler(device_, output_sampler_, nullptr); output_sampler_ = VK_NULL_HANDLE; }
-    if (output_view_) { vkDestroyImageView(device_, output_view_, nullptr); output_view_ = VK_NULL_HANDLE; }
-    if (output_image_) { vmaDestroyImage(allocator, output_image_, output_allocation_); output_image_ = VK_NULL_HANDLE; }
-    if (depth_view_) { vkDestroyImageView(device_, depth_view_, nullptr); depth_view_ = VK_NULL_HANDLE; }
-    if (depth_image_) { vmaDestroyImage(allocator, depth_image_, depth_allocation_); depth_image_ = VK_NULL_HANDLE; }
-    if (processed_view_) { vkDestroyImageView(device_, processed_view_, nullptr); processed_view_ = VK_NULL_HANDLE; }
-    if (processed_image_) { vmaDestroyImage(allocator, processed_image_, processed_allocation_); processed_image_ = VK_NULL_HANDLE; }
+    for (uint32_t i = 0; i < kMaxFramesInFlight; ++i) {
+        if (output_views_[i]) {
+            vkDestroyImageView(device_, output_views_[i], nullptr);
+            output_views_[i] = VK_NULL_HANDLE;
+        }
+        if (output_images_[i]) {
+            vmaDestroyImage(allocator, output_images_[i], output_allocations_[i]);
+            output_images_[i] = VK_NULL_HANDLE;
+            output_allocations_[i] = VK_NULL_HANDLE;
+        }
+        if (depth_views_[i]) {
+            vkDestroyImageView(device_, depth_views_[i], nullptr);
+            depth_views_[i] = VK_NULL_HANDLE;
+        }
+        if (depth_images_[i]) {
+            vmaDestroyImage(allocator, depth_images_[i], depth_allocations_[i]);
+            depth_images_[i] = VK_NULL_HANDLE;
+            depth_allocations_[i] = VK_NULL_HANDLE;
+        }
+        if (processed_views_[i]) {
+            vkDestroyImageView(device_, processed_views_[i], nullptr);
+            processed_views_[i] = VK_NULL_HANDLE;
+        }
+        if (processed_images_[i]) {
+            vmaDestroyImage(allocator, processed_images_[i], processed_allocations_[i]);
+            processed_images_[i] = VK_NULL_HANDLE;
+            processed_allocations_[i] = VK_NULL_HANDLE;
+        }
+    }
 
     auto destroy_pipeline = [&](VkPipeline& p) { if (p) { vkDestroyPipeline(device_, p, nullptr); p = VK_NULL_HANDLE; } };
     auto destroy_layout = [&](VkPipelineLayout& l) { if (l) { vkDestroyPipelineLayout(device_, l, nullptr); l = VK_NULL_HANDLE; } };

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1072,6 +1072,26 @@ void GsRenderer::clear_chunks(VkCommandBuffer drain_cmd) {
     static_dirty_ = true;
 }
 
+std::vector<GsRenderer::ChunkInventoryEntry> GsRenderer::chunk_inventory() const {
+    std::vector<ChunkInventoryEntry> out;
+    out.reserve(active_chunks_.size());
+    for (const auto& c : active_chunks_) {
+        const char* st = "active";
+        switch (c.status) {
+            case ChunkState::Status::LOADING:   st = "loading"; break;
+            case ChunkState::Status::ACTIVE:    st = "active"; break;
+            case ChunkState::Status::UNLOADING: st = "unloading"; break;
+        }
+        out.push_back({
+            .status_str        = st,
+            .page_table_offset = c.page_table_offset,
+            .splat_count       = c.splat_count,
+            .slab_count        = static_cast<uint32_t>(c.handle.slab_indices.size()),
+        });
+    }
+    return out;
+}
+
 void GsRenderer::create_transfer_queue(VkQueue transfer_q, uint32_t transfer_family,
                                         uint32_t graphics_family, bool dedicated) {
     if (!streaming_initialized_) return;

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1544,32 +1544,38 @@ void GsRenderer::update_static_gaussians(const Gaussian* data, uint32_t count) {
     static_dirty_ = true;
     sort_done_once_ = false;
 
-    // Build GPU data in a local buffer first, then memcpy to mapped memory.
-    // This avoids -O3 write-reordering issues with mapped GPU memory —
-    // tried writing directly to mapped() and the user immediately saw
-    // ghost-PC + leftover-gaussian artifacts on Apple/MoltenVK, so the
-    // staging round-trip is mandatory.
-    std::vector<GpuGaussian> staging(count);
+    // Direct write to the mapped HOST_COHERENT SSBO. Earlier code went via
+    // a `std::vector<GpuGaussian> staging(count)` to avoid alleged -O3
+    // write-reorder issues against mapped memory, but: (a) on a 2.4M-splat
+    // scene that staging vector is ~190MB and adds zero-fill + memcpy
+    // overhead measured at ~50ms/frame on Apple unified memory, and (b)
+    // VMA + HOST_COHERENT semantics already guarantee writes become visible
+    // before the next vkQueueSubmit's GPU-side acquire. Removing the
+    // intermediate cuts update_static_gaussians from ~75ms to ~12ms on a
+    // 400k-LOD-selected splat frame.
+    GpuGaussian* dst = static_cast<GpuGaussian*>(static_gaussian_ssbo_.mapped());
     for (uint32_t i = 0; i < count; ++i) {
         float bone_f;
         uint32_t bi = data[i].bone_index;
         std::memcpy(&bone_f, &bi, sizeof(float));
-        staging[i].pos_opacity = glm::vec4(data[i].position, data[i].opacity);
-        staging[i].scale_pad = glm::vec4(data[i].scale, bone_f);
-        staging[i].rot = glm::vec4(data[i].rotation.x, data[i].rotation.y,
-                                    data[i].rotation.z, data[i].rotation.w);
-        staging[i].color_pad = glm::vec4(data[i].color, data[i].emission);
+        dst[i].pos_opacity = glm::vec4(data[i].position, data[i].opacity);
+        dst[i].scale_pad   = glm::vec4(data[i].scale, bone_f);
+        dst[i].rot         = glm::vec4(data[i].rotation.x, data[i].rotation.y,
+                                       data[i].rotation.z, data[i].rotation.w);
+        dst[i].color_pad   = glm::vec4(data[i].color, data[i].emission);
     }
-    std::memcpy(static_gaussian_ssbo_.mapped(), staging.data(), count * sizeof(GpuGaussian));
 
-    // Reinitialize static sort buffers via memcpy for consistency
+    // Sort buffers also written directly. Same reasoning — the previous
+    // `std::vector<SortEntry>(sort_size)` allocation was ~19MB per buffer
+    // and only the first `count` entries get a meaningful index value, so
+    // we memset the tail and only loop over the head.
     auto init_sort_buf = [](Buffer& buf, uint32_t sort_size, uint32_t valid_count) {
-        std::vector<SortEntry> staging_sort(sort_size);
-        for (uint32_t i = 0; i < sort_size; ++i) {
-            staging_sort[i].key = 0xFFFFFFFF;
-            staging_sort[i].index = i < valid_count ? i : 0;
+        SortEntry* e = static_cast<SortEntry*>(buf.mapped());
+        std::memset(e, 0xFF, sort_size * sizeof(SortEntry));
+        for (uint32_t i = 0; i < valid_count && i < sort_size; ++i) {
+            e[i].key   = 0xFFFFFFFF;
+            e[i].index = i;
         }
-        std::memcpy(buf.mapped(), staging_sort.data(), sort_size * sizeof(SortEntry));
     };
     init_sort_buf(static_sort_a_, static_sort_size_, count);
     init_sort_buf(static_sort_b_, static_sort_size_, count);
@@ -1581,16 +1587,16 @@ void GsRenderer::reset_static_sort_only() {
     if (static_count_ == 0 || static_sort_size_ == 0) return;
     const uint32_t valid = static_count_;
     const uint32_t size  = static_sort_size_;
-    // Same staging-buffer pattern as update_static_gaussians for
-    // memcpy-into-mapped safety — direct writes to mapped GPU memory
-    // produced visible artifacts on Apple/MoltenVK.
+    // memset key=0xFF then write the sequential index range. This is
+    // ~38MB per buffer for a 2.4M splat scene vs ~400MB for the full
+    // update_static_gaussians path — measured as ~5ms vs ~75ms.
     auto init = [valid, size](Buffer& buf) {
-        std::vector<SortEntry> staging(size);
-        for (uint32_t i = 0; i < size; ++i) {
-            staging[i].key = 0xFFFFFFFF;
-            staging[i].index = i < valid ? i : 0;
+        SortEntry* e = static_cast<SortEntry*>(buf.mapped());
+        std::memset(e, 0xFF, size * sizeof(SortEntry));
+        for (uint32_t i = 0; i < valid && i < size; ++i) {
+            e[i].key = 0xFFFFFFFF;
+            e[i].index = i;
         }
-        std::memcpy(buf.mapped(), staging.data(), size * sizeof(SortEntry));
     };
     init(static_sort_a_);
     init(static_sort_b_);

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1544,32 +1544,64 @@ void GsRenderer::update_static_gaussians(const Gaussian* data, uint32_t count) {
     static_dirty_ = true;
     sort_done_once_ = false;
 
-    // Build GPU data in a local buffer first, then memcpy to mapped memory.
-    // This avoids -O3 write-reordering issues with mapped GPU memory.
-    std::vector<GpuGaussian> staging(count);
+    // Direct write to the mapped HOST_COHERENT SSBO. Earlier code went via
+    // a `std::vector<GpuGaussian> staging(count)` to avoid alleged -O3
+    // write-reorder issues against mapped memory, but: (a) on a 2.4M-splat
+    // scene that staging vector is ~190MB and adds zero-fill + memcpy
+    // overhead measured at ~50ms/frame on Apple unified memory, and (b)
+    // VMA + HOST_COHERENT semantics already guarantee writes become visible
+    // before the next vkQueueSubmit's GPU-side acquire. Removing the
+    // intermediate cuts update_static_gaussians from ~75ms to ~12ms on a
+    // 400k-LOD-selected splat frame.
+    GpuGaussian* dst = static_cast<GpuGaussian*>(static_gaussian_ssbo_.mapped());
     for (uint32_t i = 0; i < count; ++i) {
         float bone_f;
         uint32_t bi = data[i].bone_index;
         std::memcpy(&bone_f, &bi, sizeof(float));
-        staging[i].pos_opacity = glm::vec4(data[i].position, data[i].opacity);
-        staging[i].scale_pad = glm::vec4(data[i].scale, bone_f);
-        staging[i].rot = glm::vec4(data[i].rotation.x, data[i].rotation.y,
-                                    data[i].rotation.z, data[i].rotation.w);
-        staging[i].color_pad = glm::vec4(data[i].color, data[i].emission);
+        dst[i].pos_opacity = glm::vec4(data[i].position, data[i].opacity);
+        dst[i].scale_pad   = glm::vec4(data[i].scale, bone_f);
+        dst[i].rot         = glm::vec4(data[i].rotation.x, data[i].rotation.y,
+                                       data[i].rotation.z, data[i].rotation.w);
+        dst[i].color_pad   = glm::vec4(data[i].color, data[i].emission);
     }
-    std::memcpy(static_gaussian_ssbo_.mapped(), staging.data(), count * sizeof(GpuGaussian));
 
-    // Reinitialize static sort buffers via memcpy for consistency
+    // Sort buffers also written directly. Same reasoning — the previous
+    // `std::vector<SortEntry>(sort_size)` allocation was ~19MB per buffer
+    // and only the first `count` entries get a meaningful index value, so
+    // we memset the tail and only loop over the head.
     auto init_sort_buf = [](Buffer& buf, uint32_t sort_size, uint32_t valid_count) {
-        std::vector<SortEntry> staging_sort(sort_size);
-        for (uint32_t i = 0; i < sort_size; ++i) {
-            staging_sort[i].key = 0xFFFFFFFF;
-            staging_sort[i].index = i < valid_count ? i : 0;
+        SortEntry* e = static_cast<SortEntry*>(buf.mapped());
+        std::memset(e, 0xFF, sort_size * sizeof(SortEntry));
+        for (uint32_t i = 0; i < valid_count && i < sort_size; ++i) {
+            e[i].key   = 0xFFFFFFFF;
+            e[i].index = i;
         }
-        std::memcpy(buf.mapped(), staging_sort.data(), sort_size * sizeof(SortEntry));
     };
     init_sort_buf(static_sort_a_, static_sort_size_, count);
     init_sort_buf(static_sort_b_, static_sort_size_, count);
+}
+
+void GsRenderer::reset_static_sort_only() {
+    // Stale state guard: only valid once update_static_gaussians has run
+    // at least once (sort_size populated, count meaningful).
+    if (static_count_ == 0 || static_sort_size_ == 0) return;
+    const uint32_t valid = static_count_;
+    const uint32_t size  = static_sort_size_;
+    // memset key=0xFF then write the sequential index range. This is
+    // ~38MB per buffer for a 2.4M splat scene vs ~400MB for the full
+    // update_static_gaussians path — measured as ~5ms vs ~75ms.
+    auto init = [valid, size](Buffer& buf) {
+        SortEntry* e = static_cast<SortEntry*>(buf.mapped());
+        std::memset(e, 0xFF, size * sizeof(SortEntry));
+        for (uint32_t i = 0; i < valid && i < size; ++i) {
+            e[i].key = 0xFFFFFFFF;
+            e[i].index = i;
+        }
+    };
+    init(static_sort_a_);
+    init(static_sort_b_);
+    sort_done_once_ = false;
+    static_dirty_ = true;
 }
 
 void GsRenderer::update_dynamic_gaussians(const Gaussian* data, uint32_t count) {

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1544,38 +1544,32 @@ void GsRenderer::update_static_gaussians(const Gaussian* data, uint32_t count) {
     static_dirty_ = true;
     sort_done_once_ = false;
 
-    // Direct write to the mapped HOST_COHERENT SSBO. Earlier code went via
-    // a `std::vector<GpuGaussian> staging(count)` to avoid alleged -O3
-    // write-reorder issues against mapped memory, but: (a) on a 2.4M-splat
-    // scene that staging vector is ~190MB and adds zero-fill + memcpy
-    // overhead measured at ~50ms/frame on Apple unified memory, and (b)
-    // VMA + HOST_COHERENT semantics already guarantee writes become visible
-    // before the next vkQueueSubmit's GPU-side acquire. Removing the
-    // intermediate cuts update_static_gaussians from ~75ms to ~12ms on a
-    // 400k-LOD-selected splat frame.
-    GpuGaussian* dst = static_cast<GpuGaussian*>(static_gaussian_ssbo_.mapped());
+    // Build GPU data in a local buffer first, then memcpy to mapped memory.
+    // This avoids -O3 write-reordering issues with mapped GPU memory —
+    // tried writing directly to mapped() and the user immediately saw
+    // ghost-PC + leftover-gaussian artifacts on Apple/MoltenVK, so the
+    // staging round-trip is mandatory.
+    std::vector<GpuGaussian> staging(count);
     for (uint32_t i = 0; i < count; ++i) {
         float bone_f;
         uint32_t bi = data[i].bone_index;
         std::memcpy(&bone_f, &bi, sizeof(float));
-        dst[i].pos_opacity = glm::vec4(data[i].position, data[i].opacity);
-        dst[i].scale_pad   = glm::vec4(data[i].scale, bone_f);
-        dst[i].rot         = glm::vec4(data[i].rotation.x, data[i].rotation.y,
-                                       data[i].rotation.z, data[i].rotation.w);
-        dst[i].color_pad   = glm::vec4(data[i].color, data[i].emission);
+        staging[i].pos_opacity = glm::vec4(data[i].position, data[i].opacity);
+        staging[i].scale_pad = glm::vec4(data[i].scale, bone_f);
+        staging[i].rot = glm::vec4(data[i].rotation.x, data[i].rotation.y,
+                                    data[i].rotation.z, data[i].rotation.w);
+        staging[i].color_pad = glm::vec4(data[i].color, data[i].emission);
     }
+    std::memcpy(static_gaussian_ssbo_.mapped(), staging.data(), count * sizeof(GpuGaussian));
 
-    // Sort buffers also written directly. Same reasoning — the previous
-    // `std::vector<SortEntry>(sort_size)` allocation was ~19MB per buffer
-    // and only the first `count` entries get a meaningful index value, so
-    // we memset the tail and only loop over the head.
+    // Reinitialize static sort buffers via memcpy for consistency
     auto init_sort_buf = [](Buffer& buf, uint32_t sort_size, uint32_t valid_count) {
-        SortEntry* e = static_cast<SortEntry*>(buf.mapped());
-        std::memset(e, 0xFF, sort_size * sizeof(SortEntry));
-        for (uint32_t i = 0; i < valid_count && i < sort_size; ++i) {
-            e[i].key   = 0xFFFFFFFF;
-            e[i].index = i;
+        std::vector<SortEntry> staging_sort(sort_size);
+        for (uint32_t i = 0; i < sort_size; ++i) {
+            staging_sort[i].key = 0xFFFFFFFF;
+            staging_sort[i].index = i < valid_count ? i : 0;
         }
+        std::memcpy(buf.mapped(), staging_sort.data(), sort_size * sizeof(SortEntry));
     };
     init_sort_buf(static_sort_a_, static_sort_size_, count);
     init_sort_buf(static_sort_b_, static_sort_size_, count);
@@ -1587,16 +1581,16 @@ void GsRenderer::reset_static_sort_only() {
     if (static_count_ == 0 || static_sort_size_ == 0) return;
     const uint32_t valid = static_count_;
     const uint32_t size  = static_sort_size_;
-    // memset key=0xFF then write the sequential index range. This is
-    // ~38MB per buffer for a 2.4M splat scene vs ~400MB for the full
-    // update_static_gaussians path — measured as ~5ms vs ~75ms.
+    // Same staging-buffer pattern as update_static_gaussians for
+    // memcpy-into-mapped safety — direct writes to mapped GPU memory
+    // produced visible artifacts on Apple/MoltenVK.
     auto init = [valid, size](Buffer& buf) {
-        SortEntry* e = static_cast<SortEntry*>(buf.mapped());
-        std::memset(e, 0xFF, size * sizeof(SortEntry));
-        for (uint32_t i = 0; i < valid && i < size; ++i) {
-            e[i].key = 0xFFFFFFFF;
-            e[i].index = i;
+        std::vector<SortEntry> staging(size);
+        for (uint32_t i = 0; i < size; ++i) {
+            staging[i].key = 0xFFFFFFFF;
+            staging[i].index = i < valid ? i : 0;
         }
+        std::memcpy(buf.mapped(), staging.data(), size * sizeof(SortEntry));
     };
     init(static_sort_a_);
     init(static_sort_b_);

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1544,64 +1544,32 @@ void GsRenderer::update_static_gaussians(const Gaussian* data, uint32_t count) {
     static_dirty_ = true;
     sort_done_once_ = false;
 
-    // Direct write to the mapped HOST_COHERENT SSBO. Earlier code went via
-    // a `std::vector<GpuGaussian> staging(count)` to avoid alleged -O3
-    // write-reorder issues against mapped memory, but: (a) on a 2.4M-splat
-    // scene that staging vector is ~190MB and adds zero-fill + memcpy
-    // overhead measured at ~50ms/frame on Apple unified memory, and (b)
-    // VMA + HOST_COHERENT semantics already guarantee writes become visible
-    // before the next vkQueueSubmit's GPU-side acquire. Removing the
-    // intermediate cuts update_static_gaussians from ~75ms to ~12ms on a
-    // 400k-LOD-selected splat frame.
-    GpuGaussian* dst = static_cast<GpuGaussian*>(static_gaussian_ssbo_.mapped());
+    // Build GPU data in a local buffer first, then memcpy to mapped memory.
+    // This avoids -O3 write-reordering issues with mapped GPU memory.
+    std::vector<GpuGaussian> staging(count);
     for (uint32_t i = 0; i < count; ++i) {
         float bone_f;
         uint32_t bi = data[i].bone_index;
         std::memcpy(&bone_f, &bi, sizeof(float));
-        dst[i].pos_opacity = glm::vec4(data[i].position, data[i].opacity);
-        dst[i].scale_pad   = glm::vec4(data[i].scale, bone_f);
-        dst[i].rot         = glm::vec4(data[i].rotation.x, data[i].rotation.y,
-                                       data[i].rotation.z, data[i].rotation.w);
-        dst[i].color_pad   = glm::vec4(data[i].color, data[i].emission);
+        staging[i].pos_opacity = glm::vec4(data[i].position, data[i].opacity);
+        staging[i].scale_pad = glm::vec4(data[i].scale, bone_f);
+        staging[i].rot = glm::vec4(data[i].rotation.x, data[i].rotation.y,
+                                    data[i].rotation.z, data[i].rotation.w);
+        staging[i].color_pad = glm::vec4(data[i].color, data[i].emission);
     }
+    std::memcpy(static_gaussian_ssbo_.mapped(), staging.data(), count * sizeof(GpuGaussian));
 
-    // Sort buffers also written directly. Same reasoning — the previous
-    // `std::vector<SortEntry>(sort_size)` allocation was ~19MB per buffer
-    // and only the first `count` entries get a meaningful index value, so
-    // we memset the tail and only loop over the head.
+    // Reinitialize static sort buffers via memcpy for consistency
     auto init_sort_buf = [](Buffer& buf, uint32_t sort_size, uint32_t valid_count) {
-        SortEntry* e = static_cast<SortEntry*>(buf.mapped());
-        std::memset(e, 0xFF, sort_size * sizeof(SortEntry));
-        for (uint32_t i = 0; i < valid_count && i < sort_size; ++i) {
-            e[i].key   = 0xFFFFFFFF;
-            e[i].index = i;
+        std::vector<SortEntry> staging_sort(sort_size);
+        for (uint32_t i = 0; i < sort_size; ++i) {
+            staging_sort[i].key = 0xFFFFFFFF;
+            staging_sort[i].index = i < valid_count ? i : 0;
         }
+        std::memcpy(buf.mapped(), staging_sort.data(), sort_size * sizeof(SortEntry));
     };
     init_sort_buf(static_sort_a_, static_sort_size_, count);
     init_sort_buf(static_sort_b_, static_sort_size_, count);
-}
-
-void GsRenderer::reset_static_sort_only() {
-    // Stale state guard: only valid once update_static_gaussians has run
-    // at least once (sort_size populated, count meaningful).
-    if (static_count_ == 0 || static_sort_size_ == 0) return;
-    const uint32_t valid = static_count_;
-    const uint32_t size  = static_sort_size_;
-    // memset key=0xFF then write the sequential index range. This is
-    // ~38MB per buffer for a 2.4M splat scene vs ~400MB for the full
-    // update_static_gaussians path — measured as ~5ms vs ~75ms.
-    auto init = [valid, size](Buffer& buf) {
-        SortEntry* e = static_cast<SortEntry*>(buf.mapped());
-        std::memset(e, 0xFF, size * sizeof(SortEntry));
-        for (uint32_t i = 0; i < valid && i < size; ++i) {
-            e[i].key = 0xFFFFFFFF;
-            e[i].index = i;
-        }
-    };
-    init(static_sort_a_);
-    init(static_sort_b_);
-    sort_done_once_ = false;
-    static_dirty_ = true;
 }
 
 void GsRenderer::update_dynamic_gaussians(const Gaussian* data, uint32_t count) {

--- a/src/engine/gs_scene_loader.cpp
+++ b/src/engine/gs_scene_loader.cpp
@@ -26,8 +26,187 @@
 
 namespace gseurat {
 
-void GsSceneLoader::load(SceneLoadContext& ctx, const SceneData& scene_data,
-                          const GsSceneOptions& opts) {
+// CPU-only parse phase. Touches no Vulkan / ECS / GPU resources, so it can be
+// invoked from a worker thread. Returns a `ParsedScene` that the main thread
+// then consumes via `finalize_on_main`.
+ParsedScene GsSceneLoader::parse(const SceneData& scene_data) {
+    ParsedScene parsed;
+
+    // Load terrain PLY if present
+    if (scene_data.gaussian_splat) {
+        const auto& gs = *scene_data.gaussian_splat;
+        std::fprintf(stderr, "[GS] (parse) Terrain PLY: '%s' (project_root='%s')\n",
+                     gs.ply_file.c_str(), get_project_root().c_str());
+        try {
+            parsed.cloud = GaussianCloud::load_ply(gs.ply_file);
+            parsed.has_terrain = !parsed.cloud.empty();
+        } catch (const std::runtime_error& e) {
+            std::fprintf(stderr, "[GS] Warning: %s\n", e.what());
+        }
+        parsed.gs_scale_multiplier = gs.scale_multiplier;
+    }
+
+    // Compute terrain AABB (grid-to-world coordinate mapping)
+    parsed.terrain_aabb.min = glm::vec3(0.0f);
+    parsed.terrain_aabb.max = glm::vec3(0.0f);
+    if (parsed.has_terrain) {
+        parsed.terrain_aabb = parsed.cloud.bounds();
+    }
+
+    parsed.snapped_objects = scene_data.game_objects;
+    parsed.world_positions.reserve(parsed.snapped_objects.size());
+    for (const auto& go : parsed.snapped_objects) {
+        parsed.world_positions.push_back(coord::to_world(go.position, parsed.terrain_aabb));
+    }
+
+    // Pre-scan: allocate bone slots for BoneAnimated game objects.
+    parsed.bone_slot_counter = 8;  // reserve 0-7 for player
+    for (size_t i = 0; i < parsed.snapped_objects.size(); ++i) {
+        const auto& go = parsed.snapped_objects[i];
+        if (go.components.is_null() || !go.components.contains("BoneAnimated")) continue;
+        const auto& ba_json = go.components["BoneAnimated"];
+        std::string manifest_path = ba_json.value("manifest", std::string{});
+        if (manifest_path.empty()) continue;
+
+        uint32_t bone_count = 0;
+        {
+            std::ifstream mf(manifest_path);
+            if (!mf.is_open()) {
+                std::fprintf(stderr, "[GS] BoneAnimated: failed to open manifest '%s'\n",
+                             manifest_path.c_str());
+                continue;
+            }
+            auto mj = nlohmann::json::parse(mf, nullptr, false);
+            if (mj.is_discarded() || !mj.contains("bones") || !mj["bones"].is_array()) {
+                std::fprintf(stderr, "[GS] BoneAnimated: invalid manifest '%s'\n",
+                             manifest_path.c_str());
+                continue;
+            }
+            bone_count = static_cast<uint32_t>(mj["bones"].size());
+        }
+        if (parsed.bone_slot_counter + bone_count > 32) {
+            std::fprintf(stderr, "[GS] BoneAnimated: bone budget exceeded for '%s' (need %u, have %u)\n",
+                         go.id.c_str(), bone_count, 32 - parsed.bone_slot_counter);
+            continue;
+        }
+
+        GsTerrainState::BoneAllocation alloc;
+        alloc.manifest_path = manifest_path;
+        alloc.default_clip = ba_json.value("default_clip", std::string{"idle"});
+        alloc.first_bone_index = parsed.bone_slot_counter;
+        alloc.bone_count = bone_count;
+        alloc.char_scale = go.scale;
+        alloc.gs_scale_multiplier = parsed.gs_scale_multiplier;
+        alloc.world_pos = parsed.world_positions[i].vec();
+        alloc.game_object_index = i;
+        parsed.bone_allocations.push_back(alloc);
+        parsed.bone_slot_counter += bone_count;
+
+        std::fprintf(stderr, "[GS] BoneAnimated '%s': bones %u-%u (count=%u)\n",
+                     go.id.c_str(), alloc.first_bone_index,
+                     alloc.first_bone_index + bone_count - 1, bone_count);
+    }
+
+    // Merge all game objects with PLY visuals into the parsed cloud.
+    {
+        auto merged = parsed.cloud.gaussians();
+        uint32_t merged_count = 0;
+        for (size_t i = 0; i < parsed.snapped_objects.size(); ++i) {
+            const auto& go = parsed.snapped_objects[i];
+            if (go.ply_file.empty()) continue;
+            try {
+                auto placed_cloud = GaussianCloud::load_ply(go.ply_file);
+                if (placed_cloud.empty()) continue;
+                glm::vec3 local_min(1e9f);
+                glm::vec3 local_max(-1e9f);
+                for (const auto& g : placed_cloud.gaussians()) {
+                    local_min = glm::min(local_min, g.position);
+                    local_max = glm::max(local_max, g.position);
+                }
+                glm::vec3 local_center = (local_min + local_max) * 0.5f;
+                local_center.y = local_min.y;
+                float local_min_y = local_min.y;
+                float local_max_y = local_max.y;
+                glm::vec3 adjusted_pos = parsed.world_positions[i].vec();
+                auto transform = glm::translate(glm::mat4(1.0f), adjusted_pos);
+                transform = glm::rotate(transform, glm::radians(go.rotation.x), {1,0,0});
+                transform = glm::rotate(transform, glm::radians(go.rotation.y), {0,1,0});
+                transform = glm::rotate(transform, glm::radians(go.rotation.z), {0,0,1});
+                transform = glm::scale(transform, glm::vec3(go.scale));
+                transform = glm::translate(transform, -local_center);
+                auto rot_q = glm::quat(glm::radians(go.rotation));
+
+                uint32_t pbd_idx = 0;
+                float sway_threshold_frac = 0.7f;
+                if (go.pbd && parsed.pbd_anchors.size() < kMaxPbdElements) {
+                    pbd_idx = 32 + static_cast<uint32_t>(parsed.pbd_anchors.size());
+                    parsed.pbd_anchors.push_back(adjusted_pos);
+                    parsed.pbd_configs.push_back(*go.pbd);
+                    sway_threshold_frac = go.pbd->sway_threshold;
+                }
+                float sway_threshold = local_min_y + (local_max_y - local_min_y) * sway_threshold_frac;
+
+                uint32_t ba_first_bone = 0;
+                bool has_bone_anim = false;
+                for (const auto& alloc : parsed.bone_allocations) {
+                    if (alloc.game_object_index == i) {
+                        ba_first_bone = alloc.first_bone_index;
+                        has_bone_anim = true;
+                        break;
+                    }
+                }
+
+                auto placed_gs = placed_cloud.gaussians();
+                uint32_t tagged_count = 0;
+                for (auto& g : placed_gs) {
+                    float local_y = g.position.y;
+                    g.position = glm::vec3(transform * glm::vec4(g.position, 1.0f));
+                    g.scale *= go.scale;
+                    g.rotation = rot_q * g.rotation;
+                    if (pbd_idx > 0 && local_y > sway_threshold) {
+                        g.bone_index = pbd_idx;
+                        tagged_count++;
+                    }
+                    if (has_bone_anim) {
+                        g.bone_index = ba_first_bone + g.bone_index;
+                    }
+                }
+                if (pbd_idx > 0) {
+                    std::fprintf(stderr, "[GS] PBD '%s': idx=%u, threshold=%.2f (frac=%.2f), "
+                                 "model Y=[%.2f,%.2f], tagged=%u/%zu, anchor=(%.1f,%.1f,%.1f)\n",
+                                 go.name.c_str(), pbd_idx, sway_threshold, sway_threshold_frac,
+                                 local_min_y, local_max_y, tagged_count, placed_gs.size(),
+                                 adjusted_pos.x, adjusted_pos.y, adjusted_pos.z);
+                }
+                merged.insert(merged.end(), placed_gs.begin(), placed_gs.end());
+                merged_count++;
+            } catch (const std::runtime_error& e) {
+                std::fprintf(stderr, "[GS] Warning: game object '%s': %s\n",
+                             go.id.c_str(), e.what());
+            }
+        }
+        if (merged_count > 0) {
+            parsed.cloud = GaussianCloud::from_gaussians(std::move(merged));
+        }
+        if (!parsed.pbd_anchors.empty()) {
+            std::fprintf(stderr, "[GS] PBD: %zu objects configured (idx 32-%u)\n",
+                         parsed.pbd_anchors.size(),
+                         31 + static_cast<uint32_t>(parsed.pbd_anchors.size()));
+        }
+    }
+
+    // Cloud bounds for camera centering.
+    if (!parsed.cloud.empty()) {
+        auto bounds = parsed.cloud.bounds();
+        parsed.cloud_center = (bounds.min + bounds.max) * 0.5f;
+        parsed.cloud_extent = glm::length(bounds.max - bounds.min) * 0.5f;
+    }
+
+    return parsed;
+}
+
+void GsSceneLoader::finalize_on_main(SceneLoadContext& ctx, const SceneData& scene_data,
+                                     ParsedScene&& parsed, const GsSceneOptions& opts) {
 
     ctx.renderer.clear_gs_particle_emitters();
     ctx.renderer.clear_gs_animations();
@@ -39,201 +218,26 @@ void GsSceneLoader::load(SceneLoadContext& ctx, const SceneData& scene_data,
         ctx.scene.add_light(pl);
     }
 
-    // Apply weather fog to scene (picked up by renderer each frame)
     ctx.scene.set_fog_density(scene_data.weather.fog_density);
     ctx.scene.set_fog_color(scene_data.weather.fog_color);
 
-    // Load terrain PLY if present
-    GaussianCloud cloud;
-    bool has_terrain = false;
-    float gs_scale_multiplier = 1.0f;
-    if (scene_data.gaussian_splat) {
-        const auto& gs = *scene_data.gaussian_splat;
-        std::fprintf(stderr, "[GS] Terrain PLY: '%s' (project_root='%s')\n",
-                     gs.ply_file.c_str(), get_project_root().c_str());
-        try {
-            cloud = GaussianCloud::load_ply(gs.ply_file);
-            has_terrain = !cloud.empty();
-        } catch (const std::runtime_error& e) {
-            std::fprintf(stderr, "[GS] Warning: %s\n", e.what());
-        }
-        gs_scale_multiplier = gs.scale_multiplier;
+    if (parsed.has_terrain) {
+        ctx.renderer.gs_renderer().set_scale_multiplier(parsed.gs_scale_multiplier);
     }
 
+    ctx.terrain.terrain_aabb = parsed.terrain_aabb;
+    ctx.scene_objects.game_objects = parsed.snapped_objects;
+    ctx.terrain.bone_allocations = parsed.bone_allocations;
+    ctx.terrain.bone_slot_counter = parsed.bone_slot_counter;
+    ctx.terrain.pbd_anchors = parsed.pbd_anchors;
+    ctx.terrain.pbd_configs = parsed.pbd_configs;
+
+    GaussianCloud cloud = std::move(parsed.cloud);
+    const bool has_terrain = parsed.has_terrain;
+    const auto& world_positions = parsed.world_positions;
+    const auto& snapped_objects = ctx.scene_objects.game_objects;
+
     {
-        if (has_terrain) {
-            ctx.renderer.gs_renderer().set_scale_multiplier(gs_scale_multiplier);
-        }
-
-        // Compute terrain AABB (grid-to-world coordinate mapping)
-        ctx.terrain.terrain_aabb = AABB{};
-        ctx.terrain.terrain_aabb.min = glm::vec3(0.0f);
-        ctx.terrain.terrain_aabb.max = glm::vec3(0.0f);
-        if (has_terrain) {
-            ctx.terrain.terrain_aabb = cloud.bounds();
-        }
-
-        // Snap game object positions to terrain elevation (in grid coordinates)
-        // Game objects use authored Y from scene JSON.
-        // Ground elevation is handled at runtime by HeightfieldComponent + KCC.
-        auto snapped_objects = scene_data.game_objects;
-
-        // Convert grid positions to world positions via coord::to_world()
-        ctx.scene_objects.game_objects = snapped_objects;
-
-        std::vector<coord::WorldPos> world_positions;
-        world_positions.reserve(snapped_objects.size());
-        for (const auto& go : snapped_objects) {
-            world_positions.push_back(coord::to_world(go.position, ctx.terrain.terrain_aabb));
-        }
-
-        // Pre-scan: allocate bone slots for BoneAnimated game objects
-        ctx.terrain.bone_allocations.clear();
-        ctx.terrain.bone_slot_counter = 8;  // reserve 0-7 for player
-        for (size_t i = 0; i < snapped_objects.size(); ++i) {
-            const auto& go = snapped_objects[i];
-            if (go.components.is_null() || !go.components.contains("BoneAnimated")) continue;
-            const auto& ba_json = go.components["BoneAnimated"];
-            std::string manifest_path = ba_json.value("manifest", std::string{});
-            if (manifest_path.empty()) continue;
-
-            // Parse manifest JSON directly to get bone count
-            // (avoid constructing CharacterData — its destructor crashes on macOS)
-            uint32_t bone_count = 0;
-            {
-                std::ifstream mf(manifest_path);
-                if (!mf.is_open()) {
-                    std::fprintf(stderr, "[GS] BoneAnimated: failed to open manifest '%s'\n",
-                                 manifest_path.c_str());
-                    continue;
-                }
-                auto mj = nlohmann::json::parse(mf, nullptr, false);
-                if (mj.is_discarded() || !mj.contains("bones") || !mj["bones"].is_array()) {
-                    std::fprintf(stderr, "[GS] BoneAnimated: invalid manifest '%s'\n",
-                                 manifest_path.c_str());
-                    continue;
-                }
-                bone_count = static_cast<uint32_t>(mj["bones"].size());
-            }
-            if (ctx.terrain.bone_slot_counter + bone_count > 32) {
-                std::fprintf(stderr, "[GS] BoneAnimated: bone budget exceeded for '%s' (need %u, have %u)\n",
-                             go.id.c_str(), bone_count, 32 - ctx.terrain.bone_slot_counter);
-                continue;
-            }
-
-            GsTerrainState::BoneAllocation alloc;
-            alloc.manifest_path = manifest_path;
-            alloc.default_clip = ba_json.value("default_clip", std::string{"idle"});
-            alloc.first_bone_index = ctx.terrain.bone_slot_counter;
-            alloc.bone_count = bone_count;
-            alloc.char_scale = go.scale;
-            alloc.gs_scale_multiplier = gs_scale_multiplier;
-            alloc.world_pos = world_positions[i].vec();
-            alloc.game_object_index = i;
-            ctx.terrain.bone_allocations.push_back(alloc);
-            ctx.terrain.bone_slot_counter += bone_count;
-
-            std::fprintf(stderr, "[GS] BoneAnimated '%s': bones %u-%u (count=%u)\n",
-                         go.id.c_str(), alloc.first_bone_index,
-                         alloc.first_bone_index + bone_count - 1, bone_count);
-        }
-
-        // Merge all game objects with PLY visuals into the GS cloud
-        ctx.terrain.pbd_anchors.clear();
-        ctx.terrain.pbd_configs.clear();
-            {
-                auto merged = cloud.gaussians();
-                uint32_t merged_count = 0;
-                for (size_t i = 0; i < snapped_objects.size(); ++i) {
-                    const auto& go = snapped_objects[i];
-                    if (go.ply_file.empty()) continue;
-                    try {
-                        auto placed_cloud = GaussianCloud::load_ply(go.ply_file);
-                        if (placed_cloud.empty()) continue;
-                        // Compute local AABB
-                        glm::vec3 local_min(1e9f);
-                        glm::vec3 local_max(-1e9f);
-                        for (const auto& g : placed_cloud.gaussians()) {
-                            local_min = glm::min(local_min, g.position);
-                            local_max = glm::max(local_max, g.position);
-                        }
-                        // Center the model at its XZ centroid, sit bottom on ground
-                        glm::vec3 local_center = (local_min + local_max) * 0.5f;
-                        local_center.y = local_min.y;  // pivot at bottom, not center Y
-                        float local_min_y = local_min.y;
-                        float local_max_y = local_max.y;
-                        glm::vec3 adjusted_pos = world_positions[i].vec();
-                        // Build transform: translate to position, rotate, scale, then center the model
-                        auto transform = glm::translate(glm::mat4(1.0f), adjusted_pos);
-                        transform = glm::rotate(transform, glm::radians(go.rotation.x), {1,0,0});
-                        transform = glm::rotate(transform, glm::radians(go.rotation.y), {0,1,0});
-                        transform = glm::rotate(transform, glm::radians(go.rotation.z), {0,0,1});
-                        transform = glm::scale(transform, glm::vec3(go.scale));
-                        transform = glm::translate(transform, -local_center);  // center model at origin
-                        auto rot_q = glm::quat(glm::radians(go.rotation));
-
-                        // Assign PBD index from game object config
-                        uint32_t pbd_idx = 0;
-                        float sway_threshold_frac = 0.7f;
-                        if (go.pbd && ctx.terrain.pbd_anchors.size() < kMaxPbdElements) {
-                            pbd_idx = 32 + static_cast<uint32_t>(ctx.terrain.pbd_anchors.size());
-                            ctx.terrain.pbd_anchors.push_back(adjusted_pos);
-                            ctx.terrain.pbd_configs.push_back(*go.pbd);
-                            sway_threshold_frac = go.pbd->sway_threshold;
-                        }
-                        float sway_threshold = local_min_y + (local_max_y - local_min_y) * sway_threshold_frac;
-
-                        // Check if this game object has bone animation
-                        uint32_t ba_first_bone = 0;
-                        bool has_bone_anim = false;
-                        for (const auto& alloc : ctx.terrain.bone_allocations) {
-                            if (alloc.game_object_index == i) {
-                                ba_first_bone = alloc.first_bone_index;
-                                has_bone_anim = true;
-                                break;
-                            }
-                        }
-
-                        auto placed_gs = placed_cloud.gaussians();
-                        uint32_t tagged_count = 0;
-                        for (auto& g : placed_gs) {
-                            float local_y = g.position.y;  // before transform
-                            g.position = glm::vec3(transform * glm::vec4(g.position, 1.0f));
-                            g.scale *= go.scale;
-                            g.rotation = rot_q * g.rotation;
-                            // Tag canopy Gaussians with PBD index
-                            if (pbd_idx > 0 && local_y > sway_threshold) {
-                                g.bone_index = pbd_idx;
-                                tagged_count++;
-                            }
-                            if (has_bone_anim) {
-                                g.bone_index = ba_first_bone + g.bone_index;
-                            }
-                        }
-                        if (pbd_idx > 0) {
-                            std::fprintf(stderr, "[GS] PBD '%s': idx=%u, threshold=%.2f (frac=%.2f), "
-                                         "model Y=[%.2f,%.2f], tagged=%u/%zu, anchor=(%.1f,%.1f,%.1f)\n",
-                                         go.name.c_str(), pbd_idx, sway_threshold, sway_threshold_frac,
-                                         local_min_y, local_max_y, tagged_count, placed_gs.size(),
-                                         adjusted_pos.x, adjusted_pos.y, adjusted_pos.z);
-                        }
-                        merged.insert(merged.end(), placed_gs.begin(), placed_gs.end());
-                        merged_count++;
-                    } catch (const std::runtime_error& e) {
-                        std::fprintf(stderr, "[GS] Warning: game object '%s': %s\n",
-                                     go.id.c_str(), e.what());
-                    }
-                }
-                if (merged_count > 0) {
-                    cloud = GaussianCloud::from_gaussians(std::move(merged));
-                }
-                if (!ctx.terrain.pbd_anchors.empty()) {
-                    std::fprintf(stderr, "[GS] PBD: %zu objects configured (idx 32-%u)\n",
-                                 ctx.terrain.pbd_anchors.size(),
-                                 31 + static_cast<uint32_t>(ctx.terrain.pbd_anchors.size()));
-                }
-            }
-
             // Create ECS entities for game objects with components
             for (size_t i = 0; i < snapped_objects.size(); ++i) {
                 const auto& go = snapped_objects[i];
@@ -442,6 +446,15 @@ void GsSceneLoader::load(SceneLoadContext& ctx, const SceneData& scene_data,
             ctx.renderer.add_vfx_instance(std::move(inst));
         }
     }
+}
+
+// Synchronous wrapper: parse on the calling thread (blocks until PLY load
+// completes) and immediately finalize on the same thread. Used by callers
+// that don't need the async / loading-overlay path.
+void GsSceneLoader::load(SceneLoadContext& ctx, const SceneData& scene_data,
+                          const GsSceneOptions& opts) {
+    ParsedScene parsed = parse(scene_data);
+    finalize_on_main(ctx, scene_data, std::move(parsed), opts);
 }
 
 }  // namespace gseurat

--- a/src/engine/post_process.cpp
+++ b/src/engine/post_process.cpp
@@ -349,12 +349,21 @@ void PostProcessPipeline::create_render_passes(VkDevice device, VkFormat swapcha
         }
     }
 
-    // Composite render pass: swapchain format color, UI draws here too
+    // Composite render pass: swapchain format color, UI draws here too.
+    // loadOp = CLEAR (not DONT_CARE): the GS blit + UI passes don't cover
+    // every pixel of the swapchain (GS output is rendered at e.g. 320x240
+    // and stretched, leaving the surrounding swapchain area uncovered).
+    // With DONT_CARE + a 3-image swapchain cycling round-robin, an uncovered
+    // pixel inherits whatever that swapchain image was last used to display
+    // — which is the rendered content from N frames ago. That manifests as
+    // an "old initial-frame flashes back" ghost in motion. CLEAR forces a
+    // known black starting state and the cost is negligible (one tile-clear
+    // per frame on Apple-TBDR hardware).
     {
         VkAttachmentDescription color_att{};
         color_att.format = swapchain_format;
         color_att.samples = VK_SAMPLE_COUNT_1_BIT;
-        color_att.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        color_att.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
         color_att.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
         color_att.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         color_att.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -909,6 +918,14 @@ void PostProcessPipeline::record_post_process(VkCommandBuffer cmd, uint32_t swap
         rp_info.renderPass = composite_render_pass_;
         rp_info.framebuffer = composite_framebuffers_[swapchain_index];
         rp_info.renderArea.extent = {scene_width_, scene_height_};
+        // The composite color attachment was switched from LOAD_OP_DONT_CARE
+        // to LOAD_OP_CLEAR (see render-pass creation) — supply the clear
+        // value here. Black with full alpha matches the previous
+        // post_process initial-clear path.
+        VkClearValue composite_clear{};
+        composite_clear.color = {{0.0f, 0.0f, 0.0f, 1.0f}};
+        rp_info.clearValueCount = 1;
+        rp_info.pClearValues = &composite_clear;
 
         vkCmdBeginRenderPass(cmd, &rp_info, VK_SUBPASS_CONTENTS_INLINE);
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, composite_pipeline_);

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -304,9 +304,9 @@ void Renderer::init_gs(const GaussianCloud& cloud, uint32_t width, uint32_t heig
     for (uint32_t i = 0; i < kMaxFramesInFlight; i++) {
         ubo_buffers[i] = uniform_buffers_[i].buffer();
     }
-    gs_descriptor_sets_ = descriptors_.allocate_sprite_sets(
+    gs_descriptor_sets_ = descriptors_.allocate_sprite_sets_per_frame(
         context_.device(), ubo_buffers, sizeof(UniformBufferObject),
-        gs_renderer_.output_view(), gs_renderer_.output_sampler(),
+        gs_renderer_.output_views(), gs_renderer_.output_sampler(),
         flat_normal_texture_->image_view(), flat_normal_texture_->sampler());
 
     // Also create UI-space descriptor sets (orthographic projection for fullscreen blit)
@@ -315,9 +315,9 @@ void Renderer::init_gs(const GaussianCloud& cloud, uint32_t width, uint32_t heig
         for (uint32_t i = 0; i < kMaxFramesInFlight; i++) {
             ui_ubo_buffers[i] = ui_uniform_buffers_[i].buffer();
         }
-        gs_ui_descriptor_sets_ = descriptors_.allocate_sprite_sets(
+        gs_ui_descriptor_sets_ = descriptors_.allocate_sprite_sets_per_frame(
             context_.device(), ui_ubo_buffers, sizeof(UniformBufferObject),
-            gs_renderer_.output_view(), gs_renderer_.output_sampler(),
+            gs_renderer_.output_views(), gs_renderer_.output_sampler(),
             flat_normal_texture_->image_view(), flat_normal_texture_->sampler());
     }
 }
@@ -1312,7 +1312,7 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
         }
 
         gs_renderer_.set_tile_binning(flags.gs_tile_binning);
-        gs_renderer_.render(cmd, gs_view_, gs_proj_);
+        gs_renderer_.render(cmd, current_frame_, gs_view_, gs_proj_);
     }
 }
 

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -3,7 +3,6 @@
 #include "gseurat/engine/procedural_textures.hpp"
 #include "gseurat/engine/project_root.hpp"
 #include "gseurat/engine/resource_manager.hpp"
-#include "gseurat/engine/scoped_timer.hpp"
 #include "gseurat/engine/sort_entry.hpp"
 #include "gseurat/engine/sort_hash.hpp"
 #include "gseurat/engine/streaming_config.hpp"
@@ -430,10 +429,7 @@ void Renderer::draw_scene(Scene& scene,
     // records acquire barriers into `cmd` so subsequent GS compute reads
     // see fully-uploaded slabs. Must run before any pipeline that consumes
     // the slab buffers, including `record_gs_prepass`.
-    {
-        ScopedStallTimer _t_poll{"draw_scene: gs_renderer.poll_transfers"};
-        gs_renderer_.poll_transfers(cmd);
-    }
+    gs_renderer_.poll_transfers(cmd);
 
     // Forward post-process params to GS pipeline before GS compute runs
     {
@@ -1103,28 +1099,7 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             gs_prev_budget_ = gs_gaussian_budget_;
         }
 
-        // Visibility-driven gate. The heavy static-path (gather +
-        // update_static_gaussians) costs ~175ms/frame on a 2.4M-splat
-        // overworld. The cost is justified ONLY when the visible chunk
-        // set changes — typically a ~5-second-apart event as the player
-        // crosses a chunk boundary. The previous gate fired on bit-precise
-        // matrix change, which meant every camera-follow tick.
-        //
-        // Compute the visible set first (cheap frustum check, <1ms even
-        // with hundreds of chunks) and use the set change + force flags
-        // as the heavy-path trigger. LOD distance prioritisation drifts
-        // slightly stale between chunk-boundary crossings but the visual
-        // delta is imperceptible — bone-preserved player splats are
-        // re-injected on every gather, which is the only LOD output that
-        // needs near-frame freshness.
-        const glm::mat4 gs_vp_now = gs_proj_ * gs_view_;
-        const glm::vec3 dist_origin_now = glm::vec3(glm::inverse(gs_view_)[3]);
-        auto visible_now = (!gs_chunk_grid_.empty() && flags.gs_chunk_culling && !gs_skip_chunk_cull_)
-            ? gs_chunk_grid_.visible_chunks(gs_vp_now, dist_origin_now, gs_max_render_distance_)
-            : std::vector<uint32_t>{};
-        const bool visibility_changed = (visible_now != gs_prev_visible_);
-
-        bool camera_dirty = visibility_changed || budget_changed || gs_static_force_dirty_;
+        bool camera_dirty = (gs_view_ != gs_prev_view_) || budget_changed || gs_static_force_dirty_;
 
         // If scene animations are active, force static rebuild each frame
         if (gs_animator_.has_active_groups() || !gs_scene_animations_.empty()) {
@@ -1132,18 +1107,12 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             camera_dirty = true;
         }
 
-        // Sort-buffer reset is required every frame the merge runs with
-        // dynamic content — the radix-sort scatter leaves stale keys in
-        // static_sort_a_/_b_. Previously this was bundled into camera_dirty
-        // and ran the FULL static path (gather + Gaussian re-pack) every
-        // frame, costing 175ms/frame on a 2.4M-splat scene. Decouple:
-        // mark `dynamics_active` here, run the cheap sort-only reset in
-        // its own branch below, and keep camera_dirty for the actual
-        // chunk-visibility re-gather case.
-        const bool dynamics_active =
-            !gs_pending_dynamics_.empty() ||
-            !gs_particle_emitters_.empty() ||
-            !vfx_instances_.empty();
+        // Dynamic Gaussians (particles, VFX, PBD) require the static sort buffers to be
+        // reinitialized each frame via update_static_gaussians. Without this, stale sort
+        // buffer state from the previous frame's radix scatter corrupts the merge output.
+        if (!gs_pending_dynamics_.empty() || !gs_particle_emitters_.empty() || !vfx_instances_.empty()) {
+            camera_dirty = true;
+        }
 
         // Determinism harness: hold the LOD/chunk-gather selection across
         // frames so the pre-sort input set itself is bit-identical. Any
@@ -1155,30 +1124,27 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
         }
 
         if (camera_dirty && flags.gs_chunk_culling && !gs_skip_chunk_cull_ && !gs_chunk_grid_.empty()) {
-            ScopedStallTimer _t_static_path{"record_gs_prepass: camera_dirty static-path (gather + update_static)"};
-            // visible_now was computed above for the visibility_changed
-            // check; reuse here instead of repeating the frustum cull.
-            auto& visible = visible_now;
-            glm::vec3 cam_pos = dist_origin_now;
+            glm::mat4 gs_vp = gs_proj_ * gs_view_;
+            glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
+            // Use camera position for distance culling (camera sees ahead of player)
+            glm::vec3 dist_origin = cam_pos;
+            auto visible = gs_chunk_grid_.visible_chunks(gs_vp, dist_origin, gs_max_render_distance_);
 
-            if ((visibility_changed || budget_changed) && gs_budget_locked_) {
+            if ((visible != gs_prev_visible_ || budget_changed) && gs_budget_locked_) {
                 gs_budget_locked_ = false;
                 gs_stable_frame_count_ = 0;
             }
             gs_prev_visible_ = visible;
 
             // Re-gather scene Gaussians
-            {
-                ScopedStallTimer _t_gather{"record_gs_prepass: chunk_grid.gather"};
-                if (flags.gs_lod && gs_gaussian_budget_ > 0) {
-                    glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
-                    const glm::vec3* focus = gs_has_lod_focus_ ? &gs_lod_focus_pos_ : nullptr;
-                    gs_chunk_grid_.gather_lod(visible, cam_pos, gs_gaussian_budget_,
-                                              gs_static_buffer_, focus,
-                                              gs_preserve_bone_first_, gs_preserve_bone_count_);
-                } else {
-                    gs_chunk_grid_.gather(visible, gs_static_buffer_);
-                }
+            if (flags.gs_lod && gs_gaussian_budget_ > 0) {
+                glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
+                const glm::vec3* focus = gs_has_lod_focus_ ? &gs_lod_focus_pos_ : nullptr;
+                gs_chunk_grid_.gather_lod(visible, cam_pos, gs_gaussian_budget_,
+                                          gs_static_buffer_, focus,
+                                          gs_preserve_bone_first_, gs_preserve_bone_count_);
+            } else {
+                gs_chunk_grid_.gather(visible, gs_static_buffer_);
             }
 
             // Append VFX object Gaussians to static buffer
@@ -1243,7 +1209,6 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
 
             // Upload static Gaussians
             if (!gs_static_buffer_.empty()) {
-                ScopedStallTimer _t_upload{"record_gs_prepass: update_static_gaussians"};
                 auto count = static_cast<uint32_t>(gs_static_buffer_.size());
                 if (count > gs_renderer_.max_static_count()) {
                     gs_static_buffer_.resize(gs_renderer_.max_static_count());
@@ -1257,13 +1222,6 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             if (!gs_animator_.has_active_groups() && gs_scene_animations_.empty()) {
                 gs_static_force_dirty_ = false;
             }
-        } else if (dynamics_active && !determinism_test_state_.active) {
-            // Cheap path: visibility didn't change but dynamics exist,
-            // so the sort buffers still need a reset (otherwise the
-            // radix-merge reads stale keys from last frame's scatter).
-            // ~5ms instead of ~175ms.
-            ScopedStallTimer _t_sort_only{"record_gs_prepass: reset_static_sort_only"};
-            gs_renderer_.reset_static_sort_only();
         }
 
         // --- Dynamic path: every frame ---
@@ -1344,7 +1302,6 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
 
             // Upload dynamic Gaussians
             {
-                ScopedStallTimer _t_dyn{"record_gs_prepass: update_dynamic_gaussians"};
                 auto count = static_cast<uint32_t>(gs_dynamic_buffer_.size());
                 if (count > gs_renderer_.max_dynamic_count()) {
                     gs_dynamic_buffer_.resize(gs_renderer_.max_dynamic_count());

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -322,6 +322,13 @@ void Renderer::init_gs(const GaussianCloud& cloud, uint32_t width, uint32_t heig
     }
 }
 
+void Renderer::drop_all_gs_chunks_now() {
+    if (!gs_initialized_ || !gs_renderer_.streaming_initialized()) return;
+    VkCommandBuffer drain_cmd = command_pool_.begin_single_time(context_.device());
+    gs_renderer_.clear_chunks(drain_cmd);
+    command_pool_.end_single_time(context_.device(), context_.graphics_queue(), drain_cmd);
+}
+
 void Renderer::begin_determinism_test(int frames) {
     if (frames <= 0) frames = 10;
     determinism_test_state_.active = true;

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -3,6 +3,7 @@
 #include "gseurat/engine/procedural_textures.hpp"
 #include "gseurat/engine/project_root.hpp"
 #include "gseurat/engine/resource_manager.hpp"
+#include "gseurat/engine/scoped_timer.hpp"
 #include "gseurat/engine/sort_entry.hpp"
 #include "gseurat/engine/sort_hash.hpp"
 #include "gseurat/engine/streaming_config.hpp"
@@ -429,7 +430,10 @@ void Renderer::draw_scene(Scene& scene,
     // records acquire barriers into `cmd` so subsequent GS compute reads
     // see fully-uploaded slabs. Must run before any pipeline that consumes
     // the slab buffers, including `record_gs_prepass`.
-    gs_renderer_.poll_transfers(cmd);
+    {
+        ScopedStallTimer _t_poll{"draw_scene: gs_renderer.poll_transfers"};
+        gs_renderer_.poll_transfers(cmd);
+    }
 
     // Forward post-process params to GS pipeline before GS compute runs
     {
@@ -1099,7 +1103,28 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             gs_prev_budget_ = gs_gaussian_budget_;
         }
 
-        bool camera_dirty = (gs_view_ != gs_prev_view_) || budget_changed || gs_static_force_dirty_;
+        // Visibility-driven gate. The heavy static-path (gather +
+        // update_static_gaussians) costs ~175ms/frame on a 2.4M-splat
+        // overworld. The cost is justified ONLY when the visible chunk
+        // set changes — typically a ~5-second-apart event as the player
+        // crosses a chunk boundary. The previous gate fired on bit-precise
+        // matrix change, which meant every camera-follow tick.
+        //
+        // Compute the visible set first (cheap frustum check, <1ms even
+        // with hundreds of chunks) and use the set change + force flags
+        // as the heavy-path trigger. LOD distance prioritisation drifts
+        // slightly stale between chunk-boundary crossings but the visual
+        // delta is imperceptible — bone-preserved player splats are
+        // re-injected on every gather, which is the only LOD output that
+        // needs near-frame freshness.
+        const glm::mat4 gs_vp_now = gs_proj_ * gs_view_;
+        const glm::vec3 dist_origin_now = glm::vec3(glm::inverse(gs_view_)[3]);
+        auto visible_now = (!gs_chunk_grid_.empty() && flags.gs_chunk_culling && !gs_skip_chunk_cull_)
+            ? gs_chunk_grid_.visible_chunks(gs_vp_now, dist_origin_now, gs_max_render_distance_)
+            : std::vector<uint32_t>{};
+        const bool visibility_changed = (visible_now != gs_prev_visible_);
+
+        bool camera_dirty = visibility_changed || budget_changed || gs_static_force_dirty_;
 
         // If scene animations are active, force static rebuild each frame
         if (gs_animator_.has_active_groups() || !gs_scene_animations_.empty()) {
@@ -1107,12 +1132,18 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             camera_dirty = true;
         }
 
-        // Dynamic Gaussians (particles, VFX, PBD) require the static sort buffers to be
-        // reinitialized each frame via update_static_gaussians. Without this, stale sort
-        // buffer state from the previous frame's radix scatter corrupts the merge output.
-        if (!gs_pending_dynamics_.empty() || !gs_particle_emitters_.empty() || !vfx_instances_.empty()) {
-            camera_dirty = true;
-        }
+        // Sort-buffer reset is required every frame the merge runs with
+        // dynamic content — the radix-sort scatter leaves stale keys in
+        // static_sort_a_/_b_. Previously this was bundled into camera_dirty
+        // and ran the FULL static path (gather + Gaussian re-pack) every
+        // frame, costing 175ms/frame on a 2.4M-splat scene. Decouple:
+        // mark `dynamics_active` here, run the cheap sort-only reset in
+        // its own branch below, and keep camera_dirty for the actual
+        // chunk-visibility re-gather case.
+        const bool dynamics_active =
+            !gs_pending_dynamics_.empty() ||
+            !gs_particle_emitters_.empty() ||
+            !vfx_instances_.empty();
 
         // Determinism harness: hold the LOD/chunk-gather selection across
         // frames so the pre-sort input set itself is bit-identical. Any
@@ -1124,27 +1155,30 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
         }
 
         if (camera_dirty && flags.gs_chunk_culling && !gs_skip_chunk_cull_ && !gs_chunk_grid_.empty()) {
-            glm::mat4 gs_vp = gs_proj_ * gs_view_;
-            glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
-            // Use camera position for distance culling (camera sees ahead of player)
-            glm::vec3 dist_origin = cam_pos;
-            auto visible = gs_chunk_grid_.visible_chunks(gs_vp, dist_origin, gs_max_render_distance_);
+            ScopedStallTimer _t_static_path{"record_gs_prepass: camera_dirty static-path (gather + update_static)"};
+            // visible_now was computed above for the visibility_changed
+            // check; reuse here instead of repeating the frustum cull.
+            auto& visible = visible_now;
+            glm::vec3 cam_pos = dist_origin_now;
 
-            if ((visible != gs_prev_visible_ || budget_changed) && gs_budget_locked_) {
+            if ((visibility_changed || budget_changed) && gs_budget_locked_) {
                 gs_budget_locked_ = false;
                 gs_stable_frame_count_ = 0;
             }
             gs_prev_visible_ = visible;
 
             // Re-gather scene Gaussians
-            if (flags.gs_lod && gs_gaussian_budget_ > 0) {
-                glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
-                const glm::vec3* focus = gs_has_lod_focus_ ? &gs_lod_focus_pos_ : nullptr;
-                gs_chunk_grid_.gather_lod(visible, cam_pos, gs_gaussian_budget_,
-                                          gs_static_buffer_, focus,
-                                          gs_preserve_bone_first_, gs_preserve_bone_count_);
-            } else {
-                gs_chunk_grid_.gather(visible, gs_static_buffer_);
+            {
+                ScopedStallTimer _t_gather{"record_gs_prepass: chunk_grid.gather"};
+                if (flags.gs_lod && gs_gaussian_budget_ > 0) {
+                    glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
+                    const glm::vec3* focus = gs_has_lod_focus_ ? &gs_lod_focus_pos_ : nullptr;
+                    gs_chunk_grid_.gather_lod(visible, cam_pos, gs_gaussian_budget_,
+                                              gs_static_buffer_, focus,
+                                              gs_preserve_bone_first_, gs_preserve_bone_count_);
+                } else {
+                    gs_chunk_grid_.gather(visible, gs_static_buffer_);
+                }
             }
 
             // Append VFX object Gaussians to static buffer
@@ -1209,6 +1243,7 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
 
             // Upload static Gaussians
             if (!gs_static_buffer_.empty()) {
+                ScopedStallTimer _t_upload{"record_gs_prepass: update_static_gaussians"};
                 auto count = static_cast<uint32_t>(gs_static_buffer_.size());
                 if (count > gs_renderer_.max_static_count()) {
                     gs_static_buffer_.resize(gs_renderer_.max_static_count());
@@ -1222,6 +1257,13 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             if (!gs_animator_.has_active_groups() && gs_scene_animations_.empty()) {
                 gs_static_force_dirty_ = false;
             }
+        } else if (dynamics_active && !determinism_test_state_.active) {
+            // Cheap path: visibility didn't change but dynamics exist,
+            // so the sort buffers still need a reset (otherwise the
+            // radix-merge reads stale keys from last frame's scatter).
+            // ~5ms instead of ~175ms.
+            ScopedStallTimer _t_sort_only{"record_gs_prepass: reset_static_sort_only"};
+            gs_renderer_.reset_static_sort_only();
         }
 
         // --- Dynamic path: every frame ---
@@ -1302,6 +1344,7 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
 
             // Upload dynamic Gaussians
             {
+                ScopedStallTimer _t_dyn{"record_gs_prepass: update_dynamic_gaussians"};
                 auto count = static_cast<uint32_t>(gs_dynamic_buffer_.size());
                 if (count > gs_renderer_.max_dynamic_count()) {
                     gs_dynamic_buffer_.resize(gs_renderer_.max_dynamic_count());

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -1126,11 +1126,22 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
 
         bool camera_dirty = visibility_changed || budget_changed || gs_static_force_dirty_;
 
-        // If scene animations are active, force static rebuild each frame
-        if (gs_animator_.has_active_groups() || !gs_scene_animations_.empty()) {
-            gs_static_force_dirty_ = true;
-            camera_dirty = true;
-        }
+        // Animations don't require the heavy gather+re-tag — they can
+        // advance in place by calling gs_animator_.update on the
+        // existing gs_static_buffer_ + re-uploading. We track them
+        // separately and route to a much cheaper "animate-only" branch
+        // when visibility hasn't changed.
+        //
+        // The previous code forced camera_dirty=true whenever animations
+        // were present, which caused a per-frame re-gather + re-tag
+        // feedback loop: the static path always re-tags VFX/scene
+        // animations from gs_static_buffer_, leaving has_active_groups()
+        // true, which then forces camera_dirty again next frame even
+        // though visibility hadn't changed. Inside the dungeon (where
+        // scene_animations + slime VFX exist) this pinned the demo at
+        // ~14fps with a sustained 70ms/frame static-path stall.
+        const bool animations_present =
+            gs_animator_.has_active_groups() || !gs_scene_animations_.empty();
 
         // Sort-buffer reset is required every frame the merge runs with
         // dynamic content — the radix-sort scatter leaves stale keys in
@@ -1253,15 +1264,33 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             }
 
             gs_prev_view_ = gs_view_;
-            // Clear force_dirty only if it wasn't set by animations this frame
-            if (!gs_animator_.has_active_groups() && gs_scene_animations_.empty()) {
-                gs_static_force_dirty_ = false;
-            }
+            // Always clear force_dirty after completing the heavy path —
+            // the animate-only branch below handles per-frame animation
+            // updates without needing a re-gather. The previous
+            // "keep force_dirty true while animations active" behaviour
+            // pinned the dungeon at ~14fps because the heavy path then
+            // ran every frame.
+            gs_static_force_dirty_ = false;
+        } else if (animations_present && !determinism_test_state_.active &&
+                   flags.animation && !gs_static_buffer_.empty() &&
+                   gs_animator_.has_active_groups()) {
+            // Cheap animate-only path: visibility didn't change but the
+            // animator still has active groups, so step them in place
+            // and re-upload. Skips gather + re-tag (the per-frame loop
+            // that pinned the dungeon at 14fps). The animator's tagged
+            // regions remain valid because the buffer hasn't been
+            // re-gathered.
+            ScopedStallTimer _t_anim_only{"record_gs_prepass: animate-only path"};
+            gs_animator_.update(dt, gs_static_buffer_);
+            auto count = static_cast<uint32_t>(gs_static_buffer_.size());
+            if (count > gs_renderer_.max_static_count()) count = gs_renderer_.max_static_count();
+            gs_renderer_.update_static_gaussians(gs_static_buffer_.data(), count);
         } else if (dynamics_active && !determinism_test_state_.active) {
-            // Cheap path: visibility didn't change but dynamics exist,
-            // so the sort buffers still need a reset (otherwise the
-            // radix-merge reads stale keys from last frame's scatter).
-            // ~5ms instead of ~175ms.
+            // Cheap sort-only path: visibility didn't change AND no
+            // animations need stepping, but dynamics exist so the sort
+            // buffers still need a reset (otherwise the radix-merge
+            // reads stale keys from last frame's scatter). ~5ms instead
+            // of ~175ms.
             ScopedStallTimer _t_sort_only{"record_gs_prepass: reset_static_sort_only"};
             gs_renderer_.reset_static_sort_only();
         }

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -1126,22 +1126,11 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
 
         bool camera_dirty = visibility_changed || budget_changed || gs_static_force_dirty_;
 
-        // Animations don't require the heavy gather+re-tag — they can
-        // advance in place by calling gs_animator_.update on the
-        // existing gs_static_buffer_ + re-uploading. We track them
-        // separately and route to a much cheaper "animate-only" branch
-        // when visibility hasn't changed.
-        //
-        // The previous code forced camera_dirty=true whenever animations
-        // were present, which caused a per-frame re-gather + re-tag
-        // feedback loop: the static path always re-tags VFX/scene
-        // animations from gs_static_buffer_, leaving has_active_groups()
-        // true, which then forces camera_dirty again next frame even
-        // though visibility hadn't changed. Inside the dungeon (where
-        // scene_animations + slime VFX exist) this pinned the demo at
-        // ~14fps with a sustained 70ms/frame static-path stall.
-        const bool animations_present =
-            gs_animator_.has_active_groups() || !gs_scene_animations_.empty();
+        // If scene animations are active, force static rebuild each frame
+        if (gs_animator_.has_active_groups() || !gs_scene_animations_.empty()) {
+            gs_static_force_dirty_ = true;
+            camera_dirty = true;
+        }
 
         // Sort-buffer reset is required every frame the merge runs with
         // dynamic content — the radix-sort scatter leaves stale keys in
@@ -1264,33 +1253,15 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             }
 
             gs_prev_view_ = gs_view_;
-            // Always clear force_dirty after completing the heavy path —
-            // the animate-only branch below handles per-frame animation
-            // updates without needing a re-gather. The previous
-            // "keep force_dirty true while animations active" behaviour
-            // pinned the dungeon at ~14fps because the heavy path then
-            // ran every frame.
-            gs_static_force_dirty_ = false;
-        } else if (animations_present && !determinism_test_state_.active &&
-                   flags.animation && !gs_static_buffer_.empty() &&
-                   gs_animator_.has_active_groups()) {
-            // Cheap animate-only path: visibility didn't change but the
-            // animator still has active groups, so step them in place
-            // and re-upload. Skips gather + re-tag (the per-frame loop
-            // that pinned the dungeon at 14fps). The animator's tagged
-            // regions remain valid because the buffer hasn't been
-            // re-gathered.
-            ScopedStallTimer _t_anim_only{"record_gs_prepass: animate-only path"};
-            gs_animator_.update(dt, gs_static_buffer_);
-            auto count = static_cast<uint32_t>(gs_static_buffer_.size());
-            if (count > gs_renderer_.max_static_count()) count = gs_renderer_.max_static_count();
-            gs_renderer_.update_static_gaussians(gs_static_buffer_.data(), count);
+            // Clear force_dirty only if it wasn't set by animations this frame
+            if (!gs_animator_.has_active_groups() && gs_scene_animations_.empty()) {
+                gs_static_force_dirty_ = false;
+            }
         } else if (dynamics_active && !determinism_test_state_.active) {
-            // Cheap sort-only path: visibility didn't change AND no
-            // animations need stepping, but dynamics exist so the sort
-            // buffers still need a reset (otherwise the radix-merge
-            // reads stale keys from last frame's scatter). ~5ms instead
-            // of ~175ms.
+            // Cheap path: visibility didn't change but dynamics exist,
+            // so the sort buffers still need a reset (otherwise the
+            // radix-merge reads stale keys from last frame's scatter).
+            // ~5ms instead of ~175ms.
             ScopedStallTimer _t_sort_only{"record_gs_prepass: reset_static_sort_only"};
             gs_renderer_.reset_static_sort_only();
         }

--- a/src/engine/systems/transition_system.cpp
+++ b/src/engine/systems/transition_system.cpp
@@ -57,6 +57,19 @@ void transition_system(ecs::World& world, ITransitionHost& host, float dt) {
                 }
 
                 case SceneTransition::State::SceneIn: {
+                    // Pin the overlay at fully-opaque while the host is still
+                    // performing an async scene load (PLY parse + GPU upload
+                    // running in the background; the IslandDemoState Phase B
+                    // post-load body has not yet fired). Resetting `timer`
+                    // each frame in this state keeps `progress()` at zero so
+                    // the fade-in starts fresh once loading completes — that
+                    // way the user always sees the full kFadeIn sweep, not a
+                    // partially-faded reveal.
+                    if (host.is_async_loading()) {
+                        st.timer = 0.0f;
+                        fade.alpha = 1.0f;
+                        break;
+                    }
                     const float t = progress(st);
                     fade.alpha = 1.0f - t;
                     if (t >= 1.0f) {


### PR DESCRIPTION
## Summary

Fixes the post-#380/#381 portal regressions surfaced in the GS demo: streaming "deadlock" / loading-spinner stalls during normal play, the "old initial-frame configuration flashes back" ghost during transitions, and a duplicate-PC visual at spawn after a dungeon round-trip.

The branch lands these in three layers:

- **Per-frame GS intermediate images.** `output_image_`, `depth_image_`, `processed_image_` (and the render / post_process / tile_render descriptor sets that bind them) become `std::array<…, kMaxFramesInFlight>`, so Frame N+1's compute dispatch no longer races Frame N's composite read on a single shared `VkImage`. `gs_renderer_.render(cmd, current_frame, view, proj)` now takes a frame index; `DescriptorManager::allocate_sprite_sets_per_frame` binds set i to view i for the swapchain blit. Composite render-pass loadOp flips from DONT_CARE → CLEAR to defend against swapchain-image cycling.

- **Async PLY parsing + loading overlay.** `GsSceneLoader::load` is split into `parse(scene_data) -> ParsedScene` (CPU-only, safe on a worker) and `finalize_on_main(...)` (Vulkan + ECS). `AppBase::begin_async_load_gs_scene` kicks the parse off via `std::async(std::launch::async, …)`; `tick_async_load_gs_scene` (called from `main_loop` every frame) non-blockingly polls the future and runs finalize when it's ready. Portal transitions in `IslandDemoState` split into Phase A (sync prep + async kickoff) and Phase B (`finish_portal_transition`, drained from `update()` once `is_async_loading_gs_scene()` flips false). The earlier `current_scene_path == scene_path_` string-equality gate is replaced by an explicit `disable_world_streaming_` boolean.

- **Flashback fix.** Three follow-ups for the visual ghost: ① `pending_async_scene_.emplace(...)` happens before taking the `SceneData*` for the worker, otherwise the worker reads moved-from data and finalize silently uploads an empty cloud (Phase B then re-merges the OLD scene's chunks back in — the actual flashback). ② SceneIn fade entity creation moves from Phase B to Phase A so the opaque overlay covers the entire async-parse window, not just the post-finalize tail. ③ `ITransitionHost::is_async_loading()` lets `transition_system` pin SceneIn alpha at 1.0 and reset its timer until the load completes, so the fade-in animation only starts once the new scene is fully ready.

Diagnostic scaffolding shipped alongside: `ScopedStallTimer` ([\`include/gseurat/engine/scoped_timer.hpp\`](include/gseurat/engine/scoped_timer.hpp)) emits `[StallWarn] <label> blocked main thread for X.Yms` when a labelled scope crosses 50 ms; `Renderer::drop_all_gs_chunks_now` exposes a synchronous chunk drain for the portal path; the `RendererStatsDumper` snapshot grows a per-chunk inventory + pending-load count.

## Verified

- Full `cmake --build --preset macos-release` clean (`gseurat_demo`, `gseurat_staging`, `gseurat_core`).
- Smoke-test loads `seurat_island` cleanly and walks to the dungeon portal: parse runs on a worker (`[GS] (parse) Terrain PLY: …`), the WARMING UP overlay covers the load window, no stale residue between the old scene and the dungeon.
- Phase B portal stall went 282 ms → under the 50 ms `StallWarn` threshold; remaining 75 ms in Phase A is the unavoidable `vkDeviceWaitIdle` that has to drain the GPU before the new scene's resources can be safely uploaded.

## Test plan

- [ ] Walk to the dungeon portal and back several times; confirm no whole-screen flash of the previous scene during the WARMING UP overlay.
- [ ] During transition, watch logs for `[StallWarn]` entries above 50 ms — only Phase A's `wait_idle + drop_chunks` should fire.
- [ ] Walk in the overworld toward newly-streaming chunks; the OS spinner / multi-frame stall should be gone (parses are on a worker via `IslandDemoState::enqueue_async_chunk_load`).
- [ ] Round-trip dungeon → overworld: confirm the player splats are at `target_position`, not the authored bone-allocation position, and there is no second "ghost PC" at spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)