### PR TITLE
fix(engine): pump GLFW events during prewarm to keep window responsive

### DIFF
--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <cstdint>
 #include <deque>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <thread>
@@ -364,7 +365,16 @@ public:
     //
     // Soft-fail: any internal error logs and returns; the engine continues
     // with cold caches and pays the first-frame compile cost mid-frame.
-    void prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool);
+    //
+    // `pump_events` (optional) is invoked after each pipeline's
+    // `vkQueueWaitIdle` and inside the inter-pipeline yield loop. It lets
+    // the caller drain the windowing system's event queue (typically
+    // `glfwPollEvents`) without dragging GLFW into the engine layer.
+    // Without this, focus changes / window-damage events sit unprocessed
+    // for the multi-second cold-cache prewarm pass and the demo window
+    // appears frozen until prewarm completes.
+    void prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool,
+                           std::function<void()> pump_events = {});
 
     void shutdown(VmaAllocator allocator);
 

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -652,7 +652,8 @@ void GsRenderer::create_compute_pipelines() {
 // can destroy whatever was actually created on ANY exit path — including
 // the catch handler. Soft-fail: prewarm is an optimization, so any error
 // logs and returns; the engine continues with cold caches.
-void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool) {
+void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool,
+                                   std::function<void()> pump_events) {
     using clock = std::chrono::steady_clock;
     auto t_begin = clock::now();
 
@@ -1049,6 +1050,13 @@ void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool) {
             vkQueueWaitIdle(queue);
             vkFreeCommandBuffers(device_, cmd_pool, 1, &cmd);
 
+            // Drain queued window events immediately after the WaitIdle stall
+            // (which can be multi-second on a cold MoltenVK compile). Without
+            // this the demo window appears frozen for the entire prewarm pass
+            // — focus changes and expose events sit unprocessed until the
+            // main loop resumes polling.
+            if (pump_events) pump_events();
+
             auto pipeline_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 clock::now() - t_pipeline_begin).count();
             std::fprintf(stderr,
@@ -1057,10 +1065,16 @@ void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool) {
                 static_cast<long long>(pipeline_ms));
 
             // Yield to the OS so WindowServer can checkin with its watchdog
-            // (see comment above the loop). Skip the yield after the last
-            // pipeline — caller is about to return and resume the main loop.
+            // (see comment above the loop), while continuing to drain window
+            // events on a sub-tick cadence so the window stays interactive.
+            // Skip the yield after the last pipeline — caller is about to
+            // return and resume the main loop.
             if (i + 1 < entries.size()) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(kYieldMs));
+                const auto deadline = clock::now() + std::chrono::milliseconds(kYieldMs);
+                do {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                    if (pump_events) pump_events();
+                } while (clock::now() < deadline);
             }
         }
 

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -221,8 +221,11 @@ void Renderer::init_gs(const GaussianCloud& cloud, uint32_t width, uint32_t heig
         // correctness requirement; soft-fail just costs first-frame stalls.
         if (prewarm_at_startup_) {
             try {
+                // `glfwPollEvents` keeps the window responsive while the
+                // multi-second cold-cache prewarm runs on this thread.
                 gs_renderer_.prewarm_pipelines(context_.graphics_queue(),
-                                               command_pool_.pool());
+                                               command_pool_.pool(),
+                                               []() { glfwPollEvents(); });
             } catch (const std::exception& e) {
                 std::fprintf(stderr,
                     "[prewarm] init_gs caught: %s — continuing with cold cache\n",


### PR DESCRIPTION
## Symptom

> Is there a \`sleep\` command during loading? It seems like the OS messaging isn't handling things properly. For example, if I switch focus to another window and then back to the demo, the window doesn't update for a while.

PR #412 added a 50ms \`std::this_thread::sleep_for\` between pipeline prewarm compiles to keep WindowServer's watchdog happy. That fixed the hard-crash, but the main thread still doesn't pump GLFW events during prewarm — neither the \`vkQueueWaitIdle\` (which can be multi-second on a cold MoltenVK compile) nor the sleep itself. Focus-change / window-damage events queue up for the entire prewarm pass (up to ~30s on a cold cache), and the demo window stays frozen until prewarm finishes and the main loop resumes polling.

## Fix

Wire an optional \`pump_events\` callable through \`prewarm_pipelines\` so the engine layer can stay GLFW-free while the caller (\`Renderer\`, which already includes GLFW) hands in \`glfwPollEvents\`. Pump events:

- **Immediately after each \`vkQueueWaitIdle\`** — drain whatever queued during the WaitIdle stall.
- **On a 5ms cadence inside the inter-pipeline yield** — so events keep flowing during the 50ms sleep that keeps WindowServer happy.

The 50ms target is unchanged, so the watchdog fix from #412 is unaffected.

## Layering

\`gs_renderer.cpp\` does **not** gain a GLFW dependency. The new parameter is \`std::function<void()>\`, default empty — non-demo callers (and any future caller without a windowing system) get the original behaviour. Only \`renderer.cpp\` (which already includes GLFW) actually injects \`glfwPollEvents\`.

## Residual stall

The \`vkQueueWaitIdle\` itself is still a hard blocker during a cold compile. Events queued during that interval surface only when the *next* pipeline finishes its WaitIdle and we hit \`pump_events\`. So worst-case unresponsiveness shrinks from \"full prewarm pass\" (~30s) to \"one pipeline's compile time\" (typically <2s). A non-blocking compile path is a larger refactor — out of scope for this hotfix.

## Other known main-thread blockers

This PR fixes the prewarm freeze. There are still other places where the main thread blocks the message pump (sync \`load_ply\` in Phase B re-merge, the future-drain in \`perform_portal_transition\`, and the new sync \`GsSceneLoader::parse\` calls #414 introduced). Those are tracked separately and will get their own follow-up PR after #414 lands.

## Test plan

- [x] \`cmake --build build/macos-release-with-diag\` — clean (touched files rebuild + relink \`gseurat_demo\` cleanly)
- [ ] CI green
- [ ] Manual: launch with \`--prewarm\`, switch focus away & back during prewarm. Window should redraw immediately on each focus-return rather than waiting for prewarm to complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)