### PR TITLE
refactor(engine): add gs::dbg diagnostic header (Phase 0a)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,14 @@ target_compile_definitions(gseurat_core PUBLIC
     GLM_FORCE_DEPTH_ZERO_TO_ONE
 )
 
+option(GSEURAT_DEBUG_FORCE "Force debug instrumentation in Release builds" OFF)
+
+target_compile_definitions(gseurat_core PUBLIC
+    GSEURAT_DEBUG_BUILD=$<IF:$<OR:$<CONFIG:Debug>,$<BOOL:${GSEURAT_DEBUG_FORCE}>>,1,0>
+)
+
+target_sources(gseurat_core PRIVATE src/engine/debug.cpp)
+
 if(GSEURAT_SHARED_LIBS)
     target_compile_definitions(gseurat_core PUBLIC GSEURAT_ENGINE_BUILD_SHARED)
 endif()
@@ -546,6 +554,9 @@ target_include_directories(test_audio_effect_chain PRIVATE ${PROJECT_SOURCE_DIR}
 add_gseurat_test(test_ply2heightmap
     src/engine/gaussian_cloud.cpp
     src/engine/project_root.cpp)
+
+add_gseurat_test(test_debug
+    src/engine/debug.cpp)
 
 # --- GPU Tests (require actual GPU, link engine sources directly) ----------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,6 +566,7 @@ function(add_gseurat_gpu_test NAME)
         tests/gpu_test_context.cpp
         tests/onesweep_test_runner.cpp
         src/engine/vk_context.cpp
+        src/engine/debug.cpp
         src/engine/buffer.cpp
         src/engine/pipeline.cpp
         src/engine/pipeline_cache.cpp

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -100,6 +100,21 @@
         "lhs": "${hostSystemName}",
         "rhs": "Darwin"
       }
+    },
+    {
+      "name": "macos-release-with-diag",
+      "inherits": "base",
+      "displayName": "macOS Release with Diagnostics",
+      "description": "Release build with GPU labels and invariant checks (release-with-diag profile)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "GSEURAT_DEBUG_FORCE": "ON"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
     }
   ],
   "buildPresets": [
@@ -126,6 +141,10 @@
     {
       "name": "macos-release",
       "configurePreset": "macos-release"
+    },
+    {
+      "name": "macos-release-with-diag",
+      "configurePreset": "macos-release-with-diag"
     }
   ]
 }

