### PR TITLE
perf(engine): unblock GPU 60-avg log readback (#404)

### DIFF
--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -2792,13 +2792,17 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
     std::memcpy(uniform_buffer_.mapped(), &uniforms, sizeof(uniforms));
 
     // Read back GPU timestamps from previous frame (depth sort + tile sort + rasterize).
-    // Non-blocking: if results aren't ready yet, skip this frame's sample.
+    // WAIT_BIT: with kMaxFramesInFlight=2 the GPU hasn't necessarily completed
+    // frame N-1's queries by the time frame N's CPU code runs, so non-blocking
+    // reads returned VK_NOT_READY every frame and the 60-avg log never fired
+    // (#404 — silent during the #399 perf investigation). The wait is bounded
+    // to the previous frame's GPU latency and is worth the diagnostic data.
     if (timestamp_pool_ && timestamps_written_) {
         uint64_t ts[6]{};  // depth_sort_begin/end, tile_sort_begin/end, raster_begin/end
         VkResult ts_result = vkGetQueryPoolResults(
             device_, timestamp_pool_, 0, 6,
             sizeof(ts), ts, sizeof(uint64_t),
-            VK_QUERY_RESULT_64_BIT);  // no WAIT_BIT — never block on GPU
+            VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
         if (ts_result == VK_SUCCESS && ts[5] > ts[4] && ts[3] > ts[2] && ts[1] > ts[0]) {
             float depth_ms = static_cast<float>(ts[1] - ts[0]) * timestamp_period_ns_ / 1e6f;
             float tile_ms  = static_cast<float>(ts[3] - ts[2]) * timestamp_period_ns_ / 1e6f;


### PR DESCRIPTION
## Summary

Single-line fix to make GPU per-pass timing actually return data. Required for the #399 perf investigation.

## The bug

The 60-frame averaged GPU timing line `[gs_renderer] DepthSort: ... TileSort: ... Rasterize: ...` at \`gs_renderer.cpp:2817\` was **silent across the entire 3300-frame harness run**. It should fire ~50 times.

Root cause: \`gs_renderer.cpp:2798-2801\` used non-blocking \`vkGetQueryPoolResults\` (no \`WAIT_BIT\`):

\`\`\`cpp
VkResult ts_result = vkGetQueryPoolResults(
    device_, timestamp_pool_, 0, 6,
    sizeof(ts), ts, sizeof(uint64_t),
    VK_QUERY_RESULT_64_BIT);  // no WAIT_BIT — never block on GPU
\`\`\`

With \`kMaxFramesInFlight=2\`, frame N's CPU code reaches the readback before the GPU finishes frame N-1's command buffer that wrote the timestamps. \`vkGetQueryPoolResults\` returned \`VK_NOT_READY\` every frame; the accumulator stayed 0; the \`% kTimestampAvgFrames\` check at line 2813 never tripped.

## The fix

Add \`VK_QUERY_RESULT_WAIT_BIT\`. The read now blocks (CPU-side) for at most one frame's worth of pending GPU work — bounded by the previous frame's GPU latency.

## Why this is worth a small CPU stall

The diagnostic value of having GPU per-pass timing during the next #399 harness attempt outweighs the small CPU stall on the readback path. We need this data to split:

- **GPU-bound stalls**: \`rasterize_ms\` huge on a slow frame → GPU is working
- **CPU-bound stalls**: \`rasterize_ms\` tiny but \`per_frame_ms\` huge → main-thread synchronous I/O / shader compile / similar

The first \`#399\` run's median \`per_frame_ms\` was 81 ms; the readback wait is bounded by that, well below the catastrophic 25-35 second spikes we're chasing.

## Test plan

- [x] \`cmake --preset macos-release-with-diag && cmake --build build/macos-release-with-diag\` — clean
- [x] \`ctest --test-dir build/macos-release-with-diag --output-on-failure\` — 78/78 pass
- [ ] (Post-merge) Re-run harness, confirm \`[gs_renderer] DepthSort: ...\` lines appear (~50 entries expected)
- [ ] Use the new GPU timing data + \`per_frame_ms\` to attribute the #399 25-35s spikes

🤖 Generated with [Claude Code](https://claude.com/claude-code)