### PR TITLE
perf(engine): pre-warm Vulkan pipelines at startup (#406)

### DIFF
--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -353,6 +353,18 @@ public:
     void load_world(const WorldManifest& manifest);
     const WorldManifest& world_manifest() const { return world_manifest_; }
 
+    // Pre-warm every compute pipeline created in `init()` by recording one
+    // `vkCmdDispatch(1,1,1)` per pipeline against transient dummy descriptor
+    // sets, then `vkQueueWaitIdle`-ing the submit. On MoltenVK this forces
+    // each `MTLComputePipelineState` to be compiled at startup so the first
+    // real frame doesn't pay 25-35 s of mid-frame Metal compile latency
+    // (issue #399 root cause). Caller must invoke `save_pipeline_cache()`
+    // on its `VkContext` immediately after this returns so the now-warm
+    // cache is persisted before any later code can crash. All temporary
+    // resources (cmd buffer, descriptor pool, dummy buffers/images) are
+    // freed before this method returns. Safe to call once after `init()`.
+    void prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool);
+
     void shutdown(VmaAllocator allocator);
 
 private:

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -792,7 +792,10 @@ void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool) {
     dpc.maxSets = 32;
     dpc.poolSizeCount = 3;
     dpc.pPoolSizes = pool_sizes;
-    VkDescriptorPool prewarm_pool = VK_NULL_HANDLE;
+    // Assign to the function-scope handle so cleanup() can destroy it on
+    // any exit path. Earlier draft shadowed this with a local declaration —
+    // the outer handle stayed VK_NULL_HANDLE and the pool leaked on every
+    // successful run (Codex P2 review on PR #409).
     if (vkCreateDescriptorPool(device_, &dpc, nullptr, &prewarm_pool) != VK_SUCCESS) {
         throw std::runtime_error("[prewarm] Failed to create descriptor pool");
     }
@@ -992,6 +995,29 @@ void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool) {
         if (vkBeginCommandBuffer(cmd, &cbb) != VK_SUCCESS) {
             throw std::runtime_error("[prewarm] vkBeginCommandBuffer (warmup) failed");
         }
+
+        // Zero the dummy SSBO before any pipeline dispatches read from it.
+        // Several shaders (gs_onesweep_scatter, merge, tile shaders) read
+        // control/count values from their SSBO bindings before deciding how
+        // much work to do; uninitialized GPU-only allocations contain
+        // recycled VRAM that can produce huge values, causing 1×1 warmup
+        // dispatches to perform OOB reads/writes (Codex P1 review on #409).
+        // The host-visible UBO is already memset to zero on the CPU side
+        // above, so only the SSBO needs an in-command-buffer fill.
+        vkCmdFillBuffer(cmd, dummy_ssbo.buffer(), 0, VK_WHOLE_SIZE, 0);
+        VkBufferMemoryBarrier fill_barrier{};
+        fill_barrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+        fill_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        fill_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+        fill_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        fill_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        fill_barrier.buffer = dummy_ssbo.buffer();
+        fill_barrier.offset = 0;
+        fill_barrier.size = VK_WHOLE_SIZE;
+        vkCmdPipelineBarrier(cmd,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            0, 0, nullptr, 1, &fill_barrier, 0, nullptr);
 
         // Zero push constant scratch (largest is 12 bytes for tile_scan).
         uint8_t push_scratch[16] = {0};

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -627,6 +627,420 @@ void GsRenderer::create_compute_pipelines() {
                     tile_render_pipeline_layout_, tile_render_pipeline_);
 }
 
