### PR TITLE
fix(gs): kill streaming beachball + steady-state walking stalls

### DIFF
--- a/include/gseurat/engine/buffer.hpp
+++ b/include/gseurat/engine/buffer.hpp
@@ -40,6 +40,12 @@ public:
     static Buffer create_storage_indirect(VmaAllocator allocator, VkDeviceSize size);
     static Buffer create_storage_gpu_only(VmaAllocator allocator, VkDeviceSize size);
     static Buffer create_storage_readback(VmaAllocator allocator, VkDeviceSize size);
+    // Host-visible+mapped storage buffer that *also* accepts vkCmdUpdateBuffer /
+    // vkCmdCopyBuffer / vkCmdFillBuffer writes (TRANSFER_DST_BIT). Use this for
+    // SSBOs that are read by shaders every frame but updated mid-stream from
+    // the main thread — recording the update via the GPU command stream avoids
+    // the host/device race that pure mapped writes have against in-flight reads.
+    static Buffer create_storage_host_dst(VmaAllocator allocator, VkDeviceSize size);
     static Buffer create_staging(VmaAllocator allocator, VkDeviceSize size);
     static Buffer create_readback(VmaAllocator allocator, VkDeviceSize size);
 

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -356,6 +356,11 @@ private:
         VkDescriptorSet scatter_ab, VkDescriptorSet scatter_ba);
     void dispatch_tile_sort(VkCommandBuffer cmd);
     void load_cloud_legacy(const GaussianCloud& cloud);
+    // Drain pending_publications_ and record the metadata writes
+    // (page_table, chunk_table) onto `cmd` via vkCmdUpdateBuffer + a
+    // TRANSFER_WRITE -> SHADER_READ barrier. Called from poll_transfers
+    // immediately after poll_completions enqueues new publications.
+    void publish_pending_chunks(VkCommandBuffer cmd);
 
     VkDevice device_ = VK_NULL_HANDLE;
     VmaAllocator allocator_ = VK_NULL_HANDLE;
@@ -461,6 +466,20 @@ private:
         bool completion_enqueued = false; // true once enqueue_completion() ran
     };
     std::deque<PendingLoadJob> pending_loads_;
+
+    // Chunks whose Gaussian SSBO data has finished uploading on the GPU but
+    // whose metadata (page_table, chunk_table) hasn't been published yet.
+    // The transfer-completion callback only enqueues here; the actual
+    // metadata writes happen in publish_pending_chunks() recorded onto the
+    // current frame's command buffer. This avoids the host/device race that
+    // raw mapped writes have against in-flight GPU reads of the same SSBOs.
+    struct PendingChunkPublication {
+        SlabAllocator::SlabHandle handle;
+        uint32_t splat_count = 0;
+        uint32_t slabs_needed = 0;
+        uint32_t slab_size_splats = 0;
+    };
+    std::deque<PendingChunkPublication> pending_publications_;
 
     uint32_t gaussian_count_ = 0;
     uint32_t max_gaussian_count_ = 0;

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -140,6 +140,19 @@ public:
     bool static_dirty() const { return static_dirty_; }
     void set_static_dirty(bool d) { static_dirty_ = d; }
 
+    // True when a metadata mutation (currently: Unload publication that
+    // shrinks `static_count_`) has left the static sort buffers' tail
+    // entries [new_count, old_count) holding stale REAL depth keys
+    // instead of the 0xFFFFFFFF sentinels the merge step expects. The
+    // renderer queries this every frame; a true value forces a static
+    // rebuild whose update_static_gaussians call re-runs init_sort_buf
+    // and clears the flag. Without this gate, the static+dynamic merge
+    // can interleave stale entries into the sorted output (flicker /
+    // wrong-depth artefacts) on frames where dynamic emitters force
+    // camera_dirty true but visibility/animation/LOD/VFX-set state are
+    // unchanged so the rebuild-skip fast path would otherwise fire.
+    bool static_sort_needs_reinit() const { return static_sort_needs_reinit_; }
+
     void resize_output(uint32_t width, uint32_t height);
 
     // Records a one-time barrier+clear that transitions every per-frame
@@ -424,6 +437,11 @@ private:
     uint32_t static_sort_workgroups_ = 0;
     uint32_t dynamic_sort_workgroups_ = 0;
     bool static_dirty_ = true;
+    // Set by publish_pending_chunks when an Unload publication shrinks
+    // static_count_. Cleared by update_static_gaussians after init_sort_buf
+    // restores the [new_count, sort_size) sentinel tail. See the public
+    // static_sort_needs_reinit() getter for the rationale.
+    bool static_sort_needs_reinit_ = false;
 
     // --- Streaming architecture (Phase 2) ---
     StreamingConfig streaming_config_;

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -467,19 +467,42 @@ private:
     };
     std::deque<PendingLoadJob> pending_loads_;
 
-    // Chunks whose Gaussian SSBO data has finished uploading on the GPU but
-    // whose metadata (page_table, chunk_table) hasn't been published yet.
-    // The transfer-completion callback only enqueues here; the actual
-    // metadata writes happen in publish_pending_chunks() recorded onto the
-    // current frame's command buffer. This avoids the host/device race that
-    // raw mapped writes have against in-flight GPU reads of the same SSBOs.
+    // Chunks whose metadata mutation (page_table, chunk_table) has been
+    // requested but not yet published on the GPU. Both load completions and
+    // unload requests enqueue here; the actual SSBO writes happen in
+    // publish_pending_chunks() recorded onto the current frame's command
+    // buffer with TRANSFER_WRITE -> SHADER_READ barriers. This avoids the
+    // host/device race that raw mapped writes have against in-flight GPU
+    // reads of the same SSBOs.
     struct PendingChunkPublication {
+        enum class Op { Load, Unload };
+        Op op = Op::Load;
+        // Load: handle for the new chunk (slabs already filled via TransferQueue).
+        // Unload: ownership of the chunk's slab handle, captured from
+        //         active_chunks_ at unload_cloud() time. The handle stays
+        //         in this struct until publish moves it onto
+        //         deferred_slab_releases_ for fence-safe release.
         SlabAllocator::SlabHandle handle;
-        uint32_t splat_count = 0;
+        uint32_t splat_count = 0;        // Load only
         uint32_t slabs_needed = 0;
-        uint32_t slab_size_splats = 0;
+        uint32_t slab_size_splats = 0;   // Load only
+        uint32_t unload_chunk_id = 0;    // Unload only
     };
     std::deque<PendingChunkPublication> pending_publications_;
+
+    // Slabs released by an unload have to outlive any in-flight frame that
+    // was reading them via the OLD page_table. We can't return them to the
+    // allocator immediately — a concurrent load could check those same
+    // physical slabs out and TransferQueue would overwrite Gaussian data
+    // still being read by the prior frame. Hold for at least
+    // kMaxFramesInFlight ticks of poll_transfers (+1 for slack), then
+    // release. That guarantees the frame which last referenced the OLD
+    // page_table has retired.
+    struct DeferredSlabRelease {
+        SlabAllocator::SlabHandle handle;
+        uint32_t frames_remaining = 0;
+    };
+    std::deque<DeferredSlabRelease> deferred_slab_releases_;
 
     uint32_t gaussian_count_ = 0;
     uint32_t max_gaussian_count_ = 0;

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -328,6 +328,12 @@ private:
     std::vector<SceneAnimation> gs_scene_animations_;
     std::vector<VfxInstance> vfx_instances_;
     std::vector<uint32_t> gs_prev_visible_;
