### PR TITLE
fix(engine): yield to OS between prewarm pipeline compiles

### DIFF
--- a/scripts/regression/run_harness.py
+++ b/scripts/regression/run_harness.py
@@ -45,7 +45,7 @@ def run_scenario(out_dir):
     if os.path.exists(SOCKET):
         os.unlink(SOCKET)
 
-    proc = subprocess.Popen([DEMO_BIN, "--deterministic"],
+    proc = subprocess.Popen([DEMO_BIN, "--deterministic", "--prewarm"],
                             stderr=subprocess.PIPE,
                             cwd=DEMO_DIR)
     stderr_bytes = b""

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -640,6 +640,14 @@ void GsRenderer::create_compute_pipelines() {
 // grows from a few seconds (old parallel design) to ~30-60s on a cold
 // cache, but it is bounded and predictable instead of system-fatal.
 //
+// SECOND HAZARD — the macOS WindowServer watchdog (bug_type 409). Even
+// serialized, ~13 cold PSO compiles back-to-back monopolize the Metal
+// driver and starve WindowServer past its 40 s "no checkin" threshold,
+// which kills the user session. The submission loop below sleeps briefly
+// after each `WaitIdle` so the kernel can schedule WindowServer's GPU work
+// between compiles. Total added latency is small relative to compile time
+// and bounded by `entries.size() × kYieldMs`.
+//
 // All resources are tracked at function scope so the cleanup lambda below
 // can destroy whatever was actually created on ANY exit path — including
 // the catch handler. Soft-fail: prewarm is an optimization, so any error
@@ -955,9 +963,23 @@ void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool) {
         // buffer, submitted alone and `vkQueueWaitIdle`'d before moving on.
         // The wait pins us to a single in-flight Metal compile at a time,
         // so peak compile-memory pressure is 1 PSO not 13.
+        //
+        // ALSO: yield to the OS between submissions. The crash log behind
+        // #406's watchdog post-mortem (bug_type 409, "40 seconds since last
+        // successful checkin") showed WindowServer killed by the macOS
+        // watchdog while MoltenVK held the GPU driver compiling PSOs. Even
+        // with per-pipeline serialization, a long enough chain of cold
+        // compiles (~13 pipelines × multi-second each) can starve
+        // WindowServer past the 40 s threshold. After every `WaitIdle`
+        // we sleep briefly so the kernel can schedule WindowServer's GPU
+        // work and macOS can refresh its watchdog checkin. Total added
+        // latency is bounded (~entries.size() × kYieldMs) and dwarfed by
+        // PSO compile time on a cold cache.
+        constexpr int kYieldMs = 50;
         uint8_t push_scratch[16] = {0};
         for (size_t i = 0; i < entries.size(); ++i) {
             const auto& e = entries[i];
+            auto t_pipeline_begin = clock::now();
 
             VkCommandBuffer cmd = VK_NULL_HANDLE;
             VkCommandBufferAllocateInfo cba{};
@@ -1026,6 +1048,20 @@ void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool) {
             }
             vkQueueWaitIdle(queue);
             vkFreeCommandBuffers(device_, cmd_pool, 1, &cmd);
+
+            auto pipeline_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                clock::now() - t_pipeline_begin).count();
+            std::fprintf(stderr,
+                "[prewarm] %zu/%zu %s — %lld ms\n",
+                i + 1, entries.size(), e.name,
+                static_cast<long long>(pipeline_ms));
+
+            // Yield to the OS so WindowServer can checkin with its watchdog
+            // (see comment above the loop). Skip the yield after the last
+            // pipeline — caller is about to return and resume the main loop.
+            if (i + 1 < entries.size()) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(kYieldMs));
+            }
         }
 
         pipeline_count = entries.size();


### PR DESCRIPTION
## Summary
- Adds a 50 ms `std::this_thread::sleep_for` after each `vkQueueWaitIdle` in `GsRenderer::prewarm_pipelines` so the macOS WindowServer can checkin with its watchdog between back-to-back PSO compiles
- Logs per-pipeline compile time (`[prewarm] N/M name — Nms`) so any single PSO drifting toward the 40 s watchdog threshold is visible without extra instrumentation
- Regression harness now invokes the demo with `--prewarm` so this code path is exercised on every CI run

## Why
Crash log post-mortem on the most recent watchdog kill (bug_type 409, namespace WATCHDOG, "40 seconds since last successful checkin") confirmed the failure mode is **not** OOM — it is MoltenVK monopolising the GPU driver through a chain of cold PSO compiles while WindowServer cannot run, after which the macOS watchdog kills the user session.

Per-pipeline serialization from #411 (`06baa0d2`) bounds peak compile-memory to a single PSO, but does nothing for cumulative wall-clock time. With ~13 cold compiles back-to-back, total chain time can approach the 40 s threshold even when no single compile is unreasonable. The 50 ms yield gives the kernel a scheduling boundary on every iteration so WindowServer's GPU work and watchdog checkin can interleave with prewarm.

Total added latency: ~600 ms on a cold cache (13 × 50 ms), dwarfed by PSO compile time. Yield is skipped after the last entry since `init_gs` returns immediately afterwards anyway.

## Test plan
- [x] `cmake --build build/macos-release-with-diag --target gseurat_demo` clean
- [ ] Run `gseurat_demo --deterministic --prewarm` on a wiped pipeline cache, confirm WindowServer stays alive through prewarm and per-pipeline timings appear in stderr
- [ ] Run `scripts/regression/run_harness.py --self-check` end-to-end, confirm SSIM ≥ 0.90 and harness's WindowServer survives
- [ ] Re-run with warm cache — per-pipeline times should drop to < 100 ms each, total prewarm under a few seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)