### PR TITLE
perf(engine): instrument step / chunk streaming / GPU timing for #399

### DIFF
--- a/include/gseurat/engine/command_context.hpp
+++ b/include/gseurat/engine/command_context.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -67,6 +69,17 @@ struct CommandContext {
         std::int64_t reply_target = -1;  // ControlServer::ReplyTarget; -1 = none
         int frames_total = 0;
         nlohmann::json bridge_id = nullptr;  // null => no _bridge_id was set
+
+        // Per-frame wall-clock duration (ms) for each stepped frame. Filled in
+        // by the main loop as each step frame completes. Sent to the harness
+        // alongside frames_completed so single-frame spikes (e.g. chunk-load
+        // stalls) are not smeared by the existing 60-frame averager.
+        //
+        // First entry is measured from `last_step_frame_end` (set to "now" at
+        // step-command issue time), not from the previous unrelated frame —
+        // pre-step idle may be unbounded.
+        std::vector<double> per_frame_ms;
+        std::chrono::high_resolution_clock::time_point last_step_frame_end{};
     };
     DeferredStepResponse* deferred_step_response = nullptr;
 };

--- a/include/gseurat/engine/debug_dump_renderer.hpp
+++ b/include/gseurat/engine/debug_dump_renderer.hpp
@@ -39,7 +39,8 @@ public:
         uint32_t output_width       = 0;
         uint32_t output_height      = 0;
 
-        // GPU timing (averaged over 60 frames)
+        // GPU timing (last completed frame, raw — not averaged).
+        // Single-frame spike attribution per #399.
         float depth_sort_ms         = 0.0f;
         float tile_sort_ms          = 0.0f;
         float rasterize_ms          = 0.0f;