+    // Tracks vfx_instances_.size() observed during the last static-rebuild
+    // frame. A change between frames means a VfxInstance was spawned or
+    // expired, which invalidates the appended VFX-object splats in
+    // gs_static_buffer_ and forces a rebuild. Cheap proxy for "did the VFX
+    // instance set actually change" without keeping a side-table of IDs.
+    size_t gs_prev_vfx_count_ = 0;
     bool gs_skip_chunk_cull_ = false;
 
     // ── Frame-determinism harness internal state ──

--- a/src/engine/buffer.cpp
+++ b/src/engine/buffer.cpp
@@ -129,6 +129,28 @@ Buffer Buffer::create_storage_indirect(VmaAllocator allocator, VkDeviceSize size
     return buf;
 }
 
+Buffer Buffer::create_storage_host_dst(VmaAllocator allocator, VkDeviceSize size) {
+    VkBufferCreateInfo buf_info{};
+    buf_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    buf_info.size = size;
+    buf_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo alloc_info{};
+    alloc_info.usage = VMA_MEMORY_USAGE_AUTO;
+    alloc_info.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                       VMA_ALLOCATION_CREATE_MAPPED_BIT;
+
+    Buffer buf;
+    VmaAllocationInfo info;
+    if (vmaCreateBuffer(allocator, &buf_info, &alloc_info, &buf.buffer_, &buf.allocation_,
+                        &info) != VK_SUCCESS) {
+        throw std::runtime_error("Failed to create host_dst storage buffer");
+    }
+    buf.mapped_ = info.pMappedData;
+    return buf;
+}
+
 Buffer Buffer::create_storage_gpu_only(VmaAllocator allocator, VkDeviceSize size) {
     VkBufferCreateInfo buf_info{};
     buf_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1045,8 +1045,19 @@ void GsRenderer::clear_chunks(VkCommandBuffer drain_cmd) {
     static_count_ = 0;
     total_active_splats_ = 0;
     gaussian_count_ = 0;
+    dynamic_count_ = 0;
     sort_done_once_ = false;
     static_dirty_ = true;
+
+    // Zero the dynamic SSBO so a future over-count of `dynamic_count_`
+    // can't surface old-scene gaussians as ghost geometry. memset (not
+    // vkCmdFillBuffer) because Buffer::create_storage omits TRANSFER_DST_BIT;
+    // the buffer is HOST_VISIBLE+MAPPED, and `vkDeviceWaitIdle` above
+    // guarantees the GPU is idle here.
+    if (dynamic_gaussian_ssbo_.mapped() && max_dynamic_count_ > 0) {
+        std::memset(dynamic_gaussian_ssbo_.mapped(), 0,
+                    static_cast<size_t>(max_dynamic_count_) * sizeof(GpuGaussian));
+    }
 }
 
 std::vector<GsRenderer::ChunkInventoryEntry> GsRenderer::chunk_inventory() const {

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1023,6 +1023,34 @@ void GsRenderer::clear_chunks(VkCommandBuffer drain_cmd) {
     // need recording.
     if (transfer_queue_) transfer_queue_->poll_completions(drain_cmd);
 
+    // poll_completions above can fire transfer-completion callbacks that
+    // enqueue new PendingChunkPublication entries referencing OLD-scene
+    // slabs. If we don't drain them here, the next poll_transfers (after
+    // the new scene has loaded) would publish stale page_table /
+    // chunk_table writes for slabs the new scene never owned —
+    // ghost-chunk metadata leaking across scene boundary. Same hazard
+    // for deferred_slab_releases_: those handles' frame counters would
+    // tick past after we wipe everything, releasing slabs that belong
+    // to a freshly-checked-out new chunk.
+    //
+    // GPU is idle (vkDeviceWaitIdle above) so direct slab releases here
+    // are safe.
+    for (auto& p : pending_publications_) {
+        // Op::Load owns slab handles not yet in active_chunks_ — release
+        // them directly, otherwise they leak from the allocator.
+        // Op::Unload's handle is empty: the actual chunk handle is still
+        // in active_chunks_, released by the loop further down.
+        if (p.op == PendingChunkPublication::Op::Load) {
+            slab_allocator_->release(p.handle);
+        }
+    }
+    pending_publications_.clear();
+
+    for (auto& dr : deferred_slab_releases_) {
+        slab_allocator_->release(dr.handle);
+    }
+    deferred_slab_releases_.clear();
+
     // Anything still in `pending_loads_` had its `submit_with_handle`
     // runs partially completed (or not at all) — those slab handles
     // own slabs we never published into `active_chunks_`. Release
@@ -1365,6 +1393,20 @@ void GsRenderer::publish_pending_chunks(VkCommandBuffer cmd) {
             // shift, so chunk_table needs a full rewrite below.
             active_chunks_.erase(it);
             chunk_table_needs_full_rebuild = true;
+
+            // Step 4: flag the static sort buffers as needing a sentinel-
+            // tail reinit. This unload shrinks static_count_, so entries
+            // [new_count, old_count) in static_sort_a_/b_ now hold stale
+            // REAL depth keys from the prior frame's sort. Without a
+            // reinit they'd participate in the next preprocess+sort+merge
+            // as legitimate elements (their keys aren't 0xFFFFFFFF
+            // sentinels), corrupting the merged-sort output. We can't
+            // safely host-write to the sort buffer here (race vs the
+            // in-flight prior frame's GPU read), so we defer: the flag
+            // is picked up by Renderer::draw_scene's need_rebuild gate
+            // on the next camera-dirty frame, and update_static_gaussians
+            // re-runs init_sort_buf to restore the sentinel-tail invariant.
+            static_sort_needs_reinit_ = true;
         }
 
         any_published = true;
@@ -1729,6 +1771,8 @@ void GsRenderer::update_static_gaussians(const Gaussian* data, uint32_t count) {
     };
     init_sort_buf(static_sort_a_, static_sort_size_, count);
     init_sort_buf(static_sort_b_, static_sort_size_, count);
+    // Sentinel tail just rewritten — unblock the rebuild-skip fast path.
+    static_sort_needs_reinit_ = false;
 }
 
 void GsRenderer::update_dynamic_gaussians(const Gaussian* data, uint32_t count) {

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -842,14 +842,19 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
                      static_cast<float>(depth_status_size) / 1024.0f);
     }
 
-    // Page table: one uint32 per slab, initialized to 0xFFFFFFFF (invalid)
-    page_table_ssbo_ = Buffer::create_storage(allocator_,
+    // Page table: one uint32 per slab, initialized to 0xFFFFFFFF (invalid).
+    // host_dst variant: reads happen on the GPU every frame; updates from
+    // chunk-load completions are recorded as vkCmdUpdateBuffer onto the
+    // current frame's cmd buffer with a TRANSFER_WRITE -> SHADER_READ barrier
+    // so they don't tear under in-flight GPU reads.
+    page_table_ssbo_ = Buffer::create_storage_host_dst(allocator_,
         static_cast<VkDeviceSize>(config.total_slabs()) * sizeof(uint32_t));
     std::memset(page_table_ssbo_.mapped(), 0xFF,
                 config.total_slabs() * sizeof(uint32_t));
 
-    // Chunk table: 256 entries x 16 bytes each, zeroed
-    chunk_table_ssbo_ = Buffer::create_storage(allocator_, 256 * 16);
+    // Chunk table: 256 entries x 16 bytes each, zeroed. Same host_dst
+    // rationale as page_table.
+    chunk_table_ssbo_ = Buffer::create_storage_host_dst(allocator_, 256 * 16);
     std::memset(chunk_table_ssbo_.mapped(), 0, 256 * 16);
 
     // Zero the counts buffer
@@ -1196,8 +1201,12 @@ void GsRenderer::poll_transfers(VkCommandBuffer frame_cmd) {
         }
 
         // Front job is fully submitted. Queue the completion marker —
-        // exactly once per job — that publishes the chunk to the
-        // renderer when the GPU fence retires.
+        // exactly once per job. The fence-retire callback only enqueues a
+        // PendingChunkPublication; the actual page_table / chunk_table
+        // writes happen later on the current frame's command buffer in
+        // publish_pending_chunks(). That serialises the metadata update
+        // through the GPU command stream so it can't tear under in-flight
+        // shader reads.
         if (!job.completion_enqueued) {
             job.completion_enqueued = true;
             auto handle      = std::move(job.slab_handle);
@@ -1207,49 +1216,12 @@ void GsRenderer::poll_transfers(VkCommandBuffer frame_cmd) {
 
             transfer_queue_->enqueue_completion(
                 [this, handle = std::move(handle), splat_count, slabs_needed, sps_local]() mutable {
-                    uint32_t page_table_offset = 0;
-                    for (const auto& chunk : active_chunks_) {
-                        page_table_offset += static_cast<uint32_t>(chunk.handle.slab_indices.size());
-                    }
-
-                    auto* pt = static_cast<uint32_t*>(page_table_ssbo_.mapped());
-                    for (uint32_t i = 0; i < slabs_needed; ++i) {
-                        pt[page_table_offset + i] = handle.slab_indices[i];
-                    }
-
-                    auto* ct = static_cast<uint8_t*>(chunk_table_ssbo_.mapped());
-                    const uint32_t chunk_idx = static_cast<uint32_t>(active_chunks_.size());
-                    const uint32_t last_slab_splats = splat_count - (slabs_needed - 1) * sps_local;
-                    const uint32_t entry[4] = {page_table_offset, slabs_needed, last_slab_splats, splat_count};
-                    std::memcpy(ct + chunk_idx * 16, entry, 16);
-
-                    ChunkState cs;
-                    cs.status = ChunkState::Status::ACTIVE;
-                    cs.handle = std::move(handle);
-                    cs.page_table_offset = page_table_offset;
-                    cs.splat_count = splat_count;
-                    active_chunks_.push_back(std::move(cs));
-
-                    static_count_ = 0;
-                    for (const auto& c : active_chunks_) static_count_ += c.splat_count;
-                    total_active_splats_ = static_count_;
-                    gaussian_count_ = static_count_;
-
-                    std::vector<SortEntry> staging(static_sort_size_);
-                    for (uint32_t i = 0; i < static_sort_size_; ++i) {
-                        staging[i].key = 0xFFFFFFFF;
-                        staging[i].index = i < static_count_ ? i : 0;
-                    }
-                    std::memcpy(static_sort_a_.mapped(), staging.data(),
-                                static_sort_size_ * sizeof(SortEntry));
-                    std::memcpy(static_sort_b_.mapped(), staging.data(),
-                                static_sort_size_ * sizeof(SortEntry));
-
-                    static_dirty_ = true;
-
-                    std::fprintf(stderr,
-                        "GS: Async load complete — %u splats in %u slabs (total active: %u)\n",
-                        splat_count, slabs_needed, static_count_);
+                    PendingChunkPublication p;
+                    p.handle = std::move(handle);
+                    p.splat_count = splat_count;
+                    p.slabs_needed = slabs_needed;
+                    p.slab_size_splats = sps_local;
+                    pending_publications_.push_back(std::move(p));
                 });
         }
 
@@ -1259,6 +1231,115 @@ void GsRenderer::poll_transfers(VkCommandBuffer frame_cmd) {
     }
 
     transfer_queue_->poll_completions(frame_cmd);
+    publish_pending_chunks(frame_cmd);
+}
+
+void GsRenderer::publish_pending_chunks(VkCommandBuffer cmd) {
+    if (pending_publications_.empty()) return;
+    if (cmd == VK_NULL_HANDLE) return;
+
+    bool any_published = false;
+
+    while (!pending_publications_.empty()) {
+        PendingChunkPublication p = std::move(pending_publications_.front());
+        pending_publications_.pop_front();
+
+        // Page table offset for this chunk = sum of slab counts of all
+        // already-active chunks. Computed sequentially as we publish.
+        uint32_t page_table_offset = 0;
+        for (const auto& chunk : active_chunks_) {
+            page_table_offset += static_cast<uint32_t>(chunk.handle.slab_indices.size());
+        }
+
+        // page_table entries: one uint32 (the physical slab index) per slab
+        // owned by this chunk. vkCmdUpdateBuffer is bounded to 65536 bytes;
+        // a typical chunk has <=100 slabs (400 bytes), so this fits trivially.
+        if (!p.handle.slab_indices.empty()) {
+            const VkDeviceSize pt_offset_bytes =
+                static_cast<VkDeviceSize>(page_table_offset) * sizeof(uint32_t);
+            const VkDeviceSize pt_size_bytes =
+                static_cast<VkDeviceSize>(p.handle.slab_indices.size()) * sizeof(uint32_t);
+            if (pt_size_bytes <= 65536) {
+                vkCmdUpdateBuffer(cmd, page_table_ssbo_.buffer(),
+                                  pt_offset_bytes, pt_size_bytes,
+                                  p.handle.slab_indices.data());
+            } else {
+                std::fprintf(stderr,
+                    "[gs_renderer] publish: page_table update %llu bytes exceeds "
+                    "vkCmdUpdateBuffer 65536-byte limit; chunk has %zu slabs\n",
+                    static_cast<unsigned long long>(pt_size_bytes),
+                    p.handle.slab_indices.size());
+            }
+        }
+
+        // chunk_table entry: 16 bytes ({page_table_offset, slabs_needed,
+        // last_slab_splats, splat_count}) at index `chunk_idx * 16`.
+        const uint32_t chunk_idx = static_cast<uint32_t>(active_chunks_.size());
+        const uint32_t last_slab_splats =
+            p.splat_count - (p.slabs_needed - 1) * p.slab_size_splats;
+        const uint32_t entry[4] = {page_table_offset, p.slabs_needed,
+                                    last_slab_splats, p.splat_count};
+        vkCmdUpdateBuffer(cmd, chunk_table_ssbo_.buffer(),
+                          static_cast<VkDeviceSize>(chunk_idx) * 16,
+                          sizeof(entry), entry);
+
+        // CPU-side bookkeeping. Counts must update in the same step so the
+        // next frame's render() sees a consistent {static_count_, page_table,
+        // chunk_table} triple. The GPU reads the new metadata only after
+        // the barrier at the end of this function, so a graphics dispatch
+        // recorded *later* in this same cmd buffer will see fresh data.
+        ChunkState cs;
+        cs.status = ChunkState::Status::ACTIVE;
+        cs.handle = std::move(p.handle);
+        cs.page_table_offset = page_table_offset;
+        cs.splat_count = p.splat_count;
+        active_chunks_.push_back(std::move(cs));
+
+        static_count_ = 0;
+        for (const auto& c : active_chunks_) static_count_ += c.splat_count;
+        total_active_splats_ = static_count_;
+        gaussian_count_ = static_count_;
+        static_dirty_ = true;
+
+        // Note: we deliberately do NOT reinitialise static_sort_a_ /
+        // static_sort_b_ here. The depth sort regenerates keys for
+        // [0, static_count_) every frame, and entries beyond static_count_
+        // retain their 0xFFFFFFFF sentinel keys from the original sort
+        // buffer init (in load_cloud_legacy / load_cloud). The previous
+        // implementation memcpy'd a fresh sentinel pattern over the whole
+        // sort buffer here — which raced with frame N-1's sort dispatch
+        // reading the same buffer. Skipping it is correct AND removes
+        // the second host/device race in this path.
+
+        any_published = true;
+
+        std::fprintf(stderr,
+            "GS: Async load complete — %u splats in %u slabs (total active: %u)\n",
+            p.splat_count, p.slabs_needed, static_count_);
+    }
+
+    if (any_published) {
+        // Single barrier covering both metadata buffers: TRANSFER_WRITE
+        // (vkCmdUpdateBuffer's effective stage) -> SHADER_READ. Without
+        // this, subsequent compute dispatches in the same cmd buffer
+        // could read the metadata with the writes still in flight.
+        VkBufferMemoryBarrier barriers[2]{};
+        barriers[0].sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+        barriers[0].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        barriers[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        barriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barriers[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barriers[0].buffer = page_table_ssbo_.buffer();
+        barriers[0].offset = 0;
+        barriers[0].size = VK_WHOLE_SIZE;
+        barriers[1] = barriers[0];
+        barriers[1].buffer = chunk_table_ssbo_.buffer();
+
+        vkCmdPipelineBarrier(cmd,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            0, 0, nullptr, 2, barriers, 0, nullptr);
+    }
 }
 
 void GsRenderer::load_cloud_legacy(const GaussianCloud& cloud) {
@@ -1427,7 +1508,7 @@ void GsRenderer::load_cloud_legacy(const GaussianCloud& cloud) {
 
     // Allocate a dummy page table buffer for binding 8 (legacy path, USE_PAGE_TABLE=0)
     page_table_ssbo_.destroy(allocator_);
-    page_table_ssbo_ = Buffer::create_storage(allocator_, sizeof(uint32_t));
+    page_table_ssbo_ = Buffer::create_storage_host_dst(allocator_, sizeof(uint32_t));
     {
         auto* pt = static_cast<uint32_t*>(page_table_ssbo_.mapped());
         pt[0] = 0xFFFFFFFF;

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -987,34 +987,20 @@ void GsRenderer::load_cloud(const GaussianCloud& cloud) {
 
 void GsRenderer::unload_cloud(uint32_t chunk_id) {
     if (!streaming_initialized_) return;
+    // Verify the chunk actually exists before queuing — caller may
+    // double-unload during world-streamer churn. We don't mutate
+    // active_chunks_ here; publish_pending_chunks does the actual
+    // removal (and the page_table/chunk_table writes) inside the
+    // current frame's command buffer so the GPU-side metadata update
+    // is properly ordered against in-flight reads.
     auto it = std::find_if(active_chunks_.begin(), active_chunks_.end(),
         [chunk_id](const ChunkState& c) { return c.handle.chunk_id == chunk_id; });
     if (it == active_chunks_.end()) return;
 
-    // Invalidate page table entries
-    auto* pt = static_cast<uint32_t*>(page_table_ssbo_.mapped());
-    for (uint32_t i = 0; i < it->handle.slab_indices.size(); ++i) {
-        pt[it->page_table_offset + i] = 0xFFFFFFFF;
-    }
-    slab_allocator_->release(it->handle);
-    active_chunks_.erase(it);
-
-    // Rebuild chunk table and recalculate counts
-    auto* ct = static_cast<uint8_t*>(chunk_table_ssbo_.mapped());
-    uint32_t sps = streaming_config_.slab_size_splats;
-    static_count_ = 0;
-    for (size_t i = 0; i < active_chunks_.size(); ++i) {
-        auto& c = active_chunks_[i];
-        uint32_t nslabs = static_cast<uint32_t>(c.handle.slab_indices.size());
-        uint32_t last_slab_splats = c.splat_count - (nslabs - 1) * sps;
-        uint32_t entry[4] = {c.page_table_offset, nslabs, last_slab_splats, c.splat_count};
-        std::memcpy(ct + i * 16, entry, 16);
-        static_count_ += c.splat_count;
-    }
-    std::memset(ct + active_chunks_.size() * 16, 0, (256 - active_chunks_.size()) * 16);
-    total_active_splats_ = static_count_;
-    gaussian_count_ = static_count_;
-    static_dirty_ = true;
+    PendingChunkPublication p;
+    p.op = PendingChunkPublication::Op::Unload;
+    p.unload_chunk_id = chunk_id;
+    pending_publications_.push_back(std::move(p));
 }
 
 void GsRenderer::clear_chunks(VkCommandBuffer drain_cmd) {
@@ -1217,6 +1203,7 @@ void GsRenderer::poll_transfers(VkCommandBuffer frame_cmd) {
             transfer_queue_->enqueue_completion(
                 [this, handle = std::move(handle), splat_count, slabs_needed, sps_local]() mutable {
                     PendingChunkPublication p;
+                    p.op = PendingChunkPublication::Op::Load;
                     p.handle = std::move(handle);
                     p.splat_count = splat_count;
                     p.slabs_needed = slabs_needed;
@@ -1235,66 +1222,176 @@ void GsRenderer::poll_transfers(VkCommandBuffer frame_cmd) {
 }
 
 void GsRenderer::publish_pending_chunks(VkCommandBuffer cmd) {
+    // Step 1: tick the deferred-release queue *before* doing anything that
+    // might check out new slabs. Slabs whose hold-time has expired are
+    // returned to the allocator now so they're available for incoming load
+    // publications below. Slabs queued THIS call (from an Unload op below)
+    // start their countdown on the next poll_transfers tick.
+    if (!deferred_slab_releases_.empty()) {
+        auto it = deferred_slab_releases_.begin();
+        while (it != deferred_slab_releases_.end()) {
+            if (it->frames_remaining == 0) {
+                slab_allocator_->release(it->handle);
+                it = deferred_slab_releases_.erase(it);
+            } else {
+                --it->frames_remaining;
+                ++it;
+            }
+        }
+    }
+
     if (pending_publications_.empty()) return;
     if (cmd == VK_NULL_HANDLE) return;
 
     bool any_published = false;
+    bool chunk_table_needs_full_rebuild = false;
 
     while (!pending_publications_.empty()) {
         PendingChunkPublication p = std::move(pending_publications_.front());
         pending_publications_.pop_front();
 
-        // Page table offset for this chunk = sum of slab counts of all
-        // already-active chunks. Computed sequentially as we publish.
-        uint32_t page_table_offset = 0;
-        for (const auto& chunk : active_chunks_) {
-            page_table_offset += static_cast<uint32_t>(chunk.handle.slab_indices.size());
-        }
-
-        // page_table entries: one uint32 (the physical slab index) per slab
-        // owned by this chunk. vkCmdUpdateBuffer is bounded to 65536 bytes;
-        // a typical chunk has <=100 slabs (400 bytes), so this fits trivially.
-        if (!p.handle.slab_indices.empty()) {
-            const VkDeviceSize pt_offset_bytes =
-                static_cast<VkDeviceSize>(page_table_offset) * sizeof(uint32_t);
-            const VkDeviceSize pt_size_bytes =
-                static_cast<VkDeviceSize>(p.handle.slab_indices.size()) * sizeof(uint32_t);
-            if (pt_size_bytes <= 65536) {
-                vkCmdUpdateBuffer(cmd, page_table_ssbo_.buffer(),
-                                  pt_offset_bytes, pt_size_bytes,
-                                  p.handle.slab_indices.data());
-            } else {
-                std::fprintf(stderr,
-                    "[gs_renderer] publish: page_table update %llu bytes exceeds "
-                    "vkCmdUpdateBuffer 65536-byte limit; chunk has %zu slabs\n",
-                    static_cast<unsigned long long>(pt_size_bytes),
-                    p.handle.slab_indices.size());
+        if (p.op == PendingChunkPublication::Op::Load) {
+            // === LOAD ===
+            // Page table offset for this chunk = sum of slab counts of all
+            // already-active chunks. Computed sequentially as we publish.
+            uint32_t page_table_offset = 0;
+            for (const auto& chunk : active_chunks_) {
+                page_table_offset += static_cast<uint32_t>(chunk.handle.slab_indices.size());
             }
+
+            // page_table entries: one uint32 (the physical slab index) per
+            // slab owned by this chunk. vkCmdUpdateBuffer is bounded to
+            // 65536 bytes; a typical chunk has <=100 slabs (400 bytes).
+            if (!p.handle.slab_indices.empty()) {
+                const VkDeviceSize pt_offset_bytes =
+                    static_cast<VkDeviceSize>(page_table_offset) * sizeof(uint32_t);
+                const VkDeviceSize pt_size_bytes =
+                    static_cast<VkDeviceSize>(p.handle.slab_indices.size()) * sizeof(uint32_t);
+                if (pt_size_bytes <= 65536) {
+                    vkCmdUpdateBuffer(cmd, page_table_ssbo_.buffer(),
+                                      pt_offset_bytes, pt_size_bytes,
+                                      p.handle.slab_indices.data());
+                } else {
+                    std::fprintf(stderr,
+                        "[gs_renderer] publish: page_table update %llu bytes "
+                        "exceeds vkCmdUpdateBuffer 65536-byte limit; chunk has "
+                        "%zu slabs\n",
+                        static_cast<unsigned long long>(pt_size_bytes),
+                        p.handle.slab_indices.size());
+                }
+            }
+
+            // chunk_table entry: 16 bytes at index `chunk_idx * 16`. If a
+            // sibling Unload publication runs after this one, that Unload
+            // path rewrites the full table (chunk indices shift), so this
+            // single-entry write may be overwritten — that's the correct
+            // outcome. Either way, the recorded vkCmdUpdateBuffers run in
+            // recorded order on the GPU, so the final state matches CPU
+            // active_chunks_.
+            const uint32_t chunk_idx = static_cast<uint32_t>(active_chunks_.size());
+            const uint32_t last_slab_splats =
+                p.splat_count - (p.slabs_needed - 1) * p.slab_size_splats;
+            const uint32_t entry[4] = {page_table_offset, p.slabs_needed,
+                                        last_slab_splats, p.splat_count};
+            vkCmdUpdateBuffer(cmd, chunk_table_ssbo_.buffer(),
+                              static_cast<VkDeviceSize>(chunk_idx) * 16,
+                              sizeof(entry), entry);
+
+            ChunkState cs;
+            cs.status = ChunkState::Status::ACTIVE;
+            cs.handle = std::move(p.handle);
+            cs.page_table_offset = page_table_offset;
+            cs.splat_count = p.splat_count;
+            active_chunks_.push_back(std::move(cs));
+
+            std::fprintf(stderr,
+                "GS: Async load complete — %u splats in %u slabs (total active: %u)\n",
+                p.splat_count, p.slabs_needed,
+                [this]() { uint32_t s = 0; for (auto& c : active_chunks_) s += c.splat_count; return s; }());
+
+        } else {
+            // === UNLOAD ===
+            auto it = std::find_if(active_chunks_.begin(), active_chunks_.end(),
+                [&](const ChunkState& c) { return c.handle.chunk_id == p.unload_chunk_id; });
+            if (it == active_chunks_.end()) {
+                // The chunk was already gone (double-unload races, or a
+                // clear_chunks ran between unload_cloud() and publish).
+                // Nothing to write; nothing to release.
+                continue;
+            }
+
+            // Step 1: invalidate this chunk's page_table entries. Write
+            // 0xFFFFFFFF (the configured sentinel) for every slab the chunk
+            // owned at `it->page_table_offset`. The GPU dispatches recorded
+            // later in this same cmd buffer (post-barrier) read these
+            // sentinel entries and skip the slot. The PRIOR frame, which
+            // saw the old entries, has already retired (we waited on its
+            // fence) — so no in-flight read of the old slabs persists past
+            // this cmd buffer's submission.
+            const uint32_t nslabs = static_cast<uint32_t>(it->handle.slab_indices.size());
+            if (nslabs > 0) {
+                std::vector<uint32_t> sentinel(nslabs, 0xFFFFFFFFu);
+                const VkDeviceSize pt_offset_bytes =
+                    static_cast<VkDeviceSize>(it->page_table_offset) * sizeof(uint32_t);
+                const VkDeviceSize pt_size_bytes =
+                    static_cast<VkDeviceSize>(nslabs) * sizeof(uint32_t);
+                if (pt_size_bytes <= 65536) {
+                    vkCmdUpdateBuffer(cmd, page_table_ssbo_.buffer(),
+                                      pt_offset_bytes, pt_size_bytes, sentinel.data());
+                } else {
+                    std::fprintf(stderr,
+                        "[gs_renderer] publish: unload page_table sentinel %llu bytes "
+                        "exceeds vkCmdUpdateBuffer 65536-byte limit\n",
+                        static_cast<unsigned long long>(pt_size_bytes));
+                }
+            }
+
+            // Step 2: hand the slab handle to the deferred-release queue.
+            // It survives at least kMaxFramesInFlight ticks of poll_transfers
+            // before the allocator gets it back, so a concurrent Load
+            // publication can't claim these physical slabs and overwrite
+            // them while the prior frame's GPU read is still in flight.
+            DeferredSlabRelease dr;
+            dr.handle = std::move(it->handle);
+            dr.frames_remaining = kMaxFramesInFlight + 1;
+            deferred_slab_releases_.push_back(std::move(dr));
+
+            // Step 3: erase from active_chunks_. Other chunks' indices
+            // shift, so chunk_table needs a full rewrite below.
+            active_chunks_.erase(it);
+            chunk_table_needs_full_rebuild = true;
         }
 
-        // chunk_table entry: 16 bytes ({page_table_offset, slabs_needed,
-        // last_slab_splats, splat_count}) at index `chunk_idx * 16`.
-        const uint32_t chunk_idx = static_cast<uint32_t>(active_chunks_.size());
-        const uint32_t last_slab_splats =
-            p.splat_count - (p.slabs_needed - 1) * p.slab_size_splats;
-        const uint32_t entry[4] = {page_table_offset, p.slabs_needed,
-                                    last_slab_splats, p.splat_count};
-        vkCmdUpdateBuffer(cmd, chunk_table_ssbo_.buffer(),
-                          static_cast<VkDeviceSize>(chunk_idx) * 16,
-                          sizeof(entry), entry);
+        any_published = true;
+    }
 
-        // CPU-side bookkeeping. Counts must update in the same step so the
-        // next frame's render() sees a consistent {static_count_, page_table,
+    // If any unload happened, chunk indices in active_chunks_ shifted, so
+    // the chunk_table on the GPU now references stale data. Rewrite the
+    // valid prefix and zero the tail. 256 entries × 16 B = 4 KiB — fits
+    // vkCmdUpdateBuffer's 65536-byte limit easily.
+    if (chunk_table_needs_full_rebuild) {
+        std::array<uint32_t, 256 * 4> ct_data{};  // zero-initialised
+        const uint32_t sps = streaming_config_.slab_size_splats;
+        for (size_t i = 0; i < active_chunks_.size(); ++i) {
+            const auto& c = active_chunks_[i];
+            const uint32_t cn = static_cast<uint32_t>(c.handle.slab_indices.size());
+            const uint32_t last_slab_splats = c.splat_count - (cn - 1) * sps;
+            ct_data[i * 4 + 0] = c.page_table_offset;
+            ct_data[i * 4 + 1] = cn;
+            ct_data[i * 4 + 2] = last_slab_splats;
+            ct_data[i * 4 + 3] = c.splat_count;
+        }
+        vkCmdUpdateBuffer(cmd, chunk_table_ssbo_.buffer(), 0,
+                          static_cast<VkDeviceSize>(ct_data.size()) * sizeof(uint32_t),
+                          ct_data.data());
+    }
+
+    if (any_published) {
+        // Recompute counts on the CPU side in the same step so the next
+        // frame's render() sees a consistent {static_count_, page_table,
         // chunk_table} triple. The GPU reads the new metadata only after
-        // the barrier at the end of this function, so a graphics dispatch
-        // recorded *later* in this same cmd buffer will see fresh data.
-        ChunkState cs;
-        cs.status = ChunkState::Status::ACTIVE;
-        cs.handle = std::move(p.handle);
-        cs.page_table_offset = page_table_offset;
-        cs.splat_count = p.splat_count;
-        active_chunks_.push_back(std::move(cs));
-
+        // the barrier below, so a graphics dispatch recorded *later* in
+        // this same cmd buffer will see fresh data.
         static_count_ = 0;
         for (const auto& c : active_chunks_) static_count_ += c.splat_count;
         total_active_splats_ = static_count_;
@@ -1303,22 +1400,10 @@ void GsRenderer::publish_pending_chunks(VkCommandBuffer cmd) {
 
         // Note: we deliberately do NOT reinitialise static_sort_a_ /
         // static_sort_b_ here. The depth sort regenerates keys for
-        // [0, static_count_) every frame, and entries beyond static_count_
-        // retain their 0xFFFFFFFF sentinel keys from the original sort
-        // buffer init (in load_cloud_legacy / load_cloud). The previous
-        // implementation memcpy'd a fresh sentinel pattern over the whole
-        // sort buffer here — which raced with frame N-1's sort dispatch
-        // reading the same buffer. Skipping it is correct AND removes
-        // the second host/device race in this path.
+        // [0, static_count_) every frame, and entries beyond
+        // static_count_ retain their 0xFFFFFFFF sentinel keys from the
+        // original sort buffer init (in load_cloud_legacy / load_cloud).
 
-        any_published = true;
-
-        std::fprintf(stderr,
-            "GS: Async load complete — %u splats in %u slabs (total active: %u)\n",
-            p.splat_count, p.slabs_needed, static_count_);
-    }
-
-    if (any_published) {
         // Single barrier covering both metadata buffers: TRANSFER_WRITE
         // (vkCmdUpdateBuffer's effective stage) -> SHADER_READ. Without
         // this, subsequent compute dispatches in the same cmd buffer

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1,5 +1,6 @@
 #include "gseurat/engine/gs_renderer.hpp"
 #include "gseurat/engine/pipeline.hpp"
+#include "gseurat/engine/scoped_timer.hpp"
 
 #include <chrono>
 #include <cmath>
@@ -1131,6 +1132,10 @@ std::vector<TransferQueue::Handle> GsRenderer::load_cloud_async(GaussianCloud cl
 
 void GsRenderer::poll_transfers(VkCommandBuffer frame_cmd) {
     if (!transfer_queue_) return;
+    // Diagnostic: full poll path covers slab-upload submits, completion
+    // callback drains, deferred slab releases, and the metadata publish.
+    // If the beachball is in any of those paths, this fires.
+    ScopedStallTimer _t_poll{"GsRenderer::poll_transfers"};
 
     // Drain queued slab uploads as long as the staging ring has space.
     // We process the front job's slabs, then advance to the next job

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -1132,11 +1132,16 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             // walking-time main-thread stalls when streaming is gated off
             // by the demo's pre-merge.
             ScopedStallTimer _t_static_rebuild{"gs_static_rebuild (visibility+gather+upload)"};
-            glm::mat4 gs_vp = gs_proj_ * gs_view_;
-            glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
-            // Use camera position for distance culling (camera sees ahead of player)
-            glm::vec3 dist_origin = cam_pos;
-            auto visible = gs_chunk_grid_.visible_chunks(gs_vp, dist_origin, gs_max_render_distance_);
+
+            std::vector<uint32_t> visible;
+            {
+                ScopedStallTimer _t_vis{"  > gs_chunk_grid.visible_chunks (frustum+dist cull)"};
+                glm::mat4 gs_vp = gs_proj_ * gs_view_;
+                glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
+                // Use camera position for distance culling (camera sees ahead of player)
+                glm::vec3 dist_origin = cam_pos;
+                visible = gs_chunk_grid_.visible_chunks(gs_vp, dist_origin, gs_max_render_distance_);
+            }
 
             if ((visible != gs_prev_visible_ || budget_changed) && gs_budget_locked_) {
                 gs_budget_locked_ = false;
@@ -1145,23 +1150,30 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             gs_prev_visible_ = visible;
 
             // Re-gather scene Gaussians
-            if (flags.gs_lod && gs_gaussian_budget_ > 0) {
-                glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
-                const glm::vec3* focus = gs_has_lod_focus_ ? &gs_lod_focus_pos_ : nullptr;
-                gs_chunk_grid_.gather_lod(visible, cam_pos, gs_gaussian_budget_,
-                                          gs_static_buffer_, focus,
-                                          gs_preserve_bone_first_, gs_preserve_bone_count_);
-            } else {
-                gs_chunk_grid_.gather(visible, gs_static_buffer_);
+            {
+                ScopedStallTimer _t_gather{"  > gs_chunk_grid.gather[_lod] (per-splat copy)"};
+                if (flags.gs_lod && gs_gaussian_budget_ > 0) {
+                    glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
+                    const glm::vec3* focus = gs_has_lod_focus_ ? &gs_lod_focus_pos_ : nullptr;
+                    gs_chunk_grid_.gather_lod(visible, cam_pos, gs_gaussian_budget_,
+                                              gs_static_buffer_, focus,
+                                              gs_preserve_bone_first_, gs_preserve_bone_count_);
+                } else {
+                    gs_chunk_grid_.gather(visible, gs_static_buffer_);
+                }
             }
 
             // Append VFX object Gaussians to static buffer
-            for (auto& inst : vfx_instances_) {
-                inst.append_objects(gs_static_buffer_);
+            {
+                ScopedStallTimer _t_vfx_append{"  > vfx_instances.append_objects"};
+                for (auto& inst : vfx_instances_) {
+                    inst.append_objects(gs_static_buffer_);
+                }
             }
 
             // Scene buffer changed — animator indices are stale.
             // Reset so VFX animations re-tag on the new buffer.
+            ScopedStallTimer _t_animator{"  > animator reset+tag (VFX + scene anims)"};
             gs_animator_.reset();
 
             // Reset VFX animation states so they re-tag on the fresh static buffer

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -1125,20 +1125,15 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
         }
 
         if (camera_dirty && flags.gs_chunk_culling && !gs_skip_chunk_cull_ && !gs_chunk_grid_.empty()) {
-            // Diagnostic: this branch runs every frame the camera moves
-            // (i.e. constantly during walking). The CPU work below — chunk
-            // visibility, gs_static_buffer_ rebuild, then the SSBO upload
-            // path at update_static_gaussians — is the prime suspect for
-            // walking-time main-thread stalls when streaming is gated off
-            // by the demo's pre-merge.
             ScopedStallTimer _t_static_rebuild{"gs_static_rebuild (visibility+gather+upload)"};
 
+            // Visibility cull always runs — it's cheap, and we need its
+            // result to decide whether the heavier rebuild is even needed.
             std::vector<uint32_t> visible;
             {
                 ScopedStallTimer _t_vis{"  > gs_chunk_grid.visible_chunks (frustum+dist cull)"};
                 glm::mat4 gs_vp = gs_proj_ * gs_view_;
                 glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
-                // Use camera position for distance culling (camera sees ahead of player)
                 glm::vec3 dist_origin = cam_pos;
                 visible = gs_chunk_grid_.visible_chunks(gs_vp, dist_origin, gs_max_render_distance_);
             }
@@ -1147,99 +1142,130 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 gs_budget_locked_ = false;
                 gs_stable_frame_count_ = 0;
             }
+
+            // ── Skip-rebuild fast path ──
+            // Camera moving WITHIN an already-loaded set of chunks doesn't
+            // change which splats are in gs_static_buffer_ — the previously
+            // built buffer (and the GPU SSBO it was uploaded to) is still
+            // valid. Reasons we MUST rebuild:
+            //   (a) visibility set changed (chunk crossed load/cull radius)
+            //   (b) gaussian budget changed
+            //   (c) static_force_dirty_ was set externally (scene anim
+            //       triggered a re-tag, etc.)
+            //   (d) animations are active — gs_animator_.update() mutates
+            //       gs_static_buffer_ in place every frame, the upload has
+            //       to follow, and re-tagging needs the fresh indices
+            //   (e) LOD is enabled and the budget is set — gather_lod's
+            //       per-splat selection is camera-distance-dependent, so
+            //       every camera-dirty frame produces a different splat set
+            //   (f) the VFX instance set changed (a VfxTrigger spawned a
+            //       new instance or one expired) — the VFX-object splats
+            //       appended at the tail of gs_static_buffer_ are stale.
+            //       Tracked via a count-based proxy: cheap, and a same-
+            //       count-different-instances swap is rare enough that the
+            //       worst case is one stale frame before the next dirty.
+            const bool visibility_changed = (visible != gs_prev_visible_);
+            const bool animations_active =
+                gs_animator_.has_active_groups() || !gs_scene_animations_.empty();
+            const bool lod_active = flags.gs_lod && gs_gaussian_budget_ > 0;
+            const bool vfx_set_changed = (vfx_instances_.size() != gs_prev_vfx_count_);
+
+            const bool need_rebuild =
+                visibility_changed || budget_changed || gs_static_force_dirty_ ||
+                animations_active || lod_active || vfx_set_changed;
+
             gs_prev_visible_ = visible;
+            gs_prev_vfx_count_ = vfx_instances_.size();
 
-            // Re-gather scene Gaussians
-            {
-                ScopedStallTimer _t_gather{"  > gs_chunk_grid.gather[_lod] (per-splat copy)"};
-                if (flags.gs_lod && gs_gaussian_budget_ > 0) {
-                    glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
-                    const glm::vec3* focus = gs_has_lod_focus_ ? &gs_lod_focus_pos_ : nullptr;
-                    gs_chunk_grid_.gather_lod(visible, cam_pos, gs_gaussian_budget_,
-                                              gs_static_buffer_, focus,
-                                              gs_preserve_bone_first_, gs_preserve_bone_count_);
-                } else {
-                    gs_chunk_grid_.gather(visible, gs_static_buffer_);
+            if (need_rebuild) {
+                // Re-gather scene Gaussians
+                {
+                    ScopedStallTimer _t_gather{"  > gs_chunk_grid.gather[_lod] (per-splat copy)"};
+                    if (lod_active) {
+                        glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
+                        const glm::vec3* focus = gs_has_lod_focus_ ? &gs_lod_focus_pos_ : nullptr;
+                        gs_chunk_grid_.gather_lod(visible, cam_pos, gs_gaussian_budget_,
+                                                  gs_static_buffer_, focus,
+                                                  gs_preserve_bone_first_, gs_preserve_bone_count_);
+                    } else {
+                        gs_chunk_grid_.gather(visible, gs_static_buffer_);
+                    }
                 }
-            }
 
-            // Append VFX object Gaussians to static buffer
-            {
-                ScopedStallTimer _t_vfx_append{"  > vfx_instances.append_objects"};
+                // Append VFX object Gaussians to static buffer
+                {
+                    ScopedStallTimer _t_vfx_append{"  > vfx_instances.append_objects"};
+                    for (auto& inst : vfx_instances_) {
+                        inst.append_objects(gs_static_buffer_);
+                    }
+                }
+
+                // Scene buffer changed — animator indices are stale.
+                // Reset so VFX animations re-tag on the new buffer.
+                ScopedStallTimer _t_animator{"  > animator reset+tag (VFX + scene anims)"};
+                gs_animator_.reset();
+
+                // Reset VFX animation states so they re-tag on the fresh static buffer
                 for (auto& inst : vfx_instances_) {
-                    inst.append_objects(gs_static_buffer_);
+                    inst.reset_animations();
                 }
-            }
 
-            // Scene buffer changed — animator indices are stale.
-            // Reset so VFX animations re-tag on the new buffer.
-            ScopedStallTimer _t_animator{"  > animator reset+tag (VFX + scene anims)"};
-            gs_animator_.reset();
+                // Tag VFX animations on the static buffer (where object PLYs live)
+                for (auto& inst : vfx_instances_) {
+                    inst.tag_animations(gs_static_buffer_, gs_animator_);
+                }
 
-            // Reset VFX animation states so they re-tag on the fresh static buffer
-            for (auto& inst : vfx_instances_) {
-                inst.reset_animations();
-            }
-
-            // Tag VFX animations on the static buffer (where object PLYs live)
-            for (auto& inst : vfx_instances_) {
-                inst.tag_animations(gs_static_buffer_, gs_animator_);
-            }
-
-            // Phase-based state machine for scene animations
-            for (auto& sa : gs_scene_animations_) {
-                using Phase = SceneAnimation::Phase;
-                if (sa.phase == Phase::Effect) {
-                    if (sa.group_id == 0) {
-                        sa.group_id = gs_animator_.tag_region(
-                            gs_static_buffer_, sa.region,
-                            parse_effect_name(sa.effect), sa.lifetime, sa.params);
-                    } else if (!gs_animator_.has_group(sa.group_id)) {
-                        if (sa.reform) {
-                            sa.reform_group_id = gs_animator_.tag_region(
-                                gs_static_buffer_, sa.region,
-                                GsAnimEffect::Reform, sa.reform->lifetime);
-                            sa.phase = Phase::Reforming;
-                        } else if (sa.loop) {
+                // Phase-based state machine for scene animations
+                for (auto& sa : gs_scene_animations_) {
+                    using Phase = SceneAnimation::Phase;
+                    if (sa.phase == Phase::Effect) {
+                        if (sa.group_id == 0) {
                             sa.group_id = gs_animator_.tag_region(
                                 gs_static_buffer_, sa.region,
                                 parse_effect_name(sa.effect), sa.lifetime, sa.params);
-                        } else {
-                            sa.phase = Phase::Idle;
+                        } else if (!gs_animator_.has_group(sa.group_id)) {
+                            if (sa.reform) {
+                                sa.reform_group_id = gs_animator_.tag_region(
+                                    gs_static_buffer_, sa.region,
+                                    GsAnimEffect::Reform, sa.reform->lifetime);
+                                sa.phase = Phase::Reforming;
+                            } else if (sa.loop) {
+                                sa.group_id = gs_animator_.tag_region(
+                                    gs_static_buffer_, sa.region,
+                                    parse_effect_name(sa.effect), sa.lifetime, sa.params);
+                            } else {
+                                sa.phase = Phase::Idle;
+                            }
                         }
-                    }
-                } else if (sa.phase == Phase::Reforming) {
-                    if (!gs_animator_.has_group(sa.reform_group_id)) {
-                        if (sa.loop) {
-                            sa.group_id = gs_animator_.tag_region(
-                                gs_static_buffer_, sa.region,
-                                parse_effect_name(sa.effect), sa.lifetime, sa.params);
-                            sa.phase = Phase::Effect;
-                        } else {
-                            sa.phase = Phase::Idle;
+                    } else if (sa.phase == Phase::Reforming) {
+                        if (!gs_animator_.has_group(sa.reform_group_id)) {
+                            if (sa.loop) {
+                                sa.group_id = gs_animator_.tag_region(
+                                    gs_static_buffer_, sa.region,
+                                    parse_effect_name(sa.effect), sa.lifetime, sa.params);
+                                sa.phase = Phase::Effect;
+                            } else {
+                                sa.phase = Phase::Idle;
+                            }
                         }
                     }
                 }
-            }
 
-            // Animate tagged scene Gaussians in static buffer
-            if (flags.animation && gs_animator_.has_active_groups()) {
-                gs_animator_.update(dt, gs_static_buffer_);
-            }
-
-            // Upload static Gaussians
-            if (!gs_static_buffer_.empty()) {
-                auto count = static_cast<uint32_t>(gs_static_buffer_.size());
-                if (count > gs_renderer_.max_static_count()) {
-                    gs_static_buffer_.resize(gs_renderer_.max_static_count());
-                    count = gs_renderer_.max_static_count();
+                // Animate tagged scene Gaussians in static buffer
+                if (flags.animation && gs_animator_.has_active_groups()) {
+                    gs_animator_.update(dt, gs_static_buffer_);
                 }
-                // Diagnostic sub-timer for the host-mapped memcpy alone.
-                // For a 2.4M-splat pre-merged scene this is ~150 MiB of CPU
-                // writes contending with the GPU's read pipeline through
-                // unified memory; suspected primary cause of walking stalls.
-                ScopedStallTimer _t_upload{"gs_renderer.update_static_gaussians (memcpy)"};
-                gs_renderer_.update_static_gaussians(gs_static_buffer_.data(), count);
+
+                // Upload static Gaussians
+                if (!gs_static_buffer_.empty()) {
+                    auto count = static_cast<uint32_t>(gs_static_buffer_.size());
+                    if (count > gs_renderer_.max_static_count()) {
+                        gs_static_buffer_.resize(gs_renderer_.max_static_count());
+                        count = gs_renderer_.max_static_count();
+                    }
+                    ScopedStallTimer _t_upload{"  > gs_renderer.update_static_gaussians (memcpy)"};
+                    gs_renderer_.update_static_gaussians(gs_static_buffer_.data(), count);
+                }
             }
 
             gs_prev_view_ = gs_view_;

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -3,6 +3,7 @@
 #include "gseurat/engine/procedural_textures.hpp"
 #include "gseurat/engine/project_root.hpp"
 #include "gseurat/engine/resource_manager.hpp"
+#include "gseurat/engine/scoped_timer.hpp"
 #include "gseurat/engine/sort_entry.hpp"
 #include "gseurat/engine/sort_hash.hpp"
 #include "gseurat/engine/streaming_config.hpp"
@@ -1124,6 +1125,13 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
         }
 
         if (camera_dirty && flags.gs_chunk_culling && !gs_skip_chunk_cull_ && !gs_chunk_grid_.empty()) {
+            // Diagnostic: this branch runs every frame the camera moves
+            // (i.e. constantly during walking). The CPU work below — chunk
+            // visibility, gs_static_buffer_ rebuild, then the SSBO upload
+            // path at update_static_gaussians — is the prime suspect for
+            // walking-time main-thread stalls when streaming is gated off
+            // by the demo's pre-merge.
+            ScopedStallTimer _t_static_rebuild{"gs_static_rebuild (visibility+gather+upload)"};
             glm::mat4 gs_vp = gs_proj_ * gs_view_;
             glm::vec3 cam_pos = glm::vec3(glm::inverse(gs_view_)[3]);
             // Use camera position for distance culling (camera sees ahead of player)
@@ -1214,6 +1222,11 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                     gs_static_buffer_.resize(gs_renderer_.max_static_count());
                     count = gs_renderer_.max_static_count();
                 }
+                // Diagnostic sub-timer for the host-mapped memcpy alone.
+                // For a 2.4M-splat pre-merged scene this is ~150 MiB of CPU
+                // writes contending with the GPU's read pipeline through
+                // unified memory; suspected primary cause of walking stalls.
+                ScopedStallTimer _t_upload{"gs_renderer.update_static_gaussians (memcpy)"};
                 gs_renderer_.update_static_gaussians(gs_static_buffer_.data(), count);
             }
 

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -1169,10 +1169,16 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 gs_animator_.has_active_groups() || !gs_scene_animations_.empty();
             const bool lod_active = flags.gs_lod && gs_gaussian_budget_ > 0;
             const bool vfx_set_changed = (vfx_instances_.size() != gs_prev_vfx_count_);
+            // Set by GsRenderer::publish_pending_chunks when an Unload
+            // shrinks static_count_ and the static_sort_a_/b_ tail
+            // entries become stale (real depth keys, not sentinels).
+            // update_static_gaussians clears it after init_sort_buf.
+            const bool sort_reinit_needed = gs_renderer_.static_sort_needs_reinit();
 
             const bool need_rebuild =
                 visibility_changed || budget_changed || gs_static_force_dirty_ ||
-                animations_active || lod_active || vfx_set_changed;
+                animations_active || lod_active || vfx_set_changed ||
+                sort_reinit_needed;
 
             gs_prev_visible_ = visible;
             gs_prev_vfx_count_ = vfx_instances_.size();


### PR DESCRIPTION
## Summary

- **Streaming-time beachball killed** by `ed8add7a` — `unload_cloud()` was returning slab handles to the allocator immediately while the prior frame's GPU was still reading those slabs through the OLD page_table. A concurrent load could check the same physical slabs out and `vkCmdCopyBuffer`-overwrite Gaussian data mid-read, which on Apple's TBDR with shared memory manifests as a long queue stall + macOS spinner. Slabs now hold for `kMaxFramesInFlight + 1` ticks of `poll_transfers` before release.
- **Steady-state walking 60-100 ms hitches killed** by `7d865c64` — `gs_static_rebuild` rebuilt the 2.4M-splat `gs_static_buffer_` every camera-dirty frame (gather + VFX append + animator re-tag + 150 MiB upload), even when nothing material changed. New `need_rebuild` gate skips the heavy work unless visibility set, budget, force-dirty flag, animations, LOD, or VFX instance set actually changed.
- **Three structural correctness fixes** in the chunk streaming + portal-transition paths (`eba2b8cb`, `467bf96f`, `ed8add7a`): `clear_chunks` now resets `dynamic_count_` and zeros the dynamic SSBO so post-portal frames don't render stale character splats; load-completion metadata writes route through `vkCmdUpdateBuffer` on `frame_cmd` with TRANSFER_WRITE → SHADER_READ barriers instead of racing in-flight GPU reads via mapped writes; same pattern applied to unload. Two new diag-only commits (`43a25b1b`, `590b2c02`) add `ScopedStallTimer` instrumentation that was needed to nail down the steady-state rebuild as the culprit.

## Test plan

- [ ] Walk back-and-forth in the overworld for ~30 s, confirm no `[StallWarn] gs_static_rebuild` lines fire during plain walking
- [ ] Cross `sv_forest_approach` enter/exit boundary several times; confirm no beachball / OS spinner
- [ ] Trigger VFX (chimney_smoke, fountain_spray, crystal_burst) repeatedly; confirm only first spawn of a new VFX type fires a stall, re-spawns are silent
- [ ] Trigger animations (pulse, orbit, vortex, wave); confirm no sustained stalls during the animation window
- [ ] Walk through a portal transition (overworld → dungeon → overworld); confirm no ghost PC / house silhouettes in either direction
- [ ] Smoke-build all targets: `cmake --build --preset macos-release` (109 targets including `test_transfer_queue_gpu` / `test_onesweep_gpu` / `test_tile_scan_gpu`)
- [ ] Confirm initial `[StallWarn] gs_static_rebuild` ~130 ms one-time cost at scene load is still acceptable (vector capacity warm-up + first animator tag pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)