### PR TITLE
perf: fix post-load freeze via split-tail static/dynamic architecture

### DIFF
--- a/docs/superpowers/specs/2026-05-09-upfront-merge-single-init-gs-design.md
+++ b/docs/superpowers/specs/2026-05-09-upfront-merge-single-init-gs-design.md
@@ -288,3 +288,55 @@ After approval the design was implemented (commits on this branch). Manual run o
 - Independent architectural merit (cleaner shape, less GPU work, fewer moving parts).
 - Future investigators of the freeze should not have to mentally subtract the double-init_gs noise to see the actual cause.
 - Reverting would lose the spec, which now also documents the disproven hypothesis.
+
+## 9. Post-postmortem — actual root cause (2026-05-10)
+
+The freeze investigation continued on the same branch with watchdog instrumentation in `Renderer::draw_scene` / `GsRenderer::render`. Findings:
+
+1. **Watchdog timed each per-frame phase.** `vkWaitForFences`, `vkAcquireNextImageKHR`, `vkQueueSubmit`, `vkQueuePresentKHR`, command recording — all bounded to milliseconds. **`vkGetQueryPoolResults` with `VK_QUERY_RESULT_WAIT_BIT` at `gs_renderer.cpp:3269` was the only blocking CPU call**, and it surfaced 5-90 second waits.
+
+2. **The wait was bounded to the previous frame's GPU latency.** When the GPU was overloaded, that bound was 50+ seconds. So the "freeze" was a GPU-side stall surfaced through a blocking CPU read of GPU timestamps. The mach-port `IMKCFRunLoopWakeUpReliable` log was a downstream symptom (slow main thread can't pump IME events), not the cause.
+
+3. **GPU saturation cause: per-frame full 2.44M static depth sort.** Three setters all forced `static_dirty_ = true` every frame:
+   - PBD path at `gs_renderer.cpp:3349` (12 trees)
+   - `upload_bone_transforms` at `gs_renderer.cpp:2248` (player + NPCs)
+   - `set_actor_rotation` at `gs_renderer.hpp:263` (player rotation)
+   
+   All three forced re-sorts because tagged splats (PBD trees, animated chars/NPCs) lived in the static buffer alongside immobile terrain.
+
+## 10. The actual fix — Option A: split static and dynamic by bone_index
+
+After exploring three rejected approaches (one-line PBD `static_dirty_` removal — insufficient; reuse-cached-static-sort with no PBD update — would also freeze chars; SSBO double-buffering — based on a misread of the buffer layout), the architecturally honest fix:
+
+**Move all bone-animated and PBD-tagged splats into the dynamic SSBO as a "persistent prefix".**
+
+- `kDynamicHeadroom` bumped 262 144 → 1 048 576 (`gs_renderer.hpp:187`).
+- New API `GsRenderer::set_persistent_dynamics(data, count)` writes the dynamic SSBO's `[0, count)` region.
+- `update_dynamic_gaussians(data, count)` now writes at offset `persistent_dyn_count_`, treating `count` as the transient (VFX/particle) portion.
+- `IslandDemoState::on_enter` and `perform_portal_transition` partition the §A/§B merged cloud by `bone_index`:
+  - `bone_index == 0` → static-only cloud (terrain + tree trunks + non-animated props).
+  - `bone_index > 0` → `persistent_dynamics` vector, uploaded once via `set_persistent_dynamics`.
+- Removed `static_dirty_ = true` from PBD path, `upload_bone_transforms`, and `set_actor_rotation` — bone-animated splats no longer touch the static buffer.
+
+### Measured result (M5 background-mode)
+- Partition: static = 1 698 939 splats, persistent dynamic = 742 573 splats (PBD-tagged tree leaves + characters + NPCs), transient dynamic = ~200 000 (chimney_smoke + torch VFX). Total = 2.44 M.
+- Per-frame static sort: **skipped** while camera is stationary (only re-runs on chunk events).
+- Per-frame dynamic sort: ~942 k splats every frame. Mostly bounded (60-200 ms); rare outliers (20-50 s, suspected M5 GPU watchdog).
+- Fps in background-throttled mode: ~0.6 → 2-18 (30× improvement, variance-limited by background throttling).
+- **Foreground validation pending** — the ~942 k dynamic sort should land well under 16 ms in foreground M5, restoring 60 fps.
+
+### Why this is the right fix
+- "Static" now genuinely means static. Only chunk publish/unpublish and camera moves invalidate the static sort.
+- "Dynamic" holds everything that moves frame-to-frame, which is exactly what the dynamic Onesweep was designed for.
+- PBD solver and bone-animation system both remain unchanged. The dynamic preprocess shader already binds `bone_ssbo_` and `pbd_state_ssbo_` (descriptor-set bindings 5 and 6); the bone-skinning code at `gs_preprocess.comp:180-214` works identically for static and dynamic paths.
+
+### Risks not yet validated
+- Streaming chunks (`enqueue_async_chunk_load`) currently load chunk-terrain PLYs only via `load_cloud_async` → static. Chunk NPCs are loaded at scene-load time by the §A merge (already partitioned correctly). If a future scene puts animated NPCs into chunk PLYs themselves, those would need to flow through the partition too. Out of scope for the island demo.
+- The 20-50 s outlier spikes in background mode are unexplained. Likely GPU-watchdog-triggered Metal pauses under sustained CPU+GPU load with no window focus. Need foreground confirmation that they don't repro under normal use.
+
+### Code touched
+- `include/gseurat/engine/gs_renderer.hpp` (capacity, API, `set_actor_rotation`)
+- `src/engine/gs_renderer.cpp` (`set_persistent_dynamics` impl, `update_dynamic_gaussians` offset, `upload_bone_transforms`, PBD path)
+- `src/demo/island_demo_state.cpp` (partition in `on_enter` and `perform_portal_transition`)
+
+Plus watchdog instrumentation (`Renderer::draw_scene`, `AppBase` main loop, `GsRenderer::render`) that **stays in the binary** for now — it's the eyes we need if any other freeze surfaces, and it self-silences when frames are healthy.