+// Pre-warm every compute pipeline created above by recording a single
+// `vkCmdDispatch(1,1,1)` per pipeline against transient dummy descriptor
+// sets, then waiting on the queue. On MoltenVK each `vkCmdDispatch` triggers
+// `MTLComputePipelineState` compilation; doing it at startup against
+// data-irrelevant inputs spreads the cost out of the first real frame.
+//
+// The dispatch is `(1,1,1)` — every shader exits early on its bounds checks
+// or simply writes garbage into a 4 KB scratch SSBO that is destroyed
+// immediately afterward, so there is no externally observable side effect.
+// Validation may flag "uninitialized data" or "out-of-range" reads on these
+// dispatches; that is expected and documented in PR #409.
+void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool) {
+    using clock = std::chrono::steady_clock;
+    auto t_begin = clock::now();
+
+    // All resources tracked at function scope so the cleanup lambda below
+    // can destroy whatever was actually created on ANY exit path — including
+    // the catch handler. This is failure-soft: prewarm is an optimization,
+    // so any error logs and returns; the engine continues with cold caches.
+    Buffer dummy_ssbo;
+    Buffer dummy_ubo;
+    VkImage     color_img   = VK_NULL_HANDLE;
+    VmaAllocation color_alloc = VK_NULL_HANDLE;
+    VkImageView color_view  = VK_NULL_HANDLE;
+    VkImage     depth_img   = VK_NULL_HANDLE;
+    VmaAllocation depth_alloc = VK_NULL_HANDLE;
+    VkImageView depth_view  = VK_NULL_HANDLE;
+    VkDescriptorPool prewarm_pool = VK_NULL_HANDLE;
+    VkCommandBuffer cmd = VK_NULL_HANDLE;
+    size_t pipeline_count = 0;  // captured inside try, logged after cleanup
+
+    auto cleanup = [&]() {
+        if (cmd != VK_NULL_HANDLE)
+            vkFreeCommandBuffers(device_, cmd_pool, 1, &cmd);
+        if (prewarm_pool != VK_NULL_HANDLE)
+            vkDestroyDescriptorPool(device_, prewarm_pool, nullptr);
+        if (dummy_ssbo.buffer() != VK_NULL_HANDLE) dummy_ssbo.destroy(allocator_);
+        if (dummy_ubo.buffer()  != VK_NULL_HANDLE) dummy_ubo.destroy(allocator_);
+        if (color_view != VK_NULL_HANDLE) vkDestroyImageView(device_, color_view, nullptr);
+        if (color_img  != VK_NULL_HANDLE) vmaDestroyImage(allocator_, color_img, color_alloc);
+        if (depth_view != VK_NULL_HANDLE) vkDestroyImageView(device_, depth_view, nullptr);
+        if (depth_img  != VK_NULL_HANDLE) vmaDestroyImage(allocator_, depth_img, depth_alloc);
+    };
+
+    try {
+        // ── 1. Dummy buffers ──────────────────────────────────────────────
+        // Single shared SSBO + UBO. All bindings point at the same allocation;
+        // the shaders run for one workgroup and read/write at offset 0 only.
+        constexpr VkDeviceSize kDummySsboSize = 4096;  // 4 KB — covers any single
+                                                       // 64 B Gaussian/SortEntry/...
+                                                       // load/store at index 0.
+        constexpr VkDeviceSize kDummyUboSize = sizeof(GsUniforms);
+        dummy_ssbo = Buffer::create_storage_gpu_only(allocator_, kDummySsboSize);
+        dummy_ubo  = Buffer::create_uniform(allocator_, kDummyUboSize);
+        std::memset(dummy_ubo.mapped(), 0, kDummyUboSize);
+
+        // ── 2. Dummy storage images ───────────────────────────────────────
+        // post_process / tile_render layouts bind STORAGE_IMAGE descriptors;
+        // their formats are declared `rgba16f` (color) and `r16f` (depth) in
+        // the shader. A 1×1 image is fine — dispatch is (1,1,1) and we don't
+        // even cover that pixel.
+        auto make_dummy_image = [&](VkFormat format, VkImage& out_image,
+                                    VmaAllocation& out_alloc, VkImageView& out_view) {
+            VkImageCreateInfo ic{};
+            ic.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+            ic.imageType = VK_IMAGE_TYPE_2D;
+            ic.format = format;
+            ic.extent = {1, 1, 1};
+            ic.mipLevels = 1;
+            ic.arrayLayers = 1;
+            ic.samples = VK_SAMPLE_COUNT_1_BIT;
+            ic.tiling = VK_IMAGE_TILING_OPTIMAL;
+            ic.usage = VK_IMAGE_USAGE_STORAGE_BIT;
+            VmaAllocationCreateInfo ai{};
+            ai.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+            if (vmaCreateImage(allocator_, &ic, &ai, &out_image, &out_alloc, nullptr) != VK_SUCCESS) {
+                throw std::runtime_error("[prewarm] Failed to create dummy storage image");
+            }
+            VkImageViewCreateInfo vi{};
+            vi.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            vi.image = out_image;
+            vi.viewType = VK_IMAGE_VIEW_TYPE_2D;
+            vi.format = format;
+            vi.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            if (vkCreateImageView(device_, &vi, nullptr, &out_view) != VK_SUCCESS) {
+                throw std::runtime_error("[prewarm] Failed to create dummy image view");
+            }
+        };
+        make_dummy_image(VK_FORMAT_R16G16B16A16_SFLOAT, color_img, color_alloc, color_view);
+        make_dummy_image(VK_FORMAT_R16_SFLOAT,           depth_img, depth_alloc, depth_view);
+
+        // Transition both dummy images to GENERAL (= storage layout) so the
+        // descriptor write below is valid at dispatch time.
+        {
+            VkCommandBuffer xfer_cmd = VK_NULL_HANDLE;
+            VkCommandBufferAllocateInfo cba{};
+            cba.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+            cba.commandPool = cmd_pool;
+            cba.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+            cba.commandBufferCount = 1;
+            if (vkAllocateCommandBuffers(device_, &cba, &xfer_cmd) != VK_SUCCESS) {
+                throw std::runtime_error("[prewarm] Failed to allocate xfer command buffer");
+            }
+
+            VkCommandBufferBeginInfo cbb{};
+            cbb.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+            cbb.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+            if (vkBeginCommandBuffer(xfer_cmd, &cbb) != VK_SUCCESS) {
+                vkFreeCommandBuffers(device_, cmd_pool, 1, &xfer_cmd);
+                throw std::runtime_error("[prewarm] vkBeginCommandBuffer (xfer) failed");
+            }
+
+            VkImageMemoryBarrier barriers[2]{};
+            for (int i = 0; i < 2; ++i) {
+                barriers[i].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                barriers[i].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+                barriers[i].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                barriers[i].srcAccessMask = 0;
+                barriers[i].dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+                // Default-init of srcQueueFamilyIndex is 0 — which is a real
+                // queue family on most platforms, NOT "ignored". Setting
+                // explicit IGNORED prevents an inadvertent ownership transfer
+                // on multi-queue-family devices.
+                barriers[i].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                barriers[i].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                barriers[i].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            }
+            barriers[0].image = color_img;
+            barriers[1].image = depth_img;
+
+            vkCmdPipelineBarrier(xfer_cmd,
+                VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                0, 0, nullptr, 0, nullptr, 2, barriers);
+
+            if (vkEndCommandBuffer(xfer_cmd) != VK_SUCCESS) {
+                vkFreeCommandBuffers(device_, cmd_pool, 1, &xfer_cmd);
+                throw std::runtime_error("[prewarm] vkEndCommandBuffer (xfer) failed");
+            }
+            VkSubmitInfo sub{};
+            sub.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+            sub.commandBufferCount = 1;
+            sub.pCommandBuffers = &xfer_cmd;
+            if (vkQueueSubmit(queue, 1, &sub, VK_NULL_HANDLE) != VK_SUCCESS) {
+                vkFreeCommandBuffers(device_, cmd_pool, 1, &xfer_cmd);
+                throw std::runtime_error("[prewarm] vkQueueSubmit (xfer) failed");
+            }
+            vkQueueWaitIdle(queue);
+            vkFreeCommandBuffers(device_, cmd_pool, 1, &xfer_cmd);
+        }
+
+    // ── 3. Transient descriptor pool ──────────────────────────────────────
+    // Sized for one set per pipeline (13) plus headroom. Bindings are
+    // generously bounded by counting the largest layout (preprocess: 7 SSBO
+    // + 1 UBO; tile_render: 4 SSBO + 1 UBO + 2 storage images).
+    VkDescriptorPoolSize pool_sizes[] = {
+        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 128},
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 32},
+        {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,  16},
+    };
+    VkDescriptorPoolCreateInfo dpc{};
+    dpc.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    dpc.maxSets = 32;
+    dpc.poolSizeCount = 3;
+    dpc.pPoolSizes = pool_sizes;
+    VkDescriptorPool prewarm_pool = VK_NULL_HANDLE;
+    if (vkCreateDescriptorPool(device_, &dpc, nullptr, &prewarm_pool) != VK_SUCCESS) {
+        throw std::runtime_error("[prewarm] Failed to create descriptor pool");
+    }
+
+    // ── 4. Per-layout dummy descriptor sets ───────────────────────────────
+    // For each layout we'll bind, allocate one set and write every binding
+    // to the dummy resources. Image-bearing layouts get color/depth views;
+    // everything else gets the dummy SSBO/UBO.
+    struct PipelineEntry {
+        const char* name;
+        VkPipeline pipeline;
+        VkPipelineLayout layout;
+        VkDescriptorSetLayout set_layout;
+        // Bindings that are STORAGE_IMAGE (set indices) for this layout —
+        // we only have at most 3 image bindings in any layout, so a tiny
+        // fixed array suffices.
+        struct ImageBinding {
+            uint32_t binding;
+            VkImageView view;
+        };
+        std::array<ImageBinding, 3> image_bindings{};
+        uint32_t image_binding_count = 0;
+        // Bindings that are UNIFORM_BUFFER (rest are STORAGE_BUFFER).
+        std::array<uint32_t, 2> uniform_bindings{};
+        uint32_t uniform_binding_count = 0;
+        // All other bindings are STORAGE_BUFFER.
+        std::array<uint32_t, 8> storage_bindings{};
+        uint32_t storage_binding_count = 0;
+        // Push constant size.
+        uint32_t push_size = 0;
+    };
+
+    // Build entries mirroring create_compute_pipelines() exactly. The
+    // binding indices here MUST match `create_descriptor_resources()`.
+    std::vector<PipelineEntry> entries;
+    entries.reserve(13);
+
+    auto add_entry = [&](const char* name, VkPipeline p, VkPipelineLayout pl,
+                         VkDescriptorSetLayout sl, uint32_t push_size,
+                         std::initializer_list<uint32_t> ssbo_bindings,
+                         std::initializer_list<uint32_t> ubo_bindings,
+                         std::initializer_list<std::pair<uint32_t, VkImageView>> img_bindings) {
+        PipelineEntry e{};
+        e.name = name;
+        e.pipeline = p;
+        e.layout = pl;
+        e.set_layout = sl;
+        e.push_size = push_size;
+        for (auto b : ssbo_bindings) e.storage_bindings[e.storage_binding_count++] = b;
+        for (auto b : ubo_bindings)  e.uniform_bindings[e.uniform_binding_count++] = b;
+        for (const auto& ib : img_bindings) {
+            e.image_bindings[e.image_binding_count++] = {ib.first, ib.second};
+        }
+        entries.push_back(e);
+    };
+
+    // gs_preprocess: SSBO {0,1,2,4,5,6,8} + UBO {3}
+    add_entry("gs_preprocess", preprocess_pipeline_, preprocess_pipeline_layout_,
+              preprocess_layout_, sizeof(GsPreprocessPush),
+              {0,1,2,4,5,6,8}, {3}, {});
+    // gs_sort (legacy): SSBO {0} + UBO {1}
+    add_entry("gs_sort", sort_pipeline_, sort_pipeline_layout_, sort_layout_, 8,
+              {0}, {1}, {});
+    // gs_post_process: STORAGE_IMAGE {0,1,2} + UBO {3}
+    add_entry("gs_post_process", post_process_pipeline_, post_process_pipeline_layout_,
+              post_process_layout_, 0,
+              {}, {3},
+              {{0u, color_view}, {1u, depth_view}, {2u, color_view}});
+    // pbd_solver: SSBO {0,1,2} + UBO {3}
+    add_entry("pbd_solver", pbd_pipeline_, pbd_pipeline_layout_, pbd_layout_,
+              sizeof(uint32_t),
+              {0,1,2}, {3}, {});
+    // gs_merge: SSBO {0,1,2,3}
+    add_entry("gs_merge", merge_pipeline_, merge_pipeline_layout_, merge_layout_, 0,
+              {0,1,2,3}, {}, {});
+    // gs_tile_bin: SSBO {0,1,2,3,4,5} + UBO {6}
+    add_entry("gs_tile_bin", tile_bin_pipeline_, tile_bin_pipeline_layout_,
+              tile_bin_layout_, 4,
+              {0,1,2,3,4,5}, {6}, {});
+    // gs_tile_count: shares tile_bin_layout_ + tile_bin_pipeline_layout_
+    // (its push range is the unused 4-byte one from tile_bin)
+    add_entry("gs_tile_count", tile_count_pipeline_, tile_bin_pipeline_layout_,
+              tile_bin_layout_, 4,
+              {0,1,2,3,4,5}, {6}, {});
+    // gs_tile_scan: SSBO {0,1,2,3}
+    add_entry("gs_tile_scan", tile_scan_pipeline_, tile_scan_pipeline_layout_,
+              tile_scan_layout_, 12,
+              {0,1,2,3}, {}, {});
+    // gs_tile_ranges: SSBO {0,1,2}
+    add_entry("gs_tile_ranges", tile_ranges_pipeline_, tile_ranges_pipeline_layout_,
+              tile_ranges_layout_, 8,
+              {0,1,2}, {}, {});
+    // gs_tile_prepare_indirect: SSBO {0,1}
+    add_entry("gs_tile_prepare_indirect", tile_indirect_pipeline_,
+              tile_indirect_pipeline_layout_, tile_indirect_layout_, 4,
+              {0,1}, {}, {});
+    // gs_onesweep_histogram: SSBO {0,1,2}
+    add_entry("gs_onesweep_histogram", onesweep_hist_pipeline_,
+              onesweep_hist_pipeline_layout_, onesweep_hist_layout_, 4,
+              {0,1,2}, {}, {});
+    // gs_onesweep_scatter: SSBO {0,1,2,3}
+    add_entry("gs_onesweep_scatter", onesweep_scatter_pipeline_,
+              onesweep_scatter_pipeline_layout_, onesweep_scatter_layout_, 4,
+              {0,1,2,3}, {}, {});
+    // gs_tile_render: SSBO {0,1,4} + UBO {2} + STORAGE_IMAGE {3,5}
+    add_entry("gs_tile_render", tile_render_pipeline_, tile_render_pipeline_layout_,
+              tile_render_layout_, 0,
+              {0,1,4}, {2},
+              {{3u, color_view}, {5u, depth_view}});
+
+    // Allocate one descriptor set per entry. Layouts are gathered into a
+    // packed array because vkAllocateDescriptorSets takes them positionally.
+    std::vector<VkDescriptorSetLayout> set_layouts;
+    set_layouts.reserve(entries.size());
+    for (const auto& e : entries) set_layouts.push_back(e.set_layout);
+
+    std::vector<VkDescriptorSet> sets(entries.size(), VK_NULL_HANDLE);
+    VkDescriptorSetAllocateInfo dai{};
+    dai.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    dai.descriptorPool = prewarm_pool;
+    dai.descriptorSetCount = static_cast<uint32_t>(set_layouts.size());
+    dai.pSetLayouts = set_layouts.data();
+    if (vkAllocateDescriptorSets(device_, &dai, sets.data()) != VK_SUCCESS) {
+        throw std::runtime_error("[prewarm] Failed to allocate descriptor sets");
+    }
+
+    // Write valid bindings for each set.
+    {
+        // We need one persistent VkDescriptor*Info per write entry across
+        // the entire vkUpdateDescriptorSets call. Reserve enough scratch.
+        std::vector<VkDescriptorBufferInfo> ssbo_infos;
+        std::vector<VkDescriptorBufferInfo> ubo_infos;
+        std::vector<VkDescriptorImageInfo>  img_infos;
+        ssbo_infos.reserve(128);
+        ubo_infos.reserve(32);
+        img_infos.reserve(32);
+
+        std::vector<VkWriteDescriptorSet> writes;
+        writes.reserve(128);
+
+        for (size_t i = 0; i < entries.size(); ++i) {
+            const auto& e = entries[i];
+            VkDescriptorSet set = sets[i];
+            for (uint32_t bi = 0; bi < e.storage_binding_count; ++bi) {
+                ssbo_infos.push_back({dummy_ssbo.buffer(), 0, VK_WHOLE_SIZE});
+                VkWriteDescriptorSet w{};
+                w.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+                w.dstSet = set;
+                w.dstBinding = e.storage_bindings[bi];
+                w.descriptorCount = 1;
+                w.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+                w.pBufferInfo = &ssbo_infos.back();
+                writes.push_back(w);
+            }
+            for (uint32_t bi = 0; bi < e.uniform_binding_count; ++bi) {
+                ubo_infos.push_back({dummy_ubo.buffer(), 0, VK_WHOLE_SIZE});
+                VkWriteDescriptorSet w{};
+                w.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+                w.dstSet = set;
+                w.dstBinding = e.uniform_bindings[bi];
+                w.descriptorCount = 1;
+                w.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+                w.pBufferInfo = &ubo_infos.back();
+                writes.push_back(w);
+            }
+            for (uint32_t bi = 0; bi < e.image_binding_count; ++bi) {
+                img_infos.push_back({VK_NULL_HANDLE, e.image_bindings[bi].view,
+                                     VK_IMAGE_LAYOUT_GENERAL});
+                VkWriteDescriptorSet w{};
+                w.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+                w.dstSet = set;
+                w.dstBinding = e.image_bindings[bi].binding;
+                w.descriptorCount = 1;
+                w.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+                w.pImageInfo = &img_infos.back();
+                writes.push_back(w);
+            }
+        }
+        vkUpdateDescriptorSets(device_, static_cast<uint32_t>(writes.size()),
+                               writes.data(), 0, nullptr);
+    }
+
+        // ── 5. Record one-shot warmup command buffer ──────────────────────
+        {
+            VkCommandBufferAllocateInfo cba{};
+            cba.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+            cba.commandPool = cmd_pool;
+            cba.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+            cba.commandBufferCount = 1;
+            if (vkAllocateCommandBuffers(device_, &cba, &cmd) != VK_SUCCESS) {
+                throw std::runtime_error("[prewarm] Failed to allocate warmup command buffer");
+            }
+        }
+        VkCommandBufferBeginInfo cbb{};
+        cbb.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        cbb.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        if (vkBeginCommandBuffer(cmd, &cbb) != VK_SUCCESS) {
+            throw std::runtime_error("[prewarm] vkBeginCommandBuffer (warmup) failed");
+        }
+
+        // Zero push constant scratch (largest is 12 bytes for tile_scan).
+        uint8_t push_scratch[16] = {0};
+        for (size_t i = 0; i < entries.size(); ++i) {
+            const auto& e = entries[i];
+            vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, e.pipeline);
+            vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, e.layout,
+                                    0, 1, &sets[i], 0, nullptr);
+            if (e.push_size > 0) {
+                vkCmdPushConstants(cmd, e.layout, VK_SHADER_STAGE_COMPUTE_BIT,
+                                   0, e.push_size, push_scratch);
+            }
+            vkCmdDispatch(cmd, 1, 1, 1);
+        }
+        if (vkEndCommandBuffer(cmd) != VK_SUCCESS) {
+            throw std::runtime_error("[prewarm] vkEndCommandBuffer (warmup) failed");
+        }
+
+        // ── 6. Submit + wait idle: blocks until Metal compiles every PSO ──
+        VkSubmitInfo sub{};
+        sub.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        sub.commandBufferCount = 1;
+        sub.pCommandBuffers = &cmd;
+        if (vkQueueSubmit(queue, 1, &sub, VK_NULL_HANDLE) != VK_SUCCESS) {
+            throw std::runtime_error("[prewarm] vkQueueSubmit failed");
+        }
+        vkQueueWaitIdle(queue);
+        pipeline_count = entries.size();
+    } catch (const std::exception& e) {
+        // Soft-fail: prewarm is an optimization, not a correctness requirement.
+        // Clean up whatever was allocated and let the engine continue with a
+        // cold cache. The first run will pay full MoltenVK first-compile cost
+        // mid-frame, but subsequent runs benefit from #408's persistence.
+        std::fprintf(stderr,
+            "[prewarm] aborted: %s — first run will pay full MoltenVK compile cost\n",
+            e.what());
+        cleanup();
+        return;
+    }
+
+    // ── 7. Happy-path cleanup ─────────────────────────────────────────────
+    cleanup();
+
+    auto t_end = clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t_end - t_begin).count();
+    std::fprintf(stderr, "[prewarm] Compiled %zu pipelines in %lld ms\n",
+                 pipeline_count, static_cast<long long>(ms));
+}
+
 void GsRenderer::init_streaming(const StreamingConfig& config) {
     streaming_config_ = config;
     slab_allocator_ = std::make_unique<SlabAllocator>(config.total_slabs(), config.slab_size_splats);

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -211,6 +211,27 @@ void Renderer::init_gs(const GaussianCloud& cloud, uint32_t width, uint32_t heig
         gs_renderer_.init(context_.device(), context_.physical_device(),
                           context_.allocator(), VK_NULL_HANDLE,
                           context_.pipeline_cache());
+        // Pre-warm every GS compute pipeline by dispatching a single-thread
+        // workgroup against dummy descriptor sets. On MoltenVK each pipeline
+        // is lazily compiled to MTLComputePipelineState on first dispatch;
+        // doing it at init-time spreads the 25-35 s of mid-frame Metal
+        // compile latency that issue #399 surfaced. After the wait-idle
+        // returns, persist the now-warm cache to disk before any later
+        // code path can crash (PR #408 made this reliable; #409 makes
+        // sure the cache is actually populated by first run).
+        // Defense-in-depth: prewarm_pipelines is internally fail-soft, but if
+        // a future refactor ever lets an exception escape we still want the
+        // cache flush below to run unconditionally. Issue #408's lesson: a
+        // critical post-step buried after a potentially-throwing call is one
+        // bug away from being silently skipped.
+        try {
+            gs_renderer_.prewarm_pipelines(context_.graphics_queue(), command_pool_.pool());
+        } catch (const std::exception& e) {
+            std::fprintf(stderr,
+                "[prewarm] init_gs caught: %s — continuing with cold cache\n",
+                e.what());
+        }
+        context_.save_pipeline_cache();
         gs_initialized_ = true;
     }
 


### PR DESCRIPTION
Closes #406. Final root-cause fix for #399's non-deterministic mid-frame stalls.

## What this does

At the end of `Renderer::init_gs`, build a one-shot command buffer that issues a `1×1×1` `vkCmdDispatch` for every GS compute pipeline. Submit, `vkQueueWaitIdle`, then `save_pipeline_cache()`. After this returns, every Metal `MTLComputePipelineState` is compiled and persisted. First-frame gameplay has no first-compile latency.

13 pipelines covered: `gs_preprocess`, `gs_sort`, `gs_post_process`, `pbd_solver`, `gs_merge`, `gs_tile_bin`, `gs_tile_count`, `gs_tile_scan`, `gs_tile_ranges`, `gs_tile_prepare_indirect`, `gs_onesweep_histogram`, `gs_onesweep_scatter`, `gs_tile_render`. Storage-image-bearing pipelines (`gs_post_process`, `gs_tile_render`) get 1×1 dummy `rgba16f` and `r16f` images created and transitioned to `VK_IMAGE_LAYOUT_GENERAL` inline.

Resources used: one shared 4 KB SSBO, one zeroed UBO, two 1×1 storage images, one descriptor pool, one command buffer. All freed before the function returns on every exit path.

## Why this was needed even after #408

#408 made the pipeline cache file persist reliably. But on the *first* run after a clean build, the cache is empty, so MoltenVK lazily compiles each `MTLComputePipelineState` on first dispatch — which happens *during gameplay on the main thread*, producing the 25-35 second per-frame stalls #399 chronicled. Pre-warming forces all compiles up front; #408 captures the result for subsequent runs.

## Review feedback integrated pre-merge

Both reviewers caught real bugs on this 384-LOC initial implementation. Codex's catches on PR #408 made me cautious about the pattern.

- **P1 #1 (exception safety):** Original linear cleanup at function bottom would leak every GPU resource on any of 5 internal `throw` sites. Hoisted handles to function scope, wrapped body in try/catch, single `cleanup()` lambda fires on every exit path.
- **P1 #2 (soft-failure semantics):** Prewarm is an optimization, not correctness. Function now logs and returns on failure rather than propagating; init_gs call site also wraps in try/catch as defense-in-depth so `save_pipeline_cache()` always runs.
- **P2 #5 (`VK_QUEUE_FAMILY_IGNORED`):** Image barriers were zero-initialized, leaving srcQueueFamilyIndex / dstQueueFamilyIndex at 0 — a real queue family, not 'ignored'. Set explicitly.
- **P2 #6 (return-code checks):** `vkAllocateCommandBuffers`, `vkBeginCommandBuffer`, `vkEndCommandBuffer`, `vkQueueSubmit` results now inspected; failures route through the catch handler.

Spec reviewer cross-checked every binding index, push constant size, and storage-image format against `create_descriptor_resources()` and the shader-declared layouts: all 13 pipelines correctly mapped.

## Test plan

- [x] `cmake --preset macos-release-with-diag && cmake --build build/macos-release-with-diag` — clean
- [x] `ctest --test-dir build/macos-release-with-diag --output-on-failure` — 78/78 pass
- [ ] (Manual, post-merge) Run harness once. Expect at startup:
  - `[prewarm] Compiled 13 pipelines in N ms` (one-time ~15-30s on a cold machine)
  - `[PipelineCache] saved N bytes` (#408 persisting the now-warm cache)
  - per_frame_ms steady at ~16-80 ms; no multi-second spikes mid-run
- [ ] Second run should report `[PipelineCache] loaded N bytes` at startup and `[prewarm] Compiled 13 pipelines in <few ms>` (cache-hit fast path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)