### PR TITLE
refactor(engine): retire orphan culling/bone-preserve state (#396 §B)

### DIFF
--- a/include/gseurat/engine/debug_dump_renderer.hpp
+++ b/include/gseurat/engine/debug_dump_renderer.hpp
@@ -33,7 +33,6 @@ public:
 
         // Chunk grid
         uint32_t total_chunks       = 0;
-        uint32_t visible_chunks     = 0;
 
         // Output resolution
         uint32_t output_width       = 0;
@@ -106,7 +105,6 @@ public:
                 }},
                 {"chunks", {
                     {"total",    snap.total_chunks},
-                    {"visible",  snap.visible_chunks},
                 }},
                 {"gpu_timing_ms", {
                     {"depth_sort",  snap.depth_sort_ms},

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -84,7 +84,6 @@ public:
     // path on initial scene load. GPU dispatch gating still uses
     // `gs_renderer().has_cloud()` directly inside the renderer.
     bool has_gs_cloud() const { return gs_total_gaussian_count_ > 0; }
-    void set_gs_skip_chunk_cull(bool skip) { gs_skip_chunk_cull_ = skip; }
     void set_gs_blit_offset(float x, float y) { gs_blit_offset_x_ = x; gs_blit_offset_y_ = y; }
     void set_gs_background_colors(const glm::vec3& ground, const glm::vec3& sky) {
         gs_bg_ground_color_ = ground;
@@ -98,10 +97,6 @@ public:
     uint32_t gs_gaussian_budget() const { return gs_gaussian_budget_; }
     void set_gs_max_render_distance(float d) { gs_max_render_distance_ = d; }
     float gs_max_render_distance() const { return gs_max_render_distance_; }
-    uint32_t gs_visible_chunk_count() const { return static_cast<uint32_t>(gs_prev_visible_.size()); }
-    void set_gs_preserve_bone_range(uint32_t first, uint32_t count) {
-        gs_preserve_bone_first_ = first; gs_preserve_bone_count_ = count;
-    }
     void set_gs_lod_focus(const glm::vec3& pos) { gs_lod_focus_pos_ = pos; gs_has_lod_focus_ = true; }
     void clear_gs_lod_focus() { gs_has_lod_focus_ = false; }
 
@@ -339,8 +334,6 @@ private:
     GaussianAnimator gs_animator_;
     std::vector<SceneAnimation> gs_scene_animations_;
     std::vector<VfxInstance> vfx_instances_;
-    std::vector<uint32_t> gs_prev_visible_;
-    bool gs_skip_chunk_cull_ = false;
 
     // ── Frame-determinism harness internal state ──
     struct DeterminismTestState {
@@ -354,8 +347,6 @@ private:
     DeterminismTestResult determinism_test_result_;
     uint32_t gs_gaussian_budget_ = 0;  // 0 = unlimited (no LOD decimation)
     float gs_max_render_distance_ = 0.0f;  // 0 = unlimited (no distance culling)
-    uint32_t gs_preserve_bone_first_ = 0;
-    uint32_t gs_preserve_bone_count_ = 0;
     uint32_t gs_total_gaussian_count_ = 0;  // total Gaussians in loaded cloud
     bool gs_adaptive_budget_ = false;
     bool gs_budget_locked_ = false;

--- a/src/demo/gs_demo_state.cpp
+++ b/src/demo/gs_demo_state.cpp
@@ -27,7 +27,6 @@ void GsDemoState::on_enter(AppBase& app) {
 
     // Disable app-level parallax — demo manages its own camera
     app.gs_terrain().parallax_active = false;
-    app.renderer().set_gs_skip_chunk_cull(false);
     app.renderer().gs_renderer().set_skip_sort(false);
     app.renderer().gs_renderer().set_pixel_art_intensity(0.5f);
 
@@ -196,7 +195,6 @@ void GsDemoState::update(AppBase& app, float dt) {
     // P → toggle shadow box mode (hybrid: re-render every N frames)
     if (app.input().was_key_pressed(GLFW_KEY_P)) {
         shadow_box_mode_ = !shadow_box_mode_;
-        app.renderer().set_gs_skip_chunk_cull(shadow_box_mode_);
         if (shadow_box_mode_) {
             gs_frame_counter_ = 0;  // first frame does full compute
             app.renderer().gs_renderer().set_skip_sort(false);
@@ -351,8 +349,6 @@ void GsDemoState::update(AppBase& app, float dt) {
             enter_streaming_mode(app);
         } else if (streaming_mode_) {
             streaming_mode_ = false;
-            // Re-enable normal chunk culling
-            app.renderer().set_gs_skip_chunk_cull(false);
             std::fprintf(stderr, "Streaming mode: OFF\n");
         }
     }
@@ -818,9 +814,6 @@ void GsDemoState::enter_streaming_mode(AppBase& app) {
     chunk_streamer_.set_unload_radius(cloud_extent * 0.6f);
     chunk_streamer_.set_slab_size_splats(
         app.renderer().gs_renderer().streaming_config().slab_size_splats);
-
-    // Disable the renderer's internal chunk culling — we'll update manually
-    app.renderer().set_gs_skip_chunk_cull(true);
 
     streaming_mode_ = true;
     std::fprintf(stderr, "Streaming mode: ON (load_r=%.0f, unload_r=%.0f)\n",

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -105,7 +105,6 @@ void IslandDemoState::on_enter(AppBase& app) {
     pp.vignette_radius = 0.75f;    // tighter vignette for cinematic framing
     pp.vignette_softness = 0.4f;   // soft falloff
     pp.ca_intensity = 0.15f;       // subtle chromatic aberration at edges
-    app.renderer().set_gs_skip_chunk_cull(false);
     app.renderer().set_gs_max_render_distance(150.0f);  // cull distant chunks (uses player pos, not camera)
     app.renderer().gs_renderer().set_skip_sort(false);
 
@@ -580,9 +579,6 @@ void IslandDemoState::on_enter(AppBase& app) {
                 player_entity_, std::move(player_entry));
             app.world().add<gseurat::BoneAnimatedTag>(player_entity_,
                 {player_registry_id_});
-
-            // Tell renderer to preserve player character Gaussians during distance culling
-            app.renderer().set_gs_preserve_bone_range(1, player_bone_count);
 
             // Set bone 0 override for terrain sway
             app.set_bone_pre_upload_hook([this](glm::mat4* bones, uint32_t) {

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -185,7 +185,6 @@ void AppBase::main_loop() {
         snap.cull_ratio        = snap.total_gaussians > 0
                                   ? static_cast<float>(snap.culled_gaussians) / static_cast<float>(snap.total_gaussians) : 0.0f;
         snap.total_chunks      = renderer_.gs_chunk_grid().chunk_count();
-        snap.visible_chunks    = renderer_.gs_visible_chunk_count();
         snap.output_width      = gs.output_width();
         snap.output_height     = gs.output_height();
         // Last-frame raw GPU timing (per #399 instrumentation): single-frame

--- a/src/engine/gs_scene_loader.cpp
+++ b/src/engine/gs_scene_loader.cpp
@@ -386,13 +386,11 @@ void GsSceneLoader::finalize_on_main(SceneLoadContext& ctx, const SceneData& sce
                         gs.camera_fov, gs_w, gs_h, *gs.parallax);
                     ctx.terrain.parallax_active = true;
                     ctx.terrain.frame_counter = 0;
-                    ctx.renderer.set_gs_skip_chunk_cull(true);
                     ctx.renderer.gs_renderer().set_skip_sort(false);
                     auto cam_fwd = glm::normalize(gs.camera_target - gs.camera_position);
                     ctx.renderer.gs_renderer().set_shadow_box_params(cam_fwd, 0.0f, gs.camera_position, 32.0f);
                 } else {
                     ctx.terrain.parallax_active = false;
-                    ctx.renderer.set_gs_skip_chunk_cull(false);
                     ctx.renderer.gs_renderer().clear_shadow_box_params();
                 }
                 std::fprintf(stderr, "[GS] Loaded %u Gaussians (terrain: %s, game objects: %zu)\n",
@@ -400,7 +398,6 @@ void GsSceneLoader::finalize_on_main(SceneLoadContext& ctx, const SceneData& sce
                              scene_data.game_objects.size());
             } else {
                 ctx.terrain.parallax_active = false;
-                ctx.renderer.set_gs_skip_chunk_cull(false);
                 ctx.renderer.gs_renderer().clear_shadow_box_params();
                 std::fprintf(stderr, "[GS] Loaded %u Gaussians from %zu game objects\n",
                              cloud.count(), scene_data.game_objects.size());

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -276,7 +276,6 @@ void Renderer::init_gs(const GaussianCloud& cloud, uint32_t width, uint32_t heig
 
     // Build spatial chunk grid for frustum-based streaming.
     gs_chunk_grid_.build(cloud, 32.0f);
-    gs_prev_visible_.clear();
 
     // Scene-load semantics are REPLACE: drop every chunk from the previous
     // scene before queuing the new cloud. `load_cloud_async` itself is
@@ -1106,7 +1105,6 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 float scale = gs_smoothed_fps_ / gs_target_fps_;
                 gs_gaussian_budget_ = std::max(kGsBudgetMin,
                     static_cast<uint32_t>(gs_gaussian_budget_ * scale));
-                gs_prev_visible_.clear();
                 gs_stable_frame_count_ = 0;
             } else {
                 gs_stable_frame_count_++;


### PR DESCRIPTION
## Summary

Pure deletion — three setters/fields whose consumers were already removed in PR #395 (Phase 1b legacy gather/stomp purge). No behavioral change, just dead weight that survived the purge.

- `gs_prev_visible_` vector + `gs_visible_chunk_count()` + `Snapshot::visible_chunks` telemetry — was only `.clear()`'d, never populated since #395.
- `set_gs_skip_chunk_cull(bool)` + `gs_skip_chunk_cull_` flag — all 8 callers gone (5 demo + 3 in `gs_scene_loader.cpp`); zero readers in the renderer post-#395.
- `set_gs_preserve_bone_range(uint32_t, uint32_t)` + `gs_preserve_bone_first_` / `gs_preserve_bone_count_` — sole caller in `island_demo_state.cpp` gone; zero readers post-#395.

## Scope

Section **B** of issue #396 (orphan-state cleanup). Section A — `gs_chunk_grid_` / `cloud_bounds()` / `all_gaussians()` / `chunk_count()` retirement — is deferred to a follow-up PR pending the locked-in **Option 3 (pre-baked sidecar metadata file)** approach: `tools/ply_importer/` will bake `.gsvx` for engine streaming + a small sidecar (e.g. `character.bones.json`) for demo CPU bone identification. That migration is a real change and gets its own PR.

## Diff stat

```
 include/gseurat/engine/debug_dump_renderer.hpp | 2 --
 include/gseurat/engine/renderer.hpp            | 9 ---------
 src/demo/gs_demo_state.cpp                     | 7 -------
 src/demo/island_demo_state.cpp                 | 4 ----
 src/engine/app_base.cpp                        | 1 -
 src/engine/gs_scene_loader.cpp                 | 3 ---
 src/engine/renderer.cpp                        | 2 --
 7 files changed, 28 deletions(-)
```

## Test plan

- [x] `cmake --build build/macos-release-with-diag` — clean (455 targets, only the pre-existing stb_image_write sprintf deprecation warning)
- [ ] CI green
- [ ] No regression in island_demo overworld → dungeon transitions (chunk cull + bone visibility unchanged because behaviour was already routed through other paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)