### PR TITLE
refactor(engine): PR 1a — purge load_cloud + load_cloud_legacy, add tools/ply_importer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,15 @@ target_link_libraries(ply2heightmap PRIVATE glm::glm nlohmann_json::nlohmann_jso
 
 endif() # GSEURAT_BUILD_EXAMPLES
 
+# --- Offline tools ----------------------------------------------------------
+# Standalone CLI utilities that do NOT link gseurat_core.
+# Gated behind GSEURAT_BUILD_TOOLS (ON by default for top-level builds, OFF
+# when included as a submodule via add_subdirectory).
+
+if(GSEURAT_BUILD_TOOLS)
+add_subdirectory(tools/ply_importer)
+endif() # GSEURAT_BUILD_TOOLS
+
 # --- Tests ------------------------------------------------------------------
 
 if(GSEURAT_BUILD_TESTS)

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -88,7 +88,6 @@ class GsRenderer {
 public:
     void init(VkDevice device, VkPhysicalDevice physical_device, VmaAllocator allocator,
               VkDescriptorPool pool, VkPipelineCache pipeline_cache);
-    void load_cloud(const GaussianCloud& cloud);
     void init_streaming(const StreamingConfig& config);
     void unload_cloud(uint32_t chunk_id);
     // Release every active chunk and any in-flight pending async loads.
@@ -114,8 +113,8 @@ public:
     // fit in the staging ring at once. Returns one Handle per slab,
     // pre-allocated so `EngineLoadingMonitor` can poll their status
     // immediately even before any has been submitted to the GPU.
-    // Falls back to synchronous `load_cloud` (and returns {}) if streaming
-    // isn't initialized or no transfer queue exists.
+    // Requires init_streaming() and create_transfer_queue() to have been
+    // called first; logs an error and returns {} if streaming isn't ready.
     std::vector<TransferQueue::Handle> load_cloud_async(GaussianCloud cloud);
     void poll_transfers(VkCommandBuffer frame_cmd);
     void create_transfer_queue(VkQueue transfer_q, uint32_t transfer_family,
@@ -374,7 +373,6 @@ private:
         VkDescriptorSet hist_a, VkDescriptorSet hist_b,
         VkDescriptorSet scatter_ab, VkDescriptorSet scatter_ba);
     void dispatch_tile_sort(VkCommandBuffer cmd);
-    void load_cloud_legacy(const GaussianCloud& cloud);
     // Drain pending_publications_ and record the metadata writes
     // (page_table, chunk_table) onto `cmd` via vkCmdUpdateBuffer + a
     // TRANSFER_WRITE -> SHADER_READ barrier. Called from poll_transfers

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -744,7 +744,7 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
         // Sentinel-fill sort buffers: key=0xFFFFFFFF sorts to the tail and
         // is never read by the merge's [0, count) window. index=0 is a
         // safe placeholder (never read while paired with sentinel key).
-        // Subsequent load_cloud / load_cloud_legacy call init_sort_buf,
+        // load_cloud_async's completion callback calls init_sort_buf,
         // which reproduces this layout — this just covers the pre-load
         // window between init_streaming and the first scene load.
         auto sentinel_fill_sort = [](Buffer& buf, uint32_t entries) {
@@ -932,115 +932,6 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
                  config.gpu_budget_splats, config.total_slabs(), config.slab_size_splats);
 }
 
-void GsRenderer::load_cloud(const GaussianCloud& cloud) {
-    if (!streaming_initialized_) {
-        load_cloud_legacy(cloud);
-        return;
-    }
-
-    if (cloud.empty()) return;
-
-    // Wait for GPU before writing to buffers
-    if (initialized_) {
-        vkDeviceWaitIdle(device_);
-    }
-
-    // Release old scene data — return slabs to allocator, reset tracking state.
-    // Without this, loading a second scene appends to active_chunks_ and old
-    // Gaussian data persists in GPU buffers (visual corruption + VRAM leak).
-    for (auto& chunk : active_chunks_) {
-        slab_allocator_->release(chunk.handle);
-    }
-    active_chunks_.clear();
-    static_count_ = 0;
-    total_active_splats_ = 0;
-
-    sort_done_once_ = false;
-    static_dirty_ = true;
-
-    uint32_t sps = streaming_config_.slab_size_splats;
-    uint32_t slabs_needed = (cloud.count() + sps - 1) / sps;
-    auto handle = slab_allocator_->checkout(slabs_needed);
-
-    // Calculate page table offset from existing chunks
-    uint32_t page_table_offset = 0;
-    for (const auto& chunk : active_chunks_) {
-        page_table_offset += static_cast<uint32_t>(chunk.handle.slab_indices.size());
-    }
-
-    // Write page table entries
-    auto* pt = static_cast<uint32_t*>(page_table_ssbo_.mapped());
-    for (uint32_t i = 0; i < slabs_needed; ++i) {
-        pt[page_table_offset + i] = handle.slab_indices[i];
-    }
-
-    // Write Gaussian data into physical slab locations
-    {
-        auto* gpu = static_cast<GpuGaussian*>(static_gaussian_ssbo_.mapped());
-        for (uint32_t slab_idx = 0; slab_idx < slabs_needed; ++slab_idx) {
-            uint32_t phys_slab = handle.slab_indices[slab_idx];
-            uint32_t base_src = slab_idx * sps;
-            uint32_t base_dst = phys_slab * sps;
-            uint32_t count_in_slab = std::min(sps, cloud.count() - base_src);
-
-            std::vector<GpuGaussian> staging(count_in_slab);
-            for (uint32_t i = 0; i < count_in_slab; ++i) {
-                const auto& g = cloud.gaussians()[base_src + i];
-                float bone_as_float;
-                uint32_t bone_idx = g.bone_index;
-                std::memcpy(&bone_as_float, &bone_idx, sizeof(float));
-                staging[i].pos_opacity = glm::vec4(g.position, g.opacity);
-                staging[i].scale_pad = glm::vec4(g.scale, bone_as_float);
-                staging[i].rot = glm::vec4(g.rotation.x, g.rotation.y, g.rotation.z, g.rotation.w);
-                staging[i].color_pad = glm::vec4(g.color, g.emission);
-            }
-            std::memcpy(gpu + base_dst, staging.data(), count_in_slab * sizeof(GpuGaussian));
-        }
-    }
-
-    // Write chunk table entry
-    {
-        auto* ct = static_cast<uint8_t*>(chunk_table_ssbo_.mapped());
-        uint32_t chunk_idx = static_cast<uint32_t>(active_chunks_.size());
-        uint32_t last_slab_splats = cloud.count() - (slabs_needed - 1) * sps;
-        uint32_t entry[4] = {page_table_offset, slabs_needed, last_slab_splats, cloud.count()};
-        std::memcpy(ct + chunk_idx * 16, entry, 16);
-    }
-
-    // Record chunk state
-    ChunkState cs;
-    cs.status = ChunkState::Status::ACTIVE;
-    cs.handle = std::move(handle);
-    cs.page_table_offset = page_table_offset;
-    cs.splat_count = cloud.count();
-    active_chunks_.push_back(std::move(cs));
-
-    // Recalculate total static count
-    static_count_ = 0;
-    for (const auto& chunk : active_chunks_) {
-        static_count_ += chunk.splat_count;
-    }
-    total_active_splats_ = static_count_;
-    gaussian_count_ = static_count_;
-
-    // Initialize sort buffers with sentinel keys
-    auto init_sort_buf = [](Buffer& buf, uint32_t sort_size, uint32_t valid_count) {
-        std::vector<SortEntry> staging(sort_size);
-        for (uint32_t i = 0; i < sort_size; ++i) {
-            staging[i].key = 0xFFFFFFFF;
-            staging[i].index = i < valid_count ? i : 0;
-        }
-        std::memcpy(buf.mapped(), staging.data(), sort_size * sizeof(SortEntry));
-    };
-    init_sort_buf(static_sort_a_, static_sort_size_, static_count_);
-    init_sort_buf(static_sort_b_, static_sort_size_, static_count_);
-
-    static_dirty_ = true;
-
-    std::fprintf(stderr, "GS: Loaded chunk %u — %u splats in %u slabs (total active: %u)\n",
-                 active_chunks_.back().handle.chunk_id, cloud.count(), slabs_needed, static_count_);
-}
-
 void GsRenderer::unload_cloud(uint32_t chunk_id) {
     if (!streaming_initialized_) return;
     // Verify the chunk actually exists before queuing — caller may
@@ -1063,8 +954,7 @@ void GsRenderer::clear_chunks(VkCommandBuffer drain_cmd) {
     if (!streaming_initialized_ || !initialized_) return;
 
     // Wait for any in-flight transfers so we don't release slabs the GPU
-    // is still writing to. Scene transitions are heavy operations
-    // already; this matches the pre-streaming `load_cloud` behaviour.
+    // is still writing to. Scene transitions are heavy operations.
     vkDeviceWaitIdle(device_);
 
     // Drain any completion callbacks queued by transfers that finished
@@ -1287,11 +1177,15 @@ void GsRenderer::create_transfer_queue(VkQueue transfer_q, uint32_t transfer_fam
 
 std::vector<TransferQueue::Handle> GsRenderer::load_cloud_async(GaussianCloud cloud) {
     if (!streaming_initialized_ || !transfer_queue_) {
-        // No streaming infra: fall through to the synchronous path. Returning
-        // an empty handle list lets EngineLoadingMonitor advance on its
-        // min-duration timer alone (since `tick` already treats Unknown
-        // handles as resolved).
-        load_cloud(cloud);
+        // Streaming-strict mode: init_streaming + create_transfer_queue must
+        // both be called before load_cloud_async. Reaching this branch means
+        // the caller violated the contract; surface it immediately.
+        std::fprintf(stderr,
+            "GS ERROR: load_cloud_async called before streaming was initialized "
+            "(streaming_initialized_=%d, transfer_queue_=%s). "
+            "Call init_streaming() and create_transfer_queue() first.\n",
+            static_cast<int>(streaming_initialized_),
+            transfer_queue_ ? "ok" : "null");
         return {};
     }
     if (cloud.empty()) return {};
@@ -1299,12 +1193,9 @@ std::vector<TransferQueue::Handle> GsRenderer::load_cloud_async(GaussianCloud cl
     // Append-only semantics. The new chunk is checked out from the slab
     // allocator and pushed onto `active_chunks_` by the final completion
     // callback — existing chunks are *not* released. Callers that need
-    // "replace previous scene" must explicitly clear before this call
-    // (the initial demo load arrives on an empty `active_chunks_`
-    // straight out of `init_streaming`, so this matches the documented
-    // contract for both code paths). The synchronous `load_cloud` is
-    // still the right tool when a true scene replacement is needed —
-    // it does the `vkDeviceWaitIdle` + chunk release in one shot.
+    // "replace previous scene" must explicitly call clear_chunks() before
+    // this (the initial demo load arrives on an empty `active_chunks_`
+    // straight out of `init_streaming`).
     //
     // Multiple concurrent loads queue up on `pending_loads_` instead of
     // being rejected — WorldStreamer marks each chunk `LOADING` once
@@ -1809,272 +1700,6 @@ void GsRenderer::publish_pending_chunks(VkCommandBuffer cmd) {
             VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
             0, 0, nullptr, nb, barriers, 0, nullptr);
     }
-}
-
-void GsRenderer::load_cloud_legacy(const GaussianCloud& cloud) {
-    if (cloud.empty()) return;
-
-    // Wait for GPU before destroying existing buffers
-    if (initialized_) {
-        vkDeviceWaitIdle(device_);
-    }
-
-    sort_done_once_ = false;
-    static_dirty_ = true;
-
-    // Static/dynamic counts
-    static_count_ = cloud.count();
-    max_static_count_ = static_count_ + kParticleHeadroom;
-    max_dynamic_count_ = kDynamicHeadroom;
-    dynamic_count_ = 0;
-
-    // Backward compat: keep legacy members up to date
-    gaussian_count_ = static_count_;
-    max_gaussian_count_ = max_static_count_ + max_dynamic_count_;
-
-    // Helper: compute sort size (aligned to Onesweep ENTRIES_PER_WG = 2048)
-    auto compute_sort_params = [](uint32_t max_count, uint32_t& sort_size, uint32_t& num_wg) {
-        sort_size = ((max_count + 2047) / 2048) * 2048;
-        if (sort_size < max_count) sort_size = max_count;
-        num_wg = sort_size / 2048;
-        if (num_wg == 0) num_wg = 1;
-        sort_size = num_wg * 2048;
-    };
-
-    compute_sort_params(max_static_count_, static_sort_size_, static_sort_workgroups_);
-    compute_sort_params(max_dynamic_count_, dynamic_sort_size_, dynamic_sort_workgroups_);
-
-    // Legacy sort params (use static for backward compat)
-    sort_size_ = static_sort_size_;
-    num_sort_workgroups_ = static_sort_workgroups_;
-
-    // Buffer sizes
-    VkDeviceSize static_gauss_size = static_cast<VkDeviceSize>(max_static_count_) * sizeof(GpuGaussian);
-    VkDeviceSize dynamic_gauss_size = static_cast<VkDeviceSize>(max_dynamic_count_) * sizeof(GpuGaussian);
-    VkDeviceSize projected_buf_size = static_cast<VkDeviceSize>(max_static_count_ + max_dynamic_count_) * sizeof(ProjectedSplat);
-    VkDeviceSize static_sort_buf_size = static_cast<VkDeviceSize>(static_sort_size_) * sizeof(SortEntry);
-    VkDeviceSize dynamic_sort_buf_size = static_cast<VkDeviceSize>(dynamic_sort_size_) * sizeof(SortEntry);
-    VkDeviceSize merged_sort_buf_size = static_cast<VkDeviceSize>(max_static_count_ + max_dynamic_count_) * sizeof(SortEntry);
-
-    // Destroy ALL old buffers (legacy + split)
-    gaussian_ssbo_.destroy(allocator_);
-    projected_ssbo_.destroy(allocator_);
-    sort_keys_ssbo_.destroy(allocator_);
-    sort_b_ssbo_.destroy(allocator_);
-    uniform_buffer_.destroy(allocator_);
-    visible_count_ssbo_.destroy(allocator_);
-    bone_ssbo_.destroy(allocator_);
-    pbd_state_ssbo_.destroy(allocator_);
-    pbd_params_ssbo_.destroy(allocator_);
-    pbd_constraint_ssbo_.destroy(allocator_);
-    pbd_uniform_buffer_.destroy(allocator_);
-    static_gaussian_ssbo_.destroy(allocator_);
-    dynamic_gaussian_ssbo_.destroy(allocator_);
-    static_sort_a_.destroy(allocator_);
-    static_sort_b_.destroy(allocator_);
-    dynamic_sort_a_.destroy(allocator_);
-    dynamic_sort_b_.destroy(allocator_);
-    merged_sort_ssbo_.destroy(allocator_);
-    counts_ssbo_.destroy(allocator_);
-
-    // Create split buffers
-    // static_gaussian_ssbo_ is the dst of vkCmdCopyBuffer for chunk
-    // streaming — see init_streaming for the TRANSFER_DST_BIT rationale.
-    static_gaussian_ssbo_ = Buffer::create_storage_host_dst(allocator_, static_gauss_size);
-    dynamic_gaussian_ssbo_ = Buffer::create_storage(allocator_, dynamic_gauss_size);
-    projected_ssbo_ = Buffer::create_storage(allocator_, projected_buf_size);
-    // host_dst (TRANSFER_DST_BIT) — see init_streaming for rationale.
-    static_sort_a_ = Buffer::create_storage_host_dst(allocator_, static_sort_buf_size);
-    static_sort_b_ = Buffer::create_storage_host_dst(allocator_, static_sort_buf_size);
-    dynamic_sort_a_ = Buffer::create_storage(allocator_, dynamic_sort_buf_size);
-    dynamic_sort_b_ = Buffer::create_storage(allocator_, dynamic_sort_buf_size);
-    merged_sort_ssbo_ = Buffer::create_storage(allocator_, merged_sort_buf_size);
-    counts_ssbo_ = Buffer::create_storage_readback(allocator_, 3 * sizeof(uint32_t));  // {static_visible, dynamic_visible, merged_visible}
-    uniform_buffer_ = Buffer::create_uniform(allocator_, sizeof(GsUniforms));
-    visible_count_ssbo_ = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
-
-    // Legacy gaussian_ssbo_ aliases static for backward compat
-    gaussian_ssbo_ = Buffer::create_storage(allocator_,
-        static_cast<VkDeviceSize>(max_gaussian_count_) * sizeof(GpuGaussian));
-    sort_keys_ssbo_ = Buffer::create_storage(allocator_, static_sort_buf_size);
-    sort_b_ssbo_ = Buffer::create_storage(allocator_, static_sort_buf_size);
-
-    // Bone transform SSBO (always allocated, zeroed if unused)
-    bone_ssbo_ = Buffer::create_storage(allocator_, kMaxBones * sizeof(glm::mat4));
-    bone_count_ = 0;
-    {
-        auto* bones = static_cast<glm::mat4*>(bone_ssbo_.mapped());
-        for (uint32_t i = 0; i < kMaxBones; ++i) bones[i] = glm::mat4(1.0f);
-    }
-
-    // PBD state, params, and constraint SSBOs (always allocated, zeroed if unused)
-    pbd_state_ssbo_ = Buffer::create_storage(allocator_,
-        kMaxPbdElements * sizeof(PbdPhysicsState));
-    pbd_params_ssbo_ = Buffer::create_storage(allocator_,
-        kMaxPbdElements * sizeof(PbdElementParams));
-    pbd_constraint_ssbo_ = Buffer::create_storage(allocator_,
-        kMaxPbdConstraints * sizeof(PbdConstraint));
-    pbd_count_ = 0;
-    pbd_constraint_count_ = 0;
-    // Zero-initialize all PBD buffers
-    {
-        auto* states = static_cast<PbdPhysicsState*>(pbd_state_ssbo_.mapped());
-        for (uint32_t i = 0; i < kMaxPbdElements; ++i) {
-            states[i].position = glm::vec4(0.0f, 0.0f, 0.0f, 0.0f);
-            states[i].prev_position = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);  // identity quaternion (preprocess reads as rotation)
-            states[i].velocity = glm::vec4(0.0f);
-            states[i].params = glm::vec4(0.0f);
-        }
-        std::memset(pbd_params_ssbo_.mapped(), 0,
-                    kMaxPbdElements * sizeof(PbdElementParams));
-        std::memset(pbd_constraint_ssbo_.mapped(), 0,
-                    kMaxPbdConstraints * sizeof(PbdConstraint));
-    }
-    pbd_uniform_buffer_ = Buffer::create_uniform(allocator_, 32);
-
-    // Upload Gaussian data to static buffer via staging to avoid -O3 write-reordering
-    {
-        std::vector<GpuGaussian> staging(static_count_);
-        for (uint32_t i = 0; i < static_count_; ++i) {
-            const auto& g = cloud.gaussians()[i];
-            float bone_as_float;
-            uint32_t bone_idx = g.bone_index;
-            std::memcpy(&bone_as_float, &bone_idx, sizeof(float));
-            staging[i].pos_opacity = glm::vec4(g.position, g.opacity);
-            staging[i].scale_pad = glm::vec4(g.scale, bone_as_float);
-            staging[i].rot = glm::vec4(g.rotation.x, g.rotation.y, g.rotation.z, g.rotation.w);
-            staging[i].color_pad = glm::vec4(g.color, g.emission);
-        }
-        std::memcpy(static_gaussian_ssbo_.mapped(), staging.data(), static_count_ * sizeof(GpuGaussian));
-        // Also mirror to legacy buffer for backward compat
-        if (gaussian_ssbo_.mapped() && gaussian_ssbo_.mapped() != static_gaussian_ssbo_.mapped()) {
-            std::memcpy(gaussian_ssbo_.mapped(), staging.data(), static_count_ * sizeof(GpuGaussian));
-        }
-    }
-
-    // Initialize sort buffers with sentinel keys via staging memcpy
-    auto init_sort_buf = [](Buffer& buf, uint32_t sort_size, uint32_t valid_count) {
-        std::vector<SortEntry> staging(sort_size);
-        for (uint32_t i = 0; i < sort_size; ++i) {
-            staging[i].key = 0xFFFFFFFF;
-            staging[i].index = i < valid_count ? i : 0;
-        }
-        std::memcpy(buf.mapped(), staging.data(), sort_size * sizeof(SortEntry));
-    };
-    init_sort_buf(static_sort_a_, static_sort_size_, static_count_);
-    init_sort_buf(static_sort_b_, static_sort_size_, static_count_);
-    init_sort_buf(dynamic_sort_a_, dynamic_sort_size_, 0);
-    init_sort_buf(dynamic_sort_b_, dynamic_sort_size_, 0);
-
-    // Legacy sort buffers
-    init_sort_buf(sort_keys_ssbo_, static_sort_size_, static_count_);
-    init_sort_buf(sort_b_ssbo_, static_sort_size_, static_count_);
-
-    // Zero the counts buffer {0, 0, 0}
-    {
-        auto* counts = static_cast<uint32_t*>(counts_ssbo_.mapped());
-        counts[0] = 0;
-        counts[1] = 0;
-        counts[2] = 0;
-    }
-
-    // Allocate a dummy page table buffer for binding 8 (legacy path, USE_PAGE_TABLE=0)
-    page_table_ssbo_.destroy(allocator_);
-    page_table_ssbo_ = Buffer::create_storage_host_dst(allocator_, sizeof(uint32_t));
-    {
-        auto* pt = static_cast<uint32_t*>(page_table_ssbo_.mapped());
-        pt[0] = 0xFFFFFFFF;
-    }
-
-    // ── Tile binning buffers (same logic as init_streaming) ──
-    {
-        uint32_t visible_upper = static_sort_size_ + dynamic_sort_size_;
-        tile_sort_capacity_ = std::min(visible_upper * 4, 1u << 21);  // cap at 2M (16MB per buffer)
-        tile_sort_size_ = ((tile_sort_capacity_ + 2047) / 2048) * 2048;
-        tile_sort_workgroups_ = tile_sort_size_ / 2048;
-        if (tile_sort_workgroups_ == 0) tile_sort_workgroups_ = 1;
-        tile_sort_size_ = tile_sort_workgroups_ * 2048;
-
-        VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 8;  // 8 bytes/entry
-        // Allocate tile_ranges for max possible resolution (output_width_ may not
-        // reflect final size at allocation time). Generous upper bound.
-        static constexpr uint32_t kMaxTiles = 256 * 144;  // supports up to 4096×2304
-        VkDeviceSize ranges_buf_size = static_cast<VkDeviceSize>(kMaxTiles) * 2 * sizeof(uint32_t);
-
-        // Deterministic tile-bin (Fix B) intermediate SSBOs.
-        scan_dispatch_size_ = ((visible_upper + 255u) / 256u) * 256u;
-        if (scan_dispatch_size_ == 0) scan_dispatch_size_ = 256u;
-        scan_num_blocks_ = scan_dispatch_size_ / 256u;
-        VkDeviceSize per_splat_buf_size =
-            static_cast<VkDeviceSize>(scan_dispatch_size_) * sizeof(uint32_t);
-        VkDeviceSize block_sums_buf_size =
-            static_cast<VkDeviceSize>(scan_num_blocks_) * sizeof(uint32_t);
-
-        tile_sort_a_.destroy(allocator_);
-        tile_sort_b_.destroy(allocator_);
-        tile_sort_count_ssbo_.destroy(allocator_);
-        tile_ranges_ssbo_.destroy(allocator_);
-        tile_indirect_args_.destroy(allocator_);
-        per_splat_tile_count_ssbo_.destroy(allocator_);
-        per_splat_tile_offset_ssbo_.destroy(allocator_);
-        scan_block_sums_ssbo_.destroy(allocator_);
-        determinism_readback_.destroy(allocator_);
-
-        tile_sort_a_ = Buffer::create_storage_gpu_only(allocator_, entry_buf_size);
-        tile_sort_b_ = Buffer::create_storage_gpu_only(allocator_, entry_buf_size);
-        tile_sort_count_ssbo_ = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
-        tile_ranges_ssbo_ = Buffer::create_storage_gpu_only(allocator_, ranges_buf_size);
-        tile_indirect_args_ = Buffer::create_storage_indirect(allocator_, 8 * sizeof(uint32_t));
-        std::memset(tile_indirect_args_.mapped(), 0, 8 * sizeof(uint32_t));
-        per_splat_tile_count_ssbo_ =
-            Buffer::create_storage_gpu_only(allocator_, per_splat_buf_size);
-        per_splat_tile_offset_ssbo_ =
-            Buffer::create_storage_gpu_only(allocator_, per_splat_buf_size);
-        scan_block_sums_ssbo_ =
-            Buffer::create_storage_gpu_only(allocator_, block_sums_buf_size);
-        determinism_readback_ = Buffer::create_readback(allocator_, entry_buf_size);
-        determinism_readback_size_ = entry_buf_size;
-
-        std::fprintf(stderr, "GS: Tile sort -- capacity=%u entries (%u workgroups), "
-                     "output=%ux%u, buf=%.1f MB; scan=%u elems / %u blocks\n",
-                     tile_sort_size_, tile_sort_workgroups_,
-                     output_width_, output_height_,
-                     static_cast<float>(entry_buf_size * 2) / (1024.0f * 1024.0f),
-                     scan_dispatch_size_, scan_num_blocks_);
-
-        // Onesweep status buffer: 4 passes × 256 digits × max_workgroups
-        onesweep_status_.destroy(allocator_);
-        onesweep_max_wg_ = (tile_sort_capacity_ + 2047) / 2048;
-        if (onesweep_max_wg_ == 0) onesweep_max_wg_ = 1;
-        VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
-        onesweep_status_ = Buffer::create_storage_gpu_only(allocator_, status_size);
-    }
-
-    // ── Depth sort Onesweep buffers ──
-    {
-        depth_onesweep_status_.destroy(allocator_);
-        depth_sort_params_.destroy(allocator_);
-        static_depth_params_.destroy(allocator_);
-        dynamic_depth_params_.destroy(allocator_);
-
-        depth_onesweep_max_wg_ = std::max({static_sort_workgroups_, dynamic_sort_workgroups_, num_sort_workgroups_});
-        VkDeviceSize depth_status_size = static_cast<VkDeviceSize>(num_sort_passes_) * 256ull
-                                         * depth_onesweep_max_wg_ * sizeof(uint32_t);
-        depth_onesweep_status_ = Buffer::create_storage_gpu_only(allocator_, depth_status_size);
-
-        auto fill_sort_params = [&](Buffer& buf, uint32_t wg_count, uint32_t entry_count) {
-            buf = Buffer::create_storage(allocator_, 8 * sizeof(uint32_t));
-            auto* p = static_cast<uint32_t*>(buf.mapped());
-            p[0] = wg_count; p[1] = 1; p[2] = 1;
-            p[3] = 0; p[4] = 0; p[5] = 0;
-            p[6] = entry_count; p[7] = 0;
-        };
-        fill_sort_params(static_depth_params_, static_sort_workgroups_, static_sort_size_);
-        fill_sort_params(dynamic_depth_params_, dynamic_sort_workgroups_, dynamic_sort_size_);
-        fill_sort_params(depth_sort_params_, num_sort_workgroups_, sort_size_);
-    }
-
-    update_descriptors();
 }
 
 void GsRenderer::update_static_gaussians(const Gaussian* data, uint32_t count) {

--- a/src/engine/gs_scene_loader.cpp
+++ b/src/engine/gs_scene_loader.cpp
@@ -270,7 +270,7 @@ void GsSceneLoader::finalize_on_main(SceneLoadContext& ctx, const SceneData& sce
 
             ctx.renderer.init_gs(cloud, gs_w, gs_h);
 
-            // Upload PBD elements AFTER init_gs (load_cloud resets pbd_count_)
+            // Upload PBD elements AFTER init_gs (init_streaming resets pbd_count_)
             if (!ctx.terrain.pbd_anchors.empty() && ctx.terrain.pbd_anchors.size() == ctx.terrain.pbd_configs.size()) {
                 uint32_t count = static_cast<uint32_t>(ctx.terrain.pbd_anchors.size());
                 std::vector<PbdPhysicsState> states(count);

--- a/tools/ply_importer/CMakeLists.txt
+++ b/tools/ply_importer/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.25)
+
+# ply_importer — standalone offline PLY → GSVX converter.
+# Does NOT link gseurat_core; depends only on glm.
+# Built when GSEURAT_BUILD_TOOLS is ON (which is ON by default for top-level
+# builds, and OFF when included via add_subdirectory as a submodule).
+
+add_executable(ply_importer
+    main.cpp
+    ply_parse.cpp
+)
+
+target_include_directories(ply_importer PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_compile_features(ply_importer PRIVATE cxx_std_23)
+
+target_compile_definitions(ply_importer PRIVATE
+    GLM_FORCE_DEPTH_ZERO_TO_ONE
+)
+
+target_link_libraries(ply_importer PRIVATE
+    glm::glm
+)

--- a/tools/ply_importer/main.cpp
+++ b/tools/ply_importer/main.cpp
@@ -1,0 +1,98 @@
+// ply_importer — offline PLY → GSVX converter
+//
+// Usage: ply_importer <in.ply> <out.gsvx>
+//
+// Reads a binary_little_endian PLY file containing 3D Gaussian Splat data,
+// converts it to the GSeurat GSVX v2 binary format (GPU-ready, zero-parse),
+// and writes the result to disk.
+//
+// GSVX v2 layout (little-endian):
+//   [GsvxHeaderV2: 64 bytes]
+//   [GpuGaussian × count: 64 bytes each]
+//
+// This tool is intentionally standalone — it does NOT link gseurat_core.
+// It is gated behind GSEURAT_BUILD_TOOLS in the top-level CMakeLists.txt.
+
+#include "ply_parse.hpp"
+
+#include <cstdint>
+#include <cstring>
+#include <cstdio>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+// GSVX v2 header — must match GsvxHeaderV2 in include/gseurat/engine/gaussian_cloud.hpp
+// Validated by static_assert in that header; kept in sync manually.
+struct GsvxHeaderV2 {
+    char     magic[4];     // "GSVX"
+    uint32_t version;      // 2
+    uint32_t count;        // Number of Gaussians in payload
+    uint32_t flags;        // Reserved (must be 0)
+    float    aabb_min[3];  // Bounding box minimum (x, y, z)
+    float    aabb_max[3];  // Bounding box maximum (x, y, z)
+    uint8_t  reserved[24]; // Zero-filled padding to 64 bytes
+};
+static_assert(sizeof(GsvxHeaderV2) == 64, "GsvxHeaderV2 must be 64 bytes");
+
+static void write_gsvx(const std::string& out_path, const ply_importer::PlyCloud& cloud) {
+    std::ofstream file(out_path, std::ios::binary | std::ios::trunc);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open output file: " + out_path);
+    }
+
+    GsvxHeaderV2 header{};
+    header.magic[0] = 'G'; header.magic[1] = 'S';
+    header.magic[2] = 'V'; header.magic[3] = 'X';
+    header.version  = 2;
+    header.count    = static_cast<uint32_t>(cloud.gaussians.size());
+    header.flags    = 0;
+    header.aabb_min[0] = cloud.bounds.min.x;
+    header.aabb_min[1] = cloud.bounds.min.y;
+    header.aabb_min[2] = cloud.bounds.min.z;
+    header.aabb_max[0] = cloud.bounds.max.x;
+    header.aabb_max[1] = cloud.bounds.max.y;
+    header.aabb_max[2] = cloud.bounds.max.z;
+    // reserved is zero-initialized by value-init above
+
+    file.write(reinterpret_cast<const char*>(&header), sizeof(header));
+    if (!cloud.gaussians.empty()) {
+        file.write(reinterpret_cast<const char*>(cloud.gaussians.data()),
+                   static_cast<std::streamsize>(cloud.gaussians.size()
+                       * sizeof(ply_importer::GpuGaussian)));
+    }
+
+    if (!file) {
+        throw std::runtime_error("Write failed for: " + out_path);
+    }
+}
+
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        std::fprintf(stderr, "Usage: %s <in.ply> <out.gsvx>\n", argv[0]);
+        return 1;
+    }
+
+    const std::string in_path  = argv[1];
+    const std::string out_path = argv[2];
+
+    try {
+        std::fprintf(stderr, "ply_importer: parsing %s ...\n", in_path.c_str());
+        auto cloud = ply_importer::parse_ply(in_path);
+        std::fprintf(stderr, "ply_importer: parsed %u gaussians, "
+                     "AABB [%.3f,%.3f,%.3f]–[%.3f,%.3f,%.3f]\n",
+                     static_cast<uint32_t>(cloud.gaussians.size()),
+                     cloud.bounds.min.x, cloud.bounds.min.y, cloud.bounds.min.z,
+                     cloud.bounds.max.x, cloud.bounds.max.y, cloud.bounds.max.z);
+
+        write_gsvx(out_path, cloud);
+        std::fprintf(stderr, "ply_importer: wrote %s (%zu bytes)\n",
+                     out_path.c_str(),
+                     sizeof(GsvxHeaderV2)
+                         + cloud.gaussians.size() * sizeof(ply_importer::GpuGaussian));
+        return 0;
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "ply_importer error: %s\n", e.what());
+        return 1;
+    }
+}

--- a/tools/ply_importer/ply_parse.cpp
+++ b/tools/ply_importer/ply_parse.cpp
@@ -1,0 +1,259 @@
+#include "ply_parse.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace ply_importer {
+
+namespace {
+
+// SH coefficient C0 for converting DC spherical harmonic to RGB
+constexpr float kSH_C0 = 0.28209479177387814f;  // 1 / (2 * sqrt(pi))
+
+struct PlyProperty {
+    std::string name;
+    std::string type;
+    size_t offset = 0;
+    size_t size = 0;
+};
+
+size_t type_size(const std::string& type) {
+    if (type == "float" || type == "float32") return 4;
+    if (type == "double" || type == "float64") return 8;
+    if (type == "uchar" || type == "uint8") return 1;
+    if (type == "int" || type == "int32") return 4;
+    if (type == "uint" || type == "uint32") return 4;
+    if (type == "short" || type == "int16") return 2;
+    if (type == "ushort" || type == "uint16") return 2;
+    return 0;
+}
+
+float read_float(const char* data, const PlyProperty& prop) {
+    if (prop.type == "float" || prop.type == "float32") {
+        float v;
+        std::memcpy(&v, data + prop.offset, 4);
+        return v;
+    }
+    if (prop.type == "double" || prop.type == "float64") {
+        double v;
+        std::memcpy(&v, data + prop.offset, 8);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "uchar" || prop.type == "uint8") {
+        uint8_t v;
+        std::memcpy(&v, data + prop.offset, 1);
+        return static_cast<float>(v) / 255.0f;
+    }
+    return 0.0f;
+}
+
+}  // namespace
+
+PlyCloud parse_ply(const std::string& path) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open PLY file: " + path);
+    }
+
+    // Parse header
+    std::string line;
+    std::getline(file, line);
+    if (line.find("ply") == std::string::npos) {
+        throw std::runtime_error("Not a PLY file: " + path);
+    }
+
+    bool binary_little_endian = false;
+    uint32_t vertex_count = 0;
+    std::vector<PlyProperty> properties;
+    size_t vertex_stride = 0;
+
+    while (std::getline(file, line)) {
+        // Strip trailing \r for Windows line endings
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+
+        std::istringstream iss(line);
+        std::string token;
+        iss >> token;
+
+        if (token == "format") {
+            std::string fmt;
+            iss >> fmt;
+            binary_little_endian = (fmt == "binary_little_endian");
+        } else if (token == "element") {
+            std::string elem_name;
+            uint32_t count;
+            iss >> elem_name >> count;
+            if (elem_name == "vertex") {
+                vertex_count = count;
+            }
+        } else if (token == "property") {
+            std::string type, name;
+            iss >> type >> name;
+            // Skip list properties
+            if (type == "list") continue;
+
+            PlyProperty prop;
+            prop.name = name;
+            prop.type = type;
+            prop.offset = vertex_stride;
+            prop.size = type_size(type);
+            vertex_stride += prop.size;
+            properties.push_back(std::move(prop));
+        } else if (token == "end_header") {
+            break;
+        }
+    }
+
+    if (vertex_count == 0) {
+        return {};
+    }
+
+    if (!binary_little_endian) {
+        throw std::runtime_error("Only binary_little_endian PLY files are supported: " + path);
+    }
+
+    // Build property lookup
+    std::unordered_map<std::string, const PlyProperty*> prop_map;
+    for (const auto& p : properties) {
+        prop_map[p.name] = &p;
+    }
+
+    // Common PLY column name variants
+    auto find_prop = [&](const std::initializer_list<const char*>& names) -> const PlyProperty* {
+        for (const char* n : names) {
+            auto it = prop_map.find(n);
+            if (it != prop_map.end()) return it->second;
+        }
+        return nullptr;
+    };
+
+    // Position
+    auto* px = find_prop({"x"});
+    auto* py = find_prop({"y"});
+    auto* pz = find_prop({"z"});
+
+    // Scale (gsplat: scale_0/1/2, nerfstudio: scaling_0/1/2)
+    auto* sx = find_prop({"scale_0", "scaling_0"});
+    auto* sy = find_prop({"scale_1", "scaling_1"});
+    auto* sz = find_prop({"scale_2", "scaling_2"});
+
+    // Rotation quaternion (w, x, y, z ordering in PLY)
+    auto* rw = find_prop({"rot_0", "rotation_0"});
+    auto* rx = find_prop({"rot_1", "rotation_1"});
+    auto* ry = find_prop({"rot_2", "rotation_2"});
+    auto* rz = find_prop({"rot_3", "rotation_3"});
+
+    // Color: SH DC coefficients (f_dc_0/1/2) or direct RGB (red/green/blue)
+    auto* cr = find_prop({"f_dc_0", "red"});
+    auto* cg = find_prop({"f_dc_1", "green"});
+    auto* cb = find_prop({"f_dc_2", "blue"});
+    bool use_sh = (prop_map.count("f_dc_0") > 0);
+
+    // Opacity
+    auto* op = find_prop({"opacity"});
+
+    // Bone index (character skeletal posing)
+    auto* bi = find_prop({"bone_index"});
+
+    // Emissive intensity
+    auto* em = find_prop({"emission"});
+
+    if (!px || !py || !pz) {
+        throw std::runtime_error("PLY file missing position properties (x, y, z): " + path);
+    }
+
+    // Read binary vertex data
+    std::vector<char> vertex_data(static_cast<size_t>(vertex_count) * vertex_stride);
+    file.read(vertex_data.data(), static_cast<std::streamsize>(vertex_data.size()));
+    if (!file) {
+        throw std::runtime_error("Failed to read vertex data from PLY file: " + path);
+    }
+
+    PlyCloud cloud;
+    cloud.gaussians.resize(vertex_count);
+
+    for (uint32_t i = 0; i < vertex_count; ++i) {
+        const char* row = vertex_data.data() + static_cast<size_t>(i) * vertex_stride;
+        GpuGaussian& g = cloud.gaussians[i];
+
+        // Position
+        float pos_x = read_float(row, *px);
+        float pos_y = read_float(row, *py);
+        float pos_z = read_float(row, *pz);
+
+        // Scale: stored as log(scale) in standard 3DGS → apply exp()
+        float scale_x = sx ? std::exp(read_float(row, *sx)) : 0.01f;
+        float scale_y = sy ? std::exp(read_float(row, *sy)) : 0.01f;
+        float scale_z = sz ? std::exp(read_float(row, *sz)) : 0.01f;
+
+        // Rotation quaternion (normalized), stored as w,x,y,z in PLY
+        glm::quat rot(1.0f, 0.0f, 0.0f, 0.0f);
+        if (rw && rx && ry && rz) {
+            rot = glm::normalize(glm::quat(
+                read_float(row, *rw),
+                read_float(row, *rx),
+                read_float(row, *ry),
+                read_float(row, *rz)
+            ));
+        }
+
+        // Color
+        float color_r = 1.0f, color_g = 1.0f, color_b = 1.0f;
+        if (cr && cg && cb) {
+            if (use_sh) {
+                // SH DC → linear RGB: color = SH_C0 * f_dc + 0.5
+                color_r = kSH_C0 * read_float(row, *cr) + 0.5f;
+                color_g = kSH_C0 * read_float(row, *cg) + 0.5f;
+                color_b = kSH_C0 * read_float(row, *cb) + 0.5f;
+            } else {
+                color_r = read_float(row, *cr);
+                color_g = read_float(row, *cg);
+                color_b = read_float(row, *cb);
+            }
+            color_r = std::clamp(color_r, 0.0f, 1.0f);
+            color_g = std::clamp(color_g, 0.0f, 1.0f);
+            color_b = std::clamp(color_b, 0.0f, 1.0f);
+        }
+
+        // Opacity: stored as logit(opacity) → apply sigmoid()
+        float opacity = 1.0f;
+        if (op) {
+            float raw = read_float(row, *op);
+            opacity = 1.0f / (1.0f + std::exp(-raw));
+        }
+
+        // Bone index
+        uint32_t bone_index = 0;
+        if (bi) {
+            if (bi->type == "uchar" || bi->type == "uint8") {
+                uint8_t v;
+                std::memcpy(&v, row + bi->offset, 1);
+                bone_index = static_cast<uint32_t>(v);
+            } else {
+                bone_index = static_cast<uint32_t>(read_float(row, *bi));
+            }
+        }
+
+        // Emission
+        float emission = em ? read_float(row, *em) : 0.0f;
+
+        // Pack into GpuGaussian (matches GSeurat's GsRenderer upload logic)
+        float bone_as_float;
+        std::memcpy(&bone_as_float, &bone_index, sizeof(float));
+        g.pos_opacity = glm::vec4(pos_x, pos_y, pos_z, opacity);
+        g.scale_pad   = glm::vec4(scale_x, scale_y, scale_z, bone_as_float);
+        g.rot         = glm::vec4(rot.x, rot.y, rot.z, rot.w);
+        g.color_pad   = glm::vec4(color_r, color_g, color_b, emission);
+
+        cloud.bounds.expand(glm::vec3(pos_x, pos_y, pos_z));
+    }
+
+    return cloud;
+}
+
+}  // namespace ply_importer