--- a/include/gseurat/engine/debug.hpp
+++ b/include/gseurat/engine/debug.hpp
@@ -1,0 +1,68 @@
+// include/gseurat/engine/debug.hpp
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <glm/vec4.hpp>
+#include <cstdint>
+
+#ifndef GSEURAT_DEBUG_BUILD
+#  define GSEURAT_DEBUG_BUILD 0
+#endif
+
+namespace gs::dbg {
+
+inline constexpr bool kEnabled = (GSEURAT_DEBUG_BUILD != 0);
+
+// === Tier B: RAII Vulkan Debug Utils label ===
+class ScopedLabel {
+ public:
+  ScopedLabel(VkCommandBuffer cmd, const char* name,
+              glm::vec4 color = {0.5f, 0.5f, 0.5f, 1.0f}) noexcept;
+  ~ScopedLabel() noexcept;
+
+  ScopedLabel(const ScopedLabel&) = delete;
+  ScopedLabel& operator=(const ScopedLabel&) = delete;
+  ScopedLabel(ScopedLabel&&) = delete;
+  ScopedLabel& operator=(ScopedLabel&&) = delete;
+
+ private:
+  VkCommandBuffer cmd_;
+};
+
+// === Tier B: object naming ===
+void set_object_name(VkDevice device, VkObjectType type,
+                     std::uint64_t handle, const char* name) noexcept;
+
+// === Tier C: env-var diag registry ===
+enum class Diag : std::uint16_t {
+  StreamingState,    // GS_DIAG_STREAMING
+  GpuTiming,         // GS_DIAG_GPU_TIMING
+  ChunkInventory,    // GS_DIAG_CHUNKS
+  RenderStateSlots,  // GS_DIAG_RENDERSTATE
+  EventQueueSizes,   // GS_DIAG_EVENTS
+  COUNT_
+};
+
+bool enabled(Diag) noexcept;
+
+// === Lifecycle (called from VkContext) ===
+void init_function_pointers(VkInstance instance) noexcept;
+void init_diag_registry() noexcept;  // populates from getenv once
+
+// === Tier B: invariant — argument unevaluated when disabled ===
+[[noreturn]] void invariant_failed(const char* expr, const char* msg,
+                                    const char* file, int line) noexcept;
+
+}  // namespace gs::dbg
+
+#if GSEURAT_DEBUG_BUILD
+  #define GS_DBG_INVARIANT(cond, msg) \
+    do { if (!(cond)) ::gs::dbg::invariant_failed(#cond, msg, __FILE__, __LINE__); } while (0)
+  #define GS_LABEL_CONCAT_IMPL(a, b) a##b
+  #define GS_LABEL_CONCAT(a, b) GS_LABEL_CONCAT_IMPL(a, b)
+  #define GS_LABEL(cmd, name) \
+    ::gs::dbg::ScopedLabel GS_LABEL_CONCAT(_gs_dbg_label_, __LINE__)((cmd), (name))
+#else
+  #define GS_DBG_INVARIANT(cond, msg) ((void)0)
+  #define GS_LABEL(cmd, name) ((void)0)
+#endif

--- a/src/engine/debug.cpp
+++ b/src/engine/debug.cpp
@@ -1,0 +1,101 @@
+// src/engine/debug.cpp
+#include "gseurat/engine/debug.hpp"
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace gs::dbg {
+
+namespace {
+
+PFN_vkCmdBeginDebugUtilsLabelEXT  g_begin_label = nullptr;
+PFN_vkCmdEndDebugUtilsLabelEXT    g_end_label   = nullptr;
+PFN_vkSetDebugUtilsObjectNameEXT  g_set_name    = nullptr;
+
+std::array<bool, static_cast<std::size_t>(Diag::COUNT_)> g_diag_flags{};
+
+constexpr const char* env_var_for(Diag d) noexcept {
+  switch (d) {
+    case Diag::StreamingState:   return "GS_DIAG_STREAMING";
+    case Diag::GpuTiming:        return "GS_DIAG_GPU_TIMING";
+    case Diag::ChunkInventory:   return "GS_DIAG_CHUNKS";
+    case Diag::RenderStateSlots: return "GS_DIAG_RENDERSTATE";
+    case Diag::EventQueueSizes:  return "GS_DIAG_EVENTS";
+    case Diag::COUNT_:           break;
+  }
+  return "";
+}
+
+}  // namespace
+
+ScopedLabel::ScopedLabel(VkCommandBuffer cmd, const char* name, glm::vec4 color) noexcept
+    : cmd_(cmd) {
+  if constexpr (kEnabled) {
+    if (g_begin_label) {
+      VkDebugUtilsLabelEXT label{};
+      label.sType      = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+      label.pLabelName = name;
+      label.color[0]   = color.r;
+      label.color[1]   = color.g;
+      label.color[2]   = color.b;
+      label.color[3]   = color.a;
+      g_begin_label(cmd_, &label);
+    }
+  }
+}
+
+ScopedLabel::~ScopedLabel() noexcept {
+  if constexpr (kEnabled) {
+    if (g_end_label) g_end_label(cmd_);
+  }
+}
+
+void set_object_name(VkDevice device, VkObjectType type,
+                     std::uint64_t handle, const char* name) noexcept {
+  if constexpr (kEnabled) {
+    if (g_set_name) {
+      VkDebugUtilsObjectNameInfoEXT info{};
+      info.sType        = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+      info.objectType   = type;
+      info.objectHandle = handle;
+      info.pObjectName  = name;
+      g_set_name(device, &info);
+    }
+  }
+}
+
+bool enabled(Diag d) noexcept {
+  const auto idx = static_cast<std::size_t>(d);
+  return idx < g_diag_flags.size() && g_diag_flags[idx];
+}
+
+void init_function_pointers(VkInstance instance) noexcept {
+  if constexpr (kEnabled) {
+    g_begin_label = reinterpret_cast<PFN_vkCmdBeginDebugUtilsLabelEXT>(
+        vkGetInstanceProcAddr(instance, "vkCmdBeginDebugUtilsLabelEXT"));
+    g_end_label = reinterpret_cast<PFN_vkCmdEndDebugUtilsLabelEXT>(
+        vkGetInstanceProcAddr(instance, "vkCmdEndDebugUtilsLabelEXT"));
+    g_set_name = reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(
+        vkGetInstanceProcAddr(instance, "vkSetDebugUtilsObjectNameEXT"));
+  }
+}
+
+void init_diag_registry() noexcept {
+  for (std::size_t i = 0; i < g_diag_flags.size(); ++i) {
+    const char* var = env_var_for(static_cast<Diag>(i));
+    if (var[0] == '\0') continue;
+    const char* val = std::getenv(var);
+    g_diag_flags[i] = (val && val[0] == '1');
+  }
+}
+
+[[noreturn]] void invariant_failed(const char* expr, const char* msg,
+                                    const char* file, int line) noexcept {
+  std::fprintf(stderr, "[gs::dbg INVARIANT FAILED] %s\n  expr: %s\n  at: %s:%d\n",
+               msg, expr, file, line);
+  std::abort();
+}
+
+}  // namespace gs::dbg

--- a/src/engine/vk_context.cpp
+++ b/src/engine/vk_context.cpp
@@ -1,6 +1,7 @@
 #define VMA_IMPLEMENTATION
 #include "gseurat/engine/vk_context.hpp"
 
+#include "gseurat/engine/debug.hpp"
 #include "gseurat/engine/project_root.hpp"
 
 #include <cstdio>
@@ -24,6 +25,8 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL debug_callback(
 void VkContext::init(GLFWwindow* window) {
     create_instance();
     setup_debug_messenger();
+    gs::dbg::init_function_pointers(instance_);
+    gs::dbg::init_diag_registry();
     create_surface(window);
     pick_physical_device();
     create_logical_device();
@@ -35,6 +38,8 @@ void VkContext::init_headless() {
     headless_ = true;
     create_instance_headless();
     setup_debug_messenger();
+    gs::dbg::init_function_pointers(instance_);
+    gs::dbg::init_diag_registry();
     pick_physical_device_headless();
     create_logical_device_headless();
     create_allocator();

--- a/tests/test_debug.cpp
+++ b/tests/test_debug.cpp
@@ -1,0 +1,50 @@
+// tests/test_debug.cpp
+#include "gseurat/engine/debug.hpp"
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+int main() {
+  auto set_env = [](const char* name, const char* value) {
+#ifdef _WIN32
+    std::string assignment(name);
+    assignment += "=";
+    assignment += value;
+    _putenv(assignment.c_str());
+#else
+    setenv(name, value, 1);
+#endif
+  };
+  auto unset_env = [](const char* name) {
+#ifdef _WIN32
+    std::string assignment(name);
+    assignment += "=";
+    _putenv(assignment.c_str());
+#else
+    unsetenv(name);
+#endif
+  };
+
+  // Default: no diag flags set
+  unset_env("GS_DIAG_STREAMING");
+  unset_env("GS_DIAG_GPU_TIMING");
+  gs::dbg::init_diag_registry();
+  assert(!gs::dbg::enabled(gs::dbg::Diag::StreamingState));
+  assert(!gs::dbg::enabled(gs::dbg::Diag::GpuTiming));
+
+  // Set env var, re-init, verify flag flips
+  set_env("GS_DIAG_STREAMING", "1");
+  gs::dbg::init_diag_registry();
+  assert(gs::dbg::enabled(gs::dbg::Diag::StreamingState));
+  assert(!gs::dbg::enabled(gs::dbg::Diag::GpuTiming));
+
+  // "0" should be off, only "1" enables
+  set_env("GS_DIAG_STREAMING", "0");
+  gs::dbg::init_diag_registry();
+  assert(!gs::dbg::enabled(gs::dbg::Diag::StreamingState));
+
+  std::printf("test_debug: OK\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Phase 0a of the engine refactor. Adds three-tier diagnostic infrastructure as foundation for Phase 2 instrumentation. **Zero behavioral change to running engine** — `GS_LABEL` and `GS_DBG_INVARIANT` are not yet inserted into any production code path.

Spec: `docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md` §5.4 (also see #389).
Plan: `docs/superpowers/plans/2026-05-02-engine-refactor-phase1-plan.md` "PR 0a".

## What this delivers

### `gs::dbg` namespace (`include/gseurat/engine/debug.hpp`, `src/engine/debug.cpp`)

- **Tier B (compile-time, `GSEURAT_DEBUG_BUILD`)**
  - `gs::dbg::ScopedLabel` — RAII wrapper around `vkCmdBeginDebugUtilsLabelEXT` / `End`. Auto-pairs, copyable/movable forbidden.
  - `gs::dbg::set_object_name` — wraps `vkSetDebugUtilsObjectNameEXT`.
  - `GS_LABEL(cmd, name)` macro — RAII shortcut, no-op when disabled (`((void)0)`).
  - `GS_DBG_INVARIANT(cond, msg)` macro — argument unevaluated when disabled (so expensive checks like \`static_count_ == sum_chunks()\` cost nothing in release).
- **Tier C (runtime env-var)**
  - `gs::dbg::Diag` enum + `enabled(Diag)` lookup. O(1) array probe.
  - 5 diag flags wired: `GS_DIAG_STREAMING`, `GS_DIAG_GPU_TIMING`, `GS_DIAG_CHUNKS`, `GS_DIAG_RENDERSTATE`, `GS_DIAG_EVENTS`. Populated once at startup from `getenv`.

### CMake integration

- New `option(GSEURAT_DEBUG_FORCE OFF)` — enables Tier B in Release builds.
- `target_compile_definitions(gseurat_core PUBLIC GSEURAT_DEBUG_BUILD=...)` — **PUBLIC** so consumers (staging, demo, parent projects via `add_subdirectory`) see the macro and don't fall through to the header's \`#ifndef\` fallback.
- New preset `macos-release-with-diag` — Release + `GSEURAT_DEBUG_FORCE=ON`. Third build profile for catching optimization-dependent bugs while keeping trace labels.

### Wiring into engine

- `vk_context.cpp` calls `gs::dbg::init_function_pointers(instance_)` and `gs::dbg::init_diag_registry()` after `setup_debug_messenger` in both `init()` and `init_headless()`.

### Test (`tests/test_debug.cpp`)

- Verifies `Diag` registry reflects env-var state across re-init.
- Cross-platform env-var helpers (POSIX `setenv` / MSVC `_putenv`) since project supports Windows.
- Registered as `add_gseurat_test(test_debug src/engine/debug.cpp)` — matches project's `test_*` naming convention.

## Why now

The streaming-strict ghost-debugging saga (PRs #385–#388) consumed weeks. Many of those bugs would have surfaced in minutes if we had:
- Vulkan Debug Utils labels in RenderDoc traces (semantic context vs. anonymous dispatches)
- `GS_DBG_INVARIANT(static_count_ == sum_chunks(), "...")` firing the moment streaming and legacy paths drifted

This PR builds the infrastructure; PR 2 sprinkles labels and invariants throughout the renderer.

## Test plan

- [x] Build clean: \`cmake --build --preset macos-debug\`
- [x] Build clean: \`cmake --build --preset macos-release\`
- [x] Build clean: \`cmake --build --preset macos-release-with-diag\` (new profile)
- [x] \`ctest --preset macos-debug -R "^test_debug$"\` — 1/1 passing
- [ ] CI Linux/Windows clean
- [ ] Manual: insert temporary GS_LABEL into render(), capture in RenderDoc, verify hierarchy visible (deferred to PR 2 when labels are added throughout)

## Diff stats

\`6 files changed, 254 insertions(+)\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)