### PR TITLE
perf(engine): persist pipeline cache reliably under SIGTERM (#405)

### DIFF
--- a/include/gseurat/engine/vk_context.hpp
+++ b/include/gseurat/engine/vk_context.hpp
@@ -34,6 +34,14 @@ public:
     // shader compilation across pipelines and runs.
     VkPipelineCache pipeline_cache() const { return pipeline_cache_.handle(); }
 
+    // Persist the pipeline cache to disk. Safe to call before shutdown() —
+    // vkGetPipelineCacheData is a CPU-side query that doesn't require GPU
+    // idle, so this can run at the very start of teardown. Idempotent;
+    // shutdown() also calls save() but that's behind ~5+ seconds of slow
+    // VMA / device / instance teardown that frequently exceeds the
+    // SIGTERM→SIGKILL window driven by the regression harness (#405).
+    void save_pipeline_cache() { pipeline_cache_.save(); }
+
 private:
     void create_instance();
     void setup_debug_messenger();

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -30,17 +30,40 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
+#include <atomic>
 #include <chrono>
+#include <csignal>
 #include <cstdio>
 #include <optional>
 
 namespace gseurat {
+
+namespace {
+// Set by SIGTERM/SIGINT handler so the main loop can exit cleanly. Without
+// this the harness's `proc.terminate()` (SIGTERM, then SIGKILL after 5 s)
+// kills the engine without running any C++ destructors — meaning
+// Renderer::shutdown() never fires and the Vulkan pipeline cache is never
+// persisted. Every subsequent harness run then starts cold and pays the
+// MoltenVK first-compile cost on the main thread mid-frame (#405 / #399).
+std::atomic<bool> g_shutdown_requested{false};
+
+void signal_handler(int /*sig*/) {
+    g_shutdown_requested.store(true, std::memory_order_relaxed);
+}
+
+void install_signal_handlers() {
+    std::signal(SIGTERM, signal_handler);
+    std::signal(SIGINT, signal_handler);
+}
+}  // namespace
 
 void AppBase::set_start_state(std::unique_ptr<GameState> state) {
     custom_start_state_ = std::move(state);
 }
 
 void AppBase::run() {
+    install_signal_handlers();
+
     command_dispatcher_.register_default_commands();
     init_game_object_system();
 
@@ -217,7 +240,8 @@ void AppBase::main_loop() {
         step_mode_ = true;
     }
 
-    while (!glfwWindowShouldClose(window_)) {
+    while (!glfwWindowShouldClose(window_) &&
+           !g_shutdown_requested.load(std::memory_order_relaxed)) {
         glfwPollEvents();
 
         // Poll control server for bridge commands

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -62,8 +62,6 @@ void AppBase::set_start_state(std::unique_ptr<GameState> state) {
 }
 
 void AppBase::run() {
-    install_signal_handlers();
-
     command_dispatcher_.register_default_commands();
     init_game_object_system();
 
@@ -101,6 +99,14 @@ void AppBase::init_game_content() {
 }
 
 void AppBase::main_loop() {
+    // Install SIGTERM/SIGINT handlers HERE rather than in run() because
+    // DemoApp::run() and StagingApp::run() override AppBase::run() and call
+    // main_loop() directly without invoking the base — moving this to
+    // main_loop() guarantees the handlers are installed for every entry
+    // path. std::signal is idempotent if called repeatedly with the same
+    // handler, so double-install via tests/headless paths is harmless.
+    install_signal_handlers();
+
     last_update_time_ = std::chrono::steady_clock::now();
 
     // Initialize async loading subsystems

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -879,6 +879,15 @@ void Renderer::shutdown() {
         }
     }
 
+    // Persist the pipeline cache to disk FIRST, before any slow teardown.
+    // Otherwise the SIGTERM→SIGKILL window driven by the regression harness
+    // (5 s) frequently expires while VMA / device / instance teardown is
+    // still running, and the cache is lost — forcing every harness run to
+    // recompile every PSO from scratch on first dispatch (#405). vkDeviceWaitIdle
+    // isn't required: vkGetPipelineCacheData is a CPU-side query against the
+    // driver's cache state, not pending GPU work.
+    context_.save_pipeline_cache();
+
     if (gs_bg_texture_) {
         gs_bg_texture_->destroy(context_.device(), context_.allocator());
         gs_bg_texture_ = {};

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -850,6 +850,15 @@ void Renderer::draw_frame() {
 }
 
 void Renderer::shutdown() {
+    // Persist the pipeline cache to disk BEFORE vkDeviceWaitIdle and any
+    // teardown work. Otherwise the SIGTERM→SIGKILL window driven by the
+    // regression harness (5 s) can expire while waiting for in-flight GPU
+    // work or destroying textures, and the cache is lost — forcing every
+    // harness run to recompile every PSO from scratch on first dispatch
+    // (#405). vkGetPipelineCacheData is a CPU-side query against the
+    // driver's cache state and does NOT require a device idle.
+    context_.save_pipeline_cache();
+
     vkDeviceWaitIdle(context_.device());
 
     // Release texture handles (actual GPU cleanup happens via shared_ptr destructor
@@ -878,15 +887,6 @@ void Renderer::shutdown() {
             buf.destroy(context_.allocator());
         }
     }
-
-    // Persist the pipeline cache to disk FIRST, before any slow teardown.
-    // Otherwise the SIGTERM→SIGKILL window driven by the regression harness
-    // (5 s) frequently expires while VMA / device / instance teardown is
-    // still running, and the cache is lost — forcing every harness run to
-    // recompile every PSO from scratch on first dispatch (#405). vkDeviceWaitIdle
-    // isn't required: vkGetPipelineCacheData is a CPU-side query against the
-    // driver's cache state, not pending GPU work.
-    context_.save_pipeline_cache();
 
     if (gs_bg_texture_) {
         gs_bg_texture_->destroy(context_.device(), context_.allocator());


### PR DESCRIPTION
Closes #405. Root-cause fix for #399's non-deterministic 25–35 second per-frame stalls.

## What was happening

The Vulkan pipeline cache `.cache/vulkan_pipeline.bin` was never written in `build/macos-release-with-diag/` despite repeated harness runs (verified via filesystem inspection). Two compounding bugs:

1. **No SIGTERM/SIGINT handler.** The regression harness's `proc.terminate()` killed the engine without running C++ destructors. `Renderer::shutdown()` → `context_.shutdown()` → `pipeline_cache_.save()` never executed.

2. **Cache save was last in the shutdown chain.** Even on graceful exit, `save()` ran after VMA cleanup, swapchain teardown, command-pool shutdown, etc. — and the full chain in diag builds takes longer than 5 seconds, so harness's SIGKILL fires first.

Combined, every harness run started cold. MoltenVK then compiled `MTLComputePipelineState` objects on first dispatch *during gameplay on the main thread*, producing the spike pattern from #399:

| Run | Spike frame | per_frame_ms |
|---|---|---|
| v1 | 1864 | 35 332 ms |
| v1 | 1804 | 25 474 ms |
| v2 | 2404 | 6 800 ms |
| v2 | 1581 | 4 874 ms |

Different frames each run because lazy compile timing depends on dispatch order and GPU scheduling.

## The fix

**`app_base.cpp`**: install a `signal_handler` for SIGTERM/SIGINT that sets `g_shutdown_requested` (atomic). Main loop now checks it alongside `glfwWindowShouldClose` and exits gracefully — so destructors actually run when the harness sends `terminate()`.

**`Renderer::shutdown()`**: call new `VkContext::save_pipeline_cache()` at the *very start*, before any other teardown work. `vkGetPipelineCacheData` is a CPU-side query against the driver's cache state — doesn't require GPU idle. Cache is on disk within milliseconds of shutdown start, well within the 5 s SIGTERM window.

## Expected effect

After one harness run completes successfully and writes the cache, every subsequent run starts warm — MoltenVK reuses compiled Metal PSOs from disk instead of recompiling SPIR-V → MSL → PSO on the main thread mid-frame. The 25–35 second per-frame spikes from #399 should disappear from steady-state runs.

**First-run compile cost is unaffected by this PR.** See #406 for pipeline pre-warm at startup.

## Test plan

- [x] `cmake --preset macos-release-with-diag && cmake --build build/macos-release-with-diag` — clean
- [x] `ctest --test-dir build/macos-release-with-diag --output-on-failure` — 78/78 pass
- [ ] (Manual, post-merge) Run harness twice. First run: stderr should now end with `[PipelineCache] saved N bytes`. Second run: cache file present in `build/macos-release-with-diag/.cache/`, stderr starts with `[PipelineCache] loaded N bytes` (or equivalent), `per_frame_ms` shows no multi-second spikes
- [ ] Optional: `kill -TERM <pid>` an interactive engine, confirm clean shutdown via flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)