--- a/tools/ply_importer/ply_parse.cpp
+++ b/tools/ply_importer/ply_parse.cpp
@@ -26,6 +26,7 @@ size_t type_size(const std::string& type) {
     if (type == "float" || type == "float32") return 4;
     if (type == "double" || type == "float64") return 8;
     if (type == "uchar" || type == "uint8") return 1;
+    if (type == "char" || type == "int8") return 1;
     if (type == "int" || type == "int32") return 4;
     if (type == "uint" || type == "uint32") return 4;
     if (type == "short" || type == "int16") return 2;
@@ -123,14 +124,28 @@ PlyCloud parse_ply(const std::string& path) {
         } else if (token == "property" && current_element == "vertex") {
             std::string type, name;
             iss >> type >> name;
-            // Skip list properties
-            if (type == "list") continue;
+            // List properties are variable-length per row, which would
+            // invalidate the fixed vertex_stride model. 3DGS PLYs don't
+            // use list-typed vertex columns; refuse the file rather than
+            // produce silently-misaligned output.
+            if (type == "list") {
+                throw std::runtime_error(
+                    "Vertex list properties are unsupported (column: " + name + ")");
+            }
 
             PlyProperty prop;
             prop.name = name;
             prop.type = type;
             prop.offset = vertex_stride;
             prop.size = type_size(type);
+            // type_size returns 0 for any unknown PLY scalar type. Recording
+            // a zero-stride property would leave subsequent column offsets
+            // pointing into the wrong byte ranges, silently corrupting output.
+            // Fail fast instead.
+            if (prop.size == 0) {
+                throw std::runtime_error(
+                    "Unsupported PLY property type '" + type + "' (column: " + name + ")");
+            }
             vertex_stride += prop.size;
             properties.push_back(std::move(prop));
         } else if (token == "end_header") {

--- a/tools/ply_importer/ply_parse.cpp
+++ b/tools/ply_importer/ply_parse.cpp
@@ -45,11 +45,36 @@ float read_float(const char* data, const PlyProperty& prop) {
         return static_cast<float>(v);
     }
     if (prop.type == "uchar" || prop.type == "uint8") {
+        // uchar is conventionally normalized [0,255] → [0,1] (color channels)
         uint8_t v;
         std::memcpy(&v, data + prop.offset, 1);
         return static_cast<float>(v) / 255.0f;
     }
-    return 0.0f;
+    // Integer scalar types are returned as raw values (no normalization).
+    // The engine's bone_index column is the only known int-typed field; if
+    // future PLY columns need different semantics, decode them at the call
+    // site rather than baking a policy in here.
+    if (prop.type == "int" || prop.type == "int32") {
+        int32_t v;
+        std::memcpy(&v, data + prop.offset, 4);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "uint" || prop.type == "uint32") {
+        uint32_t v;
+        std::memcpy(&v, data + prop.offset, 4);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "short" || prop.type == "int16") {
+        int16_t v;
+        std::memcpy(&v, data + prop.offset, 2);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "ushort" || prop.type == "uint16") {
+        uint16_t v;
+        std::memcpy(&v, data + prop.offset, 2);
+        return static_cast<float>(v);
+    }
+    throw std::runtime_error("Unsupported PLY property type: " + prop.type);
 }
 
 }  // namespace
