### PR TITLE
fix(regression): retain artifacts + persist engine stderr on failure

### DIFF
--- a/scripts/regression/run_harness.py
+++ b/scripts/regression/run_harness.py
@@ -5,6 +5,11 @@ Modes:
     --baseline <ref>   : run scenario, diff vs tests/regression/baseline/<ref>/
     --no-pixel-diff    : run scenario, skip pixel diff (Linux/Windows CI)
     --update-baseline  : run scenario, save output as new baseline (DESTRUCTIVE)
+
+Failure-path behavior (issue #400):
+    On any non-zero return or exception, the captured frames + engine_stderr.log
+    are retained in the run's temp directory and the path is printed to stderr
+    so the user can inspect them. Successful runs delete the temp directory.
 """
 import argparse
 import os
@@ -23,10 +28,17 @@ DEMO_DIR = "build/macos-release-with-diag"
 DEMO_BIN = "./gseurat_demo"  # relative to DEMO_DIR (assets/ is sync'd there)
 SCENARIO = os.path.abspath("scripts/regression/island_demo_canonical.py")
 SOCKET = "/tmp/gseurat.sock"
+ENGINE_STDERR_LOG = "engine_stderr.log"
 
 
 def run_scenario(out_dir):
-    """Spawn engine in deterministic mode, drive the scenario, capture frames."""
+    """Spawn engine in deterministic mode, drive the scenario, capture frames.
+
+    Always writes the engine's full stderr stream to `<out_dir>/engine_stderr.log`,
+    even when the scenario subprocess raises — without that, any exception below
+    unwinds before the caller can see VK_VALIDATION / INVARIANT FAILED warnings
+    that the engine emitted before going down (issue #400).
+    """
     os.makedirs(out_dir, exist_ok=True)
 
     # Remove stale socket file so we get a clean connection
@@ -36,6 +48,7 @@ def run_scenario(out_dir):
     proc = subprocess.Popen([DEMO_BIN, "--deterministic"],
                             stderr=subprocess.PIPE,
                             cwd=DEMO_DIR)
+    stderr_bytes = b""
     try:
         # Wait for socket to appear (engine startup). Cold PLY load of the
         # 2.2M-Gaussian island takes 30-60s on warm dev machines; on
@@ -45,17 +58,6 @@ def run_scenario(out_dir):
         t0 = time.time()
         while not os.path.exists(SOCKET):
             if time.time() - t0 > 300:
-                # Drain any stderr the engine produced before timing out so
-                # the failure is diagnosable (validation errors, missing
-                # GPU, etc).
-                try:
-                    proc.terminate()
-                    _, stderr_bytes = proc.communicate(timeout=5)
-                    sys.stderr.write(
-                        "engine stderr at socket-wait timeout:\n" +
-                        stderr_bytes.decode(errors="replace") + "\n")
-                except Exception:
-                    pass
                 raise RuntimeError("engine did not create socket in 300s")
             time.sleep(0.1)
 
@@ -76,6 +78,17 @@ def run_scenario(out_dir):
             proc.kill()
             _, stderr_bytes = proc.communicate()
 
+        # Persist the engine's stderr next to the captured frames so it's
+        # always available for diagnosis — including when the scenario
+        # subprocess raised before main() could run its validation-string
+        # checks. out_dir may have been removed if a caller is racing
+        # cleanup; tolerate that.
+        try:
+            with open(os.path.join(out_dir, ENGINE_STDERR_LOG), "wb") as f:
+                f.write(stderr_bytes or b"")
+        except OSError:
+            pass
+
     return stderr_bytes.decode(errors="replace") if stderr_bytes else ""
 
 
@@ -86,6 +99,38 @@ def diff(baseline_dir, current_dir, threshold):
         "--current", current_dir,
         "--threshold", str(threshold),
     ]).returncode
+
+
+class _RunDir:
+    """Temp directory that is retained on failure for post-mortem inspection.
+
+    Replaces tempfile.TemporaryDirectory which deletes unconditionally on
+    __exit__ — including on exception (issue #400). Caller flips `keep`
+    to True before raising, or sets it implicitly via the success-path
+    `success()` call.
+    """
+
+    def __init__(self, prefix):
+        self.path = tempfile.mkdtemp(prefix=prefix)
+        self._delete = False  # default: keep, conservative
+
+    def success(self):
+        """Mark this directory eligible for cleanup on __exit__."""
+        self._delete = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if exc_type is not None:
+            self._delete = False
+        if self._delete:
+            shutil.rmtree(self.path, ignore_errors=True)
+        else:
+            sys.stderr.write(
+                f"[regression] artifacts retained: {self.path}\n"
+                f"[regression] engine stderr: {os.path.join(self.path, ENGINE_STDERR_LOG)}\n")
+        return False  # propagate exception
 
 
 def main():
@@ -107,47 +152,56 @@ def main():
         # For now we verify "engine isn't catastrophically broken across runs"
         # at SSIM >= 0.90, which catches geometry / large-scale regressions.
         SELF_CHECK_THRESHOLD = 0.90
-        with tempfile.TemporaryDirectory() as t1, tempfile.TemporaryDirectory() as t2:
-            run_scenario(t1)
-            run_scenario(t2)
-            rc = diff(t1, t2, threshold=SELF_CHECK_THRESHOLD)
+        with _RunDir("gseurat_regression_t1_") as t1, \
+             _RunDir("gseurat_regression_t2_") as t2:
+            run_scenario(t1.path)
+            run_scenario(t2.path)
+            rc = diff(t1.path, t2.path, threshold=SELF_CHECK_THRESHOLD)
             if rc == 0:
                 print(f"DETERMINISM SELF-CHECK: PASS (SSIM >= {SELF_CHECK_THRESHOLD})")
+                t1.success()
+                t2.success()
                 return 0
             print(f"DETERMINISM SELF-CHECK: FAIL — drift exceeds {SELF_CHECK_THRESHOLD} threshold",
                   file=sys.stderr)
+            # Both dirs retained for diff inspection.
             return 1
 
-    with tempfile.TemporaryDirectory() as cur:
-        stderr = run_scenario(cur)
+    with _RunDir("gseurat_regression_") as run:
+        stderr = run_scenario(run.path)
 
         # Validation-layer assertion
         if "VK_VALIDATION" in stderr or "VUID-" in stderr:
             print("VALIDATION LAYER WARNINGS/ERRORS:\n" + stderr, file=sys.stderr)
-            return 2
+            return 2  # retained
 
         # Diag invariant assertion (best-effort: check for INVARIANT FAILED in stderr)
         if "INVARIANT FAILED" in stderr:
             print("DIAG INVARIANT VIOLATION:\n" + stderr, file=sys.stderr)
-            return 3
+            return 3  # retained
 
         if args.update_baseline:
             if os.path.exists(args.update_baseline):
                 shutil.rmtree(args.update_baseline)
-            shutil.copytree(cur, args.update_baseline)
+            shutil.copytree(run.path, args.update_baseline)
             print(f"Baseline updated: {args.update_baseline}")
+            run.success()
             return 0
 
         if args.no_pixel_diff:
             print("Scenario completed (no pixel diff requested)")
+            run.success()
             return 0
 
         if not args.baseline:
             print("--baseline required unless --no-pixel-diff or --update-baseline",
                   file=sys.stderr)
-            return 4
+            return 4  # retained
 
-        return diff(args.baseline, cur, threshold=args.threshold)
+        rc = diff(args.baseline, run.path, threshold=args.threshold)
+        if rc == 0:
+            run.success()
+        return rc
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The regression harness previously lost both captured PNG frames AND the engine's stderr stream whenever the scenario subprocess raised — making any non-trivial harness failure undiagnosable. Discovered while investigating #399.

Fixes #400.

## What changed

1. **`run_scenario()` always writes `engine_stderr.log`** to its `out_dir` in the `finally` block. The previous `return` was unreachable when `subprocess.run(check=True)` raised, so the captured stderr never reached `main()`'s validation-string checks (`VK_VALIDATION` / `VUID-` / `INVARIANT FAILED`). Persisting to disk makes the engine's full output available regardless of how the function exits.

2. **Replaced `tempfile.TemporaryDirectory` with `_RunDir`** — a small context manager that retains its directory on exception OR when the caller hasn't explicitly called `success()`. Each `main()` exit path decides whether to keep the run:
   - **Cleaned up:** 0 (success), `--update-baseline` after copytree, `--no-pixel-diff`, SSIM diff returns 0
   - **Retained:** 2 (validation warnings), 3 (INVARIANT FAILED), 4 (CLI misuse), SSIM diff fails, self-check FAIL, any uncaught exception. Path printed to stderr with the location of `engine_stderr.log`.

This mirrors the project's existing diagnostic-tooling philosophy (debug dumps, etc.) — fail loud, keep evidence.

## Validation

- `python3 -m py_compile` clean.
- `python3 scripts/regression/run_harness.py --help` lists same flags as before.
- Standalone smoke-test of `_RunDir` lifecycle (no engine launch needed) covers all three states:
  - `success()` called → dir deleted ✓
  - exception in `with` block → dir retained + path printed to stderr ✓
  - default (no `success()`, no exception) → dir retained ✓

End-to-end harness run is **deferred** — the harness crushes the user's Mac (established feedback this session), and the changes are logic-only on the failure paths. The success path is unchanged from a user perspective.

## Why now

Surfaced during the post-Phase-1 baseline capture attempt on 2026-05-05, where a suspected perf regression (#399) caused frame-capture cadence to degrade from <30s/frame to 4 min/frame. We aborted the run to free the user's Mac, but the harness's `tempfile.TemporaryDirectory.__exit__` deleted the 9 captured frames before we could examine them, AND `subprocess.run(check=True)` raised before `main()` could print the engine's stderr. Both diagnostic streams lost simultaneously.

This PR makes future investigations (including a careful re-run of #399 once we have a hypothesis to test) actually viable.

## Test plan

- [x] `python3 -m py_compile` clean
- [x] `--help` flag still works
- [x] `_RunDir` lifecycle: success / exception / default-keep all verified via standalone smoke test
- [x] No engine impact — `scripts/regression/` only
- [ ] CI macos / ubuntu / windows builds green (no engine code changes — should be trivial pass)
- [ ] No need for unit-test additions; the lifecycle test is captured in the commit description and can be promoted to a `test_harness_artifacts.py` later if desired

## Related

- Fixes #400 — the bundled artifact-loss + stderr-swallowing issues
- Surfaced #399 — suspected per-frame perf regression on chunk-streaming direction reversal (this PR makes future investigations of that issue tractable)
- Phase 1 PRs (#392, #395, #398) — landed cleanly; no engine impact from this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)