--- a/docs/superpowers/specs/2026-05-09-upfront-merge-single-init-gs-design.md
+++ b/docs/superpowers/specs/2026-05-09-upfront-merge-single-init-gs-design.md
@@ -340,3 +340,78 @@ After exploring three rejected approaches (one-line PBD `static_dirty_` removal 
 - `src/demo/island_demo_state.cpp` (partition in `on_enter` and `perform_portal_transition`)
 
 Plus watchdog instrumentation (`Renderer::draw_scene`, `AppBase` main loop, `GsRenderer::render`) that **stays in the binary** for now — it's the eyes we need if any other freeze surfaces, and it self-silences when frames are healthy.
+
+## 11. Known follow-ups (post-Option A)
+
+### 11.1 Render → blank → render oscillation (visual flicker)
+
+Distinct from the freeze, the user has reported a long-standing symptom where
+rendered frames alternate visually with blank frames. After Option A landed,
+the watchdog confirmed the per-frame loop continues to iterate steadily and
+`vkWaitForFences` is not the cause. The remaining flicker is therefore not the
+race-on-sort-buffer issue we fixed (Bug 2 of follow-up #1), but a pre-existing
+rendering artefact that predates this branch.
+
+Worth investigating in a fresh, context-rich session:
+- Per-frame swapchain image presentation: is `vkAcquireNextImageKHR` ever
+  returning the *same* image_index across frames in a way that violates the
+  per-frame layout assumptions?
+- Post-process compute output: is `processed_image_[frame_in_flight]` being
+  cleared or sampled inconsistently?
+- The `gs_static_force_dirty_` reset path: with our Option A change, does any
+  bookkeeping field still toggle on/off frame-to-frame in a way that flips
+  some descriptor binding back and forth?
+- Loading-monitor state transitions: does the gating flag for
+  `dispatch_gpu_compute` rapidly toggle around the Warming→Playing edge,
+  alternating between "render correctly" and "don't dispatch"?
+
+Recommended start: capture two consecutive frames' rendered output via the
+existing screenshot mechanism (`screenshot_.has_pending()`) and diff them.
+
+### 11.2 Dungeon VFX content overload
+
+The dungeon scene authors **23 torch VFX instances**, each with its own
+emitter, point light, and a 50k-splat torch.ply visual. Even with stride-7
+decimation (~7k splats per torch → 164k total transient) the GPU stalls
+several seconds in M5 background-throttled mode, and the 23-light + 23-
+emitter activation pattern is heavy work regardless of splat count.
+
+The fundamental cost issue is that the dynamic Onesweep depth sort runs at
+`sort_size` (sized to `max_dynamic_count_` = 1 M, fixed at init), independent
+of the actual `dynamic_count_`. So reducing per-torch splat counts cuts CPU
+upload and projection cost but not the sort cost.
+
+Follow-ups:
+
+a. **Demo content fix (cheapest):** reduce the dungeon torch instance count
+   from 23 to ~6-8. Visual density is preserved; budget impact drops by 3-4×.
+   Edit: `examples/island_demo/assets/scenes/dungeon.json` (or wherever the
+   torch instance definitions live in the dungeon scene's game_objects).
+b. **Asset retargeting:** author a `torch_small.ply` at ~2k splats specifically
+   for instanced use in dungeons, separate from the showcase-quality 50k torch.
+   The decimation cap (`kMaxVfxObjectSplats = 2048` in `gs_vfx.cpp`) can then
+   stay or be relaxed for non-instanced VFX.
+c. **Engine architecture (deeper):** make `dynamic_sort_size_` adaptive
+   per-frame based on actual `dynamic_count_` rather than the fixed-max
+   capacity. Recompute `dynamic_sort_workgroups_` and the depth-sort
+   IndirectArgs buffer (`dynamic_depth_params_`) each frame from
+   `dynamic_count_`. This eliminates the "pay-for-max-capacity" trap and
+   makes the sort cost track the actual data. Risk: Onesweep status buffer
+   (`depth_onesweep_status_`) and ping-pong scatter buffers are sized for the
+   max; the dispatch can shrink without resizing them. Estimated ~50 LOC.
+
+### 11.3 Watchdog instrumentation removal
+
+Watchdog logs in `Renderer::draw_scene`, `AppBase` main loop, and
+`GsRenderer::render` self-silence when frames are healthy but produce thousands
+of lines per second during exploration. They're invaluable for incident
+investigations like the one this spec documents. Two reasonable terminal
+states:
+
+- Keep them in the binary, gated behind a `#ifdef GSEURAT_FRAME_WATCHDOG`
+  defined only in `macos-release-with-diag` (not in `macos-release`).
+- Remove the unconditional phase logs (`[loop/wd] iter_start`/`post_update`/
+  etc.) but keep the conditional `*SLOW*` logs — those are silent under
+  healthy conditions and only fire on regressions.
+
+Either way, decide before merging to main.

--- a/docs/superpowers/specs/2026-05-09-upfront-merge-single-init-gs-design.md
+++ b/docs/superpowers/specs/2026-05-09-upfront-merge-single-init-gs-design.md
@@ -1,0 +1,290 @@
+# Upfront-Merge Single `init_gs` — Design Spec
+
+**Date:** 2026-05-09
+**Branch:** `fix/double-init-gs-append-cloud` (will be reused; the broken `append_async_cloud` attempt is reverted)
+**Worktree:** `.worktrees/fix-double-init-gs/`
+**Original framing:** "Demo freezes / oscillates after on_enter due to double `init_gs` corruption when merging chunks + character on top of terrain."
+
+> **Postmortem (added after implementation):** the original framing turned out
+> to be wrong. After landing this fix the same render → spinner → blank →
+> hung-main-thread symptom reproduced with a single `init_gs` and a single
+> chunk in `active_chunks_`. The freeze is pre-existing on `origin/main`
+> and is **not addressed by this design**. We are keeping the change on
+> its architectural merits — single init_gs, single chunk, no double
+> upload, no second `clear_chunks` — and tracking the actual freeze as
+> a separate follow-up. See §8 ("Postmortem") at the end of this doc.
+
+## Why this exists
+
+Two prior attempts ran on this problem before this design:
+
+1. **Original code (current `origin/main`):** `on_enter` calls `init_gs(terrain_only)` via `load_pre_parsed_gs_scene`, then later calls `init_gs(merged)` again to re-upload terrain + chunks + character together. The second call's `clear_chunks` re-allocates the static-sort scratch buffers. The leading hypothesis at the time was that this was corrupting Radix Sort state and producing the post-load freeze.
+
+2. **Append-only attempt (`fix/double-init-gs-append-cloud` first round):** Added `Renderer::append_async_cloud`, removed the second `init_gs`, kept terrain on the GPU and called `gs_renderer.load_cloud_async(extras_only)` to add chunks + character as a second chunk. Different symptom emerged: rendering oscillated between correct frame and uniform navy (sky-only) frame. Reverted.
+
+This design replaces both. Architectural goal: **one `init_gs` per scene activation**, with the cloud already merged on the CPU before any GPU work. Same final-state shape as a fresh scene load via `WorldStreamer` (one chunk, sort-scratch sized once during `init_streaming`, no re-clear), but applied at startup / portal transition.
+
+> **Important caveat (added in postmortem):** the original framing assumed
+> the double-`init_gs` was the cause of the post-load freeze. After
+> landing this fix, the same freeze reproduced with a single init_gs.
+> The freeze is **pre-existing on origin/main** and unaddressed by this
+> design. We're keeping the cleanup on its independent architectural
+> merits. See §8.
+
+## What we're going to do
+
+**Single `init_gs` call, with the cloud already merged on the CPU side before any GPU work.** Same end-state the original code intended — one chunk in `active_chunks_`, single static-sort context, single Radix Sort pass — without the destructive re-init.
+
+The merge moves from "after `init_gs`" to "before `init_gs`": `on_enter` and `perform_portal_transition` build the full `terrain + chunks + character` gaussian vector synchronously, then hand it to `load_pre_parsed_gs_scene` which runs its single `init_gs` on the merged cloud.
+
+### What we explicitly accept
+
+The chunk PLY parses + character PLY parse run synchronously on the main thread. On a cold filesystem cache that's the ~1.5 s stall the user originally wanted to avoid. We **accept this regression for now** — correctness before optimization. The follow-up plan to recover the async benefit (parallel worker parses joined before `init_gs`) is sketched in §6 below but is explicitly out of scope for this PR.
+
+### What we explicitly preserve
+
+- The **terrain** parse stays on the existing async worker (`std::async(std::launch::async, ...)` in `on_enter`).
+- The first `init_gs` happens exactly once, on a fully-merged cloud, on the main thread, before any frame ticks. This matches the M5 Address Fault avoidance contract and the Radix Sort state ownership contract.
+- `LoadingMonitor::begin_load(handles)` in `DemoApp::run` continues to track the single `init_gs`'s slab handles and gates compute via `should_dispatch_gpu_work()` until they drain.
+
+## 1. Architecture
+
+```
+┌─ on_enter (main thread) ──────────────────────────────────────────┐
+│                                                                    │
+│  parse_future = std::async(parse_terrain)   ─── worker thread     │
+│                                                                    │
+│  ... main-thread setup (audio/world/collision/heightfield) ...    │
+│                                                                    │
+│  parsed = parse_future.get()    ◄─ blocks if worker not done      │
+│                                                                    │
+│  ┌── §A merge (NEW: BEFORE load_pre_parsed_gs_scene) ──┐          │
+│  │  std::vector<Gaussian> merged = parsed.cloud.gauss; │          │
+│  │  for each chunk in world manifest:                  │          │
+│  │      load PLY, transform, append to merged          │          │
+│  │  load character PLY, transform, append to merged    │          │
+│  │  parsed.cloud = GaussianCloud::from_gaussians(...)  │          │
+│  │  // bone allocations + ECS entity creation deferred │          │
+│  │  // until after load_pre_parsed_gs_scene runs       │          │
+│  └─────────────────────────────────────────────────────┘          │
+│                                                                    │
+│  load_pre_parsed_gs_scene(scene_data, parsed, opts)                │
+│    └── single init_gs(merged_cloud) ─── all 2.44M splats once     │
+│                                                                    │
+│  ... bone allocations + ECS entities for §A merged content ...    │
+│                                                                    │
+│  end of on_enter — pending_load_handles_ has one batch's handles  │
+│                                                                    │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+DemoApp::run picks up the handles via take_pending_load_handles(),
+calls loading_monitor_.begin_load(handles), the standard Loading→
+Warming→Playing flow runs as it does today.
+```
+
+**Key shape difference vs. the failed append attempt:** the §A merge's PLY loads happen *before* `load_pre_parsed_gs_scene`, which means they happen before any GPU work. The CPU does all the gathering, then the GPU sees one cloud, one chunk, one upload.
+
+## 2. Code changes
+
+Three files. No new public API surface required — the existing `load_pre_parsed_gs_scene` already accepts a fully-formed `ParsedScene&&`, so we just hand it a cloud that's already merged.
+
+### 2.1 `src/demo/island_demo_state.cpp` — `on_enter`
+
+Restructure the §A block to run **before** `load_pre_parsed_gs_scene`:
+
+```cpp
+ParsedScene parsed_scene = parse_future.get();
+
+// ── §A merge (now before init_gs) ──
+// Build the full terrain + chunks + character gaussian vector on the
+// CPU. Single init_gs uploads it as one chunk.
+std::vector<Gaussian> merged = parsed_scene.cloud.gaussians();
+
+if (world_streamer_) {
+    for (const auto& chunk : world_streamer_->manifest().chunks) {
+        if (chunk.grid == glm::ivec3(0, 0, 0)) continue;
+        if (chunk.ply_file.empty()) continue;
+        auto resolved = resolve_asset_path(chunk.ply_file);
+        auto extra = GaussianCloud::load_with_gsvx_first(resolved.string());
+        if (!extra.empty()) {
+            const auto& gs = extra.gaussians();
+            merged.insert(merged.end(), gs.begin(), gs.end());
+            std::fprintf(stderr, "[IslandDemo] Merged chunk [%d,%d,%d]: +%u Gaussians\n",
+                chunk.grid.x, chunk.grid.y, chunk.grid.z, extra.count());
+
+            // Process chunk's scene game_objects (NPCs)
+            // ... (existing code, builds bone_allocations side-effect) ...
+        }
+    }
+}
+
+const float gs_scale = scene_data.gaussian_splat
+    ? scene_data.gaussian_splat->scale_multiplier : 1.0f;
+gs_scale_ = gs_scale;
+
+// Character merge
+auto char_cloud = GaussianCloud::load_with_gsvx_first(
+    "assets/characters/snes_hero/snes_hero.ply");
+if (!char_cloud.empty()) {
+    for (const auto& g : char_cloud.gaussians()) {
+        Gaussian cg = g;
+        glm::vec3 rotated(-cg.position.x, cg.position.y, -cg.position.z);
+        glm::vec3 offset = rotated * kCharScale;
+        offset.y *= gs_scale;
+        cg.position = player_pos + offset + glm::vec3(0, 2.0f, 0);
+        cg.scale *= kCharScale;
+        cg.opacity = std::min(1.0f, cg.opacity * 1.3f);
+        cg.bone_index = cg.bone_index + 1;
+        merged.push_back(cg);
+    }
+}
+
+// Replace parsed_scene.cloud with the merged cloud — single init_gs
+// will upload everything below.
+parsed_scene.cloud = GaussianCloud::from_gaussians(std::move(merged));
+
+// Existing call — now does the one-and-only init_gs with the full cloud
+{
+    GsSceneOptions parse_opts;
+    parse_opts.add_default_light = true;
+    parse_opts.set_god_rays = true;
+    app.load_pre_parsed_gs_scene(scene_data, std::move(parsed_scene), parse_opts);
+}
+
+// ── No second init_gs! ──
+
+// Continue with bone-animation-registry registration, ECS spawn, etc.
+// These don't touch the GPU cloud; they only register CPU-side entries.
+populate_bone_animation_registry(...);
+... player BoneAnimationEntry setup ...
+... PBD elements re-upload ...
+```
+
+**Key changes vs. current code:**
+
+- The §A merge moves from line ~427-572 (after `load_pre_parsed_gs_scene`) to a position before it.
+- `parsed_scene.cloud` is rebuilt with the full merged cloud before being moved into `load_pre_parsed_gs_scene`.
+- The `app.renderer().init_gs(cloud, gs_w, gs_h)` call at line 581 (the second init_gs) is **removed entirely**.
+- The bone-allocation registration (`populate_bone_animation_registry` at line 588) and PBD re-upload (lines 631-651) stay where they are — they operate on CPU-side state, not the GPU cloud.
+
+**The character bone-allocation push to `app.gs_terrain().bone_allocations`** stays where it is (around lines 478-510 for chunk NPCs, and the existing player_entry setup further down). That state is the *registry* for bone animation; it's independent of the GPU upload path.
+
+**Flow for `parse_future.get()` → merge → `load_pre_parsed_gs_scene`:** The terrain parse worker still runs on its own thread, parallel to main-thread setup. The §A chunk/character PLY parses are synchronous on the main thread, after `parse_future.get()` returns. This is the 1.5 s stall we're accepting.
+
+### 2.2 `src/demo/island_demo_state.cpp` — `perform_portal_transition`
+
+Mirror the same restructure: §A merge moves from after `load_pre_parsed_gs_scene` to before. `parsed_scene.cloud` is rebuilt with the merged cloud. The second `init_gs` call disappears.
+
+The §A re-merge in portal transitions has more variants (the `skip_phase_b_remerge` fast path for non-overworld destinations, the `player_already_merged_fast` detection for scenes that author a `player` game_object). All of those branches stay; they just decide *what* to merge into the parsed cloud, not whether to issue a second `init_gs`.
+
+The `loading_monitor.begin_load(...)` call at the end (line 2530 today) keeps working unchanged — it tracks the single `init_gs`'s handles via `take_pending_load_handles()` as before.
+
+### 2.3 No new method on `Renderer`
+
+The failed attempt added `Renderer::append_async_cloud`. We don't need it anymore. `init_gs` plus its existing internal `load_cloud_async` is sufficient — the merged cloud goes through one upload.
+
+## 3. What this preserves
+
+- **Single `init_gs`:** Radix Sort scratch buffers allocated once. No clear/realloc cycle. Sort state preserved.
+- **Single chunk in `active_chunks_`:** Same shape as the original scene-load. No two-chunk-publication hazard.
+- **Async terrain parse:** The terrain PLY (the largest single load) still parses on a worker thread.
+- **All existing call sites of `load_pre_parsed_gs_scene`:** Public API unchanged.
+- **`LoadingMonitor` flow:** Same handles-tracking, same Loading → Warming → Playing transitions.
+- **Vulkan lifecycle:** All GPU calls remain main-thread, single-shot. M5 Address Fault still avoided.
+- **Bone allocation registry:** Side-effects of the merge (allocations pushed to `gs_terrain().bone_allocations`) preserved — they're now done before init_gs, but `populate_bone_animation_registry` runs after, at the same place it does today.
+
+## 4. What this changes (and the trade-off)
+
+**Regression:** chunk PLY parses + character PLY parse run synchronously on main thread. On a cold cache:
+
+- Northern forest chunk: ~158k splats → ~50-100 ms parse
+- Snes_hero character: ~30k splats → ~20-50 ms parse
+- Each chunk-NPC PLY (forest_guardian etc.): ~50-100 ms each
+
+Total: roughly **200-400 ms** of synchronous main-thread PLY work in `on_enter`. On top of `init_streaming + create_transfer_queue`'s already-measured 367 ms (first-time only), the `on_enter` total returns to the ~700-800 ms range — better than the pre-fix 1.5 s only because the PBD re-upload and other small phases have already been instrumented and are confirmed near-zero.
+
+For `perform_portal_transition`, each portal pays its own per-chunk PLY parse cost — typically 1 chunk + 1 character + a couple of NPCs = ~150-300 ms. Better than the pre-fix freeze, worse than the architectural ideal of "instant transition with a brief loading overlay".
+
+**Trade-off:** correctness *now*, performance *later*. Once we know the upfront-merge approach renders correctly without freezes, we can recover the async-parse benefit in a follow-up PR (see §6).
+
+## 5. Validation plan
+
+**Build gates:**
+
+1. `cmake --build build/macos-release-with-diag --target gseurat_demo` — clean build, no errors.
+2. Run the existing `tests/test_gaussian_cloud.cpp` to confirm cloud merge semantics unchanged (the merge path uses `GaussianCloud::from_gaussians` and `gaussians()` which already have unit coverage).
+
+**Manual gates (you, by hand):**
+
+1. **Demo startup:** Launch `gseurat_demo`, world renders, accept input (WASD movement, no freeze, no oscillation).
+2. **Portal transition (overworld → forest):** Walk into the north bridge portal, loading overlay shows briefly, world reappears, accept input.
+3. **Portal transition (forest → overworld):** Walk back through the return portal, same behavior.
+4. **Portal transition into dungeon:** Walk into a dungeon entrance, scene transitions, accept input.
+5. **Portal transition out of dungeon:** Return to overworld, accept input.
+
+**No automated regression harness run on this machine until correctness is confirmed by hand** — the WindowServer watchdog and kernel-reset incidents from prior runs are still in scope; we don't add load until we're sure the basics work.
+
+**Rollback criteria (as written before implementation):** if any of the manual gates reproduces the freeze or oscillation symptoms, revert and reconvene.
+
+**What actually happened:** the freeze reproduced. Per the postmortem in §8, the freeze is pre-existing on origin/main and unrelated to the double-`init_gs`, so this fix is *not* reverted on the original criterion. The architectural shape (single init_gs, single chunk, no double upload) is correct independently of the freeze. The freeze investigation continues as a separate follow-up.
+
+## 6. Follow-up: recover the async-parse benefit
+
+Out of scope for this PR. Sketch only:
+
+The §A chunk PLY parses + character PLY parse can run on additional `std::async` worker threads in parallel with the terrain parse. The existing `parse_future` becomes one of N futures; `on_enter` joins them all (`future.get()` on each) before assembling the merged cloud.
+
+Care needed:
+- Each worker just parses its PLY into a `GaussianCloud` — no ECS / Vulkan work.
+- The transforms (position offset, rotation, bone_index assignment) happen on the main thread after join — they need bone-allocation indices and `world_pos` from main-thread state.
+- The transform step is fast (vector arithmetic) once the parse is done.
+
+Expected wall-clock improvement for `on_enter`: parallel parse of terrain (largest, ~200ms) + chunk (~50-100ms) + character (~20-50ms) costs `max(...)` instead of `sum(...)`. Probably reduces 700-800ms back toward 400-500ms on cold cache.
+
+Probably worth a separate spec when we get there.
+
+## 7. Latent issues we are NOT addressing
+
+- **`gs_total_gaussian_count_` accuracy in adaptive LOD:** Stays accurate in this design — `init_gs` runs with the merged cloud, `cloud.count()` includes everything, the adaptive LOD budget gets set from the correct total.
+- **`gs_cloud_metadata_.bounds`:** Same — set from the merged cloud, includes everything.
+- **The `c.load_ply(p)` calls through instance** (latent bugs at `island_demo_state.cpp:2623` and `staging_state.cpp:598` from PR-A): unchanged.
+- **`perform_portal_transition`'s §B chunk re-mark loop** (lines 2508-2515 today): stays correct — `world_streamer_->on_chunk_loaded()` for each chunk still tells the streamer "this is loaded, don't re-issue".
+
+## Open questions
+
+1. **Should the §A merge logic be deduplicated between `on_enter` and `perform_portal_transition`?** They share most of the chunk-loop and character-merge code today, with subtle differences (overworld-vs-target detection, fast-path skip). Refactoring the shared body into a helper would shrink the diff, but the differences are real (each function picks different chunks). Recommend keeping them separate for this PR — same boundary as today — and revisiting deduplication only if a third caller emerges. This isn't a rule, but the user's `feedback_keep_lod_simple` and `branch_per_task` memories favor focused diffs.
+
+2. **Should we add a test** that mocks the chunk loop and asserts `init_gs` is called exactly once per `on_enter`? Probably not — it would require a Renderer mock the codebase doesn't have, and the manual-gate step 1 ("demo starts up, world renders") is more meaningful than counting init_gs calls.
+
+## Approval gate
+
+If this design matches what you had in mind, please approve in your next message. After approval I'll implement the changes on `fix/double-init-gs-append-cloud` (replacing the now-reverted `append_async_cloud` work).
+
+## 8. Postmortem
+
+After approval the design was implemented (commits on this branch). Manual run on the user's M5 reproduced **the same render → spinner → blank → hung-main-thread symptom** that the broken append-only attempt produced. The user then confirmed the same symptom is present on `origin/main`. The double-`init_gs` was not the cause of the freeze.
+
+**What we got right:**
+- Single `init_gs` per scene activation.
+- Single chunk in `active_chunks_` at startup, matching the gameplay-time shape.
+- No second `clear_chunks` call, no double GPU upload of the terrain.
+- Architecture matches the user's stated intent ("upload a single, fully merged cloud").
+
+**What we got wrong:**
+- The hypothesis ("double `init_gs` corrupts Radix Sort state → freeze") wasn't empirically tested before being built into the spec. We jumped from "this is a known bad pattern" to "this is *the* cause" without a reproducible isolation step.
+- The "fix didn't work" outcome was discoverable cheaply (small Renderer change, single demo run) but only after going through the larger restructure.
+
+**What's still broken:**
+- The post-load freeze. macOS log line `error messaging the mach port for IMKCFRunLoopWakeUpReliable` accompanies the spinner — strong indicator that the main thread is hung indefinitely (Vulkan fence wait, deadlock, or shader hang). Pre-existing on `origin/main`.
+
+**Where to look next (separate follow-up):**
+- `vkWaitForFences` / `vkAcquireNextImageKHR` in the per-frame loop — what fence is the main thread blocking on, and which submission was supposed to signal it?
+- The `[ProximityTrigger] ENTER` cluster of effects that fires on the first post-load frame (chimney_smoke VFX spawn, EmitterToggle, AnimationTrigger, EmissiveToggle): could one of these path's first dispatch hang the GPU?
+- `update_descriptors` / per-frame dynamic upload paths — descriptor-set vs buffer-lifetime hazards that wouldn't fire during the harness (which runs deterministic input that doesn't exercise the same triggers).
+- The macOS-only mach-port warning — does the same demo build hang on Linux/Windows too, or is this specific to a MoltenVK / IMKCFRunLoopWakeUpReliable interaction?
+
+**Why we kept this fix anyway:**
+- Independent architectural merit (cleaner shape, less GPU work, fewer moving parts).
+- Future investigators of the freeze should not have to mentally subtract the double-init_gs noise to see the actual cause.
+- Reverting would lose the spec, which now also documents the disproven hypothesis.

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -130,9 +130,20 @@ public:
     void update_active_gaussians(const Gaussian* data, uint32_t count);
     void update_gaussian_data(const Gaussian* data, uint32_t count);
 
-    // Per-frame dynamic upload API (VFX/particles/PBD). Static geometry
-    // arrives via load_cloud_async + publish_pending_chunks, not this path.
+    // Per-frame dynamic upload API (VFX/particles/scene-anim "transient suffix").
+    // Writes at offset persistent_dyn_count_; sets dynamic_count_ to
+    // persistent_dyn_count_ + count. Static geometry (terrain) arrives via
+    // load_cloud_async + publish_pending_chunks, not this path.
     void update_dynamic_gaussians(const Gaussian* data, uint32_t count);
+
+    // Once-per-scene (or per-chunk-event) upload API for the "persistent prefix"
+    // of the dynamic buffer: characters, NPCs, PBD-tagged trees. Replaces all
+    // existing persistent-dynamic content. Caller assembles the full vector;
+    // engine doesn't track per-source slots. After this call, dynamic_count_
+    // resets to the persistent count (transient region is zero until the next
+    // update_dynamic_gaussians).
+    void set_persistent_dynamics(const Gaussian* data, uint32_t count);
+    uint32_t persistent_dynamic_count() const { return persistent_dyn_count_; }
     uint32_t max_static_count() const { return max_static_count_; }
     uint32_t max_dynamic_count() const { return max_dynamic_count_; }
     uint32_t static_count() const { return static_count_; }
@@ -180,11 +191,16 @@ public:
         return output_views_;
     }
     VkSampler output_sampler() const { return output_sampler_; }
-    // Sized for: particles + character + animated regions + VFX object
-    // geometry (e.g. torch.ply at ~50K splats × multiple instances).
-    // 256K × 64 B = 16 MB; projected_ssbo_ grows by (256K - 8K) × 48 B ≈ 12 MB.
-    // Trivial against a 10M-static budget.
-    static constexpr uint32_t kDynamicHeadroom = 262144;
+    // Sized for: persistent dynamics (PBD-tagged trees, characters, NPCs) +
+    // transient dynamics (VFX objects, particle emitters, scene animations).
+    // The split-tail design (Option A) puts all bone-animated and PBD-tagged
+    // splats in dynamic_gaussian_ssbo_ so the static depth sort doesn't have
+    // to re-run every frame to keep them current. Persistent content sums to
+    // ~700-800k splats for the island demo (12 trees × ~60k tagged + chars
+    // + NPCs); transient adds ~200k headroom for chimney_smoke + torches.
+    // 1M × 64 B = 64 MB; projected_ssbo_ grows proportionally. M5 unified
+    // memory absorbs this trivially.
+    static constexpr uint32_t kDynamicHeadroom = 1048576;
 
     bool has_cloud() const { return gaussian_count_ > 0; }
     uint32_t gaussian_count() const { return gaussian_count_; }
@@ -259,8 +275,11 @@ public:
     void upload_bone_transforms(const glm::mat4* transforms, uint32_t count);
     void clear_bone_transforms();
 
-    // Actor world rotation for root motion (Phase 2: applied to per-Gaussian covariance)
-    void set_actor_rotation(const glm::quat& q) { actor_rotation_ = q; static_dirty_ = true; }
+    // Actor world rotation for root motion (Phase 2: applied to per-Gaussian covariance).
+    // No static_dirty_=true: bone-animated splats now live in dynamic, and the
+    // dynamic preprocess re-applies actor_rotation every frame via the bone
+    // skinning path (gs_preprocess.comp:209-213).
+    void set_actor_rotation(const glm::quat& q) { actor_rotation_ = q; }
 
     // PBD (Position Based Dynamics) solver
     void upload_pbd_elements(const PbdPhysicsState* states,
@@ -452,7 +471,8 @@ private:
     Buffer counts_ssbo_;  // {static_visible, dynamic_visible, merged_visible}
 
     uint32_t static_count_ = 0;
-    uint32_t dynamic_count_ = 0;
+    uint32_t dynamic_count_ = 0;            // persistent_dyn_count_ + transient
+    uint32_t persistent_dyn_count_ = 0;     // chars/NPCs/PBD-trees prefix in dynamic SSBO
     uint32_t max_static_count_ = 0;
     uint32_t max_dynamic_count_ = 0;
     uint32_t static_sort_size_ = 0;

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -343,17 +343,181 @@ void IslandDemoState::on_enter(AppBase& app) {
                      next_zone_id, cz.triggers.size(), rail_count);
     }
 
-    // Block on the worker-thread parse and run finalize_on_main inline. This
-    // is the spot in main where `init_scene` (synchronous) ran before; the
-    // GPU sequencing of finalize → first init_gs → §A merge → second init_gs
-    // is preserved exactly. Only the PLY parse moved off the main thread.
-    //
-    // `base_gaussians` is a copy of the parsed cloud's gaussians, retained
-    // for the §A re-merge below (line ~390 reads `parsed.cloud.gaussians()`
-    // in main; here we just keep the vector around to avoid a redundant
-    // re-parse from disk).
+    // Block on the worker-thread parse, then merge chunks + character INTO
+    // the parsed terrain cloud BEFORE running finalize_on_main. Single
+    // `init_gs` uploads the full merged cloud as one static chunk — see
+    // `docs/superpowers/specs/2026-05-09-upfront-merge-single-init-gs-design.md`
+    // for why we don't issue a second `init_gs` (clear_chunks + sort-scratch
+    // re-alloc corrupts Radix Sort state) and why we don't append a second
+    // chunk via `load_cloud_async` (two pre-render publications expose a
+    // synchronization hazard we don't fully understand).
     ParsedScene parsed_scene = parse_future.get();
-    auto base_gaussians = parsed_scene.cloud.gaussians();
+
+    // Compute player_pos here so the §A character merge below can place the
+    // character splats. `app.renderer().gs_cloud_metadata().bounds` isn't
+    // populated yet (init_gs hasn't run); `parsed_scene.terrain_aabb` carries
+    // the same value the renderer would surface post-init.
+    glm::vec3 player_pos = scene_data.player_position.vec();
+    if (glm::length(player_pos) < 0.001f && parsed_scene.has_terrain) {
+        player_pos = parsed_scene.terrain_aabb.center();
+    }
+
+    // gs_scale_ is needed by the character merge below; mirrors what the
+    // original post-init computation set later in this function.
+    gs_scale_ = scene_data.gaussian_splat
+        ? scene_data.gaussian_splat->scale_multiplier : 1.0f;
+
+    // ── §A upfront merge ──
+    // Build the full terrain + world-chunks + character gaussian vector
+    // on the CPU and replace `parsed_scene.cloud` with it. Mutates
+    // `parsed_scene.bone_allocations` + `bone_slot_counter` so that
+    // `finalize_on_main` propagates the chunk-NPC bone slots into
+    // `gs_terrain`. Chunk-NPC ECS entities are created here too —
+    // `finalize_on_main` only touches the main scene's `snapped_objects`,
+    // so chunk-scope game_objects need their entities spawned independently.
+    if (parsed_scene.has_terrain) {
+        std::vector<Gaussian> merged = parsed_scene.cloud.gaussians();
+
+        if (world_streamer_) {
+            for (const auto& chunk : world_streamer_->manifest().chunks) {
+                if (chunk.grid == glm::ivec3(0, 0, 0)) continue;  // already in terrain cloud
+                if (chunk.ply_file.empty()) continue;
+                auto resolved = resolve_asset_path(chunk.ply_file);
+                auto extra = GaussianCloud::load_with_gsvx_first(resolved.string());
+                if (!extra.empty()) {
+                    const auto& gs = extra.gaussians();
+                    merged.insert(merged.end(), gs.begin(), gs.end());
+                    std::fprintf(stderr, "[IslandDemo] Merged chunk [%d,%d,%d]: +%u Gaussians\n",
+                        chunk.grid.x, chunk.grid.y, chunk.grid.z, extra.count());
+
+                    // Process game objects from the chunk's scene file
+                    if (!chunk.scene_file.empty()) {
+                        auto chunk_scene = SceneLoader::load(chunk.scene_file);
+                        AABB chunk_aabb = extra.bounds();
+
+                        for (const auto& go : chunk_scene.game_objects) {
+                            glm::vec3 world_pos = go.position.vec() + chunk_aabb.min;
+                            // Snap Y to terrain via heightfield
+                            for (const auto& hf : collision_system_.heightfield_cache()) {
+                                auto h = sample_height(hf, world_pos.x, world_pos.z);
+                                if (h) { world_pos.y = *h; break; }
+                            }
+
+                            // Merge BoneAnimated PLY with bone slot allocation.
+                            // Bone slots flow through `parsed_scene` so that
+                            // `finalize_on_main` writes them into gs_terrain.
+                            if (!go.ply_file.empty() && !go.components.is_null()
+                                && go.components.contains("BoneAnimated")) {
+                                auto npc_cloud = GaussianCloud::load_with_gsvx_first(go.ply_file);
+                                if (!npc_cloud.empty()) {
+                                    const auto& ba_json = go.components["BoneAnimated"];
+                                    std::string manifest_path = ba_json.value("manifest", std::string{});
+
+                                    uint32_t bone_count = 0;
+                                    {
+                                        std::ifstream mf(manifest_path);
+                                        if (mf.is_open()) {
+                                            auto mj = nlohmann::json::parse(mf, nullptr, false);
+                                            if (!mj.is_discarded() && mj.contains("bones"))
+                                                bone_count = static_cast<uint32_t>(mj["bones"].size());
+                                        }
+                                    }
+
+                                    uint32_t first_bone = parsed_scene.bone_slot_counter;
+                                    if (bone_count > 0 && first_bone + bone_count <= 32) {
+                                        parsed_scene.bone_slot_counter += bone_count;
+
+                                        GsTerrainState::BoneAllocation alloc;
+                                        alloc.manifest_path = manifest_path;
+                                        alloc.default_clip = ba_json.value("default_clip", std::string{"idle"});
+                                        alloc.first_bone_index = first_bone;
+                                        alloc.bone_count = bone_count;
+                                        alloc.char_scale = go.scale;
+                                        alloc.gs_scale_multiplier = gs_scale_;
+                                        alloc.world_pos = world_pos;
+                                        alloc.game_object_index = 9999;  // not from main scene
+                                        parsed_scene.bone_allocations.push_back(alloc);
+
+                                        // Use same transform as scene loader: translate, rotate, scale, center
+                                        glm::vec3 local_min(1e9f), local_max(-1e9f);
+                                        for (const auto& g : npc_cloud.gaussians()) {
+                                            local_min = glm::min(local_min, g.position);
+                                            local_max = glm::max(local_max, g.position);
+                                        }
+                                        glm::vec3 local_center = (local_min + local_max) * 0.5f;
+                                        local_center.y = local_min.y;
+
+                                        auto xform = glm::translate(glm::mat4(1.0f), world_pos);
+                                        xform = glm::rotate(xform, glm::radians(go.rotation.x), {1,0,0});
+                                        xform = glm::rotate(xform, glm::radians(go.rotation.y), {0,1,0});
+                                        xform = glm::rotate(xform, glm::radians(go.rotation.z), {0,0,1});
+                                        xform = glm::scale(xform, glm::vec3(go.scale));
+                                        xform = glm::translate(xform, -local_center);
+                                        glm::mat3 rot_mat(xform);
+
+                                        for (const auto& g : npc_cloud.gaussians()) {
+                                            Gaussian ng = g;
+                                            ng.position = glm::vec3(xform * glm::vec4(ng.position, 1.0f));
+                                            ng.scale *= go.scale;
+                                            ng.bone_index = first_bone + ng.bone_index;
+                                            ng.opacity = std::min(1.0f, ng.opacity * 1.3f);
+                                            glm::quat rot_q(rot_mat);
+                                            glm::quat orig_q(ng.rotation[0], ng.rotation[1], ng.rotation[2], ng.rotation[3]);
+                                            glm::quat new_q = rot_q * orig_q;
+                                            ng.rotation = {new_q.w, new_q.x, new_q.y, new_q.z};
+                                            merged.push_back(ng);
+                                        }
+
+                                        std::fprintf(stderr, "[IslandDemo] Chunk NPC '%s': bones %u-%u at (%.1f, %.1f, %.1f)\n",
+                                            go.id.c_str(), first_bone, first_bone + bone_count - 1,
+                                            world_pos.x, world_pos.y, world_pos.z);
+                                    }
+                                }
+                            }
+
+                            // Create ECS entity for game objects with components.
+                            // `finalize_on_main` only touches the main scene's
+                            // `snapped_objects`, so chunk-scope entities need
+                            // to be spawned here independently.
+                            if (!go.components.is_null() && !go.components.empty()) {
+                                auto entity = app.world().create();
+                                app.world().add<ecs::Transform>(entity,
+                                    {coord::WorldPos(world_pos), {go.scale, go.scale}});
+                                for (auto& [name, data] : go.components.items()) {
+                                    app.component_registry().attach(app.world(), entity, name, data);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Character merge — load snes_hero PLY, transform to player_pos.
+        // bone_index is offset by +1 so the shader's bone[0] (terrain sway)
+        // is preserved; per-character bone slots start at 1 (the player) and
+        // chunk NPCs use slots starting at 8 (set up by parse() / appended above).
+        auto char_cloud = GaussianCloud::load_with_gsvx_first("assets/characters/snes_hero/snes_hero.ply");
+        if (!char_cloud.empty()) {
+            const auto& char_gs = char_cloud.gaussians();
+            for (const auto& g : char_gs) {
+                Gaussian cg = g;
+                glm::vec3 rotated(-cg.position.x, cg.position.y, -cg.position.z);
+                glm::vec3 offset = rotated * kCharScale;
+                offset.y *= gs_scale_;
+                cg.position = player_pos + offset + glm::vec3(0, 2.0f, 0);
+                cg.scale *= kCharScale;
+                cg.opacity = std::min(1.0f, cg.opacity * 1.3f);
+                cg.bone_index = cg.bone_index + 1;
+                merged.push_back(cg);
+            }
+        }
+
+        // Replace the parsed cloud with the merged one. Single init_gs in
+        // load_pre_parsed_gs_scene below will upload the whole thing once.
+        parsed_scene.cloud = GaussianCloud::from_gaussians(std::move(merged));
+    }
+
     {
         GsSceneOptions parse_opts;
         parse_opts.add_default_light = true;
@@ -361,15 +525,9 @@ void IslandDemoState::on_enter(AppBase& app) {
         app.load_pre_parsed_gs_scene(scene_data, std::move(parsed_scene), parse_opts);
     }
 
-    // Determine player start position
-    glm::vec3 player_pos = scene_data.player_position.vec();
-    // If player_position is zero, place at map center
-    if (glm::length(player_pos) < 0.001f && app.renderer().has_gs_cloud()) {
-        const auto& aabb = app.renderer().gs_cloud_metadata().bounds;
-        player_pos = aabb.center();
-    }
-    // Note: player_pos is in scene/terrain coordinates — no AABB offset needed.
-    // The collision grid also uses scene coordinates.
+    // `player_pos` was computed earlier (before the §A merge) using
+    // `parsed_scene.terrain_aabb` for the same fallback `gs_cloud_metadata`
+    // would have surfaced post-init.
 
     // Find the player entity created by scene loader (has PlayerController + PlayerTag)
     player_entity_ = ecs::kNullEntity;
@@ -421,170 +579,19 @@ void IslandDemoState::on_enter(AppBase& app) {
     }
 
     // Spawn player character (procedural humanoid)
+    // §A merge + single init_gs already ran above (before
+    // `load_pre_parsed_gs_scene`). Here we only do post-init bookkeeping that
+    // needs `app.renderer().has_gs_cloud()` to be true: character spawn
+    // metadata, bone-animation registry population, player registration.
     if (app.renderer().has_gs_cloud()) {
-        // Reuse the parsed terrain + game-object cloud that was stashed in
-        // `base_gaussians` after the worker-thread parse — saves a redundant
-        // re-parse from disk that the synchronous main path used to do here.
-        std::vector<Gaussian> merged = std::move(base_gaussians);
-
-        // Merge additional world chunks (northern forest) into the cloud
-        // Since load_radius(558) covers all chunks, merge them at startup
-        // to avoid load_cloud_async replacing the entire cloud
-        if (world_streamer_) {
-            for (const auto& chunk : world_streamer_->manifest().chunks) {
-                if (chunk.grid == glm::ivec3(0, 0, 0)) continue;  // already loaded
-                if (chunk.ply_file.empty()) continue;
-                auto resolved = resolve_asset_path(chunk.ply_file);
-                auto extra = GaussianCloud::load_with_gsvx_first(resolved.string());
-                if (!extra.empty()) {
-                    const auto& gs = extra.gaussians();
-                    merged.insert(merged.end(), gs.begin(), gs.end());
-                    std::fprintf(stderr, "[IslandDemo] Merged chunk [%d,%d,%d]: +%u Gaussians\n",
-                        chunk.grid.x, chunk.grid.y, chunk.grid.z, extra.count());
-
-                    // Process game objects from the chunk's scene file
-                    if (!chunk.scene_file.empty()) {
-                        auto chunk_scene = SceneLoader::load(chunk.scene_file);
-                        AABB chunk_aabb = extra.bounds();
-
-                        for (const auto& go : chunk_scene.game_objects) {
-                            // Convert grid position to world using chunk's AABB
-                            glm::vec3 world_pos = go.position.vec() + chunk_aabb.min;
-
-                            // Snap Y to terrain via heightfield
-                            for (const auto& hf : collision_system_.heightfield_cache()) {
-                                auto h = sample_height(hf, world_pos.x, world_pos.z);
-                                if (h) { world_pos.y = *h; break; }
-                            }
-
-                            // Merge BoneAnimated PLY with bone index allocation
-                            if (!go.ply_file.empty() && !go.components.is_null()
-                                && go.components.contains("BoneAnimated")) {
-                                auto npc_cloud = GaussianCloud::load_with_gsvx_first(go.ply_file);
-                                if (!npc_cloud.empty()) {
-                                    const auto& ba_json = go.components["BoneAnimated"];
-                                    std::string manifest_path = ba_json.value("manifest", std::string{});
-
-                                    // Get bone count from manifest JSON
-                                    uint32_t bone_count = 0;
-                                    {
-                                        std::ifstream mf(manifest_path);
-                                        if (mf.is_open()) {
-                                            auto mj = nlohmann::json::parse(mf, nullptr, false);
-                                            if (!mj.is_discarded() && mj.contains("bones"))
-                                                bone_count = static_cast<uint32_t>(mj["bones"].size());
-                                        }
-                                    }
-
-                                    uint32_t first_bone = app.gs_terrain().bone_slot_counter;
-                                    if (bone_count > 0 && first_bone + bone_count <= 32) {
-                                        app.gs_terrain().bone_slot_counter += bone_count;
-
-                                        // Store allocation for registry population later
-                                        GsTerrainState::BoneAllocation alloc;
-                                        alloc.manifest_path = manifest_path;
-                                        alloc.default_clip = ba_json.value("default_clip", std::string{"idle"});
-                                        alloc.first_bone_index = first_bone;
-                                        alloc.bone_count = bone_count;
-                                        alloc.char_scale = go.scale;
-                                        alloc.gs_scale_multiplier = gs_scale_;
-                                        alloc.world_pos = world_pos;
-                                        alloc.game_object_index = 9999;  // not from main scene
-                                        app.gs_terrain().bone_allocations.push_back(alloc);
-
-                                        // Use same transform as scene loader: translate, rotate, scale, center
-                                        glm::vec3 local_min(1e9f), local_max(-1e9f);
-                                        for (const auto& g : npc_cloud.gaussians()) {
-                                            local_min = glm::min(local_min, g.position);
-                                            local_max = glm::max(local_max, g.position);
-                                        }
-                                        glm::vec3 local_center = (local_min + local_max) * 0.5f;
-                                        local_center.y = local_min.y;
-
-                                        auto xform = glm::translate(glm::mat4(1.0f), world_pos);
-                                        xform = glm::rotate(xform, glm::radians(go.rotation.x), {1,0,0});
-                                        xform = glm::rotate(xform, glm::radians(go.rotation.y), {0,1,0});
-                                        xform = glm::rotate(xform, glm::radians(go.rotation.z), {0,0,1});
-                                        xform = glm::scale(xform, glm::vec3(go.scale));
-                                        xform = glm::translate(xform, -local_center);
-                                        glm::mat3 rot_mat(xform);
-
-                                        for (const auto& g : npc_cloud.gaussians()) {
-                                            Gaussian ng = g;
-                                            ng.position = glm::vec3(xform * glm::vec4(ng.position, 1.0f));
-                                            ng.scale *= go.scale;
-                                            ng.bone_index = first_bone + ng.bone_index;
-                                            ng.opacity = std::min(1.0f, ng.opacity * 1.3f);
-                                            // Rotate Gaussian orientation quaternion
-                                            glm::quat rot_q(rot_mat);
-                                            glm::quat orig_q(ng.rotation[0], ng.rotation[1], ng.rotation[2], ng.rotation[3]);
-                                            glm::quat new_q = rot_q * orig_q;
-                                            ng.rotation = {new_q.w, new_q.x, new_q.y, new_q.z};
-                                            merged.push_back(ng);
-                                        }
-
-                                        std::fprintf(stderr, "[IslandDemo] Chunk NPC '%s': bones %u-%u at (%.1f, %.1f, %.1f)\n",
-                                            go.id.c_str(), first_bone, first_bone + bone_count - 1,
-                                            world_pos.x, world_pos.y, world_pos.z);
-                                    }
-                                }
-                            }
-
-                            // Create ECS entity for game objects with components
-                            if (!go.components.is_null() && !go.components.empty()) {
-                                auto entity = app.world().create();
-                                app.world().add<ecs::Transform>(entity,
-                                    {coord::WorldPos(world_pos), {go.scale, go.scale}});
-                                for (auto& [name, data] : go.components.items()) {
-                                    app.component_registry().attach(app.world(), entity, name, data);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        uint32_t map_count = static_cast<uint32_t>(merged.size());
-
-        // Load mesh-converted character model
-        // kCharScale defined as static constexpr on the class
-        const float gs_scale = scene_data.gaussian_splat
-            ? scene_data.gaussian_splat->scale_multiplier : 1.0f;
-        gs_scale_ = gs_scale;
-        auto char_cloud = GaussianCloud::load_with_gsvx_first("assets/characters/snes_hero/snes_hero.ply");
-        if (!char_cloud.empty()) {
-            // Scale, rotate 180° (face away from camera), and position at spawn
-            const auto& char_gs = char_cloud.gaussians();
-            for (const auto& g : char_gs) {
-                Gaussian cg = g;
-                // Rotate 180° around Y: (x,y,z) → (-x, y, -z)
-                glm::vec3 rotated(-cg.position.x, cg.position.y, -cg.position.z);
-                glm::vec3 offset = rotated * kCharScale;
-                offset.y *= gs_scale;
-                cg.position = player_pos + offset + glm::vec3(0, 2.0f, 0);
-                cg.scale *= kCharScale;
-                cg.opacity = std::min(1.0f, cg.opacity * 1.3f);
-                // Offset bone_index by +1 — shader skips bone_index=0 (terrain),
-                // and update_walk_animation writes character bones at [i + 1]
-                cg.bone_index = cg.bone_index + 1;
-                merged.push_back(cg);
-            }
-        }
-
-        uint32_t char_count = static_cast<uint32_t>(merged.size()) - map_count;
-        auto cloud = GaussianCloud::from_gaussians(std::move(merged));
-
-        uint32_t gs_w = app.renderer().gs_renderer().output_width();
-        uint32_t gs_h = app.renderer().gs_renderer().output_height();
-        if (gs_w == 0) { gs_w = 320; gs_h = 240; }
-        app.renderer().init_gs(cloud, gs_w, gs_h);
-
         character_spawn_pos_ = player_pos;
         character_origin_ = player_pos;
         character_spawned_ = true;
 
-        // Re-populate registry with all bone allocations (main scene + chunks)
+        // Re-populate registry with all bone allocations (main scene + chunks).
+        // gs_terrain.bone_allocations was set by `finalize_on_main` from
+        // `parsed_scene.bone_allocations`, which the §A merge above appended
+        // chunk-NPC entries to before the move.
         populate_bone_animation_registry(app.bone_animation_registry(), app.world(), app.gs_terrain());
 
         // Register player in BoneAnimationRegistry
@@ -622,12 +629,10 @@ void IslandDemoState::on_enter(AppBase& app) {
                     glm::vec3(sway_x, sway_y, 0.0f));
             });
         }
-
-        (void)char_count;
     }
 
-    // Re-upload PBD elements — the second init_gs() above (for character merge)
-    // resets pbd_count_ to 0, wiping the upload from load_gs_scene().
+    // Re-upload PBD elements — `init_gs` resets `pbd_count_` to 0, wiping
+    // the upload from `finalize_on_main`'s `upload_pbd_elements` call.
     {
         const auto& anchors = app.gs_terrain().pbd_anchors;
         const auto& configs = app.gs_terrain().pbd_configs;
@@ -2272,13 +2277,182 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
     character_origin_ = spawn;
     character_spawn_pos_ = spawn;
 
-    // ── Block on parse + run finalize_on_main (first init_gs) ──
-    // This is the same call the demo's `on_enter` path makes after its parse
-    // future resolves. `base_gaussians` is stashed for the §B re-merge below
-    // (which would otherwise need to re-parse the just-loaded scene from
-    // disk to get the same vector — wasteful).
+    // ── Block on parse, then merge §B BEFORE running finalize_on_main ──
+    // Single `init_gs` uploads the merged cloud (new-scene terrain + chunks
+    // + character) as one static chunk — see
+    // `docs/superpowers/specs/2026-05-09-upfront-merge-single-init-gs-design.md`
+    // for the full rationale (avoids the Radix-Sort-corrupting double init_gs
+    // and the two-chunks-pre-render publication hazard).
     ParsedScene parsed_scene = parse_future.get();
-    auto base_gaussians = parsed_scene.cloud.gaussians();
+
+    // Fast-path detection: when the new scene authors a "player" game_object
+    // pointing at the snes_hero PLY, `GsSceneLoader::parse` already merged
+    // the player Gaussians into the scene cloud on the worker thread.
+    // Phase B's re-merge is then redundant for non-overworld destinations.
+    // Read from `parsed_scene.bone_allocations` (equivalent of post-finalize
+    // gs_terrain.bone_allocations).
+    bool player_already_merged_fast = false;
+    for (const auto& alloc : parsed_scene.bone_allocations) {
+        if (alloc.manifest_path.find("snes_hero") != std::string::npos) {
+            player_already_merged_fast = true;
+            break;
+        }
+    }
+    const bool skip_phase_b_remerge = !is_overworld && player_already_merged_fast
+                                      && app.renderer().has_gs_cloud();
+
+    // ── §B upfront merge ──
+    // Builds the full parsed-terrain + chunks + character cloud on the CPU
+    // and replaces parsed_scene.cloud. Mutates parsed_scene.bone_allocations
+    // + bone_slot_counter so finalize_on_main propagates them into gs_terrain.
+    // ECS entity creation for chunk-scope game_objects happens here —
+    // finalize_on_main only touches the main scene's snapped_objects.
+    if (!skip_phase_b_remerge && app.renderer().has_gs_cloud()) {
+        std::vector<Gaussian> merged = parsed_scene.cloud.gaussians();
+
+        // When returning to overworld, re-merge all world chunks
+        if (is_overworld && world_streamer_) {
+            for (const auto& chunk : world_streamer_->manifest().chunks) {
+                if (chunk.grid == glm::ivec3(0, 0, 0)) continue;
+                if (chunk.ply_file.empty()) continue;
+                auto resolved = resolve_asset_path(chunk.ply_file);
+                auto extra = GaussianCloud::load_with_gsvx_first(resolved.string());
+                if (!extra.empty()) {
+                    const auto& gs = extra.gaussians();
+                    merged.insert(merged.end(), gs.begin(), gs.end());
+                    std::fprintf(stderr, "[IslandDemo] Re-merged chunk [%d,%d,%d]: +%u Gaussians\n",
+                        chunk.grid.x, chunk.grid.y, chunk.grid.z, extra.count());
+
+                    // Process chunk scene game objects (NPCs)
+                    if (!chunk.scene_file.empty()) {
+                        auto chunk_scene = SceneLoader::load(chunk.scene_file);
+                        AABB chunk_aabb = extra.bounds();
+                        for (const auto& go : chunk_scene.game_objects) {
+                            glm::vec3 world_pos = go.position.vec() + chunk_aabb.min;
+                            // Snap Y to terrain via heightfield
+                            for (const auto& hf : collision_system_.heightfield_cache()) {
+                                auto h = sample_height(hf, world_pos.x, world_pos.z);
+                                if (h) { world_pos.y = *h; break; }
+                            }
+                            if (!go.ply_file.empty() && !go.components.is_null()
+                                && go.components.contains("BoneAnimated")) {
+                                auto npc_cloud = GaussianCloud::load_with_gsvx_first(go.ply_file);
+                                if (!npc_cloud.empty()) {
+                                    const auto& ba_json = go.components["BoneAnimated"];
+                                    std::string manifest_path = ba_json.value("manifest", std::string{});
+                                    uint32_t bone_count = 0;
+                                    { std::ifstream mf(manifest_path);
+                                      if (mf.is_open()) {
+                                          auto mj = nlohmann::json::parse(mf, nullptr, false);
+                                          if (!mj.is_discarded() && mj.contains("bones"))
+                                              bone_count = static_cast<uint32_t>(mj["bones"].size());
+                                      }
+                                    }
+                                    uint32_t first_bone = parsed_scene.bone_slot_counter;
+                                    if (bone_count > 0 && first_bone + bone_count <= 32) {
+                                        parsed_scene.bone_slot_counter += bone_count;
+                                        GsTerrainState::BoneAllocation alloc;
+                                        alloc.manifest_path = manifest_path;
+                                        alloc.default_clip = ba_json.value("default_clip", std::string{"idle"});
+                                        alloc.first_bone_index = first_bone;
+                                        alloc.bone_count = bone_count;
+                                        alloc.char_scale = go.scale;
+                                        alloc.gs_scale_multiplier = gs_scale_;
+                                        alloc.world_pos = world_pos;
+                                        alloc.game_object_index = 9999;
+                                        parsed_scene.bone_allocations.push_back(alloc);
+                                        glm::vec3 lmin(1e9f), lmax(-1e9f);
+                                        for (const auto& g : npc_cloud.gaussians()) {
+                                            lmin = glm::min(lmin, g.position);
+                                            lmax = glm::max(lmax, g.position);
+                                        }
+                                        glm::vec3 lctr = (lmin + lmax) * 0.5f;
+                                        lctr.y = lmin.y;
+                                        auto xf = glm::translate(glm::mat4(1.0f), world_pos);
+                                        xf = glm::rotate(xf, glm::radians(go.rotation.x), {1,0,0});
+                                        xf = glm::rotate(xf, glm::radians(go.rotation.y), {0,1,0});
+                                        xf = glm::rotate(xf, glm::radians(go.rotation.z), {0,0,1});
+                                        xf = glm::scale(xf, glm::vec3(go.scale));
+                                        xf = glm::translate(xf, -lctr);
+                                        glm::mat3 rm(xf);
+                                        for (const auto& g : npc_cloud.gaussians()) {
+                                            Gaussian ng = g;
+                                            ng.position = glm::vec3(xf * glm::vec4(ng.position, 1.0f));
+                                            ng.scale *= go.scale;
+                                            ng.bone_index = first_bone + ng.bone_index;
+                                            ng.opacity = std::min(1.0f, ng.opacity * 1.3f);
+                                            glm::quat rq(rm);
+                                            glm::quat oq(ng.rotation[0], ng.rotation[1], ng.rotation[2], ng.rotation[3]);
+                                            glm::quat nq = rq * oq;
+                                            ng.rotation = {nq.w, nq.x, nq.y, nq.z};
+                                            merged.push_back(ng);
+                                        }
+                                    }
+                                }
+                            }
+                            if (!go.components.is_null() && !go.components.empty()) {
+                                auto entity = app.world().create();
+                                app.world().add<ecs::Transform>(entity,
+                                    {coord::WorldPos(world_pos), {go.scale, go.scale}});
+                                for (auto& [name, data] : go.components.items())
+                                    app.component_registry().attach(app.world(), entity, name, data);
+                            }
+                        }
+                    }
+                }
+            }
+            // Mark chunks as loaded so WorldStreamer::update() doesn't issue
+            // a redundant load_cloud_async for them on the next tick (which
+            // is append-only and would duplicate every tree/NPC/spawn-PC).
+            for (const auto& chunk : world_streamer_->manifest().chunks) {
+                std::string key = std::to_string(chunk.grid.x) + "," +
+                                  std::to_string(chunk.grid.y) + "," +
+                                  std::to_string(chunk.grid.z);
+                world_streamer_->on_chunk_loaded(key, 0);
+            }
+            // Restore overworld camera settings
+            distance_ = 20.0f;
+            elevation_ = 0.6f;
+        }
+
+        // Skip the manual PC PLY merge if the parser already merged the
+        // player from a "player" game_object. Adding it again here would
+        // duplicate the splats and produce a side-by-side ghost-PC whenever
+        // target_position differs from the authored position. Re-checking
+        // against parsed_scene.bone_allocations because the chunk loop
+        // above may have just appended entries.
+        bool player_already_merged = false;
+        for (const auto& alloc : parsed_scene.bone_allocations) {
+            if (alloc.manifest_path.find("snes_hero") != std::string::npos) {
+                player_already_merged = true;
+                break;
+            }
+        }
+        if (!player_already_merged) {
+            auto char_cloud = GaussianCloud::load_with_gsvx_first(
+                "assets/characters/snes_hero/snes_hero.ply");
+            if (!char_cloud.empty()) {
+                const auto& char_gs = char_cloud.gaussians();
+                for (const auto& g : char_gs) {
+                    Gaussian cg = g;
+                    glm::vec3 rotated(-cg.position.x, cg.position.y, -cg.position.z);
+                    glm::vec3 offset = rotated * kCharScale;
+                    offset.y *= gs_scale_;
+                    cg.position = spawn + offset + glm::vec3(0, 2.0f, 0);
+                    cg.scale *= kCharScale;
+                    cg.opacity = std::min(1.0f, cg.opacity * 1.3f);
+                    cg.bone_index = cg.bone_index + 1;
+                    merged.push_back(cg);
+                }
+            }
+        }
+        std::fprintf(stderr, "[IslandDemo] Portal re-merge: %u total Gaussians%s\n",
+            static_cast<uint32_t>(merged.size()),
+            player_already_merged ? " (player from game_object)" : "");
+
+        parsed_scene.cloud = GaussianCloud::from_gaussians(std::move(merged));
+    }
+
     {
         GsSceneOptions portal_opts;
         portal_opts.add_default_light = true;
@@ -2334,189 +2508,12 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
         }
     }
 
-    // Fast-path detection: when the new scene authors a "player" game_object
-    // pointing at the snes_hero PLY, `GsSceneLoader::parse` already merged
-    // the player Gaussians into the scene cloud on the worker thread.
-    // Phase B's re-merge + 2nd init_gs is redundant for non-overworld
-    // destinations (no streamed chunks to add), and the synchronous
-    // load_ply call below would re-introduce a 100-300ms main-thread
-    // stall after we just spent the entire async-load window avoiding
-    // exactly that. Skip the whole re-merge block when both conditions
-    // hold; the renderer already has everything it needs.
-    bool player_already_merged_fast = false;
-    for (const auto& alloc : app.gs_terrain().bone_allocations) {
-        if (alloc.manifest_path.find("snes_hero") != std::string::npos) {
-            player_already_merged_fast = true;
-            break;
-        }
-    }
-    const bool skip_phase_b_remerge = !is_overworld && player_already_merged_fast
-                                      && app.renderer().has_gs_cloud();
-
-    // Re-merge world chunks + player character into the new scene. Reuses
-    // the parsed cloud's gaussians stashed in `base_gaussians` after the
-    // worker-thread parse — saves a redundant re-parse from disk that the
-    // pre-Option-C path used to do here.
-    if (!skip_phase_b_remerge && app.renderer().has_gs_cloud()) {
-        std::vector<Gaussian> merged = std::move(base_gaussians);
-
-        // When returning to overworld, re-merge all world chunks
-        if (is_overworld && world_streamer_) {
-            for (const auto& chunk : world_streamer_->manifest().chunks) {
-                if (chunk.grid == glm::ivec3(0, 0, 0)) continue;
-                if (chunk.ply_file.empty()) continue;
-                auto resolved = resolve_asset_path(chunk.ply_file);
-                auto extra = GaussianCloud::load_with_gsvx_first(resolved.string());
-                if (!extra.empty()) {
-                    const auto& gs = extra.gaussians();
-                    merged.insert(merged.end(), gs.begin(), gs.end());
-                    std::fprintf(stderr, "[IslandDemo] Re-merged chunk [%d,%d,%d]: +%u Gaussians\n",
-                        chunk.grid.x, chunk.grid.y, chunk.grid.z, extra.count());
-
-                    // Process chunk scene game objects (NPCs)
-                    if (!chunk.scene_file.empty()) {
-                        auto chunk_scene = SceneLoader::load(chunk.scene_file);
-                        AABB chunk_aabb = extra.bounds();
-                        for (const auto& go : chunk_scene.game_objects) {
-                            glm::vec3 world_pos = go.position.vec() + chunk_aabb.min;
-                            // Snap Y to terrain via heightfield
-                            for (const auto& hf : collision_system_.heightfield_cache()) {
-                                auto h = sample_height(hf, world_pos.x, world_pos.z);
-                                if (h) { world_pos.y = *h; break; }
-                            }
-                            if (!go.ply_file.empty() && !go.components.is_null()
-                                && go.components.contains("BoneAnimated")) {
-                                auto npc_cloud = GaussianCloud::load_with_gsvx_first(go.ply_file);
-                                if (!npc_cloud.empty()) {
-                                    const auto& ba_json = go.components["BoneAnimated"];
-                                    std::string manifest_path = ba_json.value("manifest", std::string{});
-                                    uint32_t bone_count = 0;
-                                    { std::ifstream mf(manifest_path);
-                                      if (mf.is_open()) {
-                                          auto mj = nlohmann::json::parse(mf, nullptr, false);
-                                          if (!mj.is_discarded() && mj.contains("bones"))
-                                              bone_count = static_cast<uint32_t>(mj["bones"].size());
-                                      }
-                                    }
-                                    uint32_t first_bone = app.gs_terrain().bone_slot_counter;
-                                    if (bone_count > 0 && first_bone + bone_count <= 32) {
-                                        app.gs_terrain().bone_slot_counter += bone_count;
-                                        GsTerrainState::BoneAllocation alloc;
-                                        alloc.manifest_path = manifest_path;
-                                        alloc.default_clip = ba_json.value("default_clip", std::string{"idle"});
-                                        alloc.first_bone_index = first_bone;
-                                        alloc.bone_count = bone_count;
-                                        alloc.char_scale = go.scale;
-                                        alloc.gs_scale_multiplier = gs_scale_;
-                                        alloc.world_pos = world_pos;
-                                        alloc.game_object_index = 9999;
-                                        app.gs_terrain().bone_allocations.push_back(alloc);
-                                        glm::vec3 lmin(1e9f), lmax(-1e9f);
-                                        for (const auto& g : npc_cloud.gaussians()) {
-                                            lmin = glm::min(lmin, g.position);
-                                            lmax = glm::max(lmax, g.position);
-                                        }
-                                        glm::vec3 lctr = (lmin + lmax) * 0.5f;
-                                        lctr.y = lmin.y;
-                                        auto xf = glm::translate(glm::mat4(1.0f), world_pos);
-                                        xf = glm::rotate(xf, glm::radians(go.rotation.x), {1,0,0});
-                                        xf = glm::rotate(xf, glm::radians(go.rotation.y), {0,1,0});
-                                        xf = glm::rotate(xf, glm::radians(go.rotation.z), {0,0,1});
-                                        xf = glm::scale(xf, glm::vec3(go.scale));
-                                        xf = glm::translate(xf, -lctr);
-                                        glm::mat3 rm(xf);
-                                        for (const auto& g : npc_cloud.gaussians()) {
-                                            Gaussian ng = g;
-                                            ng.position = glm::vec3(xf * glm::vec4(ng.position, 1.0f));
-                                            ng.scale *= go.scale;
-                                            ng.bone_index = first_bone + ng.bone_index;
-                                            ng.opacity = std::min(1.0f, ng.opacity * 1.3f);
-                                            glm::quat rq(rm);
-                                            glm::quat oq(ng.rotation[0], ng.rotation[1], ng.rotation[2], ng.rotation[3]);
-                                            glm::quat nq = rq * oq;
-                                            ng.rotation = {nq.w, nq.x, nq.y, nq.z};
-                                            merged.push_back(ng);
-                                        }
-                                    }
-                                }
-                            }
-                            if (!go.components.is_null() && !go.components.empty()) {
-                                auto entity = app.world().create();
-                                app.world().add<ecs::Transform>(entity,
-                                    {coord::WorldPos(world_pos), {go.scale, go.scale}});
-                                for (auto& [name, data] : go.components.items())
-                                    app.component_registry().attach(app.world(), entity, name, data);
-                            }
-                        }
-                    }
-                }
-            }
-            // Restore overworld camera settings
-            distance_ = 20.0f;
-            elevation_ = 0.6f;
-        }
-
-        // Skip the manual PC PLY merge if load_gs_scene already merged the
-        // player from a "player" game_object — adding it again here would
-        // duplicate the splats (one set at the authored game_object position
-        // via load_gs_scene's PLY merge, one set at `spawn` via this loop)
-        // and produce a side-by-side "ghost PC" whenever target_position
-        // differs from the authored position (every dungeon→overworld
-        // return). Detect via the bone allocation populated by
-        // gs_scene_loader's BoneAnimated pre-scan.
-        bool player_already_merged = false;
-        for (const auto& alloc : app.gs_terrain().bone_allocations) {
-            if (alloc.manifest_path.find("snes_hero") != std::string::npos) {
-                player_already_merged = true;
-                break;
-            }
-        }
-        if (!player_already_merged) {
-            auto char_cloud = GaussianCloud::load_with_gsvx_first(
-                "assets/characters/snes_hero/snes_hero.ply");
-            if (!char_cloud.empty()) {
-                const auto& char_gs = char_cloud.gaussians();
-                for (const auto& g : char_gs) {
-                    Gaussian cg = g;
-                    glm::vec3 rotated(-cg.position.x, cg.position.y, -cg.position.z);
-                    glm::vec3 offset = rotated * kCharScale;
-                    offset.y *= gs_scale_;
-                    cg.position = spawn + offset + glm::vec3(0, 2.0f, 0);
-                    cg.scale *= kCharScale;
-                    cg.opacity = std::min(1.0f, cg.opacity * 1.3f);
-                    cg.bone_index = cg.bone_index + 1;
-                    merged.push_back(cg);
-                }
-            }
-        }
-        std::fprintf(stderr, "[IslandDemo] Portal re-merge: %u total Gaussians%s\n",
-            static_cast<uint32_t>(merged.size()),
-            player_already_merged ? " (player from game_object)" : "");
-
-        auto cloud = GaussianCloud::from_gaussians(std::move(merged));
-        uint32_t gs_w = app.renderer().gs_renderer().output_width();
-        uint32_t gs_h = app.renderer().gs_renderer().output_height();
-        if (gs_w == 0) { gs_w = 320; gs_h = 240; }
-        app.renderer().init_gs(cloud, gs_w, gs_h);
-
-        // Returning to overworld merged every world chunk into the new
-        // cloud. Without re-marking them, world_streamer_->update() will
-        // see them as UNLOADED on the next tick and call load_cloud_async
-        // for each — which is append-only — duplicating every tree, NPC,
-        // and ghost-spawn-PC's worth of splats on top of the merged cloud.
-        // Mirror the on_enter loop that does the same for the initial load.
-        if (is_overworld && world_streamer_) {
-            for (const auto& chunk : world_streamer_->manifest().chunks) {
-                std::string key = std::to_string(chunk.grid.x) + "," +
-                                  std::to_string(chunk.grid.y) + "," +
-                                  std::to_string(chunk.grid.z);
-                world_streamer_->on_chunk_loaded(key, 0);
-            }
-        }
-    }
+    // The §B merge ran upstream of `load_pre_parsed_gs_scene` (above);
+    // the chunk re-mark + camera restoration also happened inside that
+    // moved block. Nothing more to do for §B here.
 
     // Arm the engine loading monitor with the slab-upload handles from the
-    // init_gs call(s) above so the engine state machine gates GPU compute
+    // single init_gs above so the engine state machine gates GPU compute
     // (`should_dispatch_gpu_work`) until the new scene's uploads have
     // drained. Without this, the next frame after this function returns
     // would dispatch GS compute against in-flight slab buffers — exactly

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -550,11 +550,15 @@ void IslandDemoState::on_enter(AppBase& app) {
     // Upload persistent dynamics (chars/NPCs/PBD-tagged tree splats) into the
     // dynamic SSBO's prefix region. The transient suffix (VFX, particles)
     // continues to be re-uploaded every frame from Renderer::record_gs_prepass.
-    if (!persistent_dynamics_pending.empty()) {
-        app.renderer().gs_renderer().set_persistent_dynamics(
-            persistent_dynamics_pending.data(),
-            static_cast<uint32_t>(persistent_dynamics_pending.size()));
-    }
+    //
+    // Called unconditionally — even with count=0 — so the prefix is cleared
+    // when entering a scene with no animated content. Without this, a stale
+    // persistent_dyn_count_ from the previous scene would shift the offset
+    // used by subsequent update_dynamic_gaussians calls and either clip or
+    // misplace transient VFX. Codex P2 on #420.
+    app.renderer().gs_renderer().set_persistent_dynamics(
+        persistent_dynamics_pending.empty() ? nullptr : persistent_dynamics_pending.data(),
+        static_cast<uint32_t>(persistent_dynamics_pending.size()));
 
     // `player_pos` was computed earlier (before the §A merge) using
     // `parsed_scene.terrain_aabb` for the same fallback `gs_cloud_metadata`

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -367,6 +367,10 @@ void IslandDemoState::on_enter(AppBase& app) {
     gs_scale_ = scene_data.gaussian_splat
         ? scene_data.gaussian_splat->scale_multiplier : 1.0f;
 
+    // Collected during §A merge below; uploaded to the dynamic SSBO's
+    // persistent prefix after `load_pre_parsed_gs_scene`.
+    std::vector<Gaussian> persistent_dynamics_pending;
+
     // ── §A upfront merge ──
     // Build the full terrain + world-chunks + character gaussian vector
     // on the CPU and replace `parsed_scene.cloud` with it. Mutates
@@ -513,9 +517,27 @@ void IslandDemoState::on_enter(AppBase& app) {
             }
         }
 
-        // Replace the parsed cloud with the merged one. Single init_gs in
-        // load_pre_parsed_gs_scene below will upload the whole thing once.
-        parsed_scene.cloud = GaussianCloud::from_gaussians(std::move(merged));
+        // Partition by bone_index:
+        //   bone_index == 0  → static (terrain + tree trunks + non-animated props)
+        //   bone_index >  0  → persistent dynamic (PBD-tagged tree leaves with
+        //                       bone_index ≥ 32, plus bone-animated characters
+        //                       and NPCs with bone_index in [1, 31]).
+        // The dynamic preprocess re-applies bone+PBD transforms every frame, so
+        // the static depth sort can stay cached when the camera is stationary.
+        // Source: 2026-05-09 Option A architectural fix.
+        std::vector<Gaussian> static_only;
+        static_only.reserve(merged.size());
+        for (const auto& g : merged) {
+            if (g.bone_index > 0) {
+                persistent_dynamics_pending.push_back(g);
+            } else {
+                static_only.push_back(g);
+            }
+        }
+        std::fprintf(stderr,
+            "[IslandDemo] Partition for split-tail: static=%zu persistent_dyn=%zu (total=%zu)\n",
+            static_only.size(), persistent_dynamics_pending.size(), merged.size());
+        parsed_scene.cloud = GaussianCloud::from_gaussians(std::move(static_only));
     }
 
     {
@@ -523,6 +545,15 @@ void IslandDemoState::on_enter(AppBase& app) {
         parse_opts.add_default_light = true;
         parse_opts.set_god_rays = true;
         app.load_pre_parsed_gs_scene(scene_data, std::move(parsed_scene), parse_opts);
+    }
+
+    // Upload persistent dynamics (chars/NPCs/PBD-tagged tree splats) into the
+    // dynamic SSBO's prefix region. The transient suffix (VFX, particles)
+    // continues to be re-uploaded every frame from Renderer::record_gs_prepass.
+    if (!persistent_dynamics_pending.empty()) {
+        app.renderer().gs_renderer().set_persistent_dynamics(
+            persistent_dynamics_pending.data(),
+            static_cast<uint32_t>(persistent_dynamics_pending.size()));
     }
 
     // `player_pos` was computed earlier (before the §A merge) using
@@ -2301,6 +2332,10 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
     const bool skip_phase_b_remerge = !is_overworld && player_already_merged_fast
                                       && app.renderer().has_gs_cloud();
 
+    // Collected during §B merge below; uploaded to the dynamic SSBO's
+    // persistent prefix after `load_pre_parsed_gs_scene`.
+    std::vector<Gaussian> portal_persistent_dynamics;
+
     // ── §B upfront merge ──
     // Builds the full parsed-terrain + chunks + character cloud on the CPU
     // and replaces parsed_scene.cloud. Mutates parsed_scene.bone_allocations
@@ -2453,6 +2488,28 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
         parsed_scene.cloud = GaussianCloud::from_gaussians(std::move(merged));
     }
 
+    // Split-tail partition (Option A — applies whether §B re-merge ran or
+    // skip_phase_b_remerge took the parser-merged path):
+    //   bone_index == 0  → static (terrain + tree trunks + non-animated props)
+    //   bone_index >  0  → persistent dynamic (PBD-tagged tree leaves +
+    //                       bone-animated chars/NPCs)
+    {
+        const auto& cloud_g = parsed_scene.cloud.gaussians();
+        std::vector<Gaussian> static_only;
+        static_only.reserve(cloud_g.size());
+        for (const auto& g : cloud_g) {
+            if (g.bone_index > 0) {
+                portal_persistent_dynamics.push_back(g);
+            } else {
+                static_only.push_back(g);
+            }
+        }
+        std::fprintf(stderr,
+            "[IslandDemo] Portal partition: static=%zu persistent_dyn=%zu (total=%zu)\n",
+            static_only.size(), portal_persistent_dynamics.size(), cloud_g.size());
+        parsed_scene.cloud = GaussianCloud::from_gaussians(std::move(static_only));
+    }
+
     {
         GsSceneOptions portal_opts;
         portal_opts.add_default_light = true;
@@ -2460,6 +2517,13 @@ void IslandDemoState::perform_portal_transition(AppBase& app,
         app.load_pre_parsed_gs_scene(target_scene_data,
                                      std::move(parsed_scene), portal_opts);
     }
+
+    // Upload persistent dynamics. set_persistent_dynamics replaces the entire
+    // dynamic prefix; passing count=0 clears any prior scene's prefix so it
+    // doesn't render alongside the new one.
+    app.renderer().gs_renderer().set_persistent_dynamics(
+        portal_persistent_dynamics.empty() ? nullptr : portal_persistent_dynamics.data(),
+        static_cast<uint32_t>(portal_persistent_dynamics.size()));
 
     // The new scene's "player" game_object (when present, e.g. seurat_island)
     // is wired up by `load_pre_parsed_gs_scene` above: PlayerController,

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -246,8 +246,10 @@ void AppBase::main_loop() {
 
     while (!glfwWindowShouldClose(window_) &&
            !g_shutdown_requested.load(std::memory_order_relaxed)) {
+#if GSEURAT_DEBUG_BUILD
         const auto t_iter_start = std::chrono::steady_clock::now();
         std::fprintf(stderr, "[loop/wd] iter_start tick=%u\n", tick_);
+#endif
         glfwPollEvents();
 
         // Poll control server for bridge commands
@@ -343,8 +345,10 @@ void AppBase::main_loop() {
             !renderer_.determinism_test_active()) {
             state_stack_.update(*this, dt);
         }
+#if GSEURAT_DEBUG_BUILD
         const auto t_after_update = std::chrono::steady_clock::now();
         std::fprintf(stderr, "[loop/wd] post_update tick=%u\n", tick_);
+#endif
 
         // Broadcast camera state to subscribed clients (throttled to 30 Hz)
         camera_broadcast_timer_ += dt;
@@ -397,11 +401,15 @@ void AppBase::main_loop() {
             ui_ctx_.begin_frame(ui_input);
         }
 
+#if GSEURAT_DEBUG_BUILD
         std::fprintf(stderr, "[loop/wd] before_build_draw_lists tick=%u\n", tick_);
+#endif
         // Let states build their draw lists
         state_stack_.build_draw_lists(*this);
+#if GSEURAT_DEBUG_BUILD
         const auto t_after_build_draw_lists = std::chrono::steady_clock::now();
         std::fprintf(stderr, "[loop/wd] after_build_draw_lists tick=%u\n", tick_);
+#endif
 
         // Loading/Warming overlay (after the active state's draw lists are
         // built so the overlay paints over them). Default AppBase impl is a
@@ -468,11 +476,14 @@ void AppBase::main_loop() {
         // skips them entirely; Warming dispatches them to flush driver state
         // against freshly-uploaded buffers; Playing is the steady state.
         const bool dispatch_gpu_compute = loading_monitor_.should_dispatch_gpu_work();
+#if GSEURAT_DEBUG_BUILD
         std::fprintf(stderr, "[loop/wd] before_draw_scene tick=%u dispatch=%d\n",
                      tick_, dispatch_gpu_compute ? 1 : 0);
+#endif
         renderer_.draw_scene(scene_, draw_lists_.entity, draw_lists_.outline, draw_lists_.reflection,
                              draw_lists_.shadow, particle_sprites, draw_lists_.overlay, ui_batches,
                              draw_lists_.debug_colliders, feature_flags_, dispatch_gpu_compute);
+#if GSEURAT_DEBUG_BUILD
         const auto t_after_draw_scene = std::chrono::steady_clock::now();
         std::fprintf(stderr, "[loop/wd] after_draw_scene tick=%u\n", tick_);
 
@@ -490,6 +501,7 @@ void AppBase::main_loop() {
                 "phases pre_update=%.1f draw_lists=%.1f draw_scene=%.1f\n",
                 tick_, iter_total_ms, pre_update_ms, draw_lists_ms, draw_scene_ms);
         }
+#endif
 
         // Per-frame wall-clock timing for synchronous step. Captured here
         // (frame fully drawn) and the delta is taken from either the previous

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -246,6 +246,8 @@ void AppBase::main_loop() {
 
     while (!glfwWindowShouldClose(window_) &&
            !g_shutdown_requested.load(std::memory_order_relaxed)) {
+        const auto t_iter_start = std::chrono::steady_clock::now();
+        std::fprintf(stderr, "[loop/wd] iter_start tick=%u\n", tick_);
         glfwPollEvents();
 
         // Poll control server for bridge commands
@@ -341,6 +343,8 @@ void AppBase::main_loop() {
             !renderer_.determinism_test_active()) {
             state_stack_.update(*this, dt);
         }
+        const auto t_after_update = std::chrono::steady_clock::now();
+        std::fprintf(stderr, "[loop/wd] post_update tick=%u\n", tick_);
 
         // Broadcast camera state to subscribed clients (throttled to 30 Hz)
         camera_broadcast_timer_ += dt;
@@ -393,8 +397,11 @@ void AppBase::main_loop() {
             ui_ctx_.begin_frame(ui_input);
         }
 
+        std::fprintf(stderr, "[loop/wd] before_build_draw_lists tick=%u\n", tick_);
         // Let states build their draw lists
         state_stack_.build_draw_lists(*this);
+        const auto t_after_build_draw_lists = std::chrono::steady_clock::now();
+        std::fprintf(stderr, "[loop/wd] after_build_draw_lists tick=%u\n", tick_);
 
         // Loading/Warming overlay (after the active state's draw lists are
         // built so the overlay paints over them). Default AppBase impl is a
@@ -461,9 +468,28 @@ void AppBase::main_loop() {
         // skips them entirely; Warming dispatches them to flush driver state
         // against freshly-uploaded buffers; Playing is the steady state.
         const bool dispatch_gpu_compute = loading_monitor_.should_dispatch_gpu_work();
+        std::fprintf(stderr, "[loop/wd] before_draw_scene tick=%u dispatch=%d\n",
+                     tick_, dispatch_gpu_compute ? 1 : 0);
         renderer_.draw_scene(scene_, draw_lists_.entity, draw_lists_.outline, draw_lists_.reflection,
                              draw_lists_.shadow, particle_sprites, draw_lists_.overlay, ui_batches,
                              draw_lists_.debug_colliders, feature_flags_, dispatch_gpu_compute);
+        const auto t_after_draw_scene = std::chrono::steady_clock::now();
+        std::fprintf(stderr, "[loop/wd] after_draw_scene tick=%u\n", tick_);
+
+        const double iter_total_ms = std::chrono::duration<double, std::milli>(
+            t_after_draw_scene - t_iter_start).count();
+        if (iter_total_ms > 100.0) {
+            const double pre_update_ms = std::chrono::duration<double, std::milli>(
+                t_after_update - t_iter_start).count();
+            const double draw_lists_ms = std::chrono::duration<double, std::milli>(
+                t_after_build_draw_lists - t_after_update).count();
+            const double draw_scene_ms = std::chrono::duration<double, std::milli>(
+                t_after_draw_scene - t_after_build_draw_lists).count();
+            std::fprintf(stderr,
+                "[loop/wd/SLOW] tick=%u total=%.1fms "
+                "phases pre_update=%.1f draw_lists=%.1f draw_scene=%.1f\n",
+                tick_, iter_total_ms, pre_update_ms, draw_lists_ms, draw_scene_ms);
+        }
 
         // Per-frame wall-clock timing for synchronous step. Captured here
         // (frame fully drawn) and the delta is taken from either the previous

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -3312,11 +3312,14 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
     // to the previous frame's GPU latency and is worth the diagnostic data.
     if (timestamp_pool_ && timestamps_written_) {
         uint64_t ts[6]{};  // depth_sort_begin/end, tile_sort_begin/end, raster_begin/end
+#if GSEURAT_DEBUG_BUILD
         const auto t_wait_start = std::chrono::steady_clock::now();
+#endif
         VkResult ts_result = vkGetQueryPoolResults(
             device_, timestamp_pool_, 0, 6,
             sizeof(ts), ts, sizeof(uint64_t),
             VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
+#if GSEURAT_DEBUG_BUILD
         const auto t_wait_end = std::chrono::steady_clock::now();
         const double wait_ms = std::chrono::duration<double, std::milli>(t_wait_end - t_wait_start).count();
         if (wait_ms > 100.0) {
@@ -3332,6 +3335,7 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
                 wait_ms, prev_depth_ms, prev_tile_ms, prev_raster_ms,
                 static_count_, dynamic_count_, gaussian_count_);
         }
+#endif
         if (ts_result == VK_SUCCESS && ts[5] > ts[4] && ts[3] > ts[2] && ts[1] > ts[0]) {
             float depth_ms = static_cast<float>(ts[1] - ts[0]) * timestamp_period_ns_ / 1e6f;
             float tile_ms  = static_cast<float>(ts[3] - ts[2]) * timestamp_period_ns_ / 1e6f;

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -2218,9 +2218,11 @@ void GsRenderer::update_dynamic_gaussians(const Gaussian* data, uint32_t count) 
         std::memcpy(dst, staging.data(), count * sizeof(GpuGaussian));
     }
 
-    // Reinitialize dynamic sort buffers for active range [0..dynamic_count_)
-    init_dynamic_sort_buf(dynamic_sort_a_, dynamic_sort_size_, dynamic_count_);
-    init_dynamic_sort_buf(dynamic_sort_b_, dynamic_sort_size_, dynamic_count_);
+    // Dynamic sort buffer init is NOT done here. It runs GPU-side in
+    // GsRenderer::render via vkCmdFillBuffer, properly synchronized against
+    // the in-flight depth-sort dispatch from frame N-1. CPU init here would
+    // race with frame N-1's GPU sort, causing intermittent flicker of
+    // persistent dynamics (chars/NPCs/PBD-tagged splats).
 }
 
 
@@ -3474,6 +3476,32 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
             } else {
                 // Reset only dynamic visible count (counts[1]) and merged (counts[2])
                 vkCmdFillBuffer(cmd, counts_ssbo_.buffer(), 4, 8, 0);
+            }
+
+            // Per-frame GPU-side init of dynamic sort buffers.
+            //
+            // Why on the GPU? The previous CPU-side init (an 8MB std::memcpy
+            // to a HOST_VISIBLE mapped buffer every frame) raced against the
+            // GPU's in-flight reads of those same buffers from frame N-1.
+            // With kMaxFramesInFlight=2, frame N+1's CPU init could clobber
+            // entries that frame N's depth-sort dispatch was still consuming,
+            // producing intermittent flicker of persistent dynamics
+            // (chars/NPCs/PBD trees would appear for "a few frames" then
+            // disappear). Moving the fill into the command buffer makes it
+            // properly serialized with the subsequent preprocess + sort
+            // dispatches via the same TRANSFER→COMPUTE barrier below.
+            //
+            // Fill pattern 0xFFFFFFFF gives both `key` and `index` fields of
+            // every SortEntry the max-uint sentinel. The preprocess shader
+            // overwrites slots [0..dynamic_count_) with real keys (depth in
+            // [0..0xFFFE] for visible, 0xFFFF for culled) and indices, so the
+            // active range is fresh. Inactive slots keep 0xFFFFFFFF, sorting
+            // them past 0xFFFF and out of the counts[1] visible window.
+            if (dynamic_count_ > 0 && dynamic_sort_a_.buffer() && dynamic_sort_b_.buffer()) {
+                const VkDeviceSize dyn_sort_bytes =
+                    static_cast<VkDeviceSize>(dynamic_sort_size_) * sizeof(SortEntry);
+                vkCmdFillBuffer(cmd, dynamic_sort_a_.buffer(), 0, dyn_sort_bytes, 0xFFFFFFFFu);
+                vkCmdFillBuffer(cmd, dynamic_sort_b_.buffer(), 0, dyn_sort_bytes, 0xFFFFFFFFu);
             }
             {
                 VkMemoryBarrier fill_barrier{};

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1183,8 +1183,13 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
     // [new_count, prev_count) tail when streaming Unloads shrink static_count_.
     static_sort_a_ = Buffer::create_storage_host_dst(allocator_, static_sort_buf_size);
     static_sort_b_ = Buffer::create_storage_host_dst(allocator_, static_sort_buf_size);
-    dynamic_sort_a_ = Buffer::create_storage(allocator_, dynamic_sort_buf_size);
-    dynamic_sort_b_ = Buffer::create_storage(allocator_, dynamic_sort_buf_size);
+    // Dynamic sort buffers also need TRANSFER_DST_BIT — render() issues a
+    // per-frame vkCmdFillBuffer against them to GPU-side init the sentinel
+    // keys before the dynamic preprocess overwrites the active range.
+    // Without TRANSFER_DST the fillbuffer is a Vulkan-spec violation
+    // (validation error / UB). Codex review on PR #420 flagged this.
+    dynamic_sort_a_ = Buffer::create_storage_host_dst(allocator_, dynamic_sort_buf_size);
+    dynamic_sort_b_ = Buffer::create_storage_host_dst(allocator_, dynamic_sort_buf_size);
     merged_sort_ssbo_ = Buffer::create_storage(allocator_, merged_sort_buf_size);
     counts_ssbo_ = Buffer::create_storage_readback(allocator_, 3 * sizeof(uint32_t));
     uniform_buffer_ = Buffer::create_uniform(allocator_, sizeof(GsUniforms));

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -2145,40 +2145,82 @@ void GsRenderer::publish_pending_chunks(VkCommandBuffer cmd) {
 }
 
 
-void GsRenderer::update_dynamic_gaussians(const Gaussian* data, uint32_t count) {
-    if (count == 0) {
-        dynamic_count_ = 0;
-        return;
+// Helper: reinitialize a dynamic sort buffer with sentinels for inactive
+// slots and identity indices for the active range [0..valid_count).
+static void init_dynamic_sort_buf(Buffer& buf, uint32_t sort_size, uint32_t valid_count) {
+    std::vector<SortEntry> staging_sort(sort_size);
+    for (uint32_t i = 0; i < sort_size; ++i) {
+        staging_sort[i].key = 0xFFFFFFFF;
+        staging_sort[i].index = i < valid_count ? i : 0;
     }
-    if (count > max_dynamic_count_) return;
+    std::memcpy(buf.mapped(), staging_sort.data(), sort_size * sizeof(SortEntry));
+}
 
-    dynamic_count_ = count;
+// Helper: encode a single Gaussian into GpuGaussian layout.
+static void encode_gaussian(const Gaussian& src, GpuGaussian& dst) {
+    float bone_f;
+    uint32_t bi = src.bone_index;
+    std::memcpy(&bone_f, &bi, sizeof(float));
+    dst.pos_opacity = glm::vec4(src.position, src.opacity);
+    dst.scale_pad   = glm::vec4(src.scale, bone_f);
+    dst.rot         = glm::vec4(src.rotation.x, src.rotation.y,
+                                src.rotation.z, src.rotation.w);
+    dst.color_pad   = glm::vec4(src.color, src.emission);
+}
 
-    // Build GPU data in local buffer, then memcpy to mapped memory
-    std::vector<GpuGaussian> staging(count);
-    for (uint32_t i = 0; i < count; ++i) {
-        float bone_f;
-        uint32_t bi = data[i].bone_index;
-        std::memcpy(&bone_f, &bi, sizeof(float));
-        staging[i].pos_opacity = glm::vec4(data[i].position, data[i].opacity);
-        staging[i].scale_pad = glm::vec4(data[i].scale, bone_f);
-        staging[i].rot = glm::vec4(data[i].rotation.x, data[i].rotation.y,
-                                    data[i].rotation.z, data[i].rotation.w);
-        staging[i].color_pad = glm::vec4(data[i].color, data[i].emission);
+void GsRenderer::set_persistent_dynamics(const Gaussian* data, uint32_t count) {
+    if (count > max_dynamic_count_) {
+        std::fprintf(stderr,
+            "[gs_renderer] set_persistent_dynamics: count=%u exceeds max_dynamic_count=%u; truncating\n",
+            count, max_dynamic_count_);
+        count = max_dynamic_count_;
     }
-    std::memcpy(dynamic_gaussian_ssbo_.mapped(), staging.data(), count * sizeof(GpuGaussian));
+    persistent_dyn_count_ = count;
+    dynamic_count_ = count;  // transient reset; next update_dynamic_gaussians extends it
 
-    // Reinitialize dynamic sort buffers via memcpy
-    auto init_sort_buf = [](Buffer& buf, uint32_t sort_size, uint32_t valid_count) {
-        std::vector<SortEntry> staging_sort(sort_size);
-        for (uint32_t i = 0; i < sort_size; ++i) {
-            staging_sort[i].key = 0xFFFFFFFF;
-            staging_sort[i].index = i < valid_count ? i : 0;
+    if (count > 0) {
+        std::vector<GpuGaussian> staging(count);
+        for (uint32_t i = 0; i < count; ++i) {
+            encode_gaussian(data[i], staging[i]);
         }
-        std::memcpy(buf.mapped(), staging_sort.data(), sort_size * sizeof(SortEntry));
-    };
-    init_sort_buf(dynamic_sort_a_, dynamic_sort_size_, count);
-    init_sort_buf(dynamic_sort_b_, dynamic_sort_size_, count);
+        std::memcpy(dynamic_gaussian_ssbo_.mapped(), staging.data(),
+                    count * sizeof(GpuGaussian));
+    }
+
+    // Reinitialize dynamic sort buffers for the active range [0..count)
+    init_dynamic_sort_buf(dynamic_sort_a_, dynamic_sort_size_, count);
+    init_dynamic_sort_buf(dynamic_sort_b_, dynamic_sort_size_, count);
+
+    std::fprintf(stderr,
+        "[gs_renderer] persistent dynamics uploaded: %u splats (chars+NPCs+PBD-trees)\n",
+        count);
+}
+
+void GsRenderer::update_dynamic_gaussians(const Gaussian* data, uint32_t count) {
+    // count is the TRANSIENT portion (VFX, particles, scene anims). Persistent
+    // prefix lives in indices [0, persistent_dyn_count_) and is preserved.
+    const uint32_t total = persistent_dyn_count_ + count;
+    if (total > max_dynamic_count_) {
+        // Cap the transient portion so total fits.
+        count = (max_dynamic_count_ > persistent_dyn_count_)
+            ? max_dynamic_count_ - persistent_dyn_count_ : 0;
+    }
+    dynamic_count_ = persistent_dyn_count_ + count;
+
+    if (count > 0) {
+        std::vector<GpuGaussian> staging(count);
+        for (uint32_t i = 0; i < count; ++i) {
+            encode_gaussian(data[i], staging[i]);
+        }
+        // Write at offset persistent_dyn_count_ * sizeof(GpuGaussian)
+        auto* dst = static_cast<uint8_t*>(dynamic_gaussian_ssbo_.mapped())
+                    + persistent_dyn_count_ * sizeof(GpuGaussian);
+        std::memcpy(dst, staging.data(), count * sizeof(GpuGaussian));
+    }
+
+    // Reinitialize dynamic sort buffers for active range [0..dynamic_count_)
+    init_dynamic_sort_buf(dynamic_sort_a_, dynamic_sort_size_, dynamic_count_);
+    init_dynamic_sort_buf(dynamic_sort_b_, dynamic_sort_size_, dynamic_count_);
 }
 
 
@@ -2243,9 +2285,11 @@ void GsRenderer::upload_bone_transforms(const glm::mat4* transforms, uint32_t co
     auto* dst = static_cast<glm::mat4*>(bone_ssbo_.mapped());
     std::memcpy(dst, transforms, n * sizeof(glm::mat4));
     bone_count_ = n;
-    // Force static preprocess to re-run so bone skinning is applied.
-    // Without this, Index-Merge skips the preprocess dispatch when camera is static.
-    static_dirty_ = true;
+    // No static_dirty_=true: bone-animated splats now live in the dynamic
+    // buffer (persistent prefix populated by IslandDemoState::on_enter →
+    // gs_renderer.set_persistent_dynamics). The dynamic preprocess runs every
+    // frame and re-applies these bone matrices via gs_preprocess.comp:198-214.
+    // The static buffer holds only terrain — no need to invalidate its sort.
 }
 
 void GsRenderer::clear_bone_transforms() {
@@ -3266,10 +3310,26 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
     // to the previous frame's GPU latency and is worth the diagnostic data.
     if (timestamp_pool_ && timestamps_written_) {
         uint64_t ts[6]{};  // depth_sort_begin/end, tile_sort_begin/end, raster_begin/end
+        const auto t_wait_start = std::chrono::steady_clock::now();
         VkResult ts_result = vkGetQueryPoolResults(
             device_, timestamp_pool_, 0, 6,
             sizeof(ts), ts, sizeof(uint64_t),
             VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
+        const auto t_wait_end = std::chrono::steady_clock::now();
+        const double wait_ms = std::chrono::duration<double, std::milli>(t_wait_end - t_wait_start).count();
+        if (wait_ms > 100.0) {
+            float prev_depth_ms = (ts_result == VK_SUCCESS && ts[1] > ts[0])
+                ? static_cast<float>(ts[1] - ts[0]) * timestamp_period_ns_ / 1e6f : -1.0f;
+            float prev_tile_ms = (ts_result == VK_SUCCESS && ts[3] > ts[2])
+                ? static_cast<float>(ts[3] - ts[2]) * timestamp_period_ns_ / 1e6f : -1.0f;
+            float prev_raster_ms = (ts_result == VK_SUCCESS && ts[5] > ts[4])
+                ? static_cast<float>(ts[5] - ts[4]) * timestamp_period_ns_ / 1e6f : -1.0f;
+            std::fprintf(stderr,
+                "[gs_render/wd/WAIT_SLOW] wait_ms=%.1f prev_depth=%.1fms prev_tile=%.1fms prev_raster=%.1fms "
+                "static=%u dyn=%u total=%u\n",
+                wait_ms, prev_depth_ms, prev_tile_ms, prev_raster_ms,
+                static_count_, dynamic_count_, gaussian_count_);
+        }
         if (ts_result == VK_SUCCESS && ts[5] > ts[4] && ts[3] > ts[2] && ts[1] > ts[0]) {
             float depth_ms = static_cast<float>(ts[1] - ts[0]) * timestamp_period_ns_ / 1e6f;
             float tile_ms  = static_cast<float>(ts[3] - ts[2]) * timestamp_period_ns_ / 1e6f;
@@ -3337,8 +3397,26 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
         vkCmdClearColorImage(cmd, depth_img, VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &range);
 
         // === PBD solver dispatch (before any preprocess) ===
-        // PBD-tagged Gaussians live in the static buffer but need re-preprocessing
-        // every frame since their positions/rotations change continuously.
+        // PBD-tagged gaussians live in the static buffer, but we deliberately do
+        // NOT force static_dirty_=true here. The static depth sort cost
+        // (~2.44M splats with the island scene) is too high to absorb every
+        // frame just to keep tree wind-sway frame-current. Instead the cached
+        // static sort is reused while the camera is stationary; trees freeze
+        // at their last-cached pose between camera-dirty events. Wind sway
+        // becomes visible whenever the camera moves (which arms
+        // `set_static_dirty(true)` upstream in Renderer::record_gs_prepass and
+        // re-runs static preprocess + sort, picking up the current
+        // pbd_state_ssbo_ contents).
+        //
+        // The PBD solver compute dispatch below still runs every frame to keep
+        // pbd_state_ssbo_ current — without that the rotation values trees
+        // pick up at the next camera move would themselves be stale.
+        //
+        // Trade-off accepted: stationary trees while camera is still vs.
+        // eliminating a per-frame 100-200ms (foreground) / 5-90s (M5
+        // background-throttled) sort cost that surfaces as a CPU freeze
+        // through vkGetQueryPoolResults's VK_QUERY_RESULT_WAIT_BIT.
+        //
         // Determinism harness: PBD uses a hardcoded 1/60s step rather than
         // the engine dt, so the upstream draw_scene `dt = 0` freeze is not
         // enough — the solver would still advance wind-sway each frame and
@@ -3346,7 +3424,6 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
         // entirely while a Mode-1 test is active so the GPU's pbd_state
         // SSBO retains its pre-test contents.
         if (pbd_count_ > 0 && !determinism_test_active_) {
-            static_dirty_ = true;
             struct {
                 float time;
                 float dt;

--- a/src/engine/gs_vfx.cpp
+++ b/src/engine/gs_vfx.cpp
@@ -154,15 +154,32 @@ void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool 
             if (std::filesystem::exists(ply_path)) {
                 auto cloud = GaussianCloud::load_with_gsvx_first(ply_path);
                 const auto& gs = cloud.gaussians();
-                glm::vec3 offset = position_ + rotated_pos;
-                for (const auto& src : gs) {
-                    Gaussian g = src;
+                // VFX object decimation: cap each VFX object's splat count to
+                // keep the dynamic SSBO budget reasonable. Reusable assets
+                // (e.g. torch.ply at 50k splats) are designed for showcase
+                // rendering, not for being instantiated 20+ times in a single
+                // scene. With kDynamicHeadroom=1M and the dungeon spawning
+                // 23 torch instances, a 50k-per-torch budget would alone
+                // exhaust 1.15M of dynamic capacity. Cap at 8k per instance
+                // (23 × 8k = 188k for the dungeon, well under budget).
+                // Stride-sampling preserves spatial distribution; the visual
+                // difference for a small mesh viewed at distance is minimal.
+                constexpr size_t kMaxVfxObjectSplats = 8192;
+                const size_t total = gs.size();
+                const size_t stride = (total > kMaxVfxObjectSplats)
+                    ? (total + kMaxVfxObjectSplats - 1) / kMaxVfxObjectSplats
+                    : 1;
+                size_t taken = 0;
+                for (size_t i = 0; i < total; i += stride) {
+                    Gaussian g = gs[i];
                     // Rotate Gaussian position around prefab origin, then offset
                     g.position = rotate_y(g.position * el.scale, rot_rad) + position_ + rotated_pos;
                     object_gaussians_.push_back(g);
+                    ++taken;
                 }
-                std::fprintf(stderr, "VFX: Object '%s' loaded %zu Gaussians from %s\n",
-                    el.name.c_str(), gs.size(), el.ply_file.c_str());
+                std::fprintf(stderr,
+                    "VFX: Object '%s' loaded %zu/%zu Gaussians from %s (stride=%zu)\n",
+                    el.name.c_str(), taken, total, el.ply_file.c_str(), stride);
             } else {
                 std::fprintf(stderr, "VFX: Object PLY not found: %s\n", el.ply_file.c_str());
             }

--- a/src/engine/gs_vfx.cpp
+++ b/src/engine/gs_vfx.cpp
@@ -158,13 +158,19 @@ void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool 
                 // keep the dynamic SSBO budget reasonable. Reusable assets
                 // (e.g. torch.ply at 50k splats) are designed for showcase
                 // rendering, not for being instantiated 20+ times in a single
-                // scene. With kDynamicHeadroom=1M and the dungeon spawning
-                // 23 torch instances, a 50k-per-torch budget would alone
-                // exhaust 1.15M of dynamic capacity. Cap at 8k per instance
-                // (23 × 8k = 188k for the dungeon, well under budget).
-                // Stride-sampling preserves spatial distribution; the visual
+                // scene. The dungeon spawns 23 torch instances; at 50k each
+                // they would alone exceed the dynamic budget. The dynamic
+                // depth-sort cost is dominated by sort_size (fixed at init
+                // based on max_dynamic_count_), so reducing actual splat
+                // counts only partially mitigates GPU work — but it does cut
+                // CPU upload bandwidth, projection cost, and overdraw. Cap at
+                // 2k per instance (23 × 2k = 46k for the dungeon). Stride-
+                // sampling preserves spatial distribution; the visual
                 // difference for a small mesh viewed at distance is minimal.
-                constexpr size_t kMaxVfxObjectSplats = 8192;
+                // Authoring fix track (see spec §11.2): reduce dungeon torch
+                // instance count, or replace torch.ply with a smaller asset
+                // (~2k splats) authored for the showcase rendering scale.
+                constexpr size_t kMaxVfxObjectSplats = 2048;
                 const size_t total = gs.size();
                 const size_t stride = (total > kMaxVfxObjectSplats)
                     ? (total + kMaxVfxObjectSplats - 1) / kMaxVfxObjectSplats

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -403,8 +403,10 @@ void Renderer::draw_scene(Scene& scene,
                            const std::vector<DebugColliderDrawInfo>& debug_colliders_list,
                            const FeatureFlags& flags,
                            bool dispatch_gpu_compute) {
+#if GSEURAT_DEBUG_BUILD
     std::fprintf(stderr, "[draw_scene/wd] entry current_frame=%u\n", current_frame_);
     const auto t_ds_entry = std::chrono::steady_clock::now();
+#endif
     auto device = context_.device();
     const auto& frame_sync = sync_.frame(current_frame_);
 
@@ -436,10 +438,12 @@ void Renderer::draw_scene(Scene& scene,
     }
     camera_.update(dt);
 
-    // Watchdog instrumentation for post-load freeze investigation. Mach-port
-    // log signature points at an indefinite main-thread block. Use a finite
-    // timeout to surface which call hangs, then fall back to UINT64_MAX so
-    // the demo doesn't crash on a real (transient) stall.
+#if GSEURAT_DEBUG_BUILD
+    // Watchdog: bounded fence wait + retry, with timing log on stalls. The
+    // diag build uses a 2-second timeout so a real hang surfaces immediately
+    // via the SLOW log; on timeout, retry with UINT64_MAX so the demo keeps
+    // running. Production builds skip this instrumentation and use the plain
+    // UINT64_MAX path.
     constexpr uint64_t kFenceWaitWatchdogNs = 2'000'000'000ull; // 2 sec
     const auto fence_t0 = std::chrono::steady_clock::now();
     VkResult fence_result = vkWaitForFences(device, 1, &frame_sync.in_flight, VK_TRUE,
@@ -477,6 +481,14 @@ void Renderer::draw_scene(Scene& scene,
         std::fprintf(stderr,
             "[renderer/watchdog] vkAcquireNextImageKHR slow: %.2f ms\n", acquire_ms);
     }
+#else
+    vkWaitForFences(device, 1, &frame_sync.in_flight, VK_TRUE, UINT64_MAX);
+
+    uint32_t image_index;
+    auto acquire_sem = sync_.acquire_semaphore(acquire_semaphore_index_);
+    vkAcquireNextImageKHR(device, swapchain_.swapchain(), UINT64_MAX, acquire_sem,
+                          VK_NULL_HANDLE, &image_index);
+#endif
     acquire_semaphore_index_ =
         (acquire_semaphore_index_ + 1) % sync_.acquire_semaphore_count();
 
@@ -495,9 +507,13 @@ void Renderer::draw_scene(Scene& scene,
     // records acquire barriers into `cmd` so subsequent GS compute reads
     // see fully-uploaded slabs. Must run before any pipeline that consumes
     // the slab buffers, including `record_gs_prepass`.
+#if GSEURAT_DEBUG_BUILD
     const auto t_ds_pre_poll = std::chrono::steady_clock::now();
+#endif
     gs_renderer_.poll_transfers(cmd);
+#if GSEURAT_DEBUG_BUILD
     const auto t_ds_post_poll = std::chrono::steady_clock::now();
+#endif
 
     // Forward post-process params to GS pipeline before GS compute runs
     {
@@ -572,9 +588,13 @@ void Renderer::draw_scene(Scene& scene,
         gs_renderer_.set_post_process_params(gs_pp);
     }
 
+#if GSEURAT_DEBUG_BUILD
     const auto t_ds_pre_prepass = std::chrono::steady_clock::now();
+#endif
     record_gs_prepass(cmd, device, dt, flags, dispatch_gpu_compute);
+#if GSEURAT_DEBUG_BUILD
     const auto t_ds_post_prepass = std::chrono::steady_clock::now();
+#endif
 
     // ===== Pass 1: Scene render pass (offscreen HDR) =====
     {
@@ -772,9 +792,13 @@ void Renderer::draw_scene(Scene& scene,
         post_process_.update_light_glow(context_.allocator(), glow);
     }
 
+#if GSEURAT_DEBUG_BUILD
     const auto t_ds_pre_pp = std::chrono::steady_clock::now();
+#endif
     post_process_.record_post_process(cmd, image_index, pp_params);
+#if GSEURAT_DEBUG_BUILD
     const auto t_ds_post_pp = std::chrono::steady_clock::now();
+#endif
 
     record_gs_blit(cmd, flags);
     // Light glow is now rendered via the UI system in GsDemoState
@@ -795,9 +819,13 @@ void Renderer::draw_scene(Scene& scene,
                                 swapchain_.extent(), context_.allocator());
     }
 
+#if GSEURAT_DEBUG_BUILD
     const auto t_ds_pre_end = std::chrono::steady_clock::now();
+#endif
     vkEndCommandBuffer(cmd);
+#if GSEURAT_DEBUG_BUILD
     const auto t_ds_post_end = std::chrono::steady_clock::now();
+#endif
 
     auto render_done_sem = sync_.render_finished_semaphore(image_index);
 
@@ -812,11 +840,15 @@ void Renderer::draw_scene(Scene& scene,
     submit.signalSemaphoreCount = 1;
     submit.pSignalSemaphores = &render_done_sem;
 
+#if GSEURAT_DEBUG_BUILD
     const auto t_ds_pre_submit = std::chrono::steady_clock::now();
+#endif
     if (vkQueueSubmit(context_.graphics_queue(), 1, &submit, frame_sync.in_flight) != VK_SUCCESS) {
         throw std::runtime_error("Failed to submit draw command buffer");
     }
+#if GSEURAT_DEBUG_BUILD
     const auto t_ds_post_submit = std::chrono::steady_clock::now();
+#endif
 
     // Screenshot readback: wait for GPU, swizzle BGRA→RGBA, write PNG
     if (screenshot_requested) {
@@ -909,8 +941,11 @@ void Renderer::draw_scene(Scene& scene,
     present.pSwapchains = &sc;
     present.pImageIndices = &image_index;
 
+#if GSEURAT_DEBUG_BUILD
     const auto t_ds_pre_present = std::chrono::steady_clock::now();
+#endif
     vkQueuePresentKHR(context_.graphics_queue(), &present);
+#if GSEURAT_DEBUG_BUILD
     const auto t_ds_post_present = std::chrono::steady_clock::now();
 
     const double draw_total_ms = std::chrono::duration<double, std::milli>(
@@ -920,8 +955,6 @@ void Renderer::draw_scene(Scene& scene,
             t_ds_pre_poll - t_ds_entry).count();
         const double poll_ms = std::chrono::duration<double, std::milli>(
             t_ds_post_poll - t_ds_pre_poll).count();
-        const double record_ms = std::chrono::duration<double, std::milli>(
-            t_ds_pre_submit - t_ds_post_poll).count();
         const double submit_ms = std::chrono::duration<double, std::milli>(
             t_ds_post_submit - t_ds_pre_submit).count();
         const double post_submit_to_present_ms = std::chrono::duration<double, std::milli>(
@@ -946,6 +979,7 @@ void Renderer::draw_scene(Scene& scene,
             setup_ms, poll_ms, prepass_ms, prepass_to_pp_ms, post_process_ms, pp_to_end_ms, end_cmdbuf_ms,
             submit_ms, post_submit_to_present_ms, present_ms);
     }
+#endif
 
     current_frame_ = (current_frame_ + 1) % kMaxFramesInFlight;
 }
@@ -1186,8 +1220,10 @@ void Renderer::draw_sprite_pass(VkCommandBuffer cmd,
 void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                                   const FeatureFlags& flags,
                                   bool dispatch_gpu_compute) {
+#if GSEURAT_DEBUG_BUILD
     const auto t_prepass_start = std::chrono::steady_clock::now();
     uint32_t dbg_dyn_count = 0;
+#endif
     // Adaptive GS budget: converge to target FPS then lock
     if (flags.gs_adaptive_budget && gs_adaptive_budget_ && gs_gaussian_budget_ > 0 && dt > 0.0f) {
         float fps = 1.0f / dt;
@@ -1382,12 +1418,17 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                     count = gs_renderer_.max_dynamic_count();
                 }
                 gs_renderer_.update_dynamic_gaussians(gs_dynamic_buffer_.data(), count);
+#if GSEURAT_DEBUG_BUILD
                 dbg_dyn_count = count;
+#endif
             }
         }
 
+#if GSEURAT_DEBUG_BUILD
         const auto t_prepass_pre_render = std::chrono::steady_clock::now();
+#endif
         gs_renderer_.render(cmd, current_frame_, gs_view_, gs_proj_);
+#if GSEURAT_DEBUG_BUILD
         const auto t_prepass_end = std::chrono::steady_clock::now();
 
         const double total_ms = std::chrono::duration<double, std::milli>(
@@ -1405,6 +1446,7 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 total_ms, cpu_gather_ms, gs_render_ms, dbg_dyn_count,
                 emitter_count, vfx_count, gs_static_force_dirty_ ? 1 : 0);
         }
+#endif
     }
 }
 

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstring>
 #include <stdexcept>
 #include <vector>
@@ -402,6 +403,8 @@ void Renderer::draw_scene(Scene& scene,
                            const std::vector<DebugColliderDrawInfo>& debug_colliders_list,
                            const FeatureFlags& flags,
                            bool dispatch_gpu_compute) {
+    std::fprintf(stderr, "[draw_scene/wd] entry current_frame=%u\n", current_frame_);
+    const auto t_ds_entry = std::chrono::steady_clock::now();
     auto device = context_.device();
     const auto& frame_sync = sync_.frame(current_frame_);
 
@@ -433,12 +436,47 @@ void Renderer::draw_scene(Scene& scene,
     }
     camera_.update(dt);
 
-    vkWaitForFences(device, 1, &frame_sync.in_flight, VK_TRUE, UINT64_MAX);
+    // Watchdog instrumentation for post-load freeze investigation. Mach-port
+    // log signature points at an indefinite main-thread block. Use a finite
+    // timeout to surface which call hangs, then fall back to UINT64_MAX so
+    // the demo doesn't crash on a real (transient) stall.
+    constexpr uint64_t kFenceWaitWatchdogNs = 2'000'000'000ull; // 2 sec
+    const auto fence_t0 = std::chrono::steady_clock::now();
+    VkResult fence_result = vkWaitForFences(device, 1, &frame_sync.in_flight, VK_TRUE,
+                                            kFenceWaitWatchdogNs);
+    const auto fence_t1 = std::chrono::steady_clock::now();
+    const double fence_ms = std::chrono::duration<double, std::milli>(fence_t1 - fence_t0).count();
+    if (fence_result == VK_TIMEOUT) {
+        std::fprintf(stderr,
+            "[renderer/watchdog] vkWaitForFences TIMEOUT after %.2f ms (current_frame=%u) — "
+            "main-thread blocked on prior frame's GPU work; retrying with infinite timeout\n",
+            fence_ms, current_frame_);
+        vkWaitForFences(device, 1, &frame_sync.in_flight, VK_TRUE, UINT64_MAX);
+    } else if (fence_ms > 50.0) {
+        std::fprintf(stderr,
+            "[renderer/watchdog] vkWaitForFences slow: %.2f ms (current_frame=%u)\n",
+            fence_ms, current_frame_);
+    }
 
     uint32_t image_index;
     auto acquire_sem = sync_.acquire_semaphore(acquire_semaphore_index_);
-    vkAcquireNextImageKHR(device, swapchain_.swapchain(), UINT64_MAX, acquire_sem, VK_NULL_HANDLE,
-                          &image_index);
+    const auto acquire_t0 = std::chrono::steady_clock::now();
+    VkResult acquire_result = vkAcquireNextImageKHR(device, swapchain_.swapchain(),
+                                                    kFenceWaitWatchdogNs, acquire_sem,
+                                                    VK_NULL_HANDLE, &image_index);
+    const auto acquire_t1 = std::chrono::steady_clock::now();
+    const double acquire_ms = std::chrono::duration<double, std::milli>(acquire_t1 - acquire_t0).count();
+    if (acquire_result == VK_TIMEOUT) {
+        std::fprintf(stderr,
+            "[renderer/watchdog] vkAcquireNextImageKHR TIMEOUT after %.2f ms — "
+            "swapchain image not available; retrying with infinite timeout\n",
+            acquire_ms);
+        vkAcquireNextImageKHR(device, swapchain_.swapchain(), UINT64_MAX, acquire_sem,
+                              VK_NULL_HANDLE, &image_index);
+    } else if (acquire_ms > 50.0) {
+        std::fprintf(stderr,
+            "[renderer/watchdog] vkAcquireNextImageKHR slow: %.2f ms\n", acquire_ms);
+    }
     acquire_semaphore_index_ =
         (acquire_semaphore_index_ + 1) % sync_.acquire_semaphore_count();
 
@@ -457,7 +495,9 @@ void Renderer::draw_scene(Scene& scene,
     // records acquire barriers into `cmd` so subsequent GS compute reads
     // see fully-uploaded slabs. Must run before any pipeline that consumes
     // the slab buffers, including `record_gs_prepass`.
+    const auto t_ds_pre_poll = std::chrono::steady_clock::now();
     gs_renderer_.poll_transfers(cmd);
+    const auto t_ds_post_poll = std::chrono::steady_clock::now();
 
     // Forward post-process params to GS pipeline before GS compute runs
     {
@@ -532,7 +572,9 @@ void Renderer::draw_scene(Scene& scene,
         gs_renderer_.set_post_process_params(gs_pp);
     }
 
+    const auto t_ds_pre_prepass = std::chrono::steady_clock::now();
     record_gs_prepass(cmd, device, dt, flags, dispatch_gpu_compute);
+    const auto t_ds_post_prepass = std::chrono::steady_clock::now();
 
     // ===== Pass 1: Scene render pass (offscreen HDR) =====
     {
@@ -730,7 +772,9 @@ void Renderer::draw_scene(Scene& scene,
         post_process_.update_light_glow(context_.allocator(), glow);
     }
 
+    const auto t_ds_pre_pp = std::chrono::steady_clock::now();
     post_process_.record_post_process(cmd, image_index, pp_params);
+    const auto t_ds_post_pp = std::chrono::steady_clock::now();
 
     record_gs_blit(cmd, flags);
     // Light glow is now rendered via the UI system in GsDemoState
@@ -751,7 +795,9 @@ void Renderer::draw_scene(Scene& scene,
                                 swapchain_.extent(), context_.allocator());
     }
 
+    const auto t_ds_pre_end = std::chrono::steady_clock::now();
     vkEndCommandBuffer(cmd);
+    const auto t_ds_post_end = std::chrono::steady_clock::now();
 
     auto render_done_sem = sync_.render_finished_semaphore(image_index);
 
@@ -766,9 +812,11 @@ void Renderer::draw_scene(Scene& scene,
     submit.signalSemaphoreCount = 1;
     submit.pSignalSemaphores = &render_done_sem;
 
+    const auto t_ds_pre_submit = std::chrono::steady_clock::now();
     if (vkQueueSubmit(context_.graphics_queue(), 1, &submit, frame_sync.in_flight) != VK_SUCCESS) {
         throw std::runtime_error("Failed to submit draw command buffer");
     }
+    const auto t_ds_post_submit = std::chrono::steady_clock::now();
 
     // Screenshot readback: wait for GPU, swizzle BGRA→RGBA, write PNG
     if (screenshot_requested) {
@@ -861,7 +909,43 @@ void Renderer::draw_scene(Scene& scene,
     present.pSwapchains = &sc;
     present.pImageIndices = &image_index;
 
+    const auto t_ds_pre_present = std::chrono::steady_clock::now();
     vkQueuePresentKHR(context_.graphics_queue(), &present);
+    const auto t_ds_post_present = std::chrono::steady_clock::now();
+
+    const double draw_total_ms = std::chrono::duration<double, std::milli>(
+        t_ds_post_present - t_ds_entry).count();
+    if (draw_total_ms > 100.0) {
+        const double setup_ms = std::chrono::duration<double, std::milli>(
+            t_ds_pre_poll - t_ds_entry).count();
+        const double poll_ms = std::chrono::duration<double, std::milli>(
+            t_ds_post_poll - t_ds_pre_poll).count();
+        const double record_ms = std::chrono::duration<double, std::milli>(
+            t_ds_pre_submit - t_ds_post_poll).count();
+        const double submit_ms = std::chrono::duration<double, std::milli>(
+            t_ds_post_submit - t_ds_pre_submit).count();
+        const double post_submit_to_present_ms = std::chrono::duration<double, std::milli>(
+            t_ds_pre_present - t_ds_post_submit).count();
+        const double present_ms = std::chrono::duration<double, std::milli>(
+            t_ds_post_present - t_ds_pre_present).count();
+        const double prepass_ms = std::chrono::duration<double, std::milli>(
+            t_ds_post_prepass - t_ds_pre_prepass).count();
+        const double prepass_to_pp_ms = std::chrono::duration<double, std::milli>(
+            t_ds_pre_pp - t_ds_post_prepass).count();
+        const double post_process_ms = std::chrono::duration<double, std::milli>(
+            t_ds_post_pp - t_ds_pre_pp).count();
+        const double pp_to_end_ms = std::chrono::duration<double, std::milli>(
+            t_ds_pre_end - t_ds_post_pp).count();
+        const double end_cmdbuf_ms = std::chrono::duration<double, std::milli>(
+            t_ds_post_end - t_ds_pre_end).count();
+        std::fprintf(stderr,
+            "[draw_scene/wd/SLOW] frame=%u total=%.1fms "
+            "setup=%.1f poll_xfers=%.1f gs_prepass=%.1f scene_pass=%.1f post_process=%.1f composite=%.1f end_cmdbuf=%.1f "
+            "submit=%.1f post_submit=%.1f present=%.1f\n",
+            current_frame_, draw_total_ms,
+            setup_ms, poll_ms, prepass_ms, prepass_to_pp_ms, post_process_ms, pp_to_end_ms, end_cmdbuf_ms,
+            submit_ms, post_submit_to_present_ms, present_ms);
+    }
 
     current_frame_ = (current_frame_ + 1) % kMaxFramesInFlight;
 }
@@ -1102,6 +1186,8 @@ void Renderer::draw_sprite_pass(VkCommandBuffer cmd,
 void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                                   const FeatureFlags& flags,
                                   bool dispatch_gpu_compute) {
+    const auto t_prepass_start = std::chrono::steady_clock::now();
+    uint32_t dbg_dyn_count = 0;
     // Adaptive GS budget: converge to target FPS then lock
     if (flags.gs_adaptive_budget && gs_adaptive_budget_ && gs_gaussian_budget_ > 0 && dt > 0.0f) {
         float fps = 1.0f / dt;
@@ -1143,12 +1229,19 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             camera_dirty = true;
         }
 
-        // Dynamic Gaussians (particles, VFX, PBD) require the static sort buffers to be
-        // reinitialized each frame via set_static_dirty. Without this, stale sort
-        // buffer state from the previous frame's radix scatter corrupts the merge output.
-        if (!gs_pending_dynamics_.empty() || !gs_particle_emitters_.empty() || !vfx_instances_.empty()) {
-            camera_dirty = true;
-        }
+        // Dynamic presence (particles, VFX, pending dynamic appends) does NOT
+        // imply static-dirty. The renderer's split-tail design keeps static
+        // and dynamic in disjoint regions of `projected` and disjoint slots
+        // of `counts`:
+        //   projected[0 .. max_static_count)         — static, gated on static_dirty_
+        //   projected[max_static_count .. +dynamic)  — dynamic, written every frame
+        //   counts[0]=static_visible, counts[1]=dynamic_visible, counts[2]=merged
+        // Phase 1 (dynamic preprocess+sort) and Phase 2 (static preprocess+sort)
+        // touch disjoint regions; Phase 3 (merge) reads both and is re-run every
+        // frame, so dropping the static rebuild while a VFX is alive is safe.
+        // PBD-on-static still self-arms `static_dirty_` from inside
+        // GsRenderer::render() because PBD-tagged splats live in the static
+        // buffer and mutate every frame; that path stays.
 
         // Determinism harness: hold the LOD/chunk-gather selection across
         // frames so the pre-sort input set itself is bit-identical. Any
@@ -1289,10 +1382,29 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                     count = gs_renderer_.max_dynamic_count();
                 }
                 gs_renderer_.update_dynamic_gaussians(gs_dynamic_buffer_.data(), count);
+                dbg_dyn_count = count;
             }
         }
 
+        const auto t_prepass_pre_render = std::chrono::steady_clock::now();
         gs_renderer_.render(cmd, current_frame_, gs_view_, gs_proj_);
+        const auto t_prepass_end = std::chrono::steady_clock::now();
+
+        const double total_ms = std::chrono::duration<double, std::milli>(
+            t_prepass_end - t_prepass_start).count();
+        if (total_ms > 100.0) {
+            const double cpu_gather_ms = std::chrono::duration<double, std::milli>(
+                t_prepass_pre_render - t_prepass_start).count();
+            const double gs_render_ms = std::chrono::duration<double, std::milli>(
+                t_prepass_end - t_prepass_pre_render).count();
+            const size_t emitter_count = gs_particle_emitters_.size();
+            const size_t vfx_count = vfx_instances_.size();
+            std::fprintf(stderr,
+                "[gs_prepass/wd/SLOW] total=%.1fms cpu_gather=%.1f gs_render=%.1f "
+                "dyn_count=%u emitters=%zu vfx_inst=%zu static_dirty=%d\n",
+                total_ms, cpu_gather_ms, gs_render_ms, dbg_dyn_count,
+                emitter_count, vfx_count, gs_static_force_dirty_ ? 1 : 0);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Eliminates the post-load CPU freeze (5-90 s per frame) by partitioning bone-animated/PBD-tagged splats out of the static buffer into a "persistent prefix" of the dynamic SSBO. Static is now terrain-only and is depth-sorted once per camera move, not every frame.
- Fixes a racy CPU-side dynamic sort buffer init that caused chars/NPCs/PBD-tagged splats to flicker (appear for "a few frames" then vanish). The init now runs GPU-side via `vkCmdFillBuffer` inside the per-frame command buffer.
- Caps VFX object PLY loads (e.g. `torch.ply`) to a sane per-instance splat count via stride-sampling, so reusable showcase assets can't single-handedly exhaust the dynamic budget when instantiated many times.

## Background

The original symptom was a post-load freeze with `IMKCFRunLoopWakeUpReliable` mach-port warnings in the macOS log. Watchdog instrumentation (added in this branch, kept for now) traced the block to `vkGetQueryPoolResults` with `VK_QUERY_RESULT_WAIT_BIT` at `gs_renderer.cpp:3269`, which surfaced 5-90 s GPU stalls as CPU waits. The GPU stall was a per-frame full 2.44M-splat depth sort, triggered by three setters that all forced `static_dirty_=true` every frame because their tagged splats (PBD trees, animated chars/NPCs) lived in the static buffer:

- PBD path at `gs_renderer.cpp:3349` (12 trees)
- `upload_bone_transforms` at `gs_renderer.cpp:2248` (player + NPCs)
- `set_actor_rotation` at `gs_renderer.hpp:263` (player rotation)

After three rounds of design (Option A → C → A revisited with a key data-layout fact about separate PLY files), Option A landed: a true split-tail design where dynamic splats are partitioned by `bone_index` at scene load.

Spec doc with full design, postmortem, and follow-ups: `docs/superpowers/specs/2026-05-09-upfront-merge-single-init-gs-design.md`.

## What's in this PR

| Commit | What |
|---|---|
| `dbee74ec` | Spec doc + Option-A postmortem (history of the rejected hypotheses) |
| `89332f09` | §A/§B merge before single `init_gs` — architectural cleanup (single init_gs, single chunk in active_chunks_, no double `clear_chunks`) |
| `87422f4a` | Split-tail by `bone_index`: terrain → static, chars/NPCs/PBD-tagged → dynamic. `kDynamicHeadroom` 262144→1048576. New `GsRenderer::set_persistent_dynamics(data, count)` API. Removed `static_dirty_=true` from PBD path, `upload_bone_transforms`, `set_actor_rotation`. |
| `e72e9bc1` | GPU-side dynamic sort buffer init via `vkCmdFillBuffer` (eliminates persistent-dynamic flicker race). Stride-sample VFX object PLYs at 8k splats/instance. |
| `f29e21ec` | Tighten VFX cap 8k → 2k. Log three follow-ups in spec §11. |

Plus watchdog instrumentation in `Renderer::draw_scene`, `AppBase` main loop, and `GsRenderer::render`. It self-silences when frames are healthy (only fires on >100 ms stalls), but produces phase-tracking logs every frame for incident triage. **Spec §11.3 covers options for removing/gating these before final merge.**

## Test plan

Manual M5 validation (per project memory — no automated harness):

- [x] Build clean: `cmake --build build/macos-release-with-diag --target gseurat_demo` — no errors.
- [x] Demo startup: world renders. Confirm `[IslandDemo] Partition for split-tail: static=1698939 persistent_dyn=742573 (total=2441512)` log line.
- [x] Static sort behavior: stationary camera in overworld does not trigger per-frame `[gs_render/wd/WAIT_SLOW]` floods. (User-validated.)
- [x] Persistent dynamic rendering: characters, NPCs, PBD-tagged tree leaves render stably (no flicker). (User-validated post `vkCmdFillBuffer` fix.)
- [x] VFX rendering: chimney_smoke, torches, etc. visible. (User-validated.)
- [x] Watchdog instrumentation: log lines visible, `[*/wd/SLOW]` lines only on actual stalls.
- [ ] Dungeon scene: walk through dungeon portal — see spec §11.2. Currently still degraded due to 23 torch instances overloading the GPU even at 2k splats each; per-instance count is reduced from 50k → 2k but the architecturally fixed dynamic sort_size (=1M) means cost is still proportional to capacity, not actual count. Follow-up either as content fix (reduce torch count in `dungeon.json`) or engine fix (adaptive sort sizing).

## Known follow-ups (spec §11)

1. **§11.1 Render→blank oscillation**: pre-existing visual flicker, distinct from the freeze we fixed. The watchdog confirmed the per-frame loop iterates steadily, so it's not a CPU hang. Worth investigating in a fresh context — start by frame-diffing two consecutive composite outputs.
2. **§11.2 Dungeon torch overload**: three options ranked, cheapest is demo content fix.
3. **§11.3 Watchdog removal/gating**: decide before this merges to main. Recommendation: wrap unconditional phase logs in `#ifdef GSEURAT_FRAME_WATCHDOG`, keep `*SLOW*` logs (silent under healthy conditions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)