### PR TITLE
fix(engine): harden gaussian_cloud PLY parser against silent corruption

### DIFF
--- a/src/engine/gaussian_cloud.cpp
+++ b/src/engine/gaussian_cloud.cpp
@@ -28,6 +28,7 @@ size_t type_size(const std::string& type) {
     if (type == "float" || type == "float32") return 4;
     if (type == "double" || type == "float64") return 8;
     if (type == "uchar" || type == "uint8") return 1;
+    if (type == "char" || type == "int8") return 1;
     if (type == "int" || type == "int32") return 4;
     if (type == "uint" || type == "uint32") return 4;
     if (type == "short" || type == "int16") return 2;
@@ -47,11 +48,40 @@ float read_float(const char* data, const PlyProperty& prop) {
         return static_cast<float>(v);
     }
     if (prop.type == "uchar" || prop.type == "uint8") {
+        // uchar is conventionally normalized [0,255] → [0,1] (color channels).
         uint8_t v;
         std::memcpy(&v, data + prop.offset, 1);
         return static_cast<float>(v) / 255.0f;
     }
-    return 0.0f;
+    // Integer scalar types are returned as raw values (no normalization).
+    // bone_index is the only known int-typed column today; if future PLY
+    // columns need different semantics, decode them at the call site.
+    if (prop.type == "int" || prop.type == "int32") {
+        int32_t v;
+        std::memcpy(&v, data + prop.offset, 4);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "uint" || prop.type == "uint32") {
+        uint32_t v;
+        std::memcpy(&v, data + prop.offset, 4);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "short" || prop.type == "int16") {
+        int16_t v;
+        std::memcpy(&v, data + prop.offset, 2);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "ushort" || prop.type == "uint16") {
+        uint16_t v;
+        std::memcpy(&v, data + prop.offset, 2);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "char" || prop.type == "int8") {
+        int8_t v;
+        std::memcpy(&v, data + prop.offset, 1);
+        return static_cast<float>(v);
+    }
+    throw std::runtime_error("Unsupported PLY property type: " + prop.type);
 }
 
 }  // namespace
@@ -75,6 +105,11 @@ GaussianCloud GaussianCloud::load_ply(const std::string& path,
     uint32_t vertex_count = 0;
     std::vector<PlyProperty> properties;
     size_t vertex_stride = 0;
+    // Track the element currently being declared so non-vertex elements
+    // (e.g. `face`, `edge`) don't leak their `property` lines into the
+    // vertex layout. Without this, vertex_stride and per-property offsets
+    // are corrupted whenever the PLY contains anything beyond `vertex`.
+    std::string current_element;
 
     while (std::getline(file, line)) {
         // Strip trailing \r for Windows line endings
@@ -89,23 +124,36 @@ GaussianCloud GaussianCloud::load_ply(const std::string& path,
             iss >> fmt;
             binary_little_endian = (fmt == "binary_little_endian");
         } else if (token == "element") {
-            std::string elem_name;
             uint32_t count;
-            iss >> elem_name >> count;
-            if (elem_name == "vertex") {
+            iss >> current_element >> count;
+            if (current_element == "vertex") {
                 vertex_count = count;
             }
-        } else if (token == "property") {
+        } else if (token == "property" && current_element == "vertex") {
             std::string type, name;
             iss >> type >> name;
-            // Skip list properties
-            if (type == "list") continue;
+            // List properties are variable-length per row, which would
+            // invalidate the fixed vertex_stride model. 3DGS PLYs don't
+            // use list-typed vertex columns; refuse the file rather than
+            // produce silently-misaligned output.
+            if (type == "list") {
+                throw std::runtime_error(
+                    "Vertex list properties are unsupported (column: " + name + ")");
+            }
 
             PlyProperty prop;
             prop.name = name;
             prop.type = type;
             prop.offset = vertex_stride;
             prop.size = type_size(type);
+            // type_size returns 0 for any unknown PLY scalar type. Recording
+            // a zero-stride property would leave subsequent column offsets
+            // pointing into the wrong byte ranges, silently corrupting reads.
+            // Fail fast instead.
+            if (prop.size == 0) {
+                throw std::runtime_error(
+                    "Unsupported PLY property type '" + type + "' (column: " + name + ")");
+            }
             vertex_stride += prop.size;
             properties.push_back(std::move(prop));
         } else if (token == "end_header") {


### PR DESCRIPTION
## Summary

Brings the engine's `gaussian_cloud.cpp::load_ply` to parity with the hardened `tools/ply_importer/ply_parse.cpp` from PR #392. Codex flagged 4 silent-corruption bugs in the standalone tool's parser during PR #392 review; the same bugs exist in the engine parser (the implementer faithfully replicated the engine's logic). This PR fixes the engine side now, before Phase 1b's high-risk per-frame surgery.

Tracking issue for the longer-term dedup decision (shared lib vs CI fixture diff vs accept-drift): #393.

## What's fixed

1. **Vertex-element scoping** — only record `property` lines while inside the `vertex` element. PLYs with `face` (or any non-vertex) elements would otherwise shift vertex offsets silently.
2. **Integer scalar decoding** in `read_float` — now decodes `int8/uint8` (signed/unsigned), `int16/uint16`, `int32/uint32`. Previously fell through to `0.0f`, so a `bone_index` column stored as `int32` would silently become 0. Truly unknown types now throw.
3. **Reject unknown property types** — `type_size` returning 0 for an unrecognized PLY scalar would record a zero-stride property, shifting every later column's offset. Now throws with column name.
4. **Reject vertex `list` properties** — variable-length list fields invalidate the fixed `vertex_stride` model. 3DGS PLYs don't use them; throw rather than misalign.

Plus extends `type_size` with the previously-missing `char`/`int8` (1 byte) entry.

## Why now

The user's plan: secure the engine's perimeter before Phase 1b tears apart per-frame data flows. None of the demo PLYs trigger these silent-corruption paths today — but having latent silent-failure modes in the parser while we're rewiring `update_static_gaussians` / `gs_chunk_grid_` / `add_vfx_instance` is the kind of debugging trap PR #385–#388 already taught us to avoid.

## Validation

- **Full build:** `cmake --build --preset macos-release-with-diag` — 616 targets clean, only pre-existing VMA nullability warnings.
- **test_gaussian_cloud:** 23/23 tests pass, including:
  - Test 7: SceneLoader round-trip preserves GS data
  - Test 10: GSVX round-trip matches PLY→GpuGaussian
  - Tests 19–21: kVulkanYDown PLY write+load round-trips
  - Test 22–23: GSVX v1/v2 round-trips
- **test_ply_path_resolution:** 6/6 tests pass.

The round-trip tests confirm the hardened parser still handles the engine's own demo PLY column shapes correctly. No demo PLY triggers the new throw paths.

## Test plan

- [x] Build all targets clean
- [x] test_gaussian_cloud passes
- [x] test_ply_path_resolution passes
- [ ] CI macos / ubuntu / windows builds green
- [ ] CI C++ test green
- [ ] User runs local Golden Frame regression on this branch (or after merge) to confirm runtime PLY load still works on demo assets

## Related

- PR #392 — Phase 1a, introduced the dual parser
- Issue #393 — two-parser drift tracking
- `docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)