--- a/include/gseurat/engine/gs_chunk_streamer.hpp
+++ b/include/gseurat/engine/gs_chunk_streamer.hpp
@@ -7,6 +7,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <nlohmann/json.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
@@ -25,6 +26,10 @@ struct StreamChunkMeta {
     uint32_t gaussian_count = 0;
     ChunkState state = ChunkState::Unloaded;
     uint32_t load_request_id = 0;
+    // Wall-clock start of the most recent load request; used by the debug
+    // event log to compute load_complete `took=Y.YYms`. Default-initialized
+    // (epoch) when no load is in flight.
+    std::chrono::steady_clock::time_point load_started_at{};
 };
 
 struct ChunkManifest {
@@ -46,10 +51,13 @@ public:
     // Update streaming state based on camera position.
     // Submits load requests to AsyncLoader for chunks within load_radius.
     // Marks chunks beyond unload_radius for removal.
-    void update(const glm::vec3& camera_pos, AsyncLoader& loader);
+    // `frame_index` is used by GSEURAT_DEBUG_BUILD-gated stderr event log.
+    void update(const glm::vec3& camera_pos, AsyncLoader& loader,
+                uint64_t frame_index);
 
     // Process completed load results. Call after AsyncLoader::poll_results().
-    void process_load_results(const std::vector<LoadResult>& results);
+    void process_load_results(const std::vector<LoadResult>& results,
+                              uint64_t frame_index);
 
     // Returns true if the active Gaussian set changed since last call to
     // assemble_active().
@@ -67,6 +75,11 @@ public:
     void set_load_radius(float r) { load_radius_ = r; }
     void set_unload_radius(float r) { unload_radius_ = r; }
     void set_memory_budget(size_t bytes) { memory_budget_ = bytes; }
+    // Slab footprint reported in [streaming] event log. Demo wires this
+    // from GsRenderer::streaming_config().slab_size_splats so the log
+    // vocabulary tracks runtime config. Value defaults to the
+    // StreamingConfig default (100k) for tests and standalone use.
+    void set_slab_size_splats(uint32_t s) { slab_size_splats_ = s; }
     float load_radius() const { return load_radius_; }
     float unload_radius() const { return unload_radius_; }
 
@@ -80,8 +93,11 @@ private:
     // Frustum culling for chunk AABBs
     static bool is_chunk_visible(const AABB& bounds, const glm::mat4& view_proj);
 
-    // Evict furthest loaded chunks to stay within memory budget
-    void evict_if_over_budget(const glm::vec3& camera_pos);
+    // Evict furthest loaded chunks to stay within memory budget.
+    // `frame_index` is used by GSEURAT_DEBUG_BUILD-gated stderr event log
+    // (these are budget-driven evictions, distinct from camera-distance
+    // unloads in update()).
+    void evict_if_over_budget(const glm::vec3& camera_pos, uint64_t frame_index);
 
     // Distance from camera to chunk center (XZ plane)
     static float chunk_distance_xz(const AABB& bounds, const glm::vec3& camera_pos);
@@ -100,6 +116,7 @@ private:
     float unload_radius_ = 384.0f;
     size_t memory_budget_ = 512 * 1024 * 1024;  // 512 MB
     size_t current_memory_ = 0;
+    uint32_t slab_size_splats_ = 100'000;  // mirror of StreamingConfig default
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -320,6 +320,18 @@ public:
     float tile_sort_ms_avg() const { return tile_sort_ms_avg_; }
     float rasterize_ms_avg() const { return rasterize_ms_avg_; }
 
+    // GPU timing for the most recent frame whose timestamps were available.
+    // Updated every frame the readback succeeds (no 60-frame averaging) so
+    // single-frame spikes are not smeared.
+    float depth_sort_ms_last() const { return depth_sort_ms_last_; }
+    float tile_sort_ms_last() const { return tile_sort_ms_last_; }
+    float rasterize_ms_last() const { return rasterize_ms_last_; }
+
+    // Live streaming config (slab_size_splats etc.). Demo plumbs this into
+    // GsChunkStreamer so its [streaming] event-log "slabs=" field uses the
+    // same vocabulary as the renderer's slab-based streamer.
+    const StreamingConfig& streaming_config() const { return streaming_config_; }
+
     // Streaming state (read-only)
     uint32_t active_chunk_count() const { return static_cast<uint32_t>(active_chunks_.size()); }
     uint32_t total_active_splats() const { return total_active_splats_; }
@@ -691,6 +703,9 @@ private:
     float depth_sort_ms_avg_ = 0.0f;     // last completed average
     float tile_sort_ms_avg_ = 0.0f;
     float rasterize_ms_avg_ = 0.0f;
+    float depth_sort_ms_last_ = 0.0f;    // last per-frame raw sample
+    float tile_sort_ms_last_ = 0.0f;
+    float rasterize_ms_last_ = 0.0f;
     bool timestamps_written_ = false;     // true after rasterize dispatch writes timestamps
     static constexpr uint32_t kTimestampAvgFrames = 60;
 

--- a/src/demo/gs_demo_state.cpp
+++ b/src/demo/gs_demo_state.cpp
@@ -816,6 +816,8 @@ void GsDemoState::enter_streaming_mode(AppBase& app) {
                                    bounds.max.z - bounds.min.z);
     chunk_streamer_.set_load_radius(cloud_extent * 0.4f);
     chunk_streamer_.set_unload_radius(cloud_extent * 0.6f);
+    chunk_streamer_.set_slab_size_splats(
+        app.renderer().gs_renderer().streaming_config().slab_size_splats);
 
     // Disable the renderer's internal chunk culling — we'll update manually
     app.renderer().set_gs_skip_chunk_cull(true);
@@ -835,14 +837,15 @@ void GsDemoState::update_streaming(AppBase& app) {
         distance_ * cos_elev * std::cos(azimuth_));
 
     auto& loader = app.async_loader();
+    const uint64_t frame_index = app.tick();
 
     // Update streamer — submits load requests for nearby chunks
-    chunk_streamer_.update(eye, loader);
+    chunk_streamer_.update(eye, loader, frame_index);
 
     // Process completed loads
     auto results = loader.poll_results();
     if (!results.empty()) {
-        chunk_streamer_.process_load_results(results);
+        chunk_streamer_.process_load_results(results, frame_index);
     }
 
     // If active set changed, re-upload to GPU

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -159,9 +159,12 @@ void AppBase::main_loop() {
         snap.visible_chunks    = renderer_.gs_visible_chunk_count();
         snap.output_width      = gs.output_width();
         snap.output_height     = gs.output_height();
-        snap.depth_sort_ms     = gs.depth_sort_ms_avg();
-        snap.tile_sort_ms      = gs.tile_sort_ms_avg();
-        snap.rasterize_ms      = gs.rasterize_ms_avg();
+        // Last-frame raw GPU timing (per #399 instrumentation): single-frame
+        // spikes were previously smeared into invisibility by the 60-frame
+        // averager. The averaged stderr log line is preserved unchanged.
+        snap.depth_sort_ms     = gs.depth_sort_ms_last();
+        snap.tile_sort_ms      = gs.tile_sort_ms_last();
+        snap.rasterize_ms      = gs.rasterize_ms_last();
         snap.gpu_total_ms      = snap.depth_sort_ms + snap.tile_sort_ms + snap.rasterize_ms;
         snap.fps               = metrics.fps;
         snap.frame_time_ms     = metrics.fps > 0.0f ? 1000.0f / metrics.fps : 0.0f;
@@ -434,6 +437,17 @@ void AppBase::main_loop() {
                              draw_lists_.shadow, particle_sprites, draw_lists_.overlay, ui_batches,
                              draw_lists_.debug_colliders, feature_flags_, dispatch_gpu_compute);
 
+        // Per-frame wall-clock timing for synchronous step. Captured here
+        // (frame fully drawn) and the delta is taken from either the previous
+        // step-frame's end or the step-command-issue timestamp for frame 0.
+        if (step_mode_ && deferred_step_response_.reply_target >= 0) {
+            auto frame_end = std::chrono::high_resolution_clock::now();
+            double dt_ms = std::chrono::duration<double, std::milli>(
+                frame_end - deferred_step_response_.last_step_frame_end).count();
+            deferred_step_response_.per_frame_ms.push_back(dt_ms);
+            deferred_step_response_.last_step_frame_end = frame_end;
+        }
+
         // Synchronous step: fire the deferred response now that this frame has
         // completed AND no more steps are queued. The harness then knows N
         // frames are fully done and can safely send screenshot/etc.
@@ -442,7 +456,8 @@ void AppBase::main_loop() {
             deferred_step_response_.reply_target >= 0) {
             nlohmann::json msg = {
                 {"type", "ok"},
-                {"frames_completed", deferred_step_response_.frames_total}
+                {"frames_completed", deferred_step_response_.frames_total},
+                {"per_frame_ms", deferred_step_response_.per_frame_ms}
             };
             // Replay _bridge_id correlation if the request had one.
             if (!deferred_step_response_.bridge_id.is_null()) {
@@ -453,6 +468,7 @@ void AppBase::main_loop() {
             deferred_step_response_.reply_target = -1;
             deferred_step_response_.frames_total = 0;
             deferred_step_response_.bridge_id = nlohmann::json(nullptr);
+            deferred_step_response_.per_frame_ms.clear();
         }
     }
 }

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -24,6 +24,7 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 
@@ -704,6 +705,13 @@ void CommandDispatcher::register_default_commands() {
         } else {
             ctx_.deferred_step_response->bridge_id = json(nullptr);
         }
+        ctx_.deferred_step_response->per_frame_ms.clear();
+        ctx_.deferred_step_response->per_frame_ms.reserve(static_cast<size_t>(n));
+        // First stepped frame's duration is measured from command-issue time,
+        // not from the previous frame: pre-step idle (in step_mode_) may be
+        // unbounded while the loop spins waiting for `pending_steps_ > 0`.
+        ctx_.deferred_step_response->last_step_frame_end =
+            std::chrono::high_resolution_clock::now();
         ctx_.pending_steps->fetch_add(n, std::memory_order_relaxed);
         // Sentinel response — poll_control_server checks for "_deferred" key
         // and skips the immediate send.

--- a/src/engine/gs_chunk_streamer.cpp
+++ b/src/engine/gs_chunk_streamer.cpp
@@ -1,8 +1,11 @@
 #include "gseurat/engine/gs_chunk_streamer.hpp"
+#include "gseurat/engine/debug.hpp"
 #include "gseurat/engine/project_root.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <cstdio>
 
 namespace gseurat {
 
@@ -47,6 +50,20 @@ ChunkManifest ChunkManifest::from_json(const nlohmann::json& j) {
 
 // --- GsChunkStreamer ---
 
+#if GSEURAT_DEBUG_BUILD
+namespace {
+// Used purely for the [streaming] event-log "slabs=" field — this streamer
+// loads whole chunks (not slabs), so we report ceil(gaussians / slab_size)
+// as the equivalent slab footprint. `slab_size` is the runtime-configurable
+// value sourced from StreamingConfig::slab_size_splats (plumbed via
+// GsChunkStreamer::set_slab_size_splats by the demo).
+inline uint32_t slabs_for(uint32_t gaussians, uint32_t slab_size) {
+    if (gaussians == 0 || slab_size == 0) return 0;
+    return (gaussians + slab_size - 1) / slab_size;
+}
+}  // namespace
+#endif
+
 void GsChunkStreamer::init(const ChunkManifest& manifest) {
     manifest_ = manifest;
     chunk_data_.clear();
@@ -55,7 +72,11 @@ void GsChunkStreamer::init(const ChunkManifest& manifest) {
     current_memory_ = 0;
 }
 
-void GsChunkStreamer::update(const glm::vec3& camera_pos, AsyncLoader& loader) {
+void GsChunkStreamer::update(const glm::vec3& camera_pos, AsyncLoader& loader,
+                             uint64_t frame_index) {
+#if !GSEURAT_DEBUG_BUILD
+    (void)frame_index;
+#endif
     for (uint32_t i = 0; i < manifest_.chunks.size(); ++i) {
         auto& chunk = manifest_.chunks[i];
         float dist = chunk_distance_xz(chunk.bounds, camera_pos);
@@ -68,9 +89,24 @@ void GsChunkStreamer::update(const glm::vec3& camera_pos, AsyncLoader& loader) {
             });
             chunk.state = ChunkState::Loading;
             chunk.load_request_id = req_id;
+            chunk.load_started_at = std::chrono::steady_clock::now();
             pending_loads_[req_id] = i;
+#if GSEURAT_DEBUG_BUILD
+            std::fprintf(stderr,
+                "[streaming] frame=%llu chunk=%u event=load_request slabs=%u\n",
+                static_cast<unsigned long long>(frame_index), i,
+                slabs_for(chunk.gaussian_count, slab_size_splats_));
+#endif
         } else if (chunk.state == ChunkState::Loaded && dist > unload_radius_) {
             // Unload
+#if GSEURAT_DEBUG_BUILD
+            uint32_t evict_slabs = 0;
+            auto data_it = chunk_data_.find(i);
+            if (data_it != chunk_data_.end()) {
+                evict_slabs = slabs_for(static_cast<uint32_t>(data_it->second.size()),
+                                        slab_size_splats_);
+            }
+#endif
             auto it = chunk_data_.find(i);
             if (it != chunk_data_.end()) {
                 current_memory_ -= it->second.size() * sizeof(Gaussian);
@@ -79,6 +115,11 @@ void GsChunkStreamer::update(const glm::vec3& camera_pos, AsyncLoader& loader) {
             chunk.state = ChunkState::Unloaded;
             chunk.load_request_id = 0;
             dirty_ = true;
+#if GSEURAT_DEBUG_BUILD
+            std::fprintf(stderr,
+                "[streaming] frame=%llu chunk=%u event=evict slabs=%u\n",
+                static_cast<unsigned long long>(frame_index), i, evict_slabs);
+#endif
         } else if (chunk.state == ChunkState::Loading && dist > unload_radius_) {
             // Cancel pending load that's now too far
             loader.cancel(chunk.load_request_id);
@@ -91,7 +132,11 @@ void GsChunkStreamer::update(const glm::vec3& camera_pos, AsyncLoader& loader) {
     }
 }
 
-void GsChunkStreamer::process_load_results(const std::vector<LoadResult>& results) {
+void GsChunkStreamer::process_load_results(const std::vector<LoadResult>& results,
+                                            uint64_t frame_index) {
+#if !GSEURAT_DEBUG_BUILD
+    (void)frame_index;
+#endif
     for (const auto& result : results) {
         auto it = pending_loads_.find(result.request_id);
         if (it == pending_loads_.end()) continue;
@@ -115,6 +160,20 @@ void GsChunkStreamer::process_load_results(const std::vector<LoadResult>& result
         chunk.state = ChunkState::Loaded;
         chunk.load_request_id = 0;
         dirty_ = true;
+#if GSEURAT_DEBUG_BUILD
+        double took_ms = 0.0;
+        if (chunk.load_started_at.time_since_epoch().count() != 0) {
+            auto now = std::chrono::steady_clock::now();
+            took_ms = std::chrono::duration<double, std::milli>(
+                now - chunk.load_started_at).count();
+        }
+        std::fprintf(stderr,
+            "[streaming] frame=%llu chunk=%u event=load_complete slabs=%u took=%.2fms\n",
+            static_cast<unsigned long long>(frame_index), chunk_idx,
+            slabs_for(static_cast<uint32_t>(chunk_data_[chunk_idx].size()),
+                      slab_size_splats_),
+            took_ms);
+#endif
     }
 
     // Enforce memory budget after loading new chunks
@@ -122,7 +181,7 @@ void GsChunkStreamer::process_load_results(const std::vector<LoadResult>& result
         // Use a dummy camera_pos (0,0,0) for eviction — proper eviction uses
         // the camera position from the most recent update() call.
         // We'll use chunk center distance to origin as a rough heuristic.
-        evict_if_over_budget(glm::vec3(0.0f));
+        evict_if_over_budget(glm::vec3(0.0f), frame_index);
     }
 }
 
@@ -226,7 +285,11 @@ bool GsChunkStreamer::is_chunk_visible(const AABB& bounds, const glm::mat4& view
     return true;
 }
 
-void GsChunkStreamer::evict_if_over_budget(const glm::vec3& camera_pos) {
+void GsChunkStreamer::evict_if_over_budget(const glm::vec3& camera_pos,
+                                            uint64_t frame_index) {
+#if !GSEURAT_DEBUG_BUILD
+    (void)frame_index;
+#endif
     while (current_memory_ > memory_budget_ && !chunk_data_.empty()) {
         // Find the furthest loaded chunk
         uint32_t furthest_idx = 0;
@@ -244,6 +307,10 @@ void GsChunkStreamer::evict_if_over_budget(const glm::vec3& camera_pos) {
         auto it = chunk_data_.find(furthest_idx);
         if (it == chunk_data_.end()) break;
 
+#if GSEURAT_DEBUG_BUILD
+        uint32_t evict_slabs = slabs_for(static_cast<uint32_t>(it->second.size()),
+                                          slab_size_splats_);
+#endif
         current_memory_ -= it->second.size() * sizeof(Gaussian);
         chunk_data_.erase(it);
 
@@ -252,6 +319,12 @@ void GsChunkStreamer::evict_if_over_budget(const glm::vec3& camera_pos) {
             manifest_.chunks[furthest_idx].load_request_id = 0;
         }
         dirty_ = true;
+#if GSEURAT_DEBUG_BUILD
+        std::fprintf(stderr,
+            "[streaming] frame=%llu chunk=%u event=evict_budget slabs=%u\n",
+            static_cast<unsigned long long>(frame_index), furthest_idx,
+            evict_slabs);
+#endif
     }
 }
 

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -2803,6 +2803,9 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
             float depth_ms = static_cast<float>(ts[1] - ts[0]) * timestamp_period_ns_ / 1e6f;
             float tile_ms  = static_cast<float>(ts[3] - ts[2]) * timestamp_period_ns_ / 1e6f;
             float raster_ms = static_cast<float>(ts[5] - ts[4]) * timestamp_period_ns_ / 1e6f;
+            depth_sort_ms_last_ = depth_ms;
+            tile_sort_ms_last_ = tile_ms;
+            rasterize_ms_last_ = raster_ms;
             depth_sort_ms_accum_ += depth_ms;
             tile_sort_ms_accum_ += tile_ms;
             rasterize_ms_accum_ += raster_ms;

--- a/tests/test_gs_chunk_streamer.cpp
+++ b/tests/test_gs_chunk_streamer.cpp
@@ -118,7 +118,7 @@ int main() {
         loader.init();
 
         // Camera at origin — should request nearby chunks
-        streamer.update(glm::vec3(16.0f, 0.0f, 16.0f), loader);
+        streamer.update(glm::vec3(16.0f, 0.0f, 16.0f), loader, 0);
         assert(streamer.loading_chunk_count() > 0);
 
         loader.shutdown();
@@ -138,7 +138,7 @@ int main() {
 
         // Camera near chunk (0,0) — loads nearby chunks
         glm::vec3 cam_near(16.0f, 0.0f, 16.0f);
-        streamer.update(cam_near, loader);
+        streamer.update(cam_near, loader, 0);
 
         // Simulate all chunks loading
         auto pending = loader.poll_results();
@@ -158,7 +158,7 @@ int main() {
 
         // Move camera far away
         glm::vec3 cam_far(500.0f, 0.0f, 500.0f);
-        streamer.update(cam_far, loader);
+        streamer.update(cam_far, loader, 0);
 
         // After moving far, loading count should be for distant chunks now
         // (any previously loaded chunks beyond unload_radius should be unloaded)
@@ -180,7 +180,7 @@ int main() {
         loader.init();
 
         // Camera near chunk (0,0) — request load
-        streamer.update(glm::vec3(16.0f, 0.0f, 16.0f), loader);
+        streamer.update(glm::vec3(16.0f, 0.0f, 16.0f), loader, 0);
         uint32_t initially_loading = streamer.loading_chunk_count();
         assert(initially_loading > 0);
 
@@ -196,7 +196,7 @@ int main() {
         // Move camera to distance 50 from chunk (0,0) center (between load=40 and unload=60)
         // The chunk was Loading (not yet Loaded), so it stays Loading
         // This tests that Loading state is preserved in the hysteresis zone
-        streamer.update(glm::vec3(66.0f, 0.0f, 16.0f), loader);
+        streamer.update(glm::vec3(66.0f, 0.0f, 16.0f), loader, 0);
 
         // The chunks that were Loading and are now between 40-60 should still be Loading
         // (not cancelled, not unloaded)
@@ -220,7 +220,7 @@ int main() {
         loader.init();
 
         // Camera at center — all 4 chunks within load radius
-        streamer.update(glm::vec3(64.0f, 0.0f, 16.0f), loader);
+        streamer.update(glm::vec3(64.0f, 0.0f, 16.0f), loader, 0);
 
         // Simulate all 4 chunks loading — use streamer's manifest for correct IDs
         std::vector<LoadResult> results;
@@ -229,7 +229,7 @@ int main() {
                 results.push_back(make_load_result(c.load_request_id, c.bounds.center(), 100));
             }
         }
-        streamer.process_load_results(results);
+        streamer.process_load_results(results, 0);
 
         // After processing, memory budget should be enforced
         // At most 2 chunks should remain loaded (budget = 2 * 100 * sizeof(Gaussian))
@@ -254,7 +254,7 @@ int main() {
         loader.init();
 
         // Request load — submits jobs, stores request IDs in streamer's manifest
-        streamer.update(glm::vec3(16.0f, 0.0f, 16.0f), loader);
+        streamer.update(glm::vec3(16.0f, 0.0f, 16.0f), loader, 0);
 
         // Create fake results using request IDs from the *streamer's* manifest
         std::vector<LoadResult> results;
@@ -263,7 +263,7 @@ int main() {
                 results.push_back(make_load_result(c.load_request_id, c.bounds.center()));
             }
         }
-        streamer.process_load_results(results);
+        streamer.process_load_results(results, 0);
         assert(streamer.active_set_dirty());
 
         // Assemble clears dirty flag
@@ -286,7 +286,7 @@ int main() {
         AsyncLoader loader;
         loader.init();
 
-        streamer.update(glm::vec3(64.0f, 0.0f, 16.0f), loader);
+        streamer.update(glm::vec3(64.0f, 0.0f, 16.0f), loader, 0);
 
         // Load all chunks — use streamer's manifest for correct request IDs
         std::vector<LoadResult> results;
@@ -295,7 +295,7 @@ int main() {
                 results.push_back(make_load_result(c.load_request_id, c.bounds.center(), 50));
             }
         }
-        streamer.process_load_results(results);
+        streamer.process_load_results(results, 0);
 
         // Wide VP sees everything
         std::vector<Gaussian> all_out;
@@ -312,7 +312,7 @@ int main() {
         auto narrow_vp = narrow_proj * narrow_view;
 
         // Reset dirty flag for second assemble
-        streamer.process_load_results({});  // no-op but keeps API clean
+        streamer.process_load_results({}, 0);  // no-op but keeps API clean
         std::vector<Gaussian> narrow_out;
         uint32_t narrow_count = streamer.assemble_active(
             narrow_vp, glm::vec3(16.0f, 0.0f, 50.0f), 100000, narrow_out);


### PR DESCRIPTION
## Summary

Diagnostic-only PR — instruments three hooks needed to attribute the *suspected* ~25× per-frame slowdown when the camera reverses direction through chunk-streaming boundaries during the canonical regression scenario (issue #399). Not a fix; the diagnostic weapon for the upcoming investigation.

The existing 60-frame averaged GPU timing smears single-frame spikes into invisibility — we currently cannot tell a single 48000 ms stall from 60 sustained 800 ms frames. This PR adds the per-frame, needle-precise data needed to make that distinction in the next harness run.

### Item 1 — Per-frame wall time in `step` response
`step` command response now carries `per_frame_ms: [33.4, 32.9, 845.2, …]` alongside `frames_completed`. Wall-clock measured at frame end. First entry measured from command-issue time so pre-step idle (which is unbounded in step mode) is excluded.

### Item 2 — Chunk lifecycle event log
`gs_chunk_streamer.cpp` emits one stderr line per chunk transition under `#if GSEURAT_DEBUG_BUILD` (so it ships only in `macos-release-with-diag` and `Debug` builds):

```
[streaming] frame=2103 chunk=14 event=load_request slabs=22
[streaming] frame=2107 chunk=14 event=load_complete slabs=22 took=42.18ms
[streaming] frame=2389 chunk=8 event=evict slabs=18
[streaming] frame=2391 chunk=11 event=evict_budget slabs=15
```

Both eviction paths are covered: camera-distance-driven (`event=evict`) and memory-budget-driven (`event=evict_budget`, previously silent — the exact path most likely to thrash on chunk reversal). Frame index sourced from `app.tick()`, plumbed via `update_streaming`. No static counters.

### Item 3 — Last-frame raw GPU timing in `debug_dump`
`RendererStatsDumper::Snapshot::gpu_timing_ms` now reads from new `GsRenderer::*_ms_last()` accessors (raw last completed frame) instead of the 60-frame rolling average. Every frame the timestamp readback succeeds, the snapshot is updated.

The 60-frame averaged stderr line at `gs_renderer.cpp:2817` is preserved byte-identical for any external parser. `*_ms_avg()` accessors retained.

## Review fixes integrated pre-merge

Code-quality reviewer caught two diagnostic-blind-spot P1s that were addressed inline:

- **P1: Hardcoded `slab_size_splats = 100'000`** would produce wrong `slabs=` values under any project that overrides the default. Plumbed runtime `StreamingConfig::slab_size_splats` from `GsRenderer::streaming_config()` (new accessor) into `GsChunkStreamer` via `set_slab_size_splats(uint32_t)` setter.
- **P1: `evict_if_over_budget` was silent.** The most-likely path for chunk-reversal thrash had no event log. Added `event=evict_budget` emission inside the eviction loop with `frame_index` plumbed through.

Plus P2: dropped default-zero arg from `update()` / `process_load_results()` / `evict_if_over_budget()` — explicit at all 12 call sites including test fixtures, so a missed future update fails to compile rather than silently logging frame=0.

## Test plan

- [x] `cmake --preset macos-release-with-diag && cmake --build build/macos-release-with-diag` — clean
- [x] `ctest --test-dir build/macos-release-with-diag --output-on-failure` — 78/78 pass
- [ ] (Manual, post-merge) Run regression harness and verify `[streaming]` log lines + `per_frame_ms` array present; correlate frame=N spike to chunk events
- [ ] (Follow-up) Investigation PR using this data to isolate the #399 spike

🤖 Generated with [Claude Code](https://claude.com/claude-code)