### PR TITLE
perf(demo): overlap PLY parse with on_enter setup via worker thread

### DIFF
--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -148,6 +148,15 @@ public:
     // Shared GS scene loading: PLY + placed objects + lights + emitters + animations + VFX
     void load_gs_scene(const SceneData& scene_data, const GsSceneOptions& opts = {});
 
+    // Pre-parsed variant: caller has already run `GsSceneLoader::parse` (typically
+    // on a worker thread to overlap PLY I/O with other on_enter setup). The
+    // finalize phase still runs on the main thread inside this call — same GPU
+    // sequencing as the synchronous `load_gs_scene`. Caller is responsible for
+    // ensuring `parsed` was produced from the same `scene_data` passed here.
+    void load_pre_parsed_gs_scene(const SceneData& scene_data,
+                                  ParsedScene&& parsed,
+                                  const GsSceneOptions& opts = {});
+
     // Async-load API. Pushes the CPU-only PLY parse + Gaussian merge to a worker
     // thread (`std::async(std::launch::async, …)`), returning immediately. The
     // main thread is expected to invoke `tick_async_load_gs_scene` once per

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -66,7 +66,24 @@ void IslandDemoState::on_enter(AppBase& app) {
     if (scene_path_.empty()) scene_path_ = resolve_asset_path("assets/scenes/seurat_island.json").string();
     app.feature_flags() = FeatureFlags::gs_viewer();
     app.feature_flags().apply_platform_defaults(app.renderer().context().is_apple_gpu());
-    app.init_scene(scene_path_);
+
+    // Load scene JSON sync (cheap) and set the active scene path. The heavy
+    // PLY parse happens in `GsSceneLoader::parse`, kicked on a worker thread
+    // immediately so it overlaps the rest of on_enter's main-thread setup
+    // work below (audio/camera zones, world manifest, collision grid,
+    // character manifest). `parse_future` is consumed just before the §A
+    // merge needs the cloud, so the worker has the maximum window to run.
+    //
+    // The GPU sequencing (init_gs → manual merge → 2nd init_gs) is preserved
+    // exactly as in the synchronous `init_scene` path — only the *parse*
+    // (PLY I/O) is moved to a worker. `std::launch::async` forces a real
+    // worker thread; deferred would silently downgrade to lazy execution
+    // and re-introduce the main-thread stall at `future.get()`.
+    auto scene_data = SceneLoader::load(scene_path_);
+    app.scene_objects().current_scene_path = scene_path_;
+    auto parse_future = std::async(std::launch::async, [&scene_data] {
+        return GsSceneLoader::parse(scene_data);
+    });
 
     // Collect audio zones from all scenes (populated below during scene loading)
     std::vector<SceneData::AudioZoneRef> scene_audio_zones;
@@ -147,8 +164,7 @@ void IslandDemoState::on_enter(AppBase& app) {
         }
     }
 
-    // Load collision grid from scene data
-    auto scene_data = SceneLoader::load(scene_path_);
+    // Load collision grid from scene data (already loaded at top of on_enter).
     if (scene_data.collision) {
         collision_grid_ = *scene_data.collision;
         // Grid origin is (0,0) — scene coordinates match grid coordinates
@@ -327,6 +343,24 @@ void IslandDemoState::on_enter(AppBase& app) {
                      next_zone_id, cz.triggers.size(), rail_count);
     }
 
+    // Block on the worker-thread parse and run finalize_on_main inline. This
+    // is the spot in main where `init_scene` (synchronous) ran before; the
+    // GPU sequencing of finalize → first init_gs → §A merge → second init_gs
+    // is preserved exactly. Only the PLY parse moved off the main thread.
+    //
+    // `base_gaussians` is a copy of the parsed cloud's gaussians, retained
+    // for the §A re-merge below (line ~390 reads `parsed.cloud.gaussians()`
+    // in main; here we just keep the vector around to avoid a redundant
+    // re-parse from disk).
+    ParsedScene parsed_scene = parse_future.get();
+    auto base_gaussians = parsed_scene.cloud.gaussians();
+    {
+        GsSceneOptions parse_opts;
+        parse_opts.add_default_light = true;
+        parse_opts.set_god_rays = true;
+        app.load_pre_parsed_gs_scene(scene_data, std::move(parsed_scene), parse_opts);
+    }
+
     // Determine player start position
     glm::vec3 player_pos = scene_data.player_position.vec();
     // If player_position is zero, place at map center
