### PR TITLE
perf(demo): instrument IslandDemo's actual chunk-load path for #399

### DIFF
--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -13,6 +13,8 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <array>
+#include <chrono>
+#include <cstdint>
 #include <functional>
 #include <future>
 #include <memory>
@@ -127,10 +129,15 @@ private:
     struct PendingChunkParse {
         std::string grid_key;
         std::future<GaussianCloud> future;
+        // Stamped at enqueue time for the [streaming] event log's `took=Yms`
+        // field. `requested_frame` is `app.tick()` at enqueue.
+        std::chrono::steady_clock::time_point requested_at{};
+        uint64_t requested_frame{0};
     };
     std::vector<PendingChunkParse> pending_chunk_parses_;
     void enqueue_async_chunk_load(const std::string& grid_key,
-                                  const std::string& ply_path);
+                                  const std::string& ply_path,
+                                  uint64_t frame_index);
     void drain_async_chunk_loads(AppBase& app);
 
     // Orbit camera (third-person around player)

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1013,6 +1013,7 @@ void IslandDemoState::update(AppBase& app, float dt) {
     // content into the dungeon's GS buffer.
     if (world_streamer_ && !disable_world_streaming_) {
         ScopedStallTimer _t_streamer{"world_streamer.update+pending_loads"};
+        const uint64_t frame_index = app.tick();
         auto events = world_streamer_->update(character_origin_);
 
         // Drain any worker-thread-completed PLY parses BEFORE kicking off
@@ -1032,7 +1033,7 @@ void IslandDemoState::update(AppBase& app, float dt) {
                     auto resolved = resolve_asset_path(chunk.ply_file);
                     std::fprintf(stderr, "[IslandDemo] Chunk [%s] async parse start: %s\n",
                         grid_key.c_str(), chunk.ply_file.c_str());
-                    enqueue_async_chunk_load(grid_key, resolved.string());
+                    enqueue_async_chunk_load(grid_key, resolved.string(), frame_index);
                     break;
                 }
             }
@@ -1041,6 +1042,11 @@ void IslandDemoState::update(AppBase& app, float dt) {
         // Process pending unloads
         for (const auto& grid_key : world_streamer_->pending_unloads()) {
             std::fprintf(stderr, "[IslandDemo] Chunk [%s] Unloaded\n", grid_key.c_str());
+#if GSEURAT_DEBUG_BUILD
+            std::fprintf(stderr,
+                "[streaming] frame=%llu chunk=%s event=evict\n",
+                static_cast<unsigned long long>(frame_index), grid_key.c_str());
+#endif
         }
 
 
@@ -2568,26 +2574,39 @@ void IslandDemoState::finish_portal_transition(AppBase& app,
 // future once per frame and only touches the GPU once the parse is done.
 
 void IslandDemoState::enqueue_async_chunk_load(const std::string& grid_key,
-                                               const std::string& ply_path) {
+                                               const std::string& ply_path,
+                                               uint64_t frame_index) {
     // Skip if a parse is already in flight for this key (the streamer will
     // re-emit `pending_loads_` keys until we tell it the chunk is loaded).
     for (const auto& p : pending_chunk_parses_) {
         if (p.grid_key == grid_key) return;
     }
-    pending_chunk_parses_.push_back({
-        grid_key,
-        std::async(std::launch::async, [ply_path]() {
-            GaussianCloud c;
-            c.load_ply(ply_path);
-            return c;
-        })
+    PendingChunkParse entry;
+    entry.grid_key = grid_key;
+    entry.future = std::async(std::launch::async, [ply_path]() {
+        GaussianCloud c;
+        c.load_ply(ply_path);
+        return c;
     });
+    entry.requested_at = std::chrono::steady_clock::now();
+    entry.requested_frame = frame_index;
+    pending_chunk_parses_.push_back(std::move(entry));
+#if GSEURAT_DEBUG_BUILD
+    std::fprintf(stderr,
+        "[streaming] frame=%llu chunk=%s event=load_request\n",
+        static_cast<unsigned long long>(frame_index), grid_key.c_str());
+#else
+    (void)frame_index;
+#endif
 }
 
 void IslandDemoState::drain_async_chunk_loads(AppBase& app) {
     // Sweep ready futures, consume their clouds, and hand them to the
     // existing async-upload pipe. Anything still parsing stays in the
     // queue for next frame.
+#if GSEURAT_DEBUG_BUILD
+    const uint64_t frame_index = app.tick();
+#endif
     for (auto it = pending_chunk_parses_.begin();
          it != pending_chunk_parses_.end(); ) {
         if (it->future.wait_for(std::chrono::seconds(0)) ==
@@ -2600,6 +2619,17 @@ void IslandDemoState::drain_async_chunk_loads(AppBase& app) {
                 std::fprintf(stderr,
                     "[IslandDemo] Chunk [%s] async parse FAILED: %s\n",
                     it->grid_key.c_str(), e.what());
+#if GSEURAT_DEBUG_BUILD
+                double took_ms = std::chrono::duration<double, std::milli>(
+                    std::chrono::steady_clock::now() - it->requested_at).count();
+                std::fprintf(stderr,
+                    "[streaming] frame=%llu chunk=%s event=parse_failed "
+                    "requested_frame=%llu took=%.2fms\n",
+                    static_cast<unsigned long long>(frame_index),
+                    it->grid_key.c_str(),
+                    static_cast<unsigned long long>(it->requested_frame),
+                    took_ms);
+#endif
                 it = pending_chunk_parses_.erase(it);
                 continue;
             }
@@ -2611,6 +2641,17 @@ void IslandDemoState::drain_async_chunk_loads(AppBase& app) {
                 std::fprintf(stderr,
                     "[IslandDemo] Chunk [%s] async parse done, queued for VRAM\n",
                     it->grid_key.c_str());
+#if GSEURAT_DEBUG_BUILD
+                double took_ms = std::chrono::duration<double, std::milli>(
+                    std::chrono::steady_clock::now() - it->requested_at).count();
+                std::fprintf(stderr,
+                    "[streaming] frame=%llu chunk=%s event=parse_complete "
+                    "requested_frame=%llu took=%.2fms\n",
+                    static_cast<unsigned long long>(frame_index),
+                    it->grid_key.c_str(),
+                    static_cast<unsigned long long>(it->requested_frame),
+                    took_ms);
+#endif
             }
             it = pending_chunk_parses_.erase(it);
         } else {


### PR DESCRIPTION
## Summary

Follow-up to #402. The first harness run with #402's instrumentation revealed two things:

1. **#399 reproduces dramatically.** Frame 1864 stalls **35.3 seconds**, frame 1804 stalls **25.5 seconds**, both at the camera-reversal phase. Median frame: 81 ms vs 16.6 ms target. Pattern around every 300-frame step boundary: normal → step-issue spike → 2 ultra-fast (~4 ms) frames → catastrophic spike → normal. Strong async-load signature.

2. **#402's `[streaming]` events fired from the wrong streamer.** The canonical scenario uses `IslandDemo` + `WorldStreamer` (an event-emitter that defers actual loads to the demo), not `GsDemoState`'s `GsChunkStreamer` (the whole-chunk loader I instrumented). Zero `[streaming]` lines in the captured `engine_stderr.log`.

This PR adds the same `#if GSEURAT_DEBUG_BUILD`-gated `[streaming]` log lines to the actual hot path: `IslandDemoState::enqueue_async_chunk_load`, `drain_async_chunk_loads`, and the `pending_unloads` loop.

## Output format

```
[streaming] frame=N chunk=KEY event=load_request
[streaming] frame=N chunk=KEY event=parse_complete requested_frame=R took=Y.YYms
[streaming] frame=N chunk=KEY event=parse_failed   requested_frame=R took=Y.YYms
[streaming] frame=N chunk=KEY event=evict
```

`took` measures wall-clock from the `std::async` dispatch (PLY parse + worker queue time). The follow-up GPU-upload latency is still unmeasured here — `load_cloud_async` returns immediately and the actual VRAM transfer completes some frames later. If the next harness run still shows unattributed stalls, that's the next thing to instrument.

## Implementation

- `PendingChunkParse` gained `requested_at` (steady_clock time_point) and `requested_frame` (uint64_t).
- Frame index plumbed via `app.tick()` in `update_streaming` and at drain time.
- `enqueue_async_chunk_load` gained a `frame_index` parameter — single call site updated.
- Existing `[IslandDemo] Chunk [%s]` log lines retained unchanged (they ship in release builds; the new `[streaming]` format is debug-only).

## Test plan

- [x] `cmake --preset macos-release-with-diag && cmake --build build/macos-release-with-diag` — clean
- [x] `ctest --test-dir build/macos-release-with-diag --output-on-failure` — 78/78 pass
- [ ] (Manual, post-merge) Re-run harness and grep `[streaming]` lines for the spike frames (1804, 1864, 2404) — confirm or falsify the chunk-load-stall hypothesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)