@@ -71,6 +96,11 @@ PlyCloud parse_ply(const std::string& path) {
     uint32_t vertex_count = 0;
     std::vector<PlyProperty> properties;
     size_t vertex_stride = 0;
+    // Track the element currently being declared so non-vertex elements
+    // (e.g. `face`, `edge`) don't leak their `property` lines into the
+    // vertex layout. Without this, vertex_stride and per-property offsets
+    // are corrupted whenever the PLY contains anything beyond `vertex`.
+    std::string current_element;
 
     while (std::getline(file, line)) {
         // Strip trailing \r for Windows line endings
@@ -85,13 +115,12 @@ PlyCloud parse_ply(const std::string& path) {
             iss >> fmt;
             binary_little_endian = (fmt == "binary_little_endian");
         } else if (token == "element") {
-            std::string elem_name;
             uint32_t count;
-            iss >> elem_name >> count;
-            if (elem_name == "vertex") {
+            iss >> current_element >> count;
+            if (current_element == "vertex") {
                 vertex_count = count;
             }
-        } else if (token == "property") {
+        } else if (token == "property" && current_element == "vertex") {
             std::string type, name;
             iss >> type >> name;
             // Skip list properties

--- a/tools/ply_importer/ply_parse.hpp
+++ b/tools/ply_importer/ply_parse.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+// Standalone PLY parser for the ply_importer offline tool.
+// Does NOT depend on gseurat_core — uses only glm and the standard library.
+//
+// Parses binary_little_endian PLY files containing 3D Gaussian Splat data
+// (position, scale, rotation, color/SH DC, opacity, bone_index, emission)
+// and returns GPU-ready packed structs for writing to .gsvx.
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace ply_importer {
+
+/// GPU-side Gaussian struct matching GSeurat's GpuGaussian.
+/// Must stay in sync with include/gseurat/engine/gaussian_cloud.hpp.
+/// 4 × vec4 = 64 bytes, std430-compatible.
+struct alignas(16) GpuGaussian {
+    glm::vec4 pos_opacity;  // xyz = position, w = opacity
+    glm::vec4 scale_pad;    // xyz = scale, w = float_bits(bone_index)
+    glm::vec4 rot;          // xyzw = quaternion (x, y, z, w)
+    glm::vec4 color_pad;    // rgb = color, w = emission
+};
+static_assert(sizeof(GpuGaussian) == 64);
+static_assert(alignof(GpuGaussian) == 16);
+
+/// Axis-aligned bounding box computed during parsing.
+struct AABB {
+    glm::vec3 min{std::numeric_limits<float>::max()};
+    glm::vec3 max{std::numeric_limits<float>::lowest()};
+
+    void expand(const glm::vec3& p) {
+        min = glm::min(min, p);
+        max = glm::max(max, p);
+    }
+};
+
+/// Result of parsing a PLY file.
+struct PlyCloud {
+    std::vector<GpuGaussian> gaussians;
+    AABB bounds;
+};
+
+/// Parse a binary_little_endian PLY file containing Gaussian splat data.
+/// Throws std::runtime_error on any parse failure.
+PlyCloud parse_ply(const std::string& path);
+
+}  // namespace ply_importer


### PR DESCRIPTION
## Summary

Phase 1a of the locked Phase 1 deletion sequence (1a → 1b → 1c) per `docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md` §6 and `docs/superpowers/plans/2026-05-02-engine-refactor-phase1-plan.md` §PR 1a.

**Net:** ~393 LOC removed from `src/engine/gs_renderer.cpp`, +new standalone `tools/ply_importer/` CLI (4 files), -2 declarations from `gs_renderer.hpp`, +9 LOC CMake wiring.

## What's deleted

- `GsRenderer::load_cloud()` (was lines 935–1043 in gs_renderer.cpp) — synchronous public API. Replaced by `load_cloud_async`, which has been the sole streaming entry point since streaming-strict (#388).
- `GsRenderer::load_cloud_legacy()` (was lines 1814–2079) — pre-streaming GPU buffer init path; unreachable in streaming-strict mode.
- The sync fallback inside `load_cloud_async` (was at line 1294 — `load_cloud(cloud);`) is now a streaming-strict contract-violation error log + early return.
- Corresponding declarations in `include/gseurat/engine/gs_renderer.hpp`.
- Stale comment references (line 747 in gs_renderer.cpp, line 273 in gs_scene_loader.cpp).

## What's added

`tools/ply_importer/` — standalone offline PLY → GSVX converter:
- `main.cpp` — CLI shell: `ply_importer <in.ply> <out.gsvx>`
- `ply_parse.{hpp,cpp}` — PLY parser (independent reimplementation; see §"Two-parser drift" follow-up below)
- `CMakeLists.txt` — links only `glm::glm`. **Not** linked into `gseurat_core`.
- Gated behind existing `GSEURAT_BUILD_TOOLS` option — defaults ON for top-level builds, OFF when included as submodule, so parent projects don't build the offline utility unintentionally.

## Notable design call

`load_cloud_legacy` was named misleadingly: it didn't contain PLY parsing, it initialized GPU buffers from an already-parsed `GaussianCloud`. The actual runtime PLY parser is `GaussianCloud::load_ply` in `src/engine/gaussian_cloud.cpp`, still in active use by the streaming path. So `tools/ply_importer/ply_parse.cpp` is a faithful reimplementation of the same logic, not a literal extraction.

This satisfies the spec's stated goal — *runtime renderer no longer depends on PLY parsing* — but creates two independent PLY parsers (engine's and tools'). They will be deduped in a follow-up.

## Validation

- Full build clean: `cmake --build --preset macos-release-with-diag` (all 616 targets, including standalone `ply_importer`).
- Smoke test: `ply_importer assets/.../emissive_test.ply /tmp/test.gsvx` → 68928-byte valid GSVX (header 64 + 1076 splats × 64 = 68928 ✓).
- `git grep -nE "\bload_cloud\b|load_cloud_legacy" -- src/ include/ examples/` → zero hits.
- pnpm workspace unaffected (`tools/pnpm-workspace.yaml` globs only `packages/*`, `apps/*`, `tests`).
- Regression harness: skipped per established convention (local-only manual check; user runs it as needed).

## Out of scope (preserved as expected for PR 1b/1c)

- `update_static_gaussians` legacy gather, `ensure_capacity` legacy growth, `gs_chunk_grid_`, `add_vfx_instance` legacy branch — PR 1b territory; verified untouched.
- `render_pipeline_`, `gs_render.comp`, `gs_tile_binning` flag — PR 1c territory; verified untouched.

## Follow-ups (file after merge)

- **Two-parser drift:** `gaussian_cloud.cpp::load_ply` and `tools/ply_importer/ply_parse.cpp` are independent and will diverge if PLY format evolves. Options: (a) extract parser into a shared `gseurat_ply_parse` library both link, or (b) add a CI fixture round-trip diff test. Tag: `tech-debt`.

## Test plan

- [x] cmake configure + build all targets clean
- [x] `ply_importer` smoke test produces valid .gsvx
- [x] Spec-compliance review (parallel agent): APPROVE-WITH-FOLLOWUPS
- [x] Code-quality review (`superpowers:code-reviewer`): APPROVE-WITH-FOLLOWUPS
- [ ] CI macos-release build green
- [ ] CI macos-debug build green
- [ ] CI Linux build green (if applicable)
- [ ] CI Windows build green
- [ ] User runs regression harness locally (optional, deferred per #391 convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)