@@ -388,15 +422,10 @@ void IslandDemoState::on_enter(AppBase& app) {
 
     // Spawn player character (procedural humanoid)
     if (app.renderer().has_gs_cloud()) {
-        // Re-parse the scene's terrain + game-object cloud from disk
-        // (Option B per #396 §A — no CPU shadow on the renderer). The
-        // result equals what `init_scene` originally fed into the renderer.
-        std::vector<Gaussian> merged;
-        {
-            SceneData sd = SceneLoader::load(app.scene_objects().current_scene_path);
-            ParsedScene parsed = GsSceneLoader::parse(sd);
-            merged = parsed.cloud.gaussians();
-        }
+        // Reuse the parsed terrain + game-object cloud that was stashed in
+        // `base_gaussians` after the worker-thread parse — saves a redundant
+        // re-parse from disk that the synchronous main path used to do here.
+        std::vector<Gaussian> merged = std::move(base_gaussians);
 
         // Merge additional world chunks (northern forest) into the cloud
         // Since load_radius(558) covers all chunks, merge them at startup

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -869,6 +869,18 @@ void AppBase::load_gs_scene(const SceneData& scene_data, const GsSceneOptions& o
     populate_bone_animation_registry(bone_anim_registry_, world_, gs_terrain_);
 }
 
+void AppBase::load_pre_parsed_gs_scene(const SceneData& scene_data,
+                                       ParsedScene&& parsed,
+                                       const GsSceneOptions& opts) {
+    SceneLoadContext ctx{
+        gs_terrain_, scene_objects_, renderer_, scene_,
+        world_, component_registry_, resources_, feature_flags_
+    };
+    GsSceneLoader loader;
+    loader.finalize_on_main(ctx, scene_data, std::move(parsed), opts);
+    populate_bone_animation_registry(bone_anim_registry_, world_, gs_terrain_);
+}
+
 void AppBase::begin_async_load_gs_scene(SceneData scene_data,
                                         const GsSceneOptions& opts) {
     // Stash everything needed for the finalize phase, then kick the parse off


### PR DESCRIPTION
## Summary

- `IslandDemoState::on_enter` kicks `GsSceneLoader::parse` on a `std::async` worker thread immediately, runs the rest of on_enter setup (audio/camera zones, world manifest, collision grid, character manifest) on the main thread in parallel, then blocks just before the §A merge needs the cloud.
- New `AppBase::load_pre_parsed_gs_scene(scene_data, ParsedScene&&, opts)` method that takes a worker-produced `ParsedScene` and runs `finalize_on_main` + `populate_bone_animation_registry` on the main thread.
- §A merge reuses the parsed gaussians via a stashed `base_gaussians` vector — drops a redundant re-parse from disk that the synchronous path used to do.
- GPU sequencing preserved exactly: `finalize_on_main` → first `init_gs(terrain+game-objects)` → §A merge → second `init_gs(merged)`. Only PLY *parse* moved off the main thread.

## Why this shape and not the parse-extension hook

The previous WIP (`7af5c812`, force-replaced by this commit) moved BOTH the parse AND the §A merge to a worker, then ran a single `init_gs` with the fully-merged 2.44M cloud. On Apple M5 / MoltenVK that reproducibly hit a `kIOGPUCommandBufferCallbackErrorPageFault` on the first compute frame in Warming, regardless of:

- whether `loading_monitor_.begin_load` was called (no-begin_load: still fault)
- whether the §A extras merge was applied (no-extras at 2.27M: still fault)
- whether init_gs was called once or twice to mimic main's pattern (double-init: still fault)

`main`'s exact two-init sequence on the same scene runs cleanly, so the difference is something subtle in the single-init GPU sequencing on M5. Not worth a RenderDoc-level debug session when the existing two-init pattern works.

## Net diff

3 files, +62 / -12 vs main. `island_demo_state.hpp` unchanged from main.

## Test plan

- [x] Build: `cmake --build --preset macos-release-with-diag` — clean (11/11)
- [x] Runtime — `seurat_island` on Apple M5: loads, ~70 FPS stable, no page fault, identical splat count (2,441,512) + cull ratio vs main
- [x] Runtime — `dungeon` scene: loads cleanly
- [ ] Regression harness (defer to CI — too heavy to run locally per `feedback_harness_crushes_mac.md`)
- [ ] Portal transitions still work (uses unchanged `begin_async_load_gs_scene` path; not exercised in my smoke test — would benefit from a portal-walk during review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)