### PR TITLE
docs: engine refactor Phase 1 — design + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-05-02-engine-refactor-phase1-plan.md
+++ b/docs/superpowers/plans/2026-05-02-engine-refactor-phase1-plan.md
@@ -1,0 +1,1750 @@
+# Engine Refactor Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor the GSeurat Vulkan engine over 17 PRs to (1) purge legacy runtime paths that caused the streaming-strict ghost-debugging saga (PRs #385–#388), (2) split the 4,687 LOC `gs_renderer` God Class into 5 cohesive systems, (3) enforce ECS purity (no Vulkan headers, communicate via components and typed events), and (4) install a tiered diagnostic system with Vulkan Debug Utils labels and a release-with-diagnostics build profile — all gated by an automated golden-frame regression harness running in deterministic mode.
+
+**Architecture:** System-centric decomposition (Resource Manager + Streaming + Sort + TileBin + PostProcess) consumed by an ~80-line `GsRenderer::render()` orchestrator. ECS systems push data into a persistent-mapped `RenderState` (double-buffered per frame-in-flight) via small typed writer APIs. CommandDispatcher and scene loader emit Bevy-style frame-buffered typed events instead of poking renderer state directly. Three diagnostic tiers: always-on (NDEBUG-gated, existing), compile-time (`GSEURAT_DEBUG_BUILD`, new), runtime (`gs::dbg::Diag` env-var registry, extends existing `GS_DIAG_STREAMING`). New `release-with-diag` build profile via `GSEURAT_DEBUG_FORCE` CMake option.
+
+**Tech Stack:** C++23, Vulkan 1.3 (with `VK_EXT_debug_utils` already enabled in Debug builds), VMA, GLFW, GLM, nlohmann/json, miniaudio, MoltenVK on macOS / native Vulkan on Linux+Windows. CMake with presets. Standalone-binary test pattern via `add_gseurat_test()` macro. Game Director regression harness on Python via Unix socket at `/tmp/gseurat.sock`.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md` (commit `9ecb35f7`).
+
+---
+
+## How to use this plan
+
+This plan covers 17 PRs across 5 phases plus pre-flight Phase 0. **Strict serial execution** — each PR merges green before the next begins. Per-phase detail level:
+
+| Phase | Detail level | Why |
+|---|---|---|
+| **Phase 0** | Full bite-sized step-by-step | Immediately actionable; foundation for everything else |
+| **Phases 1–5** | PR-level breakdown (files, key changes, validation gate, commit message) | Codebase will shift during Phase 0 execution; over-specifying now creates rot |
+
+When each later phase is about to begin, write a detailed sub-plan for its PRs using the same writing-plans skill, referencing this plan's PR-level breakdown as the spec input.
+
+**Branch hygiene rules** (apply to every PR in this plan):
+1. Each PR lives on its own branch named `refactor/<N>-<topic>` (e.g., `refactor/0a-debug-header`).
+2. Each PR uses its own worktree at `.worktrees/refactor-<N>-<topic>` — never switch branches in the main checkout.
+3. Branch is created from `main` (latest), not from a previous refactor branch.
+4. Commits never go to `main` directly. PR-and-merge workflow only.
+5. All PRs follow the **per-PR validation gate** below before merge.
+
+**Per-PR validation gate** (template applied to every PR):
+
+```
+1. Build: cmake --build --preset macos-debug              ✓ green
+2. Build: cmake --build --preset macos-release-with-diag  ✓ green   (after PR 0a lands)
+3. Validation layers: zero warnings/errors in regression scenario   (after PR 0b lands)
+4. Regression harness: SSIM ≥ 0.985 vs baseline                     (after PR 0b lands)
+5. Determinism self-check: SSIM = 1.000 on repeated runs            (after PR 0b lands)
+6. GS_DIAG_STREAMING invariant: static_count == sum(active_chunks)  (after PR 2 lands)
+7. GPU timing budget: per-pass ≤ 5% regression vs baseline          (after PR 0b lands)
+```
+
+Items 3–7 are PR-0b-conditional: they activate as their dependencies land. Until PR 0b ships, the gate is "build green + manual playtest".
+
+---
+
+# Phase 0 — Foundation
+
+Two PRs, executed serially. PR 0a delivers the diagnostic header; PR 0b delivers Determinism Mode and the regression harness. **No refactor work begins until both are merged.**
+
+## PR 0a: `gs::dbg::` header + CMake
+
+**Branch:** `refactor/0a-debug-header`
+**Worktree:** `.worktrees/refactor-0a-debug-header`
+**Risk:** Low
+**Dependencies:** none
+
+### File structure for PR 0a
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `include/gseurat/engine/debug.hpp` | Public `gs::dbg` API: `kEnabled` constexpr, `ScopedLabel` RAII class, `set_object_name`, `Diag` enum, `enabled(Diag)`, `invariant_failed`, `GS_LABEL` and `GS_DBG_INVARIANT` macros |
+| Create | `src/engine/debug.cpp` | Implementation: load `vkCmd{Begin,End}DebugUtilsLabelEXT` and `vkSetDebugUtilsObjectNameEXT` function pointers; populate `Diag` registry from `getenv` once at startup; `invariant_failed` aborts with formatted message |
+| Modify | `src/engine/vk_context.cpp:125-142` | After `setup_debug_messenger`, call `gs::dbg::init_function_pointers(instance_)` and `gs::dbg::init_diag_registry()` |
+| Modify | `include/gseurat/engine/vk_context.hpp` | Expose `instance_` getter if not present (needed for `gs::dbg::set_object_name`) |
+| Modify | `CMakeLists.txt` | Add `option(GSEURAT_DEBUG_FORCE ...)`; set `target_compile_definitions(gseurat_core PRIVATE GSEURAT_DEBUG_BUILD=...)` |
+| Modify | `CMakePresets.json` | Add `macos-release-with-diag` preset inheriting from `base`, `CMAKE_BUILD_TYPE=Release`, `GSEURAT_DEBUG_FORCE=ON` |
+| Create | `tests/test_debug.cpp` | Standalone-binary test (per `add_gseurat_test()` pattern): verify `Diag::enabled` reflects env vars; verify `GS_DBG_INVARIANT` no-ops in release |
+| Modify | `CMakeLists.txt:371-387` | Add `add_gseurat_test(debug)` |
+
+### Tasks
+
+- [ ] **Task 1: Create branch and worktree**
+
+```bash
+cd /Users/eccyan/dev/GSeurat
+git fetch origin
+git worktree add .worktrees/refactor-0a-debug-header -b refactor/0a-debug-header origin/main
+cd .worktrees/refactor-0a-debug-header
+git status   # should show clean tree on refactor/0a-debug-header
+```
+
+- [ ] **Task 2: Create `include/gseurat/engine/debug.hpp` header skeleton**
+
+```cpp
+// include/gseurat/engine/debug.hpp
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <glm/vec4.hpp>
+#include <cstdint>
+
+#ifndef GSEURAT_DEBUG_BUILD
+#  define GSEURAT_DEBUG_BUILD 0
+#endif
+
+namespace gs::dbg {
+
+inline constexpr bool kEnabled = (GSEURAT_DEBUG_BUILD != 0);
+
+// === Tier B: RAII Vulkan Debug Utils label ===
+class ScopedLabel {
+ public:
+  ScopedLabel(VkCommandBuffer cmd, const char* name,
+              glm::vec4 color = {0.5f, 0.5f, 0.5f, 1.0f}) noexcept;
+  ~ScopedLabel() noexcept;
+
+  ScopedLabel(const ScopedLabel&) = delete;
+  ScopedLabel& operator=(const ScopedLabel&) = delete;
+  ScopedLabel(ScopedLabel&&) = delete;
+  ScopedLabel& operator=(ScopedLabel&&) = delete;
+
+ private:
+  VkCommandBuffer cmd_;
+};
+
+// === Tier B: object naming ===
+void set_object_name(VkDevice device, VkObjectType type,
+                     std::uint64_t handle, const char* name) noexcept;
+
+// === Tier C: env-var diag registry ===
+enum class Diag : std::uint16_t {
+  StreamingState,    // GS_DIAG_STREAMING
+  GpuTiming,         // GS_DIAG_GPU_TIMING
+  ChunkInventory,    // GS_DIAG_CHUNKS
+  RenderStateSlots,  // GS_DIAG_RENDERSTATE
+  EventQueueSizes,   // GS_DIAG_EVENTS
+  COUNT_
+};
+
+bool enabled(Diag) noexcept;
+
+// === Lifecycle (called from VkContext) ===
+void init_function_pointers(VkInstance instance) noexcept;
+void init_diag_registry() noexcept;  // populates from getenv once
+
+// === Tier B: invariant — argument unevaluated when disabled ===
+[[noreturn]] void invariant_failed(const char* expr, const char* msg,
+                                    const char* file, int line) noexcept;
+
+}  // namespace gs::dbg
+
+#if GSEURAT_DEBUG_BUILD
+  #define GS_DBG_INVARIANT(cond, msg) \
+    do { if (!(cond)) ::gs::dbg::invariant_failed(#cond, msg, __FILE__, __LINE__); } while (0)
+  #define GS_LABEL_CONCAT_IMPL(a, b) a##b
+  #define GS_LABEL_CONCAT(a, b) GS_LABEL_CONCAT_IMPL(a, b)
+  #define GS_LABEL(cmd, name) \
+    ::gs::dbg::ScopedLabel GS_LABEL_CONCAT(_gs_dbg_label_, __LINE__)((cmd), (name))
+#else
+  #define GS_DBG_INVARIANT(cond, msg) ((void)0)
+  #define GS_LABEL(cmd, name) ((void)0)
+#endif
+```
+
+- [ ] **Task 3: Create `src/engine/debug.cpp` implementation**
+
+```cpp
+// src/engine/debug.cpp
+#include "gseurat/engine/debug.hpp"
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace gs::dbg {
+
+namespace {
+
+PFN_vkCmdBeginDebugUtilsLabelEXT  g_begin_label = nullptr;
+PFN_vkCmdEndDebugUtilsLabelEXT    g_end_label   = nullptr;
+PFN_vkSetDebugUtilsObjectNameEXT  g_set_name    = nullptr;
+
+std::array<bool, static_cast<std::size_t>(Diag::COUNT_)> g_diag_flags{};
+
+constexpr const char* env_var_for(Diag d) noexcept {
+  switch (d) {
+    case Diag::StreamingState:   return "GS_DIAG_STREAMING";
+    case Diag::GpuTiming:        return "GS_DIAG_GPU_TIMING";
+    case Diag::ChunkInventory:   return "GS_DIAG_CHUNKS";
+    case Diag::RenderStateSlots: return "GS_DIAG_RENDERSTATE";
+    case Diag::EventQueueSizes:  return "GS_DIAG_EVENTS";
+    case Diag::COUNT_:           break;
+  }
+  return "";
+}
+
+}  // namespace
+
+ScopedLabel::ScopedLabel(VkCommandBuffer cmd, const char* name, glm::vec4 color) noexcept
+    : cmd_(cmd) {
+  if constexpr (kEnabled) {
+    if (g_begin_label) {
+      VkDebugUtilsLabelEXT label{};
+      label.sType      = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+      label.pLabelName = name;
+      label.color[0]   = color.r;
+      label.color[1]   = color.g;
+      label.color[2]   = color.b;
+      label.color[3]   = color.a;
+      g_begin_label(cmd_, &label);
+    }
+  }
+}
+
+ScopedLabel::~ScopedLabel() noexcept {
+  if constexpr (kEnabled) {
+    if (g_end_label) g_end_label(cmd_);
+  }
+}
+
+void set_object_name(VkDevice device, VkObjectType type,
+                     std::uint64_t handle, const char* name) noexcept {
+  if constexpr (kEnabled) {
+    if (g_set_name) {
+      VkDebugUtilsObjectNameInfoEXT info{};
+      info.sType        = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+      info.objectType   = type;
+      info.objectHandle = handle;
+      info.pObjectName  = name;
+      g_set_name(device, &info);
+    }
+  }
+}
+
+bool enabled(Diag d) noexcept {
+  const auto idx = static_cast<std::size_t>(d);
+  return idx < g_diag_flags.size() && g_diag_flags[idx];
+}
+
+void init_function_pointers(VkInstance instance) noexcept {
+  if constexpr (kEnabled) {
+    g_begin_label = reinterpret_cast<PFN_vkCmdBeginDebugUtilsLabelEXT>(
+        vkGetInstanceProcAddr(instance, "vkCmdBeginDebugUtilsLabelEXT"));
+    g_end_label = reinterpret_cast<PFN_vkCmdEndDebugUtilsLabelEXT>(
+        vkGetInstanceProcAddr(instance, "vkCmdEndDebugUtilsLabelEXT"));
+    g_set_name = reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(
+        vkGetInstanceProcAddr(instance, "vkSetDebugUtilsObjectNameEXT"));
+  }
+}
+
+void init_diag_registry() noexcept {
+  for (std::size_t i = 0; i < g_diag_flags.size(); ++i) {
+    const char* var = env_var_for(static_cast<Diag>(i));
+    if (var[0] == '\0') continue;
+    const char* val = std::getenv(var);
+    g_diag_flags[i] = (val && val[0] == '1');
+  }
+}
+
+[[noreturn]] void invariant_failed(const char* expr, const char* msg,
+                                    const char* file, int line) noexcept {
+  std::fprintf(stderr, "[gs::dbg INVARIANT FAILED] %s\n  expr: %s\n  at: %s:%d\n",
+               msg, expr, file, line);
+  std::abort();
+}
+
+}  // namespace gs::dbg
+```
+
+- [ ] **Task 4: Wire into `vk_context.cpp`**
+
+Modify `src/engine/vk_context.cpp`. After `setup_debug_messenger()` returns (end of line 142), add a call to initialize `gs::dbg`:
+
+```cpp
+// Add include at top of file:
+#include "gseurat/engine/debug.hpp"
+
+// Inside init() or wherever setup_debug_messenger() is called,
+// AFTER setup_debug_messenger() returns:
+gs::dbg::init_function_pointers(instance_);
+gs::dbg::init_diag_registry();
+```
+
+Cross-reference: vk_context.cpp:26 already calls `setup_debug_messenger()` after `create_instance()`. Insert the two `gs::dbg::init_*` calls immediately after that call site.
+
+- [ ] **Task 5: Update CMakeLists.txt with `GSEURAT_DEBUG_BUILD` definition and `GSEURAT_DEBUG_FORCE` option**
+
+Locate the `gseurat_core` target definition in `CMakeLists.txt`. Add:
+
+```cmake
+option(GSEURAT_DEBUG_FORCE "Force debug instrumentation in Release builds" OFF)
+
+# Apply to gseurat_core target (location: search for `add_library(gseurat_core ...)`)
+target_compile_definitions(gseurat_core PRIVATE
+    GSEURAT_DEBUG_BUILD=$<IF:$<OR:$<CONFIG:Debug>,$<BOOL:${GSEURAT_DEBUG_FORCE}>>,1,0>
+)
+
+# Add debug.cpp to gseurat_core sources
+target_sources(gseurat_core PRIVATE src/engine/debug.cpp)
+```
+
+Verify `include/gseurat/engine/debug.hpp` is reachable via existing target_include_directories on `gseurat_core`.
+
+- [ ] **Task 6: Add `macos-release-with-diag` preset to `CMakePresets.json`**
+
+Insert after the existing `macos-release` preset (around line 103):
+
+```json
+{
+  "name": "macos-release-with-diag",
+  "inherits": "base",
+  "displayName": "macOS Release with Diagnostics",
+  "description": "Release build with GPU labels and invariant checks (release-with-diag profile)",
+  "cacheVariables": {
+    "CMAKE_BUILD_TYPE": "Release",
+    "GSEURAT_DEBUG_FORCE": "ON"
+  },
+  "condition": {
+    "type": "equals",
+    "lhs": "${hostSystemName}",
+    "rhs": "Darwin"
+  }
+}
+```
+
+Add a corresponding `buildPresets` entry below if the file has a `buildPresets` section.
+
+- [ ] **Task 7: Verify all three build profiles compile cleanly**
+
+```bash
+cmake --preset macos-debug && cmake --build --preset macos-debug --target gseurat_core
+cmake --preset macos-release && cmake --build --preset macos-release --target gseurat_core
+cmake --preset macos-release-with-diag && cmake --build --preset macos-release-with-diag --target gseurat_core
+```
+
+Expected: all three produce `gseurat_core` static library with no warnings/errors. If `-Wno-unused-function` complaints appear from `kEnabled=false` paths, that's expected and harmless (the `if constexpr` branches dead-code-eliminate).
+
+- [ ] **Task 8: Smoke-test `GS_LABEL` in the running engine**
+
+Insert a single `GS_LABEL` at the top of `GsRenderer::render()` to verify integration. In `src/engine/gs_renderer.cpp` (find `render(` around line 3244):
+
+```cpp
+void GsRenderer::render(/* existing args */) {
+  GS_LABEL(cmd, "GsRenderer::render (smoke test)");   // ← add this line
+  // ... existing body unchanged
+}
+```
+
+Build with `macos-release-with-diag`, run the demo, capture a frame in RenderDoc. Verify the label appears in the trace. Then **remove the smoke-test line** (PR 2 will add labels comprehensively).
+
+- [ ] **Task 9: Write unit test for `Diag` registry**
+
+Create `tests/test_debug.cpp`:
+
+```cpp
+// tests/test_debug.cpp
+#include "gseurat/engine/debug.hpp"
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+
+int main() {
+  // Default: no diag flags set
+  gs::dbg::init_diag_registry();
+  assert(!gs::dbg::enabled(gs::dbg::Diag::StreamingState));
+  assert(!gs::dbg::enabled(gs::dbg::Diag::GpuTiming));
+
+  // Set env var, re-init, verify flag flips
+  setenv("GS_DIAG_STREAMING", "1", 1);
+  gs::dbg::init_diag_registry();
+  assert(gs::dbg::enabled(gs::dbg::Diag::StreamingState));
+  assert(!gs::dbg::enabled(gs::dbg::Diag::GpuTiming));
+
+  // "0" should be off, only "1" enables
+  setenv("GS_DIAG_STREAMING", "0", 1);
+  gs::dbg::init_diag_registry();
+  assert(!gs::dbg::enabled(gs::dbg::Diag::StreamingState));
+
+  std::printf("test_debug: OK\n");
+  return 0;
+}
+```
+
+Add to `CMakeLists.txt` (search for `add_gseurat_test(` to find the right location):
+
+```cmake
+add_gseurat_test(debug)
+```
+
+- [ ] **Task 10: Run the test**
+
+```bash
+cmake --build --preset macos-debug --target test_debug
+ctest --preset macos-debug -R "^debug$" --output-on-failure
+```
+
+Expected: `test_debug: OK` and ctest reports 1/1 passing.
+
+- [ ] **Task 11: Commit**
+
+```bash
+git add include/gseurat/engine/debug.hpp \
+        src/engine/debug.cpp \
+        src/engine/vk_context.cpp \
+        CMakeLists.txt \
+        CMakePresets.json \
+        tests/test_debug.cpp
+git commit -m "$(cat <<'EOF'
+feat(engine): add gs::dbg diagnostic header (Phase 0a)
+
+Three-tier diagnostic infrastructure:
+- Tier B (compile-time, GSEURAT_DEBUG_BUILD): GS_LABEL RAII for Vulkan
+  Debug Utils labels, GS_DBG_INVARIANT macro (expression unevaluated
+  when disabled), set_object_name helper.
+- Tier C (runtime env-var): gs::dbg::Diag enum + enabled() lookup,
+  initialized once from getenv at VkContext::init.
+
+CMake: new GSEURAT_DEBUG_FORCE option enables Tier B in Release builds.
+New macos-release-with-diag preset inherits from base + CMAKE_BUILD_TYPE
+Release + GSEURAT_DEBUG_FORCE=ON. Spec: §5.4.
+
+Test (tests/test_debug.cpp): verifies Diag registry reflects env var
+state across re-init.
+
+Closes Phase 0a per docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md
+EOF
+)"
+git push -u origin refactor/0a-debug-header
+```
+
+- [ ] **Task 12: Open PR**
+
+```bash
+gh pr create --title "refactor(engine): add gs::dbg diagnostic header (Phase 0a)" \
+  --body "$(cat <<'EOF'
+## Summary
+Phase 0a of the engine refactor (spec: docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md).
+
+Adds three-tier diagnostic infrastructure as foundation for Phase 2 instrumentation. Zero behavioral change to the running engine — `GS_LABEL` and `GS_DBG_INVARIANT` are not yet inserted into any production code path.
+
+## Changes
+- New header `include/gseurat/engine/debug.hpp` — `gs::dbg::ScopedLabel` (RAII), `set_object_name`, `Diag` enum + `enabled()` lookup, `GS_LABEL` and `GS_DBG_INVARIANT` macros
+- New `src/engine/debug.cpp` — function pointer loading from `vkGetInstanceProcAddr`; env var → flag bitmap at startup
+- `vk_context.cpp` calls `gs::dbg::init_function_pointers` + `init_diag_registry` after debug messenger setup
+- New CMake option `GSEURAT_DEBUG_FORCE` + new preset `macos-release-with-diag`
+- Standalone test `tests/test_debug.cpp`
+
+## Test plan
+- [ ] `cmake --build --preset macos-debug` clean
+- [ ] `cmake --build --preset macos-release` clean
+- [ ] `cmake --build --preset macos-release-with-diag` clean
+- [ ] `ctest --preset macos-debug -R "^debug$"` passes
+- [ ] Manual: insert temporary GS_LABEL into render(), capture in RenderDoc, verify hierarchy visible
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Task 13: Validation gate**
+
+After PR opens, wait for CI. Required green: build (Debug, Release, Release-with-diag), `test_debug` passing. No regression suite yet (PR 0b adds it).
+
+- [ ] **Task 14: Merge**
+
+```bash
+gh pr merge --merge --delete-branch=false
+```
+
+(Per project convention from PR #388, branches are not deleted on merge.)
+
+---
+
+## PR 0b: Determinism Mode + golden-frame regression harness
+
+**Branch:** `refactor/0b-golden-frames`
+**Worktree:** `.worktrees/refactor-0b-golden-frames`
+**Risk:** Medium
+**Dependencies:** PR 0a merged
+
+### File structure for PR 0b
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `include/gseurat/engine/sim_clock.hpp` | `gs::SimClock` abstraction — wall-clock or simulated time |
+| Create | `src/engine/sim_clock.cpp` | Implementation |
+| Create | `include/gseurat/engine/random.hpp` | Seeded RNG facade — single source for all engine randomness |
+| Create | `src/engine/random.cpp` | Implementation |
+| Modify | `src/engine/trigger_systems.cpp` | Replace `std::random_device`/`std::mt19937` with `gs::random` |
+| Modify | `src/engine/camera.cpp` | Replace RNG with `gs::random` |
+| Modify | `include/gseurat/engine/scoped_timer.hpp` | Route `steady_clock::now` through `gs::SimClock` (or document why it stays — see Task 7) |
+| Modify | `src/engine/save_system.cpp` | Route clock through `gs::SimClock` (or document why it stays) |
+| Modify | `src/demo/gs_demo_state.cpp` | Route clock through `gs::SimClock` |
+| Modify | `src/engine/app_base.cpp:?` | Tick uses `gs::SimClock::dt()` instead of wall-clock delta |
+| Modify | `src/demo/demo_app.cpp:27-37` | Add `--deterministic` CLI flag parsing |
+| Modify | `src/demo/demo_app.{hpp,cpp}` | Plumb `deterministic_` bool into `gs::SimClock` and `gs::random::seed()` |
+| Create | `scripts/regression/island_demo_canonical.py` | Canonical 60s walkthrough scenario |
+| Create | `scripts/regression/run_harness.py` | Build + run + capture + diff orchestrator |
+| Create | `scripts/regression/diff_golden.py` | SSIM diff implementation |
+| Create | `tests/regression/baseline/.gitkeep` | Directory for baseline frames |
+| Create | `tests/regression/README.md` | Documents baseline regeneration procedure |
+| Create | `.github/workflows/regression.yml` | CI workflow: macOS pixel diff + Linux/Windows build-only |
+| Create | `tests/test_sim_clock.cpp` | Verify deterministic mode produces fixed-step time |
+| Create | `tests/test_random.cpp` | Verify same seed produces identical sequences |
+| Modify | `CMakeLists.txt` | Add `add_gseurat_test(sim_clock)` and `add_gseurat_test(random)` |
+
+### Tasks
+
+- [ ] **Task 1: Create branch and worktree**
+
+```bash
+cd /Users/eccyan/dev/GSeurat
+git worktree add .worktrees/refactor-0b-golden-frames -b refactor/0b-golden-frames origin/main
+cd .worktrees/refactor-0b-golden-frames
+```
+
+- [ ] **Task 2: Define `gs::SimClock` interface (`include/gseurat/engine/sim_clock.hpp`)**
+
+```cpp
+// include/gseurat/engine/sim_clock.hpp
+#pragma once
+
+#include <cstdint>
+
+namespace gs {
+
+class SimClock {
+ public:
+  // Initialize. If deterministic=true, time advances strictly via tick(dt);
+  // wall-clock methods return simulated time. If false, all methods return
+  // wall-clock time and tick() is a no-op.
+  static void init(bool deterministic) noexcept;
+
+  // Advance simulated time by exactly fixed_dt seconds.
+  // No-op in non-deterministic mode.
+  static void tick() noexcept;
+
+  // Current time in seconds since init.
+  static double now_seconds() noexcept;
+
+  // Current time in milliseconds (integer truncation).
+  static std::uint64_t now_ms() noexcept;
+
+  // Fixed delta-time per tick (deterministic mode only).
+  // Always returns 1.0/60.0 regardless of mode (callers should use this
+  // instead of measuring real elapsed time).
+  static constexpr double fixed_dt() noexcept { return 1.0 / 60.0; }
+
+  static bool is_deterministic() noexcept;
+};
+
+}  // namespace gs
+```
+
+- [ ] **Task 3: Implement `gs::SimClock` (`src/engine/sim_clock.cpp`)**
+
+```cpp
+// src/engine/sim_clock.cpp
+#include "gseurat/engine/sim_clock.hpp"
+
+#include <chrono>
+
+namespace gs {
+
+namespace {
+bool g_deterministic = false;
+double g_sim_seconds = 0.0;
+std::chrono::steady_clock::time_point g_wall_origin{};
+}  // namespace
+
+void SimClock::init(bool deterministic) noexcept {
+  g_deterministic = deterministic;
+  g_sim_seconds = 0.0;
+  g_wall_origin = std::chrono::steady_clock::now();
+}
+
+void SimClock::tick() noexcept {
+  if (g_deterministic) {
+    g_sim_seconds += fixed_dt();
+  }
+}
+
+double SimClock::now_seconds() noexcept {
+  if (g_deterministic) {
+    return g_sim_seconds;
+  }
+  using D = std::chrono::duration<double>;
+  return std::chrono::duration_cast<D>(
+             std::chrono::steady_clock::now() - g_wall_origin).count();
+}
+
+std::uint64_t SimClock::now_ms() noexcept {
+  return static_cast<std::uint64_t>(now_seconds() * 1000.0);
+}
+
+bool SimClock::is_deterministic() noexcept { return g_deterministic; }
+
+}  // namespace gs
+```
+
+- [ ] **Task 4: Define `gs::random` facade (`include/gseurat/engine/random.hpp`)**
+
+```cpp
+// include/gseurat/engine/random.hpp
+#pragma once
+
+#include <cstdint>
+
+namespace gs::random {
+
+// Seed once at startup. Determinism mode uses a fixed seed (0xC0FFEE);
+// normal mode uses std::random_device.
+void seed(std::uint64_t seed) noexcept;
+void seed_from_device() noexcept;
+
+// Uniform float in [0, 1).
+float next_float() noexcept;
+
+// Uniform int in [lo, hi].
+int next_int(int lo, int hi) noexcept;
+
+// Uniform uint in [0, 2^32).
+std::uint32_t next_u32() noexcept;
+
+}  // namespace gs::random
+```
+
+- [ ] **Task 5: Implement `gs::random` (`src/engine/random.cpp`)**
+
+```cpp
+// src/engine/random.cpp
+#include "gseurat/engine/random.hpp"
+
+#include <random>
+
+namespace gs::random {
+
+namespace {
+std::mt19937_64 g_rng{0xC0FFEE};
+}  // namespace
+
+void seed(std::uint64_t s) noexcept { g_rng.seed(s); }
+
+void seed_from_device() noexcept {
+  std::random_device rd;
+  g_rng.seed(static_cast<std::uint64_t>(rd()) ^
+             (static_cast<std::uint64_t>(rd()) << 32));
+}
+
+float next_float() noexcept {
+  std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+  return dist(g_rng);
+}
+
+int next_int(int lo, int hi) noexcept {
+  std::uniform_int_distribution<int> dist(lo, hi);
+  return dist(g_rng);
+}
+
+std::uint32_t next_u32() noexcept {
+  return static_cast<std::uint32_t>(g_rng());
+}
+
+}  // namespace gs::random
+```
+
+- [ ] **Task 6: Audit and migrate RNG sites**
+
+Run from worktree root:
+
+```bash
+grep -rn "std::random_device\|std::mt19937\|rand()" src/ include/ \
+  --include="*.cpp" --include="*.hpp" --include="*.h"
+```
+
+Expected sites (from prior survey): `src/engine/trigger_systems.cpp` (2 sites), `src/engine/camera.cpp` (1 site).
+
+For each site:
+1. Remove `std::mt19937 rng_(std::random_device{}());` field/local
+2. Replace usages: `dist(rng_)` → `gs::random::next_float()` / `gs::random::next_int(...)` etc.
+3. Add `#include "gseurat/engine/random.hpp"` to the file
+
+- [ ] **Task 7: Audit and migrate clock sites**
+
+Run from worktree root:
+
+```bash
+grep -rn "steady_clock::now\|system_clock::now\|high_resolution_clock::now" \
+  src/ include/ --include="*.cpp" --include="*.hpp" --include="*.h"
+```
+
+Expected sites: `src/engine/app_base.cpp` (frame-time calculation), `include/gseurat/engine/scoped_timer.hpp` (perf timing — keep wall-clock; ScopedTimer is for human-visible perf reporting, not simulation), `src/engine/save_system.cpp` (timestamp on save — keep wall-clock; user wants real save dates), `src/demo/gs_demo_state.cpp` (likely simulation-affecting — migrate), `include/gseurat/engine/debug_dump.hpp` (timestamp on dump — keep wall-clock).
+
+For each site, **decide**:
+- Simulation-affecting (animation phase, particle spawn time, PBD wind, frame dt) → **migrate to `gs::SimClock::now_seconds()` or `fixed_dt()`**
+- Human-facing (perf timing, save timestamps, debug dump timestamps) → **keep wall-clock** but document why with a one-line comment
+
+For `app_base.cpp` specifically: the frame loop must use `gs::SimClock::fixed_dt()` for the simulation tick when `is_deterministic()`. If it currently does `dt = clock.delta()`, change to:
+
+```cpp
+const double dt = gs::SimClock::is_deterministic() ?
+                  gs::SimClock::fixed_dt() :
+                  /* existing wall-clock delta */;
+gs::SimClock::tick();  // advances sim time in deterministic mode
+```
+
+- [ ] **Task 8: Add `--deterministic` CLI flag in `src/demo/demo_app.cpp:27-37`**
+
+Edit `parse_args`:
+
+```cpp
+void DemoApp::parse_args(int argc, char* argv[]) {
+    for (int i = 1; i < argc; ++i) {
+        std::string_view arg(argv[i]);
+        if (arg == "--scene" && i + 1 < argc) {
+            scene_path_ = argv[++i];
+            scene_path_explicit_ = true;
+        } else if (arg == "--viewer") {
+            viewer_mode_ = true;
+        } else if (arg == "--deterministic") {     // new
+            deterministic_ = true;                  // new
+        }
+    }
+}
+```
+
+Add `bool deterministic_ = false;` to `DemoApp` private members in the corresponding header.
+
+In `DemoApp::run()` or wherever `SimClock::init` belongs, wire it:
+
+```cpp
+gs::SimClock::init(deterministic_);
+if (deterministic_) {
+    gs::random::seed(0xC0FFEE);
+} else {
+    gs::random::seed_from_device();
+}
+```
+
+- [ ] **Task 9: Disable vsync in deterministic mode**
+
+Locate the swapchain present mode selection (search for `VK_PRESENT_MODE_FIFO_KHR` in `src/engine/`). When `gs::SimClock::is_deterministic()` is true at swapchain creation, prefer `VK_PRESENT_MODE_IMMEDIATE_KHR` if available, otherwise fallback to whatever non-vsync mode the device supports.
+
+- [ ] **Task 10: Write `gs::SimClock` and `gs::random` tests**
+
+Create `tests/test_sim_clock.cpp`:
+
+```cpp
+// tests/test_sim_clock.cpp
+#include "gseurat/engine/sim_clock.hpp"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+
+int main() {
+  // Deterministic mode: tick advances by exactly fixed_dt
+  gs::SimClock::init(true);
+  assert(gs::SimClock::is_deterministic());
+  assert(gs::SimClock::now_seconds() == 0.0);
+
+  gs::SimClock::tick();
+  // 1/60 = 0.01666..., compare with epsilon
+  const double dt = gs::SimClock::fixed_dt();
+  const double t1 = gs::SimClock::now_seconds();
+  assert(std::fabs(t1 - dt) < 1e-9);
+
+  for (int i = 0; i < 59; ++i) gs::SimClock::tick();
+  const double t60 = gs::SimClock::now_seconds();
+  assert(std::fabs(t60 - 1.0) < 1e-6);  // 60 ticks = 1.0s
+
+  // Non-deterministic mode: tick is a no-op; now_seconds returns wall-clock
+  gs::SimClock::init(false);
+  assert(!gs::SimClock::is_deterministic());
+  const double w0 = gs::SimClock::now_seconds();
+  gs::SimClock::tick();
+  const double w1 = gs::SimClock::now_seconds();
+  assert(w1 >= w0);  // wall-clock monotonic
+  // Don't assert on tick being no-op precisely — wall-clock advances regardless.
+
+  std::printf("test_sim_clock: OK\n");
+  return 0;
+}
+```
+
+Create `tests/test_random.cpp`:
+
+```cpp
+// tests/test_random.cpp
+#include "gseurat/engine/random.hpp"
+#include <cassert>
+#include <cstdio>
+#include <vector>
+
+int main() {
+  // Same seed → identical sequence
+  gs::random::seed(42);
+  std::vector<float> a;
+  for (int i = 0; i < 100; ++i) a.push_back(gs::random::next_float());
+
+  gs::random::seed(42);
+  std::vector<float> b;
+  for (int i = 0; i < 100; ++i) b.push_back(gs::random::next_float());
+
+  for (size_t i = 0; i < a.size(); ++i) {
+    assert(a[i] == b[i]);  // bit-exact
+  }
+
+  // Different seed → different sequence (statistically)
+  gs::random::seed(43);
+  std::vector<float> c;
+  for (int i = 0; i < 100; ++i) c.push_back(gs::random::next_float());
+  bool any_differ = false;
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (a[i] != c[i]) { any_differ = true; break; }
+  }
+  assert(any_differ);
+
+  std::printf("test_random: OK\n");
+  return 0;
+}
+```
+
+Add to `CMakeLists.txt` near other `add_gseurat_test()` calls:
+
+```cmake
+add_gseurat_test(sim_clock)
+add_gseurat_test(random)
+```
+
+- [ ] **Task 11: Run determinism tests**
+
+```bash
+cmake --build --preset macos-debug --target test_sim_clock test_random
+ctest --preset macos-debug -R "^(sim_clock|random)$" --output-on-failure
+```
+
+Expected: both pass.
+
+- [ ] **Task 12: Manual determinism verification — pixel-identical playback**
+
+Build the demo and run twice with the same flags, capturing one frame each:
+
+```bash
+cmake --build --preset macos-release-with-diag --target gseurat_demo
+
+./build/macos-release-with-diag/gseurat_demo --deterministic &
+DEMO_PID=$!
+sleep 5
+python3 scripts/game_director.py screenshot --output /tmp/det_run1.png
+kill $DEMO_PID
+
+./build/macos-release-with-diag/gseurat_demo --deterministic &
+DEMO_PID=$!
+sleep 5
+python3 scripts/game_director.py screenshot --output /tmp/det_run2.png
+kill $DEMO_PID
+
+# Compare — should be byte-identical
+diff /tmp/det_run1.png /tmp/det_run2.png
+```
+
+Expected: `diff` produces no output (files are byte-identical). If they differ, determinism is incomplete — track down the source by re-running the audit with verbose grep and bisecting which subsystem changes between runs. Common culprits:
+- A `std::random_device` site missed in the audit
+- A `std::chrono` site reading wall-clock during simulation
+- An audio thread executing before/after first frame at different times
+- A texture-streaming or shader-cache cold/warm path
+
+Do not proceed until this passes. **Determinism is a hard prerequisite for the rest of Phase 0b.**
+
+- [ ] **Task 13: Write the canonical 60s scenario script (`scripts/regression/island_demo_canonical.py`)**
+
+```python
+"""Canonical 60-second island_demo walkthrough for regression diffing.
+
+Run via: python3 scripts/regression/run_harness.py
+Standalone: python3 scripts/regression/island_demo_canonical.py --output-dir <dir>
+
+The engine MUST be running with --deterministic. Frame-aligned input dispatch
+ensures the same scenario produces bit-identical pixels across runs.
+"""
+import argparse
+import os
+import socket
+import sys
+import time
+
+SOCKET_PATH = "/tmp/gseurat.sock"
+
+# Frames at which to capture screenshots (60Hz simulation, 60s total).
+CAPTURE_FRAMES = [0, 300, 600, 900, 1200, 1500, 1800, 2100, 2400, 2700, 3000, 3300]
+
+# Frame-aligned input timeline: (frame_number, action_string).
+INPUT_TIMELINE = [
+    (1,    "key_down W"),       # start walking forward
+    (300,  "goto portal_a"),    # teleport to portal entrance (5s in)
+    (360,  "key_up W"),
+    (361,  "key_down W"),       # walk through portal
+    (420,  "key_up W"),
+    (1200, "goto forest_mid"),  # 20s in: forest checkpoint
+    (1201, "key_down W"),
+    (1800, "key_up W"),         # 30s: stop in forest
+    (1801, "goto portal_a"),    # 30s+1f: trigger return portal
+    (2400, "key_down S"),       # 40s: walk backward at start
+    (2700, "key_up S"),         # 45s: stop
+    # 3300 = end (linger 5s for post-portal flashback detection window)
+]
+
+def send(sock, command):
+    sock.sendall((command + "\n").encode())
+    return sock.recv(65536).decode()
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--socket", default=SOCKET_PATH)
+    args = parser.parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(args.socket)
+
+    # Step engine in deterministic mode: 1 frame per "step" command.
+    timeline_idx = 0
+    capture_set = set(CAPTURE_FRAMES)
+    for frame in range(3301):
+        # Dispatch any inputs scheduled for this frame.
+        while timeline_idx < len(INPUT_TIMELINE) and INPUT_TIMELINE[timeline_idx][0] == frame:
+            send(sock, INPUT_TIMELINE[timeline_idx][1])
+            timeline_idx += 1
+
+        send(sock, "step 1")  # advance 1 simulation frame
+
+        if frame in capture_set:
+            out_path = os.path.join(args.output_dir, f"frame_{frame:05d}.png")
+            send(sock, f"screenshot {out_path}")
+
+    sock.close()
+    print(f"Captured {len(CAPTURE_FRAMES)} frames to {args.output_dir}")
+
+if __name__ == "__main__":
+    main()
+```
+
+This depends on the engine's control server supporting `step <n>` (advance N frames in deterministic mode). Verify that command exists in the control server; if not, add it as part of Task 14.
+
+- [ ] **Task 14: Verify or add engine `step` command**
+
+Search `src/engine/` for the control-server command dispatcher (likely `command_dispatcher.cpp` or `control_server.cpp`):
+
+```bash
+grep -rn '"step"' src/engine/
+```
+
+If `step <n>` exists and advances N frames in deterministic mode without rendering more than N frames, no change needed. If not, add it: dispatcher reads `n`, calls the main loop's tick function `n` times. This is the discrete-time hook that makes frame-by-frame regression possible.
+
+- [ ] **Task 15: Implement SSIM diff (`scripts/regression/diff_golden.py`)**
+
+```python
+"""SSIM diff between two directories of PNG frames.
+
+Usage:
+    python3 scripts/regression/diff_golden.py \
+        --baseline tests/regression/baseline/<commit>/ \
+        --current tests/regression/current/ \
+        --threshold 0.985
+"""
+import argparse
+import os
+import sys
+
+import numpy as np
+from PIL import Image
+
+# scikit-image required for SSIM. Install via: pip install scikit-image
+from skimage.metrics import structural_similarity as ssim
+
+def load_rgb(path):
+    img = Image.open(path).convert("RGB")
+    return np.asarray(img, dtype=np.float32) / 255.0
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", required=True)
+    parser.add_argument("--current", required=True)
+    parser.add_argument("--threshold", type=float, default=0.985)
+    parser.add_argument("--report", default=None)
+    args = parser.parse_args()
+
+    baseline_files = sorted(f for f in os.listdir(args.baseline) if f.endswith(".png"))
+    current_files = sorted(f for f in os.listdir(args.current) if f.endswith(".png"))
+
+    if baseline_files != current_files:
+        print(f"FAIL: file set mismatch.\n  baseline: {baseline_files}\n  current: {current_files}",
+              file=sys.stderr)
+        return 2
+
+    failures = []
+    report_lines = []
+    for fname in baseline_files:
+        b = load_rgb(os.path.join(args.baseline, fname))
+        c = load_rgb(os.path.join(args.current, fname))
+        if b.shape != c.shape:
+            failures.append((fname, "shape mismatch", b.shape, c.shape))
+            continue
+        score = ssim(b, c, channel_axis=2, data_range=1.0)
+        report_lines.append(f"{fname}: SSIM={score:.6f}")
+        if score < args.threshold:
+            failures.append((fname, "ssim_low", score, args.threshold))
+
+    if args.report:
+        with open(args.report, "w") as fh:
+            fh.write("\n".join(report_lines) + "\n")
+            if failures:
+                fh.write("\nFAILURES:\n")
+                for f in failures:
+                    fh.write(f"  {f}\n")
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}", file=sys.stderr)
+        return 1
+
+    print("\n".join(report_lines))
+    print(f"PASS ({len(baseline_files)} frames ≥ {args.threshold})")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Add `scikit-image` and `Pillow` to project Python deps. Verify install path or add to `requirements.txt` if one exists.
+
+- [ ] **Task 16: Implement harness orchestrator (`scripts/regression/run_harness.py`)**
+
+```python
+"""Run the regression harness: build, run scenario, optionally diff vs baseline.
+
+Modes:
+    --self-check       : run scenario twice, assert SSIM=1.0 (determinism check)
+    --baseline <ref>   : run scenario, diff vs tests/regression/baseline/<ref>/
+    --no-pixel-diff    : run scenario, skip pixel diff (Linux/Windows CI)
+    --update-baseline  : run scenario, save output as new baseline (DESTRUCTIVE)
+"""
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+DEMO_BIN = "build/macos-release-with-diag/gseurat_demo"
+SCENARIO = "scripts/regression/island_demo_canonical.py"
+SOCKET = "/tmp/gseurat.sock"
+
+def run_scenario(out_dir):
+    """Spawn engine in deterministic mode, drive the scenario, capture frames."""
+    os.makedirs(out_dir, exist_ok=True)
+    proc = subprocess.Popen([DEMO_BIN, "--deterministic"],
+                            stderr=subprocess.PIPE)
+    try:
+        # Wait for socket to appear (engine startup).
+        t0 = time.time()
+        while not os.path.exists(SOCKET):
+            if time.time() - t0 > 10:
+                raise RuntimeError("engine did not create socket in 10s")
+            time.sleep(0.1)
+        # Drive the scenario.
+        subprocess.run(["python3", SCENARIO,
+                        "--output-dir", out_dir,
+                        "--socket", SOCKET],
+                       check=True)
+    finally:
+        proc.terminate()
+        try: proc.wait(timeout=5)
+        except subprocess.TimeoutExpired: proc.kill()
+
+    stderr = proc.stderr.read().decode()
+    return stderr
+
+def diff(baseline_dir, current_dir, threshold):
+    return subprocess.run([
+        "python3", "scripts/regression/diff_golden.py",
+        "--baseline", baseline_dir,
+        "--current", current_dir,
+        "--threshold", str(threshold),
+    ]).returncode
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--self-check", action="store_true")
+    p.add_argument("--baseline", default=None)
+    p.add_argument("--no-pixel-diff", action="store_true")
+    p.add_argument("--update-baseline", default=None,
+                   help="Path to save new baseline; replaces existing")
+    p.add_argument("--threshold", type=float, default=0.985)
+    args = p.parse_args()
+
+    if args.self_check:
+        with tempfile.TemporaryDirectory() as t1, tempfile.TemporaryDirectory() as t2:
+            run_scenario(t1)
+            run_scenario(t2)
+            rc = diff(t1, t2, threshold=1.0)
+            if rc == 0:
+                print("DETERMINISM SELF-CHECK: PASS (SSIM=1.0 across runs)")
+                return 0
+            print("DETERMINISM SELF-CHECK: FAIL — engine is non-deterministic", file=sys.stderr)
+            return 1
+
+    with tempfile.TemporaryDirectory() as cur:
+        stderr = run_scenario(cur)
+
+        # Validation-layer assertion
+        if "VK_VALIDATION" in stderr or "VUID-" in stderr:
+            print("VALIDATION LAYER WARNINGS/ERRORS:\n" + stderr, file=sys.stderr)
+            return 2
+
+        # Diag invariant assertion (best-effort: check for INVARIANT FAILED in stderr)
+        if "INVARIANT FAILED" in stderr:
+            print("DIAG INVARIANT VIOLATION:\n" + stderr, file=sys.stderr)
+            return 3
+
+        if args.update_baseline:
+            if os.path.exists(args.update_baseline):
+                shutil.rmtree(args.update_baseline)
+            shutil.copytree(cur, args.update_baseline)
+            print(f"Baseline updated: {args.update_baseline}")
+            return 0
+
+        if args.no_pixel_diff:
+            print("Scenario completed (no pixel diff requested)")
+            return 0
+
+        if not args.baseline:
+            print("--baseline required unless --no-pixel-diff or --update-baseline", file=sys.stderr)
+            return 4
+
+        return diff(args.baseline, cur, threshold=args.threshold)
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Task 17: Establish baseline frames**
+
+Build the demo, capture the first baseline:
+
+```bash
+cmake --build --preset macos-release-with-diag --target gseurat_demo
+mkdir -p tests/regression/baseline/main
+python3 scripts/regression/run_harness.py --update-baseline tests/regression/baseline/main
+```
+
+Verify the 12 PNGs were created in `tests/regression/baseline/main/`. Inspect 2-3 visually to confirm they look correct (engine actually rendered the scenario).
+
+- [ ] **Task 18: Self-check determinism end-to-end**
+
+```bash
+python3 scripts/regression/run_harness.py --self-check
+```
+
+Expected: `DETERMINISM SELF-CHECK: PASS (SSIM=1.0 across runs)`. If FAIL, return to Task 12 and find the remaining non-determinism source.
+
+- [ ] **Task 19: Self-check the harness against the baseline (zero-change diff)**
+
+```bash
+python3 scripts/regression/run_harness.py --baseline tests/regression/baseline/main --threshold 0.985
+```
+
+Expected: `PASS (12 frames ≥ 0.985)` with all SSIM scores at 1.000000. If any score is below 1.000, the engine has residual non-determinism.
+
+- [ ] **Task 20: Add CI workflow (`.github/workflows/regression.yml`)**
+
+```yaml
+name: Regression Harness
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  golden-frames:
+    name: Golden Frames (macOS, Apple Silicon)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with: { lfs: true }
+      - name: Install Python deps
+        run: pip3 install scikit-image Pillow numpy
+      - name: Configure
+        run: cmake --preset macos-release-with-diag
+      - name: Build
+        run: cmake --build --preset macos-release-with-diag --target gseurat_demo
+      - name: Determinism self-check
+        run: python3 scripts/regression/run_harness.py --self-check
+      - name: Regression diff vs baseline
+        run: python3 scripts/regression/run_harness.py
+             --baseline tests/regression/baseline/main
+             --threshold 0.985
+      - name: Upload diff artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-diff
+          path: tests/regression/diff/
+
+  build-and-validate:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: cmake --preset $(echo ${{ matrix.os }} | sed 's/-latest/-release-with-diag/' | sed 's/ubuntu/linux/')
+      - name: Build
+        run: cmake --build --preset $(echo ${{ matrix.os }} | sed 's/-latest/-release-with-diag/' | sed 's/ubuntu/linux/')
+      - name: Run scenario without pixel diff
+        run: python3 scripts/regression/run_harness.py --no-pixel-diff
+```
+
+Verify Linux/Windows preset names match what's in `CMakePresets.json`. Adjust the sed expressions or replace with explicit case mapping if presets don't follow this pattern.
+
+- [ ] **Task 21: Write `tests/regression/README.md`**
+
+```markdown
+# Regression Harness
+
+The regression harness runs a canonical 60-second walkthrough of `island_demo` in deterministic mode and compares 12 captured frames against a baseline using SSIM diff.
+
+**Hard requirement:** the engine MUST be built with `--preset macos-release-with-diag` (or another `GSEURAT_DEBUG_FORCE=ON` preset) so validation layers and diagnostic tiers are active. Pixel diff runs on macOS only because floating-point rasterization differs across MoltenVK / Lavapipe / AMD / Intel.
+
+## Running locally
+
+```bash
+# Self-check determinism (run scenario twice, assert SSIM=1.0)
+python3 scripts/regression/run_harness.py --self-check
+
+# Full regression diff vs baseline
+python3 scripts/regression/run_harness.py \
+    --baseline tests/regression/baseline/main \
+    --threshold 0.985
+```
+
+## When tests fail
+
+1. **SSIM < threshold:** inspect `tests/regression/diff/` for the failing frames. If the change is intentional (e.g., a deliberate visual change), update the baseline.
+2. **Determinism self-check fails:** something in the engine reads wall-clock time or unseeded RNG. Audit recent changes to `src/engine/` and `include/gseurat/engine/` for `std::random_device`, `std::chrono::*::now`, or other entropy sources.
+3. **Validation layer warnings:** the harness fails if stderr contains `VK_VALIDATION` or `VUID-` strings. Address the layer warning before merging.
+
+## Updating the baseline
+
+Only update when shipping intentional visual changes:
+
+```bash
+python3 scripts/regression/run_harness.py --update-baseline tests/regression/baseline/main
+git add tests/regression/baseline/main/
+git commit -m "test(regression): update baseline for <reason>"
+```
+
+Always commit baseline updates in a separate PR, never alongside refactor/feature changes.
+
+## Adding a frame to the baseline
+
+Edit `scripts/regression/island_demo_canonical.py`: add a frame number to `CAPTURE_FRAMES`. Update the baseline.
+```
+
+- [ ] **Task 22: Run full pre-merge gate locally**
+
+```bash
+# Build all profiles
+cmake --build --preset macos-debug
+cmake --build --preset macos-release
+cmake --build --preset macos-release-with-diag
+
+# Unit tests
+ctest --preset macos-debug --output-on-failure
+
+# Determinism + regression
+python3 scripts/regression/run_harness.py --self-check
+python3 scripts/regression/run_harness.py --baseline tests/regression/baseline/main --threshold 0.985
+```
+
+All steps must pass before commit.
+
+- [ ] **Task 23: Commit and push**
+
+```bash
+git add -A   # large change set; review staged files before commit
+git status
+# Verify: no .build/ artifacts, no .DS_Store, no /tmp paths.
+# tests/regression/baseline/main/*.png should be in git (they're ground truth).
+
+git commit -m "$(cat <<'EOF'
+feat(engine,scripts): determinism mode + golden-frame regression harness (Phase 0b)
+
+Determinism mode (HARD prerequisite for golden-frame diffing):
+- gs::SimClock abstraction: simulated time in deterministic mode,
+  wall-clock otherwise. fixed_dt() = 1/60s.
+- gs::random facade: single seeded RNG source replacing std::random_device.
+- --deterministic CLI flag wired through DemoApp; seeds RNG to 0xC0FFEE,
+  initializes SimClock, prefers IMMEDIATE present mode (no vsync pacing).
+- Audited and migrated 3 RNG sites and 4 simulation-affecting clock sites.
+  Human-facing clocks (perf timing, save timestamps) intentionally left
+  on wall-clock; documented with one-line comments.
+
+Golden-frame regression harness:
+- scripts/regression/island_demo_canonical.py: 60s walkthrough,
+  frame-aligned input dispatch, 12-frame capture cadence.
+- scripts/regression/diff_golden.py: SSIM diff (skimage), 0.985 default.
+- scripts/regression/run_harness.py: orchestrator. --self-check verifies
+  SSIM=1.0 across repeated runs; --baseline diffs vs ground truth;
+  --no-pixel-diff for non-macOS CI; --update-baseline for ground-truth
+  refresh (DESTRUCTIVE).
+- Validation-layer assertion: harness fails if stderr contains
+  VK_VALIDATION or VUID- strings.
+- .github/workflows/regression.yml: macOS pixel diff + Linux/Windows
+  build-and-validate (no pixel diff).
+
+Tests: tests/test_sim_clock.cpp, tests/test_random.cpp.
+
+Spec §7. Closes Phase 0b.
+EOF
+)"
+git push -u origin refactor/0b-golden-frames
+```
+
+- [ ] **Task 24: Open PR with explicit baseline-included flag**
+
+```bash
+gh pr create --title "feat(engine): determinism mode + regression harness (Phase 0b)" \
+  --body "$(cat <<'EOF'
+## Summary
+Phase 0b: Determinism Mode + golden-frame regression harness — the safety net for the rest of the refactor.
+
+Without this, every subsequent PR risks regressing visuals undetected (the failure mode that reverted two prior attempts in this area). See spec §7 for full design.
+
+## Changes
+
+### Determinism Mode
+- `gs::SimClock` abstraction (`include/gseurat/engine/sim_clock.hpp`): simulated time vs wall-clock
+- `gs::random` facade (`include/gseurat/engine/random.hpp`): single seeded RNG source
+- `--deterministic` CLI flag in `DemoApp::parse_args`
+- Audit + migration of 3 RNG sites and 4 sim-affecting clock sites
+- Vsync disabled in deterministic mode
+
+### Regression harness
+- `scripts/regression/island_demo_canonical.py`: 60s scenario
+- `scripts/regression/run_harness.py`: orchestrator
+- `scripts/regression/diff_golden.py`: SSIM diff
+- `tests/regression/baseline/main/*.png`: ground-truth frames (12 PNGs)
+- `.github/workflows/regression.yml`: macOS pixel diff + Linux/Windows build-only
+
+### Tests
+- `tests/test_sim_clock.cpp`
+- `tests/test_random.cpp`
+
+## Test plan
+- [ ] Unit: `ctest --preset macos-debug` includes new sim_clock + random tests
+- [ ] Build: all three profiles green
+- [ ] Local: `python3 scripts/regression/run_harness.py --self-check` passes
+- [ ] Local: `python3 scripts/regression/run_harness.py --baseline tests/regression/baseline/main` passes
+- [ ] CI: macos-14 job green; ubuntu/windows build-and-validate green
+
+## Notes for reviewers
+- 12 PNGs (~1MB total via Git LFS) added under `tests/regression/baseline/main/`. These are ground truth and should be reviewed visually for sanity, not byte-by-byte.
+- Baseline regeneration procedure documented in `tests/regression/README.md`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Task 25: Merge once green**
+
+```bash
+gh pr merge --merge --delete-branch=false
+```
+
+After merge, **Phase 0 is complete**. The full per-PR validation gate from this plan's preamble now activates for all subsequent PRs.
+
+---
+
+# Phases 1–5 (PR-level guides)
+
+Each PR below has a focused brief. When the corresponding phase begins, expand its PRs into detailed sub-plans using the writing-plans skill, referencing the spec section and this brief as input.
+
+The validation gate from the plan preamble applies to every PR. Test-plan additions specific to each PR are noted.
+
+---
+
+## Phase 1 — Deletion
+
+Spec §6 Phase 1. Goal: purge legacy runtime paths whose coexistence with streaming caused PRs #385–#388.
+
+### PR 1a: `refactor/1a-purge-ply-legacy`
+
+**Risk:** Medium
+
+**Files to modify or delete:**
+- Delete: `gs_renderer.cpp` lines 935–1043 (`load_cloud`) and 1814–2079 (`load_cloud_legacy`)
+- Delete: corresponding declarations in `gs_renderer.hpp`
+- Audit and update callers — `git grep "load_cloud"` and remove every call site
+- Create: `tools/ply_importer/` directory with extracted PLY parsing logic. New CMake target `ply_importer` (executable, **not** linked into `gseurat_core`).
+  - `tools/ply_importer/main.cpp` — CLI entry point: `ply_importer <in.ply> <out.gsvx>`
+  - `tools/ply_importer/ply_parse.{hpp,cpp}` — PLY parsing logic (extracted as-is from `load_cloud_legacy`)
+  - `tools/ply_importer/CMakeLists.txt` — declares the new target
+
+**Validation gate additions:**
+- Build `ply_importer` target green
+- Smoke test: `ply_importer assets/<some.ply> /tmp/out.gsvx` produces valid `.gsvx`
+- Regression harness pass — pixel-identical (SSIM=1.0) since `load_cloud_legacy` was unreachable in streaming-strict mode
+
+**Suggested commit message:**
+```
+refactor(engine): purge load_cloud_legacy, extract to tools/ply_importer
+
+Phase 1a per spec §6. Removes ~265 LOC of dead PLY-load code from
+runtime renderer; extracts parse logic to standalone offline utility.
+gseurat_core no longer links PLY parsing.
+```
+
+### PR 1b: `refactor/1b-purge-streaming-legacy`
+
+**Risk:** High — touches per-frame data flow.
+
+**Files to modify or delete:**
+- Delete: `gs_renderer.cpp` lines 2080–2117 (`update_static_gaussians` legacy gather/stomp)
+- Delete: `gs_renderer.cpp` lines 2154–2228 (`ensure_capacity` legacy growth)
+- Delete: `renderer.cpp:1127` legacy chunk-cull block (search for `gs_chunk_grid_` and `streaming_strict` — the gated legacy block)
+- Delete: `gs_chunk_grid_` field and all references
+- Delete: `add_vfx_instance` legacy branch (the `!streaming_initialized()` insertion into `gs_static_buffer_`)
+- Delete: `gs_static_buffer_` if no remaining users (verify with `git grep gs_static_buffer_` after the previous deletes)
+- Delete: corresponding declarations in headers
+
+**Validation gate additions:**
+- Pre-merge: explicit code-review on the deleted symbol set. Reviewer runs `git grep "<symbol>"` for each removed name; must return zero hits.
+- Regression harness: SSIM ≥ 0.985 (some sub-ULP shading drift possible due to descriptor binding order changes; **no geometric drift acceptable**)
+- `GS_DIAG_STREAMING=1` invariant clean for entire 60s
+
+**Suggested commit message:**
+```
+refactor(engine): purge legacy streaming-collision paths
+
+Phase 1b per spec §6. Removes update_static_gaussians legacy gather,
+ensure_capacity legacy growth, gs_chunk_grid_ runtime culling, and
+the !streaming_initialized() branch of add_vfx_instance. These paths
+were unreachable in streaming-strict mode (PR #388) and were the root
+cause of the static_count_ vs sum(active_chunks_.splats) collision.
+```
+
+### PR 1c (conditional): `refactor/1c-purge-fullras`
+
+**Risk:** Medium — only proceed if audit confirms `tile_render_pipeline_` covers all `render_pipeline_` use cases.
+
+**Pre-PR audit (do BEFORE creating worktree):**
+1. `git grep "render_pipeline_" src/engine/`
+2. For every dispatch site, identify the entry condition. If all entry conditions imply `tile_render_pipeline_` would be a valid substitute → proceed with deletion. If any entry condition exists where `render_pipeline_` is the only correct path → **skip this PR** and document why in spec §9.
+3. Document audit findings in `docs/refactor-1c-audit.md` regardless of outcome.
+
+**Files to modify (conditional):**
+- Delete: `render_pipeline_` field, creation, and dispatch
+- Delete: corresponding shader file if no other pipeline uses it
+- Update: `gs_renderer.cpp::render` to dispatch only `tile_render_pipeline_`
+
+**Validation gate additions:** standard regression harness.
+
+---
+
+## Phase 2 — Instrumentation
+
+Spec §6 Phase 2. Goal: add comprehensive Vulkan Debug Utils labels and known-invariant assertions to current (post-deletion) renderer. PR 0a's `gs::dbg` is the foundation.
+
+### PR 2: `refactor/2-debug-utils`
+
+**Risk:** Low — purely additive.
+
+**Files to modify:**
+- `src/engine/gs_renderer.cpp` — add `GS_LABEL` to every `vkCmdDispatch` and `vkCmdDraw*` call site. Two-level hierarchy: outer label per logical group (e.g., "Sort", "TileBin"), inner label per dispatch (e.g., "Onesweep::Histogram").
+- `src/engine/gs_renderer.cpp:1435–1547` — replace `getenv("GS_DIAG_STREAMING")` with `gs::dbg::enabled(gs::dbg::Diag::StreamingState)`
+- Add `GS_DBG_INVARIANT(static_count_ == sum_active_chunk_splats(), "static drift")` at end of `publish_pending_chunks` (the invariant that took 2 weeks to surface in #387)
+- Add `GS_DBG_INVARIANT` for any other documented invariant: post-conditions of `unload_cloud`, `clear_chunks`, `init_streaming`
+- `vk_context.cpp` after device creation — call `gs::dbg::set_object_name` for the device, queues, and major buffers/images that exist at startup. (For lazily-created buffers, set names at creation site.)
+
+**Validation gate additions:**
+- RenderDoc capture: trace shows nested label hierarchy. Manually inspect 3 frames; label tree must be sensible.
+- Regression harness clean (SSIM = 1.0 since labels and disabled invariants are no-ops in non-debug builds).
+
+**Suggested commit message:**
+```
+feat(engine): comprehensive Vulkan Debug Utils labels + invariants
+
+Phase 2 per spec §6. Two-level label hierarchy on every dispatch.
+GS_DBG_INVARIANT for static_count vs sum(active_chunks) — would have
+caught PR #387 in minutes instead of weeks. set_object_name on all
+long-lived buffers/images. Migrates GS_DIAG_STREAMING getenv to
+gs::dbg::Diag registry.
+```
+
+---
+
+## Phase 3 — Infrastructure
+
+Spec §6 Phase 3. Goal: build event bus and `RenderState` scaffolding before any caller migrates to them. **No callers migrate in this phase.**
+
+### PR 3a: `refactor/3a-event-bus`
+
+**Risk:** Low — additive infrastructure only.
+
+**Files to create:**
+- `include/gseurat/engine/ecs/events.hpp` — `EventQueue<T>`, `EventCursor`, `World::events<T>()` accessor
+- `src/engine/ecs/events.cpp` — type-erased registry (`World` holds `std::unordered_map<std::type_index, std::unique_ptr<EventQueueBase>>`); `EventCleanupStage` (calls `rotate()` on every queue at end-of-frame)
+- `tests/test_event_queue.cpp` — verifies send → read with same-frame and next-frame cursors; rotate behavior with retention=2
+
+**Files to modify:**
+- `src/engine/system_scheduler.cpp` — register `EventCleanupStage` as the final stage of `update()`
+- `include/gseurat/engine/ecs/world.hpp` — expose `events<T>()` template accessor
+
+**Validation gate additions:** standard. No production callers yet, so no behavior change expected. SSIM = 1.0.
+
+**Suggested commit message:**
+```
+feat(ecs): typed event queue infrastructure (Bevy Events<T> model)
+
+Phase 3a per spec §5.3. Per-event-type EventQueue<T> with 2-frame
+retention; consumers poll via cursor. EventCleanupStage rotates
+buffers at end-of-frame. No callers migrated yet — Phase 4.
+```
+
+### PR 3b: `refactor/3b-render-state`
+
+**Risk:** Medium — new persistent-mapped buffers, but renderer signature unchanged.
+
+**Files to create:**
+- `include/gseurat/engine/render_state.hpp` — `gs::RenderState` class, `kMaxFramesInFlight` constant, writer types (`BonesWriter`, `VfxWriter`, `PbdWriter`, `ParticlesWriter`, `PointLightsWriter`)
+- `src/engine/render_state.cpp` — implementation: persistent-mapped buffer creation via VMA, double-buffering by frame_idx, dirty range tracking, `begin_frame` / `end_frame`
+- `tests/test_render_state.cpp` — verifies writer slot bounds, dirty range tracking, frame-in-flight isolation
+
+**Files to modify:**
+- `src/engine/app_base.cpp` — construct `RenderState` member; call `begin_frame` / `end_frame` in main loop. **Do not yet route callers through it** — that's Phase 4.
+
+**Validation gate additions:** standard. Memory growth visible in `vmaBuildStatsString` — document the increase (~12 MB for double-buffered dynamic data) in PR description.
+
+**Suggested commit message:**
+```
+feat(engine): RenderState contract (persistent-mapped, double-buffered)
+
+Phase 3b per spec §5.2. Adds gs::RenderState with typed writer APIs
+(BonesWriter, VfxWriter, PbdWriter, ParticlesWriter, PointLightsWriter).
+Persistent-mapped, double-buffered per frame-in-flight. AppBase
+constructs and frames it; no callers migrated yet (Phase 4).
+```
+
+---
+
+## Phase 4 — Caller migration
+
+Spec §6 Phase 4. Goal: migrate callers from direct AppBase-state mutation to events and RenderState writers, in subsystem-isolated PRs.
+
+### PR 4a: `refactor/4a-cmd-events`
+
+**Risk:** Medium
+
+**Files to modify:**
+- `src/engine/command_dispatcher.cpp` — replace `ctx_.renderer.vfx_instances_mutable()` access with `world.events<VfxSpawnEvent>().send({...})`. Defines `VfxSpawnEvent` struct.
+- New: `src/engine/systems/vfx_system.{hpp,cpp}` — consumes `VfxSpawnEvent`, manages VFX entity lifecycle in ECS (initially still backed by `vfx_instances_` data; full ECS-componentization is a future concern).
+- Register `VfxSystem` in `system_scheduler.cpp`.
+
+**Validation gate additions:** scenario test triggering VFX via Game Director (`scripts/scenario_runner.py --role vfx-designer` or equivalent). Visual comparison: VFX must spawn at the correct position with the correct preset.
+
+### PR 4b: `refactor/4b-bones-writer`
+
+**Risk:** Medium
+
+**Files to modify:**
+- `src/engine/bone_animation_system.cpp` — write computed transforms via `render_state.bones_writer(frame_idx)`
+- `src/engine/renderer.cpp:1106-1434` — `update_dynamic_gaussians` reads from RenderState bones buffer instead of `gs_animator_`
+- `src/engine/app_base.{hpp,cpp}` — drop `gs_animator_` field; ECS-side BoneAnimationComponent stores per-entity animation state
+
+**Validation gate additions:** scenario must include a bone-animated entity in motion. Frame at t=10s captures animation phase; SSIM ≥ 0.985 expected (sub-ULP differences possible from interpolation reordering).
+
+### PR 4c: `refactor/4c-vfx-pbd-writers`
+
+**Risk:** Medium
+
+**Files to modify:**
+- `src/engine/systems/vfx_system.cpp` — write splat data via `render_state.vfx_writer(frame_idx)`
+- `src/engine/systems/pbd_system.{hpp,cpp}` — new system; consumes PBD events, writes via `render_state.pbd_writer(frame_idx)`
+- `src/engine/renderer.cpp` — drop `vfx_instances_` and `gs_pending_dynamics_` reads; use RenderState
+- `src/engine/app_base.{hpp,cpp}` — drop both fields
+
+**Validation gate additions:** scenario must include both VFX active in motion and PBD trees swaying. Determinism is critical here (PBD wind must use seeded RNG). SSIM ≥ 0.985.
+
+### PR 4d: `refactor/4d-scene-loader-events`
+
+**Risk:** Medium
+
+**Files to modify:**
+- `src/engine/gs_scene_loader.cpp:289` — emit `PbdElementsLoadedEvent` and `PointLightsLoadedEvent` instead of calling `renderer.upload_pbd_elements` / `set_point_lights`
+- `src/engine/systems/pbd_system.cpp` — consume `PbdElementsLoadedEvent`
+- New: `src/engine/systems/lighting_system.{hpp,cpp}` — consume `PointLightsLoadedEvent`, write via `render_state.point_lights_writer`
+
+**Validation gate additions:** scenario must include scene-load mid-walkthrough (e.g., portal transition). Pre/post portal frames at t=10s and t=12s must match SSIM ≥ 0.985.
+
+### PR 4e: `refactor/4e-misc-writers`
+
+**Risk:** Low
+
+**Files to modify:**
+- Particle systems → `particles_writer`
+- Any remaining direct AppBase shared-state reads in renderer
+- Remove last residual fields from `AppBase` (if any: `gs_particle_emitters_`, `gs_pending_dynamics_`, etc.)
+
+**Validation gate additions:** standard. After this PR, `git grep "gs_animator_\|vfx_instances_\|gs_pending_dynamics_\|gs_particle_emitters_" src/engine/renderer.cpp` should return zero hits.
+
+---
+
+## Phase 5 — Renderer system extraction
+
+Spec §6 Phase 5. Goal: split `gs_renderer.cpp` into 5 cohesive systems consumed by an ~80-line orchestrator. **Smallest-coupling-first to build confidence and establish patterns.**
+
+### PR 5a: `refactor/5a-resource-mgr`
+
+**Risk:** High — changes ownership of every long-lived Vulkan resource.
+
+**Files to create:**
+- `include/gseurat/engine/gs_renderer/gs_resources.hpp` — `struct GsResourceManager` containing `vk::raii::Buffer` / `vk::raii::Image` arrays for output/depth/processed images (per-frame) and all SSBOs
+
+**Files to modify:**
+- `gs_renderer.cpp` — every resource creation moves to `GsResourceManager`'s constructor. Pass `GsResourceManager&` reference to all internal dispatch methods. Resource access via `resources.<field>` instead of `this-><field>`.
+- `gs_renderer.hpp` — declare `GsResourceManager& resources_;` member; constructor now takes `GsResourceManager&`.
+- `app_base.cpp` — construct `GsResourceManager` before constructing `GsRenderer`.
+
+**Validation gate additions:** standard. Memory layout unchanged; SSIM = 1.0 expected.
+
+### PR 5b: `refactor/5b-post-process` ← **first system extraction**
+
+**Risk:** Medium — single pass, lowest coupling. Establishes the extraction pattern.
+
+**Files to create:**
+- `include/gseurat/engine/gs_renderer/post/gs_post_process_system.hpp`
+- `src/engine/gs_renderer/post/gs_post_process_system.cpp`
+
+**Files to modify:**
+- `gs_renderer.cpp` — replace post-process pipeline ownership and dispatch with `post_.dispatch(...)`. Pipeline + descriptor layout move into the system class.
+
+**Validation gate additions:** RenderDoc trace must show `PostProcess` outer label with single inner pass. SSIM = 1.0.
+
+### PR 5c: `refactor/5c-sort-system`
+
+**Risk:** High — 3 passes with shared state; reference pattern for tile-bin extraction.
+
+**Files to create:**
+- `include/gseurat/engine/gs_renderer/sort/gs_sort_system.hpp`
+- `src/engine/gs_renderer/sort/gs_sort_system.cpp`
+
+**Files to modify:**
+- `gs_renderer.cpp` — depth sort dispatch (lines 2952–3003) and merge dispatch move into `GsSortSystem::dispatch`. Onesweep histogram + scatter pipelines owned by the system.
+
+**Validation gate additions:** stress-test scenario with rapid camera motion (varying sort order). SSIM ≥ 0.985.
+
+### PR 5d: `refactor/5d-tile-bin-system`
+
+**Risk:** High — 6-pass chain, biggest extraction.
+
+**Files to create:**
+- `include/gseurat/engine/gs_renderer/tile_bin/gs_tile_bin_system.hpp`
+- `src/engine/gs_renderer/tile_bin/gs_tile_bin_system.cpp`
+
+**Files to modify:**
+- `gs_renderer.cpp:3004–3243` (`dispatch_tile_sort`) moves entirely into the new system.
+
+**Validation gate additions:** standard regression. GPU timing budget critical here — TileBin is the hot path; `±5%` regression threshold.
+
+### PR 5e: `refactor/5e-streaming-system` ← **renderer becomes orchestrator**
+
+**Risk:** Highest — touches the most-recently-stabilized streaming logic.
+
+**Files to create:**
+- `include/gseurat/engine/gs_renderer/streaming/gs_streaming_system.hpp`
+- `src/engine/gs_renderer/streaming/gs_streaming_system.cpp`
+
+**Files to modify:**
+- `gs_renderer.cpp::publish_pending_chunks` (lines 1548–1813) and chunk lifecycle (`unload_cloud`, `clear_chunks`, `chunk_inventory`, `init_streaming`) move into `GsStreamingSystem`.
+- After this PR, `GsRenderer::render()` is < 100 LOC and contains no `vkCmdDispatch` calls. All GPU work delegated to systems.
+
+**Validation gate additions:**
+- Full streaming stress test: walk through entire island_demo with `GS_DIAG_STREAMING=1` for 5 minutes. Invariant must hold throughout.
+- SSIM ≥ 0.985 across full 60s scenario.
+- Final `gs_renderer.cpp` LOC count < 800 (down from 3,919). Header LOC < 200 (down from 768).
+
+**Suggested commit message:**
+```
+refactor(engine): extract GsStreamingSystem; GsRenderer is now an orchestrator
+
+Phase 5e per spec §6. Final renderer split. GsRenderer::render() is
+~80 LOC of system orchestration; no vkCmdDispatch calls remain.
+Closes Phase 1 of the engine refactor.
+
+gs_renderer.cpp: 3919 → ~600 LOC
+gs_renderer.hpp: 768 → ~150 LOC
+214 fields → ~30 fields (rest moved to GsResourceManager + per-system state)
+```
+
+---
+
+# Cross-cutting concerns
+
+## Communication discipline (avoid the "stuck on a wall" trap)
+
+Per project memory `feedback_dont_dismiss_bugs.md` and the regression-safety theme of this refactor:
+
+- If a PR's regression harness FAILS, do not bypass with `--threshold` lowering. Investigate root cause.
+- If determinism self-check fails after a refactor PR, the refactor introduced a non-deterministic dependency. Bisect within the PR's diff.
+- If validation layers fire after a refactor PR, do not silence — fix the root cause.
+- If a phase exceeds estimated time by > 50%, **stop and reassess** before continuing. The strict-serial discipline means downstream phases can't paper over upstream errors.
+
+## Tool requirements
+
+- macOS dev box: Apple Silicon (matches CI runner architecture for golden frames)
+- `gh` CLI: PR creation and merge
+- Python 3.10+ with `scikit-image`, `Pillow`, `numpy`
+- Vulkan SDK 1.3+ with `VK_EXT_debug_utils` (already present in project deps)
+- Git LFS (for baseline PNG storage if size grows)
+
+---
+
+# Self-review notes
+
+After writing this plan, I checked it against the spec:
+
+**Spec coverage:**
+- §1 Context → covered by plan preamble + PR 1a/1b/1c briefs
+- §2 Goals → all 8 goals mapped to specific PRs (1: PR 1a/1b/1c; 2: PR 5a–5e; 3: PR 5a, RenderState class in 3b; 4: PR 4a–4e; 5: PR 3a + PR 4a/4d; 6: PR 0a + PR 2; 7: PR 0a; 8: PR 0b)
+- §3 Architectural Principles → PR 0a sketches, PR 3b enforces "Vulkan headers confined", PR 1b removes legacy
+- §4 Current State → referenced in PR 1b file:line table
+- §5 Target Architecture → PR 0a (5.4), PR 3b (5.2), PR 3a (5.3), PR 5a–5e (5.5)
+- §6 Rollout → directly mapped phase-by-phase
+- §7 Regression Safety Harness → PR 0b is the entire harness, including determinism + CI parity
+- §8 Risks → mitigations referenced via the per-PR validation gates and the strict-serial discipline
+- §9 Open Questions → vk::raii locked in (PR 5a uses it explicitly); EventCursor implementation flagged for refinement during PR 3a
+- §10 Glossary → no plan-side ambiguity
+
+**Placeholder scan:** No "TBD", "TODO", "implement later", or empty stubs in Phase 0 tasks (the only fully-detailed phase). Phases 1–5 are PR-level guides intentionally — each will be expanded into a detailed sub-plan when its phase begins. The `tools/ply_importer/` extraction is referenced concretely (`main.cpp`, `ply_parse.{hpp,cpp}`, `CMakeLists.txt`) rather than as a vague "extract to standalone utility."
+
+**Type consistency:**
+- `gs::dbg::ScopedLabel`, `gs::dbg::Diag`, `gs::dbg::enabled` — used identically in PR 0a tasks 2, 3, 4, 9
+- `gs::SimClock::fixed_dt()` returning `double` — consistent across Tasks 2, 3, 7, 10, 11, 12
+- `gs::random::next_float()` — consistent across Tasks 4, 5, 10, 11
+- `gs::RenderState` writer names (`bones_writer`, `vfx_writer`, etc.) — consistent across PR 3b, 4b, 4c, 4d, 4e
+- `kMaxFramesInFlight` — referenced consistently in spec §5.2 + PR 3b
+
+**Scope check:** 17 PRs is upper-edge for a single plan, but each phase is independently shippable per the spec's strict-serial discipline. Phase 0's 25 tasks are bite-sized as required. Phases 1–5 PR-level guides are sufficient runway for the next 1–2 weeks of work; detailed sub-plans for each later phase are produced on demand. This decomposition matches the spec's deliberate avoidance of front-loaded over-specification.

--- a/docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md
+++ b/docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md
@@ -385,7 +385,7 @@ Strict serial execution. One PR merged green before the next begins. Each PR pas
 | PR | Branch | Description | Risk | Touches |
 |---|---|---|---|---|
 | 0a | `refactor/0a-debug-header` | `gs::dbg::` header + CMake `GSEURAT_DEBUG_FORCE` + new `release-with-diag` preset. No callers yet. | Low | new files only |
-| 0b | `refactor/0b-golden-frames` | Game Director regression harness (§7). | Low | `scripts/`, `tests/` only |
+| 0b | `refactor/0b-golden-frames` | Determinism audit (seeded RNG, `gs::SimClock`, fixed-`dt` tick), Game Director regression harness, macOS CI workflow (§7). | Medium | `src/engine/` (SimClock, RNG audit), `scripts/regression/`, `tests/regression/`, `.github/workflows/` |
 
 ### Phase 1: Deletion
 
@@ -452,25 +452,51 @@ The single most important deliverable. Without this, the refactor will regress s
    - Walks 30 seconds through forest
    - Returns through portal
    - Lingers 5 seconds at start (post-portal "flashback" detection window)
-2. **Frame capture cadence.** 12 golden frames at fixed timestamps (t=0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55s). Captured via `screenshot` command into `tests/regression/golden/<commit>/`.
-3. **SSIM diff harness.** `scripts/regression/diff_golden.py` — compares current run against `main` baseline. Threshold: SSIM ≥ 0.985 per frame (allows minor floating-point drift, catches geometry/color regressions). Threshold tunable via `--ssim-threshold`.
-4. **Validation-layer assertion.** Run scenario with `release-with-diag` build; assert zero validation warnings/errors on stderr.
-5. **Diag invariant assertion.** Run with `GS_DIAG_STREAMING=1`; assert `static_count == sum(active_chunks_.splats)` invariant holds for entire 60s.
-6. **GPU timing budget.** Capture per-pass timing via `VK_EXT_calibrated_timestamps` at t=10, 30, 50s. Compare against baseline; fail if any pass regresses > 5% (configurable).
+2. **Determinism Mode (mandatory — hard prerequisite).** Without this, golden-frame diffing is impossible because PBD wind, particles, and animations introduce per-run drift. The harness boots the engine with a `--deterministic` flag that enforces:
+   - **Fixed RNG seed** — `gs::random::seed(0xC0FFEE)` at startup; all subsystems (particle spawn, PBD wind noise, audio jitter, animation phase offsets) draw from a single seeded generator. Audit every `std::random_device`, `rand()`, and `mt19937` instantiation in the codebase as part of Phase 0b; replace ad-hoc RNG with a single seeded source.
+   - **Fixed simulation `dt = 1.0f / 60.0f` per frame.** Engine ignores wall-clock time; advances simulation by 16.667ms per `tick()` regardless of real elapsed time. Any code path that reads wall-clock time (e.g., `std::chrono::steady_clock::now()` for animation phase) must consult a `gs::SimClock` abstraction that returns simulated time in deterministic mode.
+   - **Disabled vsync / swapchain present pacing.** Render-and-readback runs as fast as the GPU permits; no `std::this_thread::sleep_for` between frames.
+   - **Fixed input timeline.** Game Director input commands are dispatched at exact frame boundaries (frame N = "press W", frame N+120 = "release W"), not by wall-clock timer.
+   - **Audio disabled or muted-deterministic.** Audio engine threads introduce non-determinism from OS scheduling. In deterministic mode, audio runs in a synchronous tick loop or is disabled entirely. (Audio output is not part of golden-frame diff anyway.)
+   - **Verification.** Run the harness twice on the same commit; SSIM must be 1.000 (pixel-identical). If not, determinism is broken — investigate before trusting any subsequent diff.
+3. **Frame capture cadence.** 12 golden frames at fixed simulation timestamps (frames 0, 300, 600, …, 3300 — i.e., every 5 simulated seconds). Captured via `screenshot` command into `tests/regression/golden/<commit>/`.
+4. **SSIM diff harness.** `scripts/regression/diff_golden.py` — compares current run against `main` baseline. Threshold: SSIM ≥ 0.985 per frame (allows minor floating-point drift, catches geometry/color regressions). Threshold tunable via `--ssim-threshold`. **In deterministic mode with no real changes, expected SSIM is 1.000** — the threshold accounts only for intentional refactor side-effects (e.g., descriptor binding order changes that cause sub-ULP shading drift), never for stochastic simulation.
+5. **CI hardware parity (mandatory).** Floating-point rasterization differs across MoltenVK (Apple Silicon) vs Lavapipe / AMD / Intel (Linux/Windows). Golden-frame diffing **must run on the same architecture as the baseline**. Phase 0b commits to:
+   - **macOS CI runner only** for pixel diff (`macos-14` / Apple Silicon, matching local dev hardware).
+   - **Linux/Windows CI** still runs build + validation-layer checks + scenario completion, but skips pixel diff.
+   - Baseline frames are captured on macOS CI runner, not local dev machines (avoids "works on my Mac" drift between developers).
+6. **Validation-layer assertion.** Run scenario with `release-with-diag` build; assert zero validation warnings/errors on stderr.
+7. **Diag invariant assertion.** Run with `GS_DIAG_STREAMING=1`; assert `static_count == sum(active_chunks_.splats)` invariant holds for entire 60s.
+8. **GPU timing budget.** Capture per-pass timing via `VK_EXT_calibrated_timestamps` at frames 600, 1800, 3000. Compare against baseline; fail if any pass regresses > 5% (configurable). Note: timing has more variance than pixels — wider tolerance is intentional.
 
 ### CI integration
 
 ```yaml
 # .github/workflows/regression.yml
-- name: Build release-with-diag
-  run: cmake --build --preset macos-release-with-diag
-- name: Run regression harness
-  run: python3 scripts/regression/run_harness.py --baseline main --threshold 0.985
-- name: Upload diff artifacts on failure
-  if: failure()
-  uses: actions/upload-artifact@v4
-  with:
-    path: tests/regression/diff/
+jobs:
+  golden-frames:
+    runs-on: macos-14   # Apple Silicon, matches local dev + baseline capture hardware
+    steps:
+      - name: Build release-with-diag
+        run: cmake --build --preset macos-release-with-diag
+      - name: Determinism self-check (run twice, assert SSIM=1.0)
+        run: python3 scripts/regression/run_harness.py --self-check
+      - name: Run regression harness vs baseline
+        run: python3 scripts/regression/run_harness.py --baseline main --threshold 0.985
+      - name: Upload diff artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with: { path: tests/regression/diff/ }
+
+  build-and-validate:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Build + scenario completion + validation-layer clean
+        # No pixel diff on Linux/Windows — FP rasterization differs across drivers.
+        run: python3 scripts/regression/run_harness.py --no-pixel-diff
 ```
 
 ### Baseline establishment
@@ -498,6 +524,7 @@ Phase 0b's PR captures golden frames against `main` at `5fc4c6a9` (post-#388). E
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
+| **Determinism audit incomplete; harness produces flaky diffs** | Medium | High | Self-check step in CI runs harness twice on every PR; SSIM=1.0 required. Any drift between runs fails the build before downstream PRs trust the harness. Audit checklist: `grep -rn "random_device\|mt19937\|rand()\|steady_clock::now\|system_clock::now" src/` before Phase 0b ships. |
 | **Phase 1b deletion misses a live caller** | Medium | High | Phase 0b harness catches visual regression. Granular PR (1a/1b/1c) limits blast radius. Code review checklist: grep for every removed symbol before merge. |
 | **`render_pipeline_` removal in 1c breaks an edge case** (e.g., low-end GPU fallback) | Medium | Medium | 1c is **conditional**. If audit reveals any caller, skip the PR and document. |
 | **Persistent-mapped buffer race in `RenderState`** (system writes while GPU reads previous frame's data) | Medium | High | `RenderState::begin_frame()` waits on the previous frame's fence before allowing writes. `GS_DBG_INVARIANT` checks slot < capacity in writer. RenderDoc trace + golden-frame harness catches data races visually. |
@@ -511,7 +538,7 @@ Phase 0b's PR captures golden frames against `main` at `5fc4c6a9` (post-#388). E
 
 ## 9. Open Questions / Deferred
 
-1. **Should `GsResourceManager` use `vk::raii` or raw handles?** Recommend `vk::raii::Buffer` / `vk::raii::Image` for RAII cleanup, matching modern Vulkan-Hpp idiom. Verify it compiles cleanly under `-fno-rtti` if applicable.
+1. **`GsResourceManager` resource handle type — RESOLVED: `vk::raii`.** Use `vk::raii::Buffer` / `vk::raii::Image` for RAII cleanup, matching modern Vulkan-Hpp idiom. Move-only semantics; no copy. Resource manager is move-constructed once at startup, lives for the lifetime of `AppBase`. Verify it compiles cleanly under `-fno-rtti` if applicable.
 2. **`EventQueue<T>` allocation strategy.** Default to `std::vector<T>` (allocations per send). For hot-path events (>1k/frame), revisit with a small-buffer-optimized queue. Not a Phase 1 concern.
 3. **Naming: `system` vs `subsystem`.** I used `GsStreamingSystem`, `GsSortSystem`, etc. throughout. The ECS layer also has "systems". Naming collision is acceptable because they're in different namespaces (`gs::ecs::*System` vs `gs::*System`), but document the convention in CONTRIBUTING. Alternative: `Pass` (e.g., `GsTileBinPass`) — less accurate since each owns multiple GPU dispatches.
 4. **What replaces `gs_scene_animations_` after Phase 1?** Currently soft-disabled in streaming-strict (PR #388). The Phase 2 GPU region-tagging compute pass is out of scope here but should be planned alongside this refactor — it will be cleaner to land against the new `RenderState` contract.
@@ -527,6 +554,8 @@ Phase 0b's PR captures golden frames against `main` at `5fc4c6a9` (post-#388). E
 - **Tier B / Tier C** — diagnostic tiers. Tier B is compile-time-gated (`GSEURAT_DEBUG_BUILD`); Tier C is runtime env-var-gated.
 - **System** (in this doc, capitalized) — a Phase 5 unit of decomposition (e.g., `GsSortSystem`). Distinct from ECS systems (lower-case "system").
 - **Phase X PR Y** — a specific PR in the rollout (e.g., "Phase 4 PR 4b" = `refactor/4b-bones-writer`).
+- **`gs::SimClock`** — abstraction returning simulated time. In normal mode, returns wall-clock; in `--deterministic` mode, returns `frame_count * (1.0 / 60.0)`. Replaces direct `std::chrono::steady_clock::now()` calls in any subsystem that affects rendering.
+- **Determinism Mode** — engine boot flag (`--deterministic`) enforcing fixed RNG seed, `SimClock`, fixed `dt`, disabled vsync, frame-aligned input dispatch. Hard prerequisite for golden-frame diffing.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md
+++ b/docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md
@@ -1,0 +1,539 @@
+# Engine Refactor — Phase 1 Design
+
+**Date:** 2026-05-02
+**Author:** eccyan + Claude (brainstorming session)
+**Branch:** `feature/refactor-phase1-design`
+**Status:** Draft, awaiting review
+**Supersedes:** None
+**Predecessor:** PR #388 (streaming-strict-mode merged 2026-05-02)
+
+---
+
+## 1. Context & Motivation
+
+The streaming-strict ghost-debugging saga (PRs #385–#388) eliminated four ghost-rendering bugs over two weeks of intense investigation. The root causes were not individual bugs but **structural**:
+
+- **Single God Class (`gs_renderer.cpp`)** at **4,687 LOC** with **214 private fields** dispatching **14 GPU passes**, where streaming and legacy paths competed to mutate the same `static_count_` field on alternating frames.
+- **Tight ECS-Renderer coupling at the `AppBase` level** — the renderer reaches into `gs_animator_`, `vfx_instances_`, `gs_pending_dynamics_`, `gs_particle_emitters_`, and `gs_scene_animations_` every frame, while `CommandDispatcher` mutates `vfx_instances_mutable()` directly. Systems do not communicate via components or events; they share AppBase members and call each other directly.
+- **No GPU traceability** — zero `vkCmdBeginDebugUtilsLabelEXT` usage. RenderDoc traces show numbered dispatches with no semantic context. Every diagnostic has been hand-coded ad-hoc (`GS_DIAG_STREAMING` env var, scattered `std::fprintf` debugging).
+- **No structured cost-aware diagnostic mode** — heavy invariant checks (`static_count_ == sum(active_chunks_.splats)`) ship in release builds (or are stripped from debug builds, with no middle ground), and there is no "release with diagnostics" build profile for catching optimization-dependent timing bugs.
+
+This design proposes a **5-phase, 15–17-PR refactor** to address all three concerns. The end state is a renderer that consumes a typed `RenderState` and emits GPU commands, an ECS layer that communicates exclusively through components and events, and a tiered diagnostic system that costs nothing in release while providing deep traceability in debug and "release with diagnostics" builds.
+
+**Two prior attempts in this area were reverted because regressions were not detected until manual playtesting.** This design treats regression safety as a **prerequisite**, not an outcome: Phase 0b builds an automated golden-frame harness via Game Director **before any refactor work begins**.
+
+---
+
+## 2. Goals & Non-Goals
+
+### In scope (Phase 1)
+
+1. **Purge legacy runtime code** — remove `load_cloud_legacy`, `update_static_gaussians` gather, `gs_chunk_grid_` runtime culling, legacy `add_vfx_instance` insertion, and (if confirmed superseded) `render_pipeline_`. Extract reusable PLY parsing to an offline utility decoupled from the runtime renderer.
+2. **System-centric decomposition of `GsRenderer`** — split into `GsResourceManager`, `GsStreamingSystem`, `GsSortSystem`, `GsTileBinSystem`, `GsPostProcessSystem`. `GsRenderer` becomes an ~80-line orchestrator.
+3. **Pure renderer contract** — renderer reads from a typed `RenderState` and a `Camera`. It does not query ECS, does not own animation/PBD logic, does not know about VFX semantics.
+4. **ECS data-flow contract** — `RenderState` (persistent-mapped, per-frame-in-flight) is populated by ECS systems through small typed writer APIs. Components stay POD.
+5. **Event bus** — typed frame-buffered queues (Bevy `Events<T>` model) with 2-frame retention. CommandDispatcher and scene-loader switch from direct renderer mutation to event emission.
+6. **Diagnostic tier system** — three-tier model (always-on / compile-time / runtime env-var), with `gs::dbg::ScopedLabel` (RAII Vulkan Debug Utils), `GS_DBG_INVARIANT` (compile-time-gated heavy checks), and an `enum class Diag` registry for env-var toggles.
+7. **`GSEURAT_DEBUG_FORCE` CMake option** — third build profile (release with diagnostics) for catching optimization-dependent bugs.
+8. **Regression safety harness** — Game Director golden-frame scenario covering the canonical island_demo walk; SSIM diff against `main` baseline; validation-layer-clean assertion; per-pass GPU timing budget.
+
+### Out of scope (deferred to Phase 2 or later)
+
+- **Frame graph / render graph framework.** Considered as Question 2 option (C); rejected as over-engineering at current scale. The system-centric split provides most of the benefit. Revisit if pass count grows beyond ~20 or if explicit transient-resource aliasing becomes a memory pressure point.
+- **GPU-side region tagging compute pass** for `gs_scene_animations_`. Currently soft-disabled in streaming-strict mode (PR #388). Restoring this is non-trivial and depends on the `RenderState` contract being in place; targeted for Phase 2.
+- **VFX-object dirty-flag** to avoid 50ms `StallWarn` from per-frame 200K-splat memcpy. Will benefit from Phase 1's writer APIs (the writer can naturally track dirty ranges) but the actual optimization is a Phase 2 concern.
+- **Multi-threaded SystemScheduler.** Current scheduler is sequential. Event bus design is compatible with future parallelism but Phase 1 keeps strict serial execution.
+- **Dynamic per-frame-in-flight count.** Hard-coded `kMaxFramesInFlight = 2` per locked decision. Revisit only if a specific need (e.g., HDR display chain) emerges.
+- **Renderer plug-in API for parent projects** (e.g., a hypothetical "Bricklayer-as-renderer-host" use case). The system-centric split makes future extraction easier, but this is not a Phase 1 deliverable.
+
+---
+
+## 3. Architectural Principles
+
+The three user-stated pillars, with the locked-in design decisions:
+
+| Pillar | Locked decision |
+|---|---|
+| **High cohesion, low coupling** | System-centric split (Q2 option B). Each system owns its passes + pipelines + descriptor sets. Inter-system communication via events or RenderState only. |
+| **Graphics traceability** | `vk::raii`-friendly `gs::dbg::ScopedLabel` RAII type wraps `vkCmdBeginDebugUtilsLabelEXT` / `End`. Object names via `vkSetDebugUtilsObjectNameEXT`. Two-level label hierarchy: outer per-system, inner per-dispatch. |
+| **Performance-safe debug modes** | Three tiers: always-on (`NDEBUG`-gated, existing), compile-time (`GSEURAT_DEBUG_BUILD`, new), runtime env-var (`gs::dbg::Diag`, extends existing `GS_DIAG_STREAMING`). Macros only where expression-unevaluation matters; `constexpr` + RAII elsewhere. |
+
+### Foundational invariants the design enforces
+
+1. **Renderer is pure data-flow.** `GsRenderer::render(cmd, render_state, camera, frame_idx)` is the entire surface area. No ECS query, no game state read, no event subscription.
+2. **Vulkan headers are confined.** `vulkan.h` is included by `gs_renderer/*`, `render_state.{hpp,cpp}`, and `gs::dbg` only. ECS components and systems compile without Vulkan headers.
+3. **Per-frame-in-flight is centralized.** Only `RenderState` indexes by `frame_idx`. Individual systems and components are unaware of frame multiplicity.
+4. **Events are pure data.** `events.send(T)` has no observable side effects; consumers poll explicitly.
+5. **Streaming is the only path.** Legacy code is deleted, not gated. Every code path that exists at runtime is reachable in streaming-strict mode.
+
+---
+
+## 4. Current State Snapshot (baseline measurements)
+
+Captured for regression and ROI tracking. All numbers from `main` at commit `5fc4c6a9` (post-#388 merge).
+
+### `gs_renderer.cpp` size and seams
+
+- **LOC:** 3,919 (cpp) + 768 (hpp) = **4,687 total**
+- **Private field count:** ~214 (header lines 389–766)
+- **GPU passes dispatched:** 14
+  - Sort group: `onesweep_hist_pipeline_`, `onesweep_scatter_pipeline_`
+  - Tile-bin group: `tile_count_pipeline_`, `tile_scan_pipeline_`, `tile_indirect_pipeline_`, `tile_bin_pipeline_`, `tile_ranges_pipeline_`, `tile_render_pipeline_`
+  - Other: `render_pipeline_` (legacy full rasterize, deletion candidate), `preprocess_pipeline_`, `merge_pipeline_`, `pbd_pipeline_`, `post_process_pipeline_`
+
+### Major method line ranges (for refactor cross-reference)
+
+| Function | Lines | Phase |
+|---|---|---|
+| `init_streaming` | 631–934 | survives |
+| `load_cloud` (legacy entry point) | 935–1043 | **Phase 1a delete** |
+| `unload_cloud`, `clear_chunks`, `chunk_inventory` | 1044–1273 | survives (chunk lifecycle) |
+| `poll_transfers` + `diag_streaming_dump` | 1332–1547 | survives |
+| `publish_pending_chunks` | 1548–1813 | survives, moves to `GsStreamingSystem` |
+| `load_cloud_legacy` | 1814–2079 | **Phase 1a delete** |
+| `update_static_gaussians` (legacy gather/stomp) | 2080–2117 | **Phase 1b delete** |
+| `update_dynamic_gaussians` | 2118–2153 | survives, refactored against `RenderState` |
+| `ensure_capacity` (legacy growth) | 2154–2228 | **Phase 1b delete** |
+| `dispatch_depth_onesweep` | 2952–3003 | moves to `GsSortSystem` |
+| `dispatch_tile_sort` | 3004–3243 | moves to `GsTileBinSystem` |
+| `render` (main per-frame, ~460 LOC) | 3244–3705 | becomes ~80-line orchestrator |
+
+### ECS coupling pain points
+
+| Today | File:Line | Phase 4 fix |
+|---|---|---|
+| AppBase reads `gs_animator_`, drives `update_dynamic_gaussians` | `src/engine/renderer.cpp:1106–1434` | 4b: `BoneAnimationSystem → bones_writer()` |
+| `CommandDispatcher` mutates `vfx_instances_mutable()` | `src/engine/command_dispatcher.cpp` | 4a: emit `VfxSpawnEvent` |
+| Scene loader calls `renderer.upload_pbd_elements()` | `src/engine/gs_scene_loader.cpp:289` | 4d: emit `PbdElementsLoadedEvent` |
+| `kMaxFramesInFlight` indexing scattered through renderer | many | centralized in `RenderState` |
+
+### Existing diagnostic infrastructure (preserve and extend)
+
+- **Validation layers:** `VK_LAYER_KHRONOS_validation` enabled in `vk_context.cpp:113–141` under `#ifndef NDEBUG`. Keep as-is.
+- **Debug dump registry:** `include/gseurat/engine/debug_dump.hpp` (231 LOC, concept-based, on-demand JSON export). Each new system in Phase 5 implements `DebugDumpable` and registers with `app.debug_dump_registry().register_module(&dumper)`.
+- **`GS_DIAG_STREAMING` env var:** `gs_renderer.cpp:1435–1447`. Migrates to `gs::dbg::Diag::StreamingState` registry in Phase 2.
+- **Vulkan Debug Utils:** **not currently used.** Phase 2 introduces.
+
+---
+
+## 5. Target Architecture
+
+### 5.1 The new renderer surface
+
+```cpp
+// include/gseurat/engine/gs_renderer.hpp (post-Phase 5)
+class GsRenderer {
+public:
+  GsRenderer(VkContext&, GsResourceManager&);
+  void render(VkCommandBuffer cmd,
+              const RenderState& state,
+              const Camera& camera,
+              FrameIndex frame_idx) noexcept;
+private:
+  // Owns the systems; ~80 LOC of orchestration in render().
+  GsStreamingSystem    streaming_;
+  GsSortSystem         sort_;
+  GsTileBinSystem      tile_bin_;
+  GsPostProcessSystem  post_;
+};
+```
+
+`render()` body is a sequence of `GS_LABEL`-bracketed system calls:
+
+```cpp
+void GsRenderer::render(VkCommandBuffer cmd, const RenderState& s,
+                        const Camera& cam, FrameIndex idx) noexcept {
+  GS_LABEL(cmd, "GsRenderer::frame");
+  streaming_.process_pending(cmd, s, idx);   // GS_LABEL inside: "Streaming"
+  sort_.dispatch(cmd, s, cam, idx);          // GS_LABEL inside: "Sort"
+  tile_bin_.dispatch(cmd, s, cam, idx);      // GS_LABEL inside: "TileBin"
+  post_.dispatch(cmd, s, idx);               // GS_LABEL inside: "PostProcess"
+}
+```
+
+### 5.2 `RenderState` (the contract)
+
+`RenderState` is the single object through which ECS systems push data to the renderer. It owns persistent-mapped Vulkan buffers (double-buffered per frame-in-flight) and exposes typed writer APIs.
+
+```cpp
+// include/gseurat/engine/render_state.hpp
+namespace gs {
+
+inline constexpr uint32_t kMaxFramesInFlight = 2;  // compile-time constant
+
+class RenderState {
+public:
+  RenderState(VkContext&, GsResourceManager&);
+
+  // === Writers — called from ECS systems during update() ===
+  // All writers take frame_idx ∈ [0, kMaxFramesInFlight).
+  BonesWriter        bones_writer(FrameIndex);
+  VfxWriter          vfx_writer(FrameIndex);
+  PbdWriter          pbd_writer(FrameIndex);
+  ParticlesWriter    particles_writer(FrameIndex);
+  PointLightsWriter  point_lights_writer(FrameIndex);
+
+  // === Renderer-side read access — const, called from GsRenderer::render() ===
+  VkBuffer bones_buffer(FrameIndex) const noexcept;
+  VkBuffer vfx_splats_buffer(FrameIndex) const noexcept;
+  VkBuffer pbd_elements_buffer(FrameIndex) const noexcept;
+  // ... etc
+
+  // === Lifecycle ===
+  void begin_frame(FrameIndex);  // resets dirty ranges
+  void end_frame(FrameIndex);    // flushes mapped writes if non-coherent
+
+private:
+  std::array<PerFrameData, kMaxFramesInFlight> per_frame_;
+};
+
+// Writer example — typed, slot-indexed, dirty-range-tracking
+class BonesWriter {
+public:
+  void write(uint32_t slot, const glm::mat4& transform) noexcept;
+  size_t capacity() const noexcept;
+  // No commit() — RenderState::end_frame() handles flushing.
+};
+
+}  // namespace gs
+```
+
+**Ownership:** `RenderState` is owned by `AppBase`. Passed by mutable reference to `SystemScheduler::update()` (via `World` resource), passed by const reference to `GsRenderer::render()`.
+
+**Per-frame-in-flight discipline:** Only `RenderState` indexes by `frame_idx`. ECS systems request a writer for the current frame and write through it. Renderer reads buffers for the same frame index. Synchronization with the GPU (waiting on the previous frame's fence before reusing slot N) is handled inside `RenderState::begin_frame()` via the existing in-flight fence already in `VkContext`.
+
+**Migration shape:** Today, ~200K splats × 64B = ~12 MB of dynamic data. RenderState's persistent-mapped buffers replace per-frame staging+memcpy with direct mapped writes. Writers track dirty ranges so `end_frame()` can issue a minimal `vkFlushMappedMemoryRanges` (only required for non-coherent memory; on Apple Silicon's unified memory it's a no-op).
+
+### 5.3 Event Bus
+
+Bevy `Events<T>` model: per-event-type typed queues with 2-frame retention.
+
+```cpp
+// include/gseurat/engine/ecs/events.hpp
+namespace gs::ecs {
+
+inline constexpr uint32_t kEventRetentionFrames = 2;
+
+template <typename T>
+class EventQueue {
+public:
+  void send(T evt) noexcept;
+  std::span<const T> read(EventCursor& cursor) const noexcept;
+  size_t pending_count() const noexcept;  // for debug dump
+  void rotate() noexcept;                 // called by EventCleanupStage at end-of-frame
+private:
+  std::array<std::vector<T>, kEventRetentionFrames> buffers_;
+  uint8_t write_idx_;
+};
+
+// Per-consumer cursor — tracks last seen event across rotates.
+// Implementation detail (per-buffer index vs monotonic event-id counter)
+// finalized during writing-plans; both are workable.
+struct EventCursor {
+  size_t last_read_per_buffer[kEventRetentionFrames] = {0, 0};
+};
+
+// World provides typed access:
+template <typename T> EventQueue<T>& World::events() noexcept;
+
+}  // namespace gs::ecs
+```
+
+**Scheduler integration:** A new `EventCleanupStage` runs as the final stage of `SystemScheduler::update()`, calling `rotate()` on every registered event queue. Events sent in frame N are visible to consumers in frame N (current buffer) and frame N+1 (previous buffer).
+
+**Phase 4 migration map:**
+
+| Phase | Producer site | Event type | Consumer |
+|---|---|---|---|
+| 4a | `CommandDispatcher::handle_vfx_spawn()` | `VfxSpawnEvent { preset, position, rotation }` | `VfxSystem` |
+| 4d | `gs_scene_loader.cpp:289` | `PbdElementsLoadedEvent { elements, constraints }` | `PbdSystem` |
+| 4d | scene loader, point-light load | `PointLightsLoadedEvent { lights }` | `LightingSystem` |
+| 4e | particle emitter trigger | `ParticleEmitterEvent { emitter_id, ... }` | `ParticleSystem` |
+
+### 5.4 Diagnostic tier system
+
+Three tiers, each with a different cost profile:
+
+| Tier | Mechanism | Examples | Release cost |
+|---|---|---|---|
+| **A: Always-on** | `assert()`, validation layers gated by `NDEBUG` | Pre/post-conditions; layer warnings | 0 (existing pattern) |
+| **B: Compile-time** | `GSEURAT_DEBUG_BUILD` macro + `gs::dbg::kEnabled` constexpr | `GS_LABEL`, `GS_DBG_INVARIANT`, `set_object_name` | 0 (becomes `((void)0)`) |
+| **C: Runtime env-var** | `gs::dbg::Diag` enum + `enabled()` lookup | Per-frame streaming dump, GPU timing print, chunk inventory | Single `bool` load on hot paths |
+
+#### Header sketch
+
+```cpp
+// include/gseurat/engine/debug.hpp
+namespace gs::dbg {
+
+inline constexpr bool kEnabled = GSEURAT_DEBUG_BUILD;  // CMake-defined: 1 in Debug, 0 in Release
+
+// === Tier B: RAII Vulkan Debug Utils ===
+class ScopedLabel {
+  VkCommandBuffer cmd_;
+public:
+  ScopedLabel(VkCommandBuffer cmd, const char* name,
+              glm::vec4 color = {0.5f, 0.5f, 0.5f, 1.0f}) noexcept;
+  ~ScopedLabel() noexcept;
+  ScopedLabel(const ScopedLabel&) = delete;
+  ScopedLabel& operator=(const ScopedLabel&) = delete;
+};
+
+void set_object_name(VkDevice, VkObjectType, uint64_t handle, const char* name) noexcept;
+
+// === Tier C: env-var diag registry ===
+enum class Diag : uint16_t {
+  StreamingState,    // GS_DIAG_STREAMING
+  GpuTiming,         // GS_DIAG_GPU_TIMING
+  ChunkInventory,    // GS_DIAG_CHUNKS
+  RenderStateSlots,  // GS_DIAG_RENDERSTATE
+  EventQueueSizes,   // GS_DIAG_EVENTS
+};
+
+bool enabled(Diag) noexcept;   // O(1) lookup; populated once at startup from getenv
+
+// === Tier B: invariant — argument unevaluated when disabled ===
+void invariant_failed(const char* expr, const char* msg, const char* file, int line) noexcept;
+
+}  // namespace gs::dbg
+
+#if GSEURAT_DEBUG_BUILD
+  #define GS_DBG_INVARIANT(cond, msg) \
+    do { if (!(cond)) ::gs::dbg::invariant_failed(#cond, msg, __FILE__, __LINE__); } while (0)
+  #define GS_LABEL(cmd, name) \
+    ::gs::dbg::ScopedLabel _gs_dbg_label_##__LINE__((cmd), (name))
+#else
+  #define GS_DBG_INVARIANT(cond, msg) ((void)0)
+  #define GS_LABEL(cmd, name) ((void)0)
+#endif
+```
+
+#### CMake integration
+
+```cmake
+# CMakeLists.txt additions
+option(GSEURAT_DEBUG_FORCE "Force debug instrumentation in Release builds" OFF)
+
+target_compile_definitions(gseurat_core PRIVATE
+    GSEURAT_DEBUG_BUILD=$<OR:$<CONFIG:Debug>,$<BOOL:${GSEURAT_DEBUG_FORCE}>>
+)
+```
+
+This gives a third build profile via a new preset:
+```json
+{
+  "name": "macos-release-with-diag",
+  "inherits": "macos-release",
+  "cacheVariables": { "GSEURAT_DEBUG_FORCE": "ON" }
+}
+```
+
+### 5.5 System decomposition (post-Phase 5)
+
+```
+include/gseurat/engine/gs_renderer/
+├── gs_renderer.hpp              orchestrator (~150 LOC header + ~80 LOC body)
+├── render_state.hpp             RenderState + writers
+├── gs_resources.hpp             GsResourceManager — passive struct of buffer/image handles
+├── streaming/
+│   ├── gs_streaming_system.hpp  chunk lifecycle, transfer queue, page table, publish
+│   └── gs_streaming_system.cpp  (~700 LOC, lifted intact from current renderer)
+├── sort/
+│   └── gs_sort_system.{hpp,cpp} onesweep histogram + scatter, merge (~400 LOC)
+├── tile_bin/
+│   └── gs_tile_bin_system.{hpp,cpp}  6-pass tile-bin chain (~600 LOC)
+└── post/
+    └── gs_post_process_system.{hpp,cpp}  fog, tone, DOF (~300 LOC)
+
+include/gseurat/engine/debug.hpp     gs::dbg:: header
+src/engine/debug.cpp                  ScopedLabel + Diag registry impl
+
+include/gseurat/engine/ecs/events.hpp EventQueue<T> + World::events<T>()
+src/engine/ecs/event_cleanup_stage.cpp Scheduler integration
+```
+
+`GsResourceManager` is a passive struct (per Q2 sub-decision) — pure data, no behavior:
+
+```cpp
+// include/gseurat/engine/gs_renderer/gs_resources.hpp
+struct GsResourceManager {
+  // Output images, per frame in flight
+  std::array<vk::raii::Image, kMaxFramesInFlight> output_image;
+  std::array<vk::raii::Image, kMaxFramesInFlight> depth_image;
+  std::array<vk::raii::Image, kMaxFramesInFlight> processed_image;
+
+  // Splat SSBOs
+  vk::raii::Buffer static_gaussian_ssbo;
+  vk::raii::Buffer projected_ssbo;
+  vk::raii::Buffer merged_sort_ssbo;
+  vk::raii::Buffer static_sort_a;
+  vk::raii::Buffer static_sort_b;
+  // ... ~30 buffers total
+
+  // No methods. Systems hold references and call vk APIs directly.
+};
+```
+
+---
+
+## 6. Rollout
+
+Strict serial execution. One PR merged green before the next begins. Each PR passes the regression-safety gate (§7).
+
+### Phase 0: Pre-flight (foundation)
+
+| PR | Branch | Description | Risk | Touches |
+|---|---|---|---|---|
+| 0a | `refactor/0a-debug-header` | `gs::dbg::` header + CMake `GSEURAT_DEBUG_FORCE` + new `release-with-diag` preset. No callers yet. | Low | new files only |
+| 0b | `refactor/0b-golden-frames` | Game Director regression harness (§7). | Low | `scripts/`, `tests/` only |
+
+### Phase 1: Deletion
+
+| PR | Branch | Description | Risk |
+|---|---|---|---|
+| 1a | `refactor/1a-purge-ply-legacy` | Delete `load_cloud_legacy` (lines 1814–2079). Move PLY parse code to new `tools/ply_importer/` (offline utility, not linked into `gseurat_core`). | Medium |
+| 1b | `refactor/1b-purge-streaming-legacy` | Delete `update_static_gaussians` gather (2080–2117), `ensure_capacity` legacy growth (2154–2228), `gs_chunk_grid_` runtime culling in `renderer.cpp`, legacy branch of `add_vfx_instance`. | High |
+| 1c | `refactor/1c-purge-fullras` | **Conditional.** Verify `tile_render_pipeline_` covers all `render_pipeline_` use cases under streaming-strict. If yes, delete. If no, document why and skip. | Medium |
+
+**Phase 1 verification:** Pixel-identical golden-frame match against pre-deletion `main`. If pixel drift > SSIM threshold, deletion was incomplete or incorrect.
+
+### Phase 2: Instrumentation
+
+| PR | Branch | Description | Risk |
+|---|---|---|---|
+| 2 | `refactor/2-debug-utils` | Add `GS_LABEL` to every dispatch site in current (post-deletion) renderer. Add `GS_DBG_INVARIANT` for the `static_count_ == sum(active_chunks_)` invariant and ~5 other known invariants. Migrate `GS_DIAG_STREAMING` getenv to `gs::dbg::Diag` registry. | Low |
+
+**Phase 2 verification:** RenderDoc capture of golden-frame scenario; verify label hierarchy is sensible. Validation layer clean.
+
+### Phase 3: Infrastructure
+
+| PR | Branch | Description | Risk |
+|---|---|---|---|
+| 3a | `refactor/3a-event-bus` | `EventQueue<T>` template + `World::events<T>()` accessor + `EventCleanupStage` registered with `SystemScheduler`. **No callers migrated yet.** | Low |
+| 3b | `refactor/3b-render-state` | `RenderState` passive struct with persistent-mapped buffers and writer APIs. AppBase constructs and owns it. **Renderer signature does not change yet** — RenderState is built but unused. Validates the buffer creation/mapping path. | Medium |
+
+### Phase 4: Caller migration
+
+| PR | Branch | Description | Risk |
+|---|---|---|---|
+| 4a | `refactor/4a-cmd-events` | `CommandDispatcher` emits `VfxSpawnEvent` instead of `vfx_instances_mutable()`. New `VfxSystem` consumes events. | Medium |
+| 4b | `refactor/4b-bones-writer` | `BoneAnimationSystem` writes via `RenderState::bones_writer()`. Renderer's `update_dynamic_gaussians` reads from RenderState. | Medium |
+| 4c | `refactor/4c-vfx-pbd-writers` | `VfxSystem` writes via `vfx_writer()`; PBD via `pbd_writer()`. Removes `gs_animator_`/`vfx_instances_` from AppBase. | Medium |
+| 4d | `refactor/4d-scene-loader-events` | Scene loader emits `PbdElementsLoadedEvent`, `PointLightsLoadedEvent`. Removes direct `upload_pbd_elements`/`set_point_lights` calls. | Medium |
+| 4e | `refactor/4e-misc-writers` | Particle systems, point lights — final cleanup of AppBase shared state. | Low |
+
+**Phase 4 verification (per PR):** AppBase no longer references the migrated subsystem's data directly. Renderer signature progressively narrowed. Golden-frame match.
+
+### Phase 5: Renderer system extraction
+
+| PR | Branch | Description | Risk |
+|---|---|---|---|
+| 5a | `refactor/5a-resource-mgr` | Lift `GsResourceManager` (passive struct) out of `GsRenderer`. Pass by reference to all dispatch methods. | High |
+| 5b | `refactor/5b-post-process` | Extract `GsPostProcessSystem` (single pass, lowest coupling — go first to establish patterns). | Medium |
+| 5c | `refactor/5c-sort-system` | Extract `GsSortSystem` (3 passes, well-bounded). | High |
+| 5d | `refactor/5d-tile-bin-system` | Extract `GsTileBinSystem` (6-pass chain). | High |
+| 5e | `refactor/5e-streaming-system` | Extract `GsStreamingSystem`. `GsRenderer::render()` becomes ~80 LOC orchestrator. | Highest |
+
+**Phase 5 verification:** End of phase, `GsRenderer::render()` is < 100 LOC and contains no `vkCmdDispatch` or `vkCmdDraw` calls — all GPU work delegated to systems.
+
+---
+
+## 7. Regression Safety Harness (Phase 0b deep-dive)
+
+The single most important deliverable. Without this, the refactor will regress something subtle and we won't notice until weeks later.
+
+### Components
+
+1. **Canonical 60-second walkthrough scenario.** Defined in `scripts/regression/island_demo_canonical.py` — a Game Director script that:
+   - Boots fresh (no save state)
+   - Spawns at island start
+   - Walks to portal A (forest entrance)
+   - Triggers portal transition
+   - Walks 30 seconds through forest
+   - Returns through portal
+   - Lingers 5 seconds at start (post-portal "flashback" detection window)
+2. **Frame capture cadence.** 12 golden frames at fixed timestamps (t=0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55s). Captured via `screenshot` command into `tests/regression/golden/<commit>/`.
+3. **SSIM diff harness.** `scripts/regression/diff_golden.py` — compares current run against `main` baseline. Threshold: SSIM ≥ 0.985 per frame (allows minor floating-point drift, catches geometry/color regressions). Threshold tunable via `--ssim-threshold`.
+4. **Validation-layer assertion.** Run scenario with `release-with-diag` build; assert zero validation warnings/errors on stderr.
+5. **Diag invariant assertion.** Run with `GS_DIAG_STREAMING=1`; assert `static_count == sum(active_chunks_.splats)` invariant holds for entire 60s.
+6. **GPU timing budget.** Capture per-pass timing via `VK_EXT_calibrated_timestamps` at t=10, 30, 50s. Compare against baseline; fail if any pass regresses > 5% (configurable).
+
+### CI integration
+
+```yaml
+# .github/workflows/regression.yml
+- name: Build release-with-diag
+  run: cmake --build --preset macos-release-with-diag
+- name: Run regression harness
+  run: python3 scripts/regression/run_harness.py --baseline main --threshold 0.985
+- name: Upload diff artifacts on failure
+  if: failure()
+  uses: actions/upload-artifact@v4
+  with:
+    path: tests/regression/diff/
+```
+
+### Baseline establishment
+
+Phase 0b's PR captures golden frames against `main` at `5fc4c6a9` (post-#388). Every subsequent PR diffs against this baseline. The baseline is updated only when intentional visual changes ship (separate from refactor PRs).
+
+### What the harness catches
+
+- Geometric regressions (splats in wrong position, missing chunks, ghost geometry)
+- Color/shading regressions (wrong descriptor binding, uninitialized buffer, post-process pipeline mis-wired)
+- Streaming corruption (chunk publish race, sort-tail leak, page-table desync) — **these are the bugs that motivated this refactor**
+- Validation layer regressions (descriptor type mismatch, barrier omission, layout transition error)
+- Performance regressions (per-pass timing drift, indirect-dispatch correctness)
+
+### What the harness does NOT catch
+
+- Audio regressions (separate harness, out of scope here)
+- Save/load regressions (separate harness)
+- UI regressions in Bricklayer/Echidna (different test suites)
+- Bugs that only manifest after > 60s of play (we accept this; 60s catches the streaming ghost class of bugs)
+
+---
+
+## 8. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **Phase 1b deletion misses a live caller** | Medium | High | Phase 0b harness catches visual regression. Granular PR (1a/1b/1c) limits blast radius. Code review checklist: grep for every removed symbol before merge. |
+| **`render_pipeline_` removal in 1c breaks an edge case** (e.g., low-end GPU fallback) | Medium | Medium | 1c is **conditional**. If audit reveals any caller, skip the PR and document. |
+| **Persistent-mapped buffer race in `RenderState`** (system writes while GPU reads previous frame's data) | Medium | High | `RenderState::begin_frame()` waits on the previous frame's fence before allowing writes. `GS_DBG_INVARIANT` checks slot < capacity in writer. RenderDoc trace + golden-frame harness catches data races visually. |
+| **Event cursor desync** (consumer reads stale events after rotate) | Low | Medium | Cursor is consumer-owned and tracks per-buffer last-read index. Unit test: send 1000 events, consume in chunks, verify no duplicate / no skip. |
+| **Phase 5d (TileBinSystem) is too coupled to extract cleanly** | Medium | High | The 6-pass chain is intentionally kept as one system (Q2 decision). Extraction is mechanical (lift class, no logic change). If during execution the coupling is worse than expected, fall back to leaving TileBin as the largest remaining system in `GsRenderer`. |
+| **`GSEURAT_DEBUG_FORCE` build profile breaks Release optimizations** | Low | Low | Only enables instrumentation; does not change `-O3`. Validate via `release-with-diag` golden-frame timing budget — must match Release within 10%. |
+| **Refactor takes longer than 4 weeks** | Medium | Low | Each PR is independently shippable. Phase 1 alone delivers value (cleaner code, smaller renderer) even if Phase 4-5 is paused. No big-bang merges. |
+| **Reviewer fatigue on 15+ PRs** | High | Medium | Each PR has a single, narrow purpose. PR descriptions follow a template (purpose, files touched, golden-frame diff link, validation log). Pair-review on highest-risk PRs (1b, 5a, 5e). |
+
+---
+
+## 9. Open Questions / Deferred
+
+1. **Should `GsResourceManager` use `vk::raii` or raw handles?** Recommend `vk::raii::Buffer` / `vk::raii::Image` for RAII cleanup, matching modern Vulkan-Hpp idiom. Verify it compiles cleanly under `-fno-rtti` if applicable.
+2. **`EventQueue<T>` allocation strategy.** Default to `std::vector<T>` (allocations per send). For hot-path events (>1k/frame), revisit with a small-buffer-optimized queue. Not a Phase 1 concern.
+3. **Naming: `system` vs `subsystem`.** I used `GsStreamingSystem`, `GsSortSystem`, etc. throughout. The ECS layer also has "systems". Naming collision is acceptable because they're in different namespaces (`gs::ecs::*System` vs `gs::*System`), but document the convention in CONTRIBUTING. Alternative: `Pass` (e.g., `GsTileBinPass`) — less accurate since each owns multiple GPU dispatches.
+4. **What replaces `gs_scene_animations_` after Phase 1?** Currently soft-disabled in streaming-strict (PR #388). The Phase 2 GPU region-tagging compute pass is out of scope here but should be planned alongside this refactor — it will be cleaner to land against the new `RenderState` contract.
+5. **Echidna / Bricklayer integration impact.** The renderer surface narrows to `render(cmd, state, cam, idx)`. Verify Bricklayer's render preview path still works after Phase 5e (it should — Bricklayer constructs its own RenderState).
+
+---
+
+## 10. Glossary
+
+- **`RenderState`** — the typed contract object owned by AppBase, populated by ECS systems via writers, consumed by `GsRenderer::render()`.
+- **Writer** — a small typed API on RenderState (e.g., `BonesWriter`) that ECS systems use to push data without touching Vulkan.
+- **Frame-in-flight (`FrameIndex`)** — integer ∈ [0, kMaxFramesInFlight). RenderState double-buffers per frame index.
+- **Tier B / Tier C** — diagnostic tiers. Tier B is compile-time-gated (`GSEURAT_DEBUG_BUILD`); Tier C is runtime env-var-gated.
+- **System** (in this doc, capitalized) — a Phase 5 unit of decomposition (e.g., `GsSortSystem`). Distinct from ECS systems (lower-case "system").
+- **Phase X PR Y** — a specific PR in the rollout (e.g., "Phase 4 PR 4b" = `refactor/4b-bones-writer`).
+
+---
+
+## 11. Approval gate
+
+This design is ready for review. Upon approval:
+
+1. Spec is committed to `main` (via separate PR off `feature/refactor-phase1-design`).
+2. Implementation transitions to the **writing-plans** skill, which will produce `docs/superpowers/plans/2026-05-XX-engine-refactor-phase1-plan.md` — a step-by-step PR-by-PR plan with checkpoints.
+3. Phase 0 begins.


### PR DESCRIPTION
## Summary

Single review surface for the Phase 1 engine refactor. Two artifacts:

- **Design spec** (`docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md`) — 5-phase, 17-PR refactor addressing the architectural causes of the streaming-strict ghost-debugging saga (PRs #385–#388): God-class `gs_renderer` (4,687 LOC, 214 fields, 14 GPU passes), tight ECS-Renderer coupling at AppBase level, zero GPU traceability, no structured cost-aware diagnostic mode.
- **Implementation plan** (`docs/superpowers/plans/2026-05-02-engine-refactor-phase1-plan.md`) — 1,750 lines. Phase 0 (foundation) is fully bite-sized step-by-step (39 tasks across 2 PRs). Phases 1–5 are PR-level briefs that get expanded into detailed sub-plans on demand.

## Locked design decisions

- **Split axis:** System-centric (Streaming + Sort + TileBin + PostProcess + passive ResourceManager) consumed by an ~80-LOC `GsRenderer::render()` orchestrator
- **ECS data-flow contract:** Pure-CPU components + persistent-mapped `RenderState` (Option C) — keeps Vulkan headers out of ECS, zero-copy via persistent-mapped buffers double-buffered per frame-in-flight
- **Event bus:** Bevy-style typed `EventQueue<T>` with 2-frame retention
- **Diagnostic tiers:** Tier A (always-on, NDEBUG-gated) / Tier B (compile-time, `GSEURAT_DEBUG_BUILD`) / Tier C (runtime env-var, `gs::dbg::Diag` registry); `GS_LABEL` (RAII), `GS_DBG_INVARIANT` (macro for expression-unevaluation)
- **New CMake option `GSEURAT_DEBUG_FORCE`** + new preset `macos-release-with-diag` (release with diagnostics)
- **Determinism Mode** (Phase 0b hard prerequisite): `gs::SimClock` + seeded `gs::random` + `--deterministic` flag + frame-aligned input + macOS-only pixel diff

## Rollout discipline

- 17 PRs, strict serial (one merged green before the next begins)
- Each PR own branch + own worktree, never touch \`main\` directly
- Per-PR validation gate: build (3 profiles) + validation layer clean + regression harness (SSIM ≥ 0.985) + determinism self-check (SSIM = 1.000) + invariant clean + GPU timing budget (≤ 5% regression)
- Phase 0b's golden-frame harness is the safety net that should have caught the two prior reverted attempts in this area

## Test plan

- [ ] Read both docs end-to-end
- [ ] Sanity check spec §6 PR table against plan PR-level breakdowns (consistency)
- [ ] Confirm Phase 0 task granularity is right (full step-by-step) and Phases 1–5 brief-level is acceptable for now
- [ ] Confirm the CI hardware-parity decision (macOS-only pixel diff) is acceptable
- [ ] Confirm Determinism Mode scope (RNG audit + clock audit + vsync handling + audio sync-tick or disable) is correctly bounded

## What this PR does NOT do

Zero engine code changes. Pure documentation. Implementation begins in subsequent PRs (\`refactor/0a-debug-header\` → \`refactor/0b-golden-frames\` → ...).

🤖 Generated with [Claude Code](https://claude.com/claude-code)