### PR TITLE
fix(engine): cross-frame SSBO race — per-frame compute buffers + Option A

### DIFF
--- a/docs/superpowers/issues/onesweep_status_double_buffering_hang.md
+++ b/docs/superpowers/issues/onesweep_status_double_buffering_hang.md
@@ -1,0 +1,123 @@
+# Onesweep Status Buffer — Cross-Frame Race + Failed Per-Framing Attempt
+
+**Status:** Known residual issue. Tech debt.
+**Branch where it was discovered:** `fix/cross-frame-ssbo-race` (commit `354479b0`, reverted at `8251f05c`)
+**Severity:** Low — visual symptom is currently absent / hidden by the post-Option-A dynamic tail size, but the race is real on paper and may resurface if the dynamic count grows.
+
+## Summary
+
+The cross-frame race fix on `fix/cross-frame-ssbo-race` converts the GS compute pipeline's per-frame SSBOs and descriptor sets to `std::array<…, kMaxFramesInFlight>`. Two buffers were deferred from Phase 3 and addressed in a follow-up commit (Phase 3.6):
+
+- `onesweep_status_` — tile-sort lookback status buffer
+- `depth_onesweep_status_` — depth-sort lookback status buffer
+
+Both are filled (`vkCmdFillBuffer`) at the start of every per-frame compute dispatch (`dispatch_tile_sort`, `dispatch_depth_onesweep`) and read by the same dispatch's lookback radix sort. On paper the race is real:
+
+> With `kMaxFramesInFlight=2`, cmdbuf N+1's `vkCmdFillBuffer` on the same single-instance status buffer can stomp cmdbuf N's still-in-progress lookback state on the GPU. Submission order applies to start-of-batch only — pipeline stages can overlap across batches on the same queue.
+
+Phase 3.6 attempted the obvious fix: per-frame both status buffers and bind slot `[frame_in_flight]` from the relevant dispatches.
+
+**It made things visibly worse.** Reverted at `8251f05c`. This document records what was tried, the regression symptom, and the candidate root causes for a future fix attempt.
+
+## What Phase 3.6 changed (the reverted diff)
+
+`include/gseurat/engine/gs_renderer.hpp` (+37 / -19) and `src/engine/gs_renderer.cpp` (+122 / -52). The mechanical changes:
+
+1. **Buffer field promotion:**
+   - `Buffer onesweep_status_` → `std::array<Buffer, kMaxFramesInFlight> onesweep_statuses_`
+   - `Buffer depth_onesweep_status_` → `std::array<Buffer, kMaxFramesInFlight> depth_onesweep_statuses_`
+
+2. **Create / destroy / `vkCmdFillBuffer`:** wrapped or routed through `[frame_in_flight]` per the established pattern from Phases 1–3.5.
+
+3. **`dispatch_depth_onesweep` signature change:** added a `uint32_t frame_in_flight` parameter and threaded it through both call sites in `render()` (static depth sort dispatch at the `static_dirty_frames_remaining_ > 0` branch, dynamic depth sort dispatch on the per-frame path).
+
+4. **Static-depth descriptor set promotion:** promoted `static_depth_hist_set_a_/b_` and `static_depth_scatter_set_ab_/ba_` from single `VkDescriptorSet` to `std::array<…, kMaxFramesInFlight>`. The rationale: these sets bind `depth_onesweep_statuses_[f]` (newly per-frame), so the sets themselves must also be per-frame. `static_sort_a_/b_` (the buffers these sets *also* bind) were left single-instance per the existing "GPU-fenced via `static_dirty_`" claim.
+
+5. **Pool capacity bump:** `maxSets` 232 → 236 (+4 for the 4 new per-frame static-depth sets).
+
+6. **`layouts[]` allocation slot extension:** 4 new entries at indices 54–57 for the static-depth `[1]` slots, with `kSetCount` 54 → 58.
+
+7. **Obsolete-comment scrub:** removed the "stays single-instance" comments at the previously-deferred sites in `update_descriptors`.
+
+Build was clean. Vulkan validation layer (`macos-debug` build) reported **zero** `SYNC-HAZARD-*` warnings.
+
+## Observed symptom (the regression)
+
+Visual diagnosis via Game Director consecutive screenshots, 15-shot batch with 0.3 s pacing:
+
+| Branch tip | Screenshot count at full-swapchain resolution (~410 KB, identified by sampling as the engine's "WARMING UP / PREPARING SCENE" loading overlay) |
+|---|---|
+| Phase 3.5 (`506af492`, post-revert) | 3 / 15 |
+| Phase 3.6 (`354479b0`, applied) | 14 / 15 |
+
+That is, with Phase 3.6 applied the engine essentially never reached the **Playing** state of `EngineLoadingMonitor` during the screenshot window — it stayed in **Loading** or **Warming**, with the overlay drawn on top. With Phase 3.6 reverted, the engine reached Playing immediately and stayed there.
+
+The user's Mac WindowServer also crashed mid-test on one of the Phase 3.6 runs (one of two restarts experienced during this branch's validation cycle); we cannot rule out that Phase 3.6's specific GPU pattern is what triggered the WindowServer watchdog, though Phase 3.5 alone has not reproduced that crash.
+
+## Why the simple "race fix" failed — candidate hypotheses
+
+Each of the following is a plausible root cause; none have been confirmed. Listed roughly in order of expected likelihood.
+
+### H1. Static-depth-sort timing-coupling broke when its buffer was per-framed
+
+Before Phase 3.6, the static depth sort wrote to `static_sort_a_/b_` (single instance) using a single-instance `depth_onesweep_status_` to coordinate radix-sort workgroups. The `static_dirty_` flow guaranteed the static sort only fired on dirty events, and the *original* `static_dirty_` was a `bool` that ran the sort *once* per cycle.
+
+After Phase 3 (earlier on this same branch) the flag became `static_dirty_frames_remaining_`, counting down from `kMaxFramesInFlight=2`. That means **the static depth sort runs twice in a row** during a dirty cycle, once per per-frame slot — and those two cmdbufs can execute concurrently on the GPU.
+
+With `depth_onesweep_status_` still single-instance through Phase 3.5, this was the still-racing scenario Phase 3.6 was supposed to fix. But:
+
+- `static_sort_a_/b_` themselves remained single-instance in Phase 3.6 (the implementer's comment claimed they were "GPU-fenced via `static_dirty_`").
+- That claim is wrong once the countdown lets two cmdbufs write to `static_sort_a_/b_` in a row.
+- So even with `depth_onesweep_statuses_[f]` properly per-frame, the *output* of the static sort (`static_sort_a_/b_`) can still race across the two countdown frames.
+
+Subsequent merge dispatches read `static_sort_a_` for the merged output, then tile-bin reads merged, etc. If the static-sort write races, downstream reads see corrupt data.
+
+This would explain why Phase 3.6 didn't fix the visual issue — but not directly why the engine got stuck in **Loading** / **Warming**. See H2 / H3 for that.
+
+### H2. `LoadingMonitor` arming depends on a status the depth sort indirectly controls
+
+`EngineLoadingMonitor` transitions `Loading → Warming → Playing` based on `TransferQueue::Handle` completion tracked via `begin_load(handles)`. The handles tracked are the slab uploads from `load_cloud_async`. None of them are directly tied to the depth sort or onesweep status buffers.
+
+However, the transition is gated by **`should_dispatch_gpu_work() = state_ != Loading`**, and the *Warming* phase counts down `kMaxWarmupFrames` of actual GPU dispatches. If Phase 3.6 introduced a GPU stall — for example a deadlock inside an onesweep dispatch due to a corrupt status buffer — the warmup-frame counter would stall too. The engine would never reach Playing.
+
+The screenshot evidence is consistent with this: the engine stayed in a state where `should_overlay_loading_ui() == true`, i.e. **`Loading` or `Warming`**, not Playing.
+
+### H3. `depth_onesweep_max_wg_` is computed once and shared across slots
+
+The status-buffer fill size is `num_sort_passes_ × 256 × depth_onesweep_max_wg_ × sizeof(uint32_t)`. Both per-frame slots are sized from the same `depth_onesweep_max_wg_`. If `depth_onesweep_max_wg_` is recomputed when the static or dynamic sort sizes change (which they do mid-load), there could be a window where the per-frame status buffer slot is the wrong size — too small for the active dispatch's workgroup count — producing OOB writes that corrupt VRAM and hang.
+
+Worth checking: when is `depth_onesweep_max_wg_` set, and does it get recomputed after `set_persistent_dynamics` / `update_active_gaussians` (which change dynamic counts)?
+
+### H4. Descriptor-pool sizing was just-barely-sufficient under static + dynamic depth promotion
+
+Phase 3.6's pool bump was modest (+4 `maxSets`, no `STORAGE_BUFFER` increase). The Phase 3.6 implementer noted "STORAGE_BUFFER 416 — plenty of headroom — the new 4 sets need ~12 storage-buffer slots." That's true on paper, but if any pool consumer outside the listed sets (e.g. some on-the-fly per-frame descriptor allocation elsewhere) raised the actual count, allocation could silently fail at runtime and produce broken descriptor sets. `vkAllocateDescriptorSets` would `VK_ERROR_OUT_OF_POOL_MEMORY`; the implementer didn't add a check for that error code on the new allocation path, so a silent failure is possible.
+
+### H5. MoltenVK / Apple TBDR specifics
+
+Stderr shows `[vk_context] No dedicated transfer queue; using graphics queue fallback` and `Apple M5 (vendor 0x106B) [Apple — TBDR]`. The single graphics+compute+transfer queue means every cmdbuf submission goes through one queue. On a TBDR with aggressive tile reordering, the timing characteristics of cross-cmdbuf compute can differ from desktop discrete GPUs in ways the Vulkan validation layer doesn't model. We have no validation-layer signal, no PIX trace, no GPU debug capture to confirm or rule out a MoltenVK-specific scheduling issue.
+
+## What the next attempt should investigate
+
+In rough order of cost-to-investigate vs. payoff:
+
+1. **First check H3:** add an assertion that the per-frame `depth_onesweep_statuses_[f]` buffer size matches the actual dispatch's workgroup count at fill time. If the assertion fires, the size is the issue.
+
+2. **Add a `VkResult` check on the Phase 3.6 pool allocation** to rule out H4.
+
+3. **Promote `static_sort_a_/b_` to per-frame** (`std::array<Buffer, kMaxFramesInFlight>`) as part of any re-attempt, on the theory that the `static_dirty_frames_remaining_=kMaxFramesInFlight` countdown means two cmdbufs really do write to it concurrently (H1). This will require also updating the merge / tile / etc. sets to bind the per-frame static sort slot. Substantial diff.
+
+4. **Add GPU-side serialization** as a fallback diagnostic: wrap the static depth sort dispatch in a `vkCmdPipelineBarrier(ALL_COMMANDS → ALL_COMMANDS)` to force serial execution and see if the hang goes away. If yes, the issue is GPU concurrency; if no, the issue is something else (descriptor staleness, allocation failure, etc.).
+
+5. **Capture a Vulkan GPU dump** (RenderDoc or Xcode Frame Capture). The validation layer is the wrong tool here — it didn't catch the race in the first place. A captured frame would show the actual dispatch order and any descriptor-set staleness.
+
+## What we shipped instead
+
+`fix/cross-frame-ssbo-race` ships the race-fix work *up to Phase 3.5* (commit `506af492`), with Phase 3.6 reverted (`8251f05c`) and Phase 4 (`496cafc9`) cleaning up the now-obsolete static-PBD trade-off comments. The observed visual improvement vs. `origin/main`:
+
+- Pre-branch baseline (every-other-frame blank vignette in steady-state gameplay): **gone**
+- Post-Option-A + Phase 3.5 race-fix tip: **near-zero observed blanks during gameplay**. The few "blank" screenshots in the validation batch were the **WARMING UP / PREPARING SCENE** loading overlay at full swapchain resolution, not actual blank GS output.
+- Long ≥1 s `vkQueueSubmit` stalls observed in pre-branch watchdog traces: not reproduced post-branch.
+
+The residual `onesweep_status_` / `depth_onesweep_status_` race is real but apparently not visually disruptive at current dynamic-tail sizes (with Option A + dungeon-torch cap, steady-state dynamic count is ~450 k, well under both the 1 MiB `kDynamicHeadroom` and whatever buffer-size threshold makes the race observable).
+
+If a future scene pushes the dynamic count higher, the flicker may re-emerge from this race, and this document is the entry point for fixing it then.

--- a/docs/superpowers/plans/2026-05-11-cross-frame-ssbo-race-fix.md
+++ b/docs/superpowers/plans/2026-05-11-cross-frame-ssbo-race-fix.md
@@ -1,0 +1,772 @@
+# Cross-Frame SSBO Race Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the every-other-frame blank swapchain image by per-frame double-buffering the compute SSBOs that feed the (already per-frame) GS output images, then restore Option A by routing PBD + characters into the dynamic tail, and content-fix the dungeon scene so its torches stop overflowing the dynamic headroom.
+
+**Architecture:** Convert single-instance `Buffer X_ssbo_` fields to `std::array<Buffer, kMaxFramesInFlight>`, and the matching compute descriptor sets to per-frame arrays. The dispatch path (already receiving `frame_in_flight`) binds the per-frame set / buffer per frame. Static-tail buffers stay single-instance (they only mutate on `static_dirty_=true`, which is GPU-fenced). Per-frame intermediate images and their render/post-process descriptor sets are already per-frame and need no allocation change — only re-binding to the per-frame compute buffers.
+
+**Tech Stack:** C++23, Vulkan 1.4 (MoltenVK on M5), CMake (`macos-release`, `macos-release-with-diag`, `macos-debug` presets), Game Director (Python over Unix socket).
+
+**Spec:** `docs/superpowers/specs/2026-05-11-cross-frame-ssbo-race-fix-design.md` (commit `6b62fe90`).
+
+**Branch:** `fix/cross-frame-ssbo-race` (already created off `origin/main`, spec already committed).
+
+---
+
+## File Structure
+
+Almost all engine changes live in two files. Demo and content changes are isolated to Phases 4–5.
+
+| File | Phases | Role |
+|---|---|---|
+| `include/gseurat/engine/gs_renderer.hpp` | 1, 2 | Buffer + descriptor set member declarations |
+| `src/engine/gs_renderer.cpp` | 1, 2, 3 | Buffer create/destroy, `update_descriptors`, dispatch routing |
+| `src/demo/island_demo_state.cpp` | 4 | `on_enter` + `perform_portal_transition` cloud partitioning |
+| `assets/scenes/dungeon.json` (or equivalent) | 5 | Torch VFX content reduction |
+
+Shader files (`shaders/gs_*.comp`) are **untouched** — binding indices stay the same; only the descriptor-set→buffer wiring changes.
+
+---
+
+## Racing SSBO Inventory (Phase 1 scope)
+
+These single-instance buffers all become `std::array<Buffer, kMaxFramesInFlight>`:
+
+| Buffer | Header line | Factory | Notes |
+|---|---|---|---|
+| `projected_ssbo_` | hpp:445 | `create_storage` | Frustum-cull output |
+| `sort_keys_ssbo_` | hpp:446 | `create_storage` | Legacy depth-sort key A |
+| `sort_b_ssbo_` | hpp:447 | `create_storage` | Legacy depth-sort key B |
+| `visible_count_ssbo_` | hpp:450 | `create_storage_readback` | Atomic counter |
+| `dynamic_sort_a_` | hpp:468 | `create_storage_host_dst` | Dynamic-tail sort A |
+| `dynamic_sort_b_` | hpp:469 | `create_storage_host_dst` | Dynamic-tail sort B |
+| `counts_ssbo_` | hpp:471 | `create_storage_readback` | {static, dyn, merged} counts |
+| `merged_sort_ssbo_` | hpp:445-area | `create_storage` | Per-frame merge output |
+
+Compute descriptor sets that become per-frame (hpp:573–613):
+- `preprocess_set_` → `preprocess_sets_[f]`
+- `sort_set_` → `sort_sets_[f]`
+- `static_preprocess_set_` → `static_preprocess_sets_[f]`
+- `dynamic_preprocess_set_` → `dynamic_preprocess_sets_[f]`
+- Depth-onesweep histogram + scatter sets
+
+`render_sets_[f]` and `post_process_sets_[f]` already exist as per-frame arrays. Their bindings get rewritten to point at the per-frame buffer slot in Phase 2.
+
+---
+
+## Phase 1 — Per-frame storage for racing SSBOs
+
+**Goal:** All listed buffers become per-frame arrays. All accesses temporarily use slot `[0]` so behavior is unchanged. Build succeeds; demo runs identically (still flickers — that's expected, the race fix lands in Phase 3).
+
+### Task 1.1 — Convert buffer declarations to per-frame arrays
+
+**Files:**
+- Modify: `include/gseurat/engine/gs_renderer.hpp:443-471`
+
+- [ ] **Step 1: Update member declarations**
+
+In `include/gseurat/engine/gs_renderer.hpp`, replace each single-instance racing buffer with an array:
+
+```cpp
+// Before
+Buffer projected_ssbo_;
+Buffer sort_keys_ssbo_;
+Buffer sort_b_ssbo_;
+Buffer visible_count_ssbo_;
+Buffer dynamic_sort_a_;
+Buffer dynamic_sort_b_;
+Buffer counts_ssbo_;
+Buffer merged_sort_ssbo_;
+
+// After
+std::array<Buffer, kMaxFramesInFlight> projected_ssbos_{};
+std::array<Buffer, kMaxFramesInFlight> sort_keys_ssbos_{};
+std::array<Buffer, kMaxFramesInFlight> sort_b_ssbos_{};
+std::array<Buffer, kMaxFramesInFlight> visible_count_ssbos_{};
+std::array<Buffer, kMaxFramesInFlight> dynamic_sort_as_{};
+std::array<Buffer, kMaxFramesInFlight> dynamic_sort_bs_{};
+std::array<Buffer, kMaxFramesInFlight> counts_ssbos_{};
+std::array<Buffer, kMaxFramesInFlight> merged_sort_ssbos_{};
+```
+
+Leave `static_gaussian_ssbo_`, `dynamic_gaussian_ssbo_`, `gaussian_ssbo_`, `static_sort_a_`, `static_sort_b_`, `uniform_buffer_`, `bone_ssbo_`, `pbd_*` unchanged.
+
+- [ ] **Step 2: Audit hpp accessors**
+
+`grep -n "visible_count_ssbo_\|counts_ssbo_" include/gseurat/engine/gs_renderer.hpp` returns the host-readback helpers (~hpp:211–216). They read `.mapped()` from the buffer. Update to read slot `[0]` for now — the host-readback path will be revisited if it shows up as a hot path:
+
+```cpp
+// Around hpp:211-216
+if (counts_ssbos_[0].mapped()) {
+    auto* c = static_cast<const uint32_t*>(counts_ssbos_[0].mapped());
+    ...
+}
+if (visible_count_ssbos_[0].mapped())
+    return *static_cast<const uint32_t*>(visible_count_ssbos_[0].mapped());
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+cmake --build build/macos-release-with-diag --target gseurat_demo 2>&1 | tail -20
+```
+
+Expected: many compile errors in `gs_renderer.cpp` referencing the old names. That's the next task.
+
+### Task 1.2 — Update buffer create/destroy in `gs_renderer.cpp`
+
+**Files:**
+- Modify: `src/engine/gs_renderer.cpp:1141-1158` (destroy)
+- Modify: `src/engine/gs_renderer.cpp:1180-1244` (create + sentinel-fill)
+
+- [ ] **Step 1: Wrap creates in a per-frame loop**
+
+Around `src/engine/gs_renderer.cpp:1180` (and 1191-1196, 1243-1244), replace each create call with a loop:
+
+```cpp
+for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+    projected_ssbos_[f]     = Buffer::create_storage(allocator_, projected_buf_size);
+    sort_keys_ssbos_[f]     = Buffer::create_storage(allocator_, static_sort_buf_size);
+    sort_b_ssbos_[f]        = Buffer::create_storage(allocator_, static_sort_buf_size);
+    visible_count_ssbos_[f] = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
+    dynamic_sort_as_[f]     = Buffer::create_storage_host_dst(allocator_, dynamic_sort_buf_size);
+    dynamic_sort_bs_[f]     = Buffer::create_storage_host_dst(allocator_, dynamic_sort_buf_size);
+    counts_ssbos_[f]        = Buffer::create_storage_readback(allocator_, 3 * sizeof(uint32_t));
+    merged_sort_ssbos_[f]   = Buffer::create_storage(allocator_, merged_sort_buf_size);
+}
+```
+
+Preserve the comments at 1181-1192 (TRANSFER_DST_BIT rationale) — move them just above the loop.
+
+- [ ] **Step 2: Per-frame sentinel-fill**
+
+Around `src/engine/gs_renderer.cpp:1207-1237`, wrap the `memset` and `sentinel_fill_sort` calls in the same per-frame loop. `static_gaussian_ssbo_` and `dynamic_gaussian_ssbo_` are NOT per-frame, so their memsets stay outside the loop:
+
+```cpp
+// Outside loop (unchanged)
+std::memset(static_gaussian_ssbo_.mapped(), 0, ...);
+std::memset(dynamic_gaussian_ssbo_.mapped(), 0, ...);
+
+// Inside loop, per slot
+for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+    std::memset(projected_ssbos_[f].mapped(), 0,
+                static_cast<size_t>(max_static_count_ + max_dynamic_count_) * sizeof(ProjectedSplat));
+    sentinel_fill_sort(dynamic_sort_as_[f], dynamic_sort_size_);
+    sentinel_fill_sort(dynamic_sort_bs_[f], dynamic_sort_size_);
+    std::memset(merged_sort_ssbos_[f].mapped(), 0, ...);
+}
+```
+
+Static sort buffers stay outside the loop.
+
+- [ ] **Step 3: Per-frame destroy**
+
+Around `src/engine/gs_renderer.cpp:1141-1158`, wrap the racing-buffer destroys in a per-frame loop. Static / gaussian / uniform destroys stay outside.
+
+```cpp
+for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+    projected_ssbos_[f].destroy(allocator_);
+    sort_keys_ssbos_[f].destroy(allocator_);
+    sort_b_ssbos_[f].destroy(allocator_);
+    visible_count_ssbos_[f].destroy(allocator_);
+    dynamic_sort_as_[f].destroy(allocator_);
+    dynamic_sort_bs_[f].destroy(allocator_);
+    counts_ssbos_[f].destroy(allocator_);
+    merged_sort_ssbos_[f].destroy(allocator_);
+}
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+cmake --build build/macos-release-with-diag --target gseurat_demo 2>&1 | tail -30
+```
+
+Expected: errors only at `update_descriptors`, dispatch sites, and other consumers that still reference the old single-instance names.
+
+### Task 1.3 — Convert remaining consumers in `gs_renderer.cpp` to slot `[0]`
+
+**Files:**
+- Modify: `src/engine/gs_renderer.cpp` — every remaining touch site
+
+- [ ] **Step 1: Locate touch sites**
+
+```bash
+grep -nE "projected_ssbo_\b|sort_keys_ssbo_\b|sort_b_ssbo_\b|visible_count_ssbo_\b|dynamic_sort_a_\b|dynamic_sort_b_\b|counts_ssbo_\b|merged_sort_ssbo_\b" src/engine/gs_renderer.cpp
+```
+
+This is the complete list of remaining single-instance reads/writes.
+
+- [ ] **Step 2: Replace each `X_ssbo_` access with `X_ssbos_[0]`**
+
+For every site — descriptor writes (`update_descriptors`, ~cpp:2310–2545), dispatch buffer-handle reads (cpp:2471, 2613–2642), the post-portal projected-tail zeroing (cpp:1594, 1820), the per-frame `vkCmdFillBuffer` for `dynamic_sort_a/b_` and `counts_ssbo_` inside `render()` (cpp:3484, 3487, 3512–3513).
+
+Use slot `[0]` everywhere. **Do not** index by `frame_in_flight` yet — Phase 3 does that.
+
+Pattern:
+```cpp
+// Before
+projected_ssbo_.buffer()
+// After
+projected_ssbos_[0].buffer()
+
+// Before
+vkCmdFillBuffer(cmd, dynamic_sort_a_.buffer(), 0, dyn_sort_bytes, 0xFFFFFFFFu);
+// After
+vkCmdFillBuffer(cmd, dynamic_sort_as_[0].buffer(), 0, dyn_sort_bytes, 0xFFFFFFFFu);
+```
+
+- [ ] **Step 3: Build clean**
+
+```bash
+cmake --build build/macos-release-with-diag --target gseurat_demo 2>&1 | tail -10
+```
+
+Expected: build succeeds with no errors.
+
+### Task 1.4 — Verify no behavior change
+
+**Acceptance criterion:** Demo runs and looks visually identical to current `main` (still flickers — that's correct, we haven't fixed the race yet).
+
+- [ ] **Step 1: Launch demo (user-side)**
+
+Ask the user to launch:
+```bash
+cd build/macos-release-with-diag && ./gseurat_demo &
+```
+
+- [ ] **Step 2: Confirm demo enters Playing state**
+
+```bash
+sleep 6 && python3 scripts/game_director.py player
+```
+
+Expected: returns coords like `(187, 197)` — confirms socket alive and demo past loading.
+
+- [ ] **Step 3: Capture 8 screenshots**
+
+```bash
+for i in 1 2 3 4 5 6 7 8; do
+  python3 scripts/game_director.py screenshot /tmp/phase1_s$i.png
+done
+```
+
+Expected: blank/rendered alternation still present (we haven't fixed it yet). Confirms behavior unchanged.
+
+- [ ] **Step 4: Quit demo**
+
+```bash
+python3 scripts/game_director.py quit
+```
+
+### Task 1.5 — Phase 1 commit
+
+- [ ] **Step 1: Stage + commit**
+
+```bash
+git add include/gseurat/engine/gs_renderer.hpp src/engine/gs_renderer.cpp
+git commit -m "$(cat <<'EOF'
+refactor(engine): convert racing GS SSBOs to per-frame arrays (storage only)
+
+Phase 1 of cross-frame SSBO race fix. Converts projected, sort_keys,
+sort_b, visible_count, dynamic_sort_a/b, counts, and merged_sort
+buffers from single-instance to std::array<Buffer, kMaxFramesInFlight>.
+All consumers still access slot [0] — no behavior change, no race fix
+yet. Phase 2 introduces per-frame descriptor sets; Phase 3 wires
+frame_in_flight into the dispatch path to actually use the per-frame
+slots.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 2 — Per-frame compute descriptor sets
+
+**Goal:** Compute descriptor sets are arrays of `kMaxFramesInFlight`, with set `[f]` bound to the corresponding `*_ssbos_[f]`. Dispatch still uses set `[0]` — no race fix yet, but the per-frame plumbing is in place.
+
+### Task 2.1 — Descriptor set field arrays
+
+**Files:**
+- Modify: `include/gseurat/engine/gs_renderer.hpp:573-613`
+
+- [ ] **Step 1: Convert descriptor handles to arrays**
+
+```cpp
+// Before
+VkDescriptorSet preprocess_set_ = VK_NULL_HANDLE;
+VkDescriptorSet sort_set_ = VK_NULL_HANDLE;
+VkDescriptorSet static_preprocess_set_ = VK_NULL_HANDLE;
+VkDescriptorSet dynamic_preprocess_set_ = VK_NULL_HANDLE;
+
+// After
+std::array<VkDescriptorSet, kMaxFramesInFlight> preprocess_sets_{};
+std::array<VkDescriptorSet, kMaxFramesInFlight> sort_sets_{};
+std::array<VkDescriptorSet, kMaxFramesInFlight> static_preprocess_sets_{};
+std::array<VkDescriptorSet, kMaxFramesInFlight> dynamic_preprocess_sets_{};
+```
+
+Onesweep histogram/scatter set fields — check `gs_renderer.hpp` for declarations (search for `histogram` / `scatter` / `onesweep`). If they're single-instance, array them too. If they're already per-something else (e.g., per-pass), document and skip — Phase 1 validation will surface any miss via SYNC-HAZARD.
+
+### Task 2.2 — Pool allocation in `gs_renderer.cpp`
+
+**Files:**
+- Modify: `src/engine/gs_renderer.cpp:475-490` (descriptor set allocation)
+- Modify: `src/engine/gs_renderer.cpp` — `create_descriptor_pool` site
+
+- [ ] **Step 1: Allocate `kMaxFramesInFlight` of each compute set**
+
+At cpp:475-490 the current code allocates one set per slot (`sets[0]` = preprocess, `sets[1]` = sort, etc.). Extend the allocation to allocate `kMaxFramesInFlight` of each:
+
+```cpp
+VkDescriptorSetLayout layouts[] = {
+    /* preprocess */         preprocess_layout_, preprocess_layout_,
+    /* sort */               sort_layout_, sort_layout_,
+    /* render */             render_layout_, render_layout_,     // already per-frame
+    /* post_process */       post_process_layout_, post_process_layout_,  // already per-frame
+    /* static_preprocess */  static_preprocess_layout_, static_preprocess_layout_,
+    /* dynamic_preprocess */ dynamic_preprocess_layout_, dynamic_preprocess_layout_,
+    /* tile_render */        tile_render_layout_, tile_render_layout_,  // already per-frame
+    // ... onesweep sets, doubled
+};
+VkDescriptorSet sets[std::size(layouts)] = {};
+... vkAllocateDescriptorSets ...
+
+preprocess_sets_[0] = sets[0];
+preprocess_sets_[1] = sets[1];
+sort_sets_[0]       = sets[2];
+sort_sets_[1]       = sets[3];
+// ... etc
+```
+
+- [ ] **Step 2: Audit `create_descriptor_pool` capacity**
+
+Locate `create_descriptor_pool` (grep `vkCreateDescriptorPool`). The `maxSets` and per-type `descriptorCount` budgets need to absorb the doubled compute-set count. Bump the relevant counts by `kMaxFramesInFlight` factor for the affected pool sizes.
+
+### Task 2.3 — `update_descriptors` writes per-frame sets
+
+**Files:**
+- Modify: `src/engine/gs_renderer.cpp:2310-2545`
+
+- [ ] **Step 1: Wrap each per-set descriptor block in a per-frame loop**
+
+For the preprocess block at cpp:2312-2341, wrap in `for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) { ... }` and:
+- Use `preprocess_sets_[f]` as `dstSet`
+- Bind `projected_ssbos_[f]`, `sort_keys_ssbos_[f]`, `visible_count_ssbos_[f]` as the per-frame buffer infos
+- Single-instance buffers (`gaussian_ssbo_`, `bone_ssbo_`, `pbd_state_ssbo_`, `page_table_ssbo_`, `uniform_buffer_`) keep their existing bindings
+
+Repeat the pattern for:
+- Sort set block (cpp:2344-2353) → `sort_sets_[f]`, `sort_keys_ssbos_[f]`
+- Static preprocess block (cpp:2482-2510) → `static_preprocess_sets_[f]`, per-frame `projected_ssbos_[f]`, `counts_ssbos_[f]`
+- Dynamic preprocess block (cpp:2514-2540) → `dynamic_preprocess_sets_[f]`, per-frame `projected_ssbos_[f]`, `dynamic_sort_as_[f]`, `counts_ssbos_[f]`
+- Onesweep set writes (cpp:2407 onward) — same per-frame pattern
+
+The render set (cpp:2356-2382) and post_process set (cpp:2384-2404) **already** loop over `f` — just update their buffer bindings to use `projected_ssbos_[f]`, `sort_keys_ssbos_[f]`, `visible_count_ssbos_[f]`.
+
+- [ ] **Step 2: Build clean**
+
+```bash
+cmake --build build/macos-release-with-diag --target gseurat_demo 2>&1 | tail -10
+```
+
+Expected: build succeeds. Dispatch sites still bind set `[0]` so behavior is unchanged.
+
+### Task 2.4 — Verify Phase 2 still behaves identically to Phase 1
+
+- [ ] **Step 1: Run demo, screenshot, verify flicker still present**
+
+Same procedure as Task 1.4. Expected: same blank/rendered alternation.
+
+This confirms the per-frame descriptor sets compile and run, with set `[0]` actively producing identical output.
+
+### Task 2.5 — Phase 2 commit
+
+```bash
+git add include/gseurat/engine/gs_renderer.hpp src/engine/gs_renderer.cpp
+git commit -m "$(cat <<'EOF'
+refactor(engine): per-frame descriptor sets for GS compute pipeline
+
+Phase 2 of cross-frame SSBO race fix. preprocess_set_, sort_set_,
+static_preprocess_set_, dynamic_preprocess_set_, and onesweep sets
+become std::array<VkDescriptorSet, kMaxFramesInFlight>. update_descriptors
+writes each per-frame set to its corresponding *_ssbos_[f] slot. The
+descriptor pool capacity is bumped to absorb the doubled compute-set
+count. Dispatch sites still bind set [0]; Phase 3 routes frame_in_flight
+to actually use the per-frame slot.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3 — Wire `frame_in_flight` through dispatch
+
+**Goal:** Each compute dispatch binds set `[frame_in_flight]`. The race is fixed: zero blank frames in screenshot regression. No SYNC-HAZARD warnings in validation layer.
+
+### Task 3.1 — Route `frame_in_flight` into dispatch helpers
+
+**Files:**
+- Modify: `src/engine/gs_renderer.cpp` — `dispatch_gpu_compute`, `dispatch_depth_onesweep`, `dispatch_tile_render`, and any other dispatch helpers in `render()`
+
+- [ ] **Step 1: Audit dispatch sites for `vkCmdBindDescriptorSets` calls binding the racing sets**
+
+```bash
+grep -n "vkCmdBindDescriptorSets\|preprocess_set\|sort_set\|static_preprocess_set\|dynamic_preprocess_set" src/engine/gs_renderer.cpp
+```
+
+For each binding of one of the racing sets, locate the enclosing function and confirm it has access to `frame_in_flight`. `render()` (cpp:3260) already receives `frame_in_flight`; internal helpers usually take `cmd` and read state — they may need a new `uint32_t frame_in_flight` parameter threaded in.
+
+- [ ] **Step 2: Replace `[0]` with `[frame_in_flight]` at every binding**
+
+```cpp
+// Before (after Phase 2)
+vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                        preprocess_pipeline_layout_, 0, 1,
+                        &preprocess_sets_[0], 0, nullptr);
+// After
+vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                        preprocess_pipeline_layout_, 0, 1,
+                        &preprocess_sets_[frame_in_flight], 0, nullptr);
+```
+
+Same pattern for `sort_sets_`, `static_preprocess_sets_`, `dynamic_preprocess_sets_`, onesweep sets.
+
+- [ ] **Step 3: Also route per-frame buffer-handle reads**
+
+A few sites read buffer handles directly (e.g., cpp:2471, 2613, 3484, 3487, 3512-3513 — `vkCmdFillBuffer` against the dynamic sort buffers, `vkCmdCopyBuffer` against merged_sort, etc.). Replace `[0]` with `[frame_in_flight]` at each. The render path already has `frame_in_flight` in scope.
+
+- [ ] **Step 4: Build clean**
+
+```bash
+cmake --build build/macos-release-with-diag --target gseurat_demo 2>&1 | tail -10
+```
+
+### Task 3.2 — Run validation layers (macos-debug build)
+
+**Goal:** Vulkan validation reports zero SYNC-HAZARD warnings.
+
+- [ ] **Step 1: Build with validation**
+
+```bash
+cmake --build build/macos-debug --target gseurat_demo 2>&1 | tail -10
+```
+
+- [ ] **Step 2: Launch the debug demo and watch for SYNC-HAZARD**
+
+```bash
+cd build/macos-debug && ./gseurat_demo 2>&1 | grep -iE "(sync-hazard|SYNC_HAZARD|validation)"
+```
+
+Run for ~30 seconds, then quit. Expected: zero `SYNC-HAZARD-WRITE-AFTER-READ` / `READ-AFTER-WRITE` warnings.
+
+If any appear, identify the buffer they cite and add it to Phase 1's array conversion. Re-run from Task 1.1 with that buffer included.
+
+### Task 3.3 — Visual regression (screenshot test)
+
+- [ ] **Step 1: Launch with-diag demo**
+
+```bash
+cd build/macos-release-with-diag && ./gseurat_demo &
+sleep 6
+python3 scripts/game_director.py player
+```
+
+- [ ] **Step 2: Take 30 screenshots**
+
+```bash
+for i in $(seq 1 30); do
+  python3 scripts/game_director.py screenshot /tmp/phase3_s$i.png
+done
+```
+
+- [ ] **Step 3: Eyeball-scan for blank frames**
+
+Open `/tmp/phase3_s*.png` in Finder Quick Look (Space to preview, arrow keys to walk through). Acceptance: zero frames where the scene is a uniform dark gradient instead of rendered geometry.
+
+- [ ] **Step 4: Quit demo**
+
+```bash
+python3 scripts/game_director.py quit
+```
+
+### Task 3.4 — Watchdog timing check
+
+- [ ] **Step 1: Capture 60 seconds of stderr**
+
+```bash
+cd build/macos-release-with-diag && timeout 60 ./gseurat_demo 2> /tmp/phase3_wd.log
+```
+
+- [ ] **Step 2: Count WAIT_SLOW occurrences**
+
+```bash
+grep -c "WAIT_SLOW" /tmp/phase3_wd.log
+```
+
+Expected: dropped from ~1/30 frames to near-zero, since the GPU is no longer trailing behind the CPU on racing buffers.
+
+### Task 3.5 — Phase 3 commit
+
+```bash
+git add src/engine/gs_renderer.cpp include/gseurat/engine/gs_renderer.hpp
+git commit -m "$(cat <<'EOF'
+fix(engine): route frame_in_flight to GS compute dispatch (cross-frame race fix)
+
+Phase 3 of cross-frame SSBO race fix and the actual flicker fix.
+Compute dispatches now bind preprocess_sets_[frame_in_flight] /
+sort_sets_[frame_in_flight] / static_preprocess_sets_[f] /
+dynamic_preprocess_sets_[f] / onesweep_sets_[f], routing each
+in-flight frame to its own per-frame compute SSBOs. Frame N+1's
+preprocess no longer clobbers projected/sort_keys/visible_count
+that frame N's tile-render is still reading on the GPU.
+
+Validation: 30 consecutive Game Director screenshots show zero
+blank frames; macos-debug validation layer reports zero SYNC-HAZARD
+warnings; watchdog WAIT_SLOW occurrences dropped to near-zero.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4 — Restore Option A (PBD + characters into dynamic tail)
+
+**Goal:** PBD-tagged splats and character/NPC bone-animated splats live in the dynamic tail. Static cloud retains only terrain + props. The "PBD lives in static, don't dirty per-frame" trade-off is removed since PBD now lives in the cheaply re-sortable per-frame dynamic.
+
+### Task 4.1 — Locate current partition logic
+
+**Files:**
+- Modify: `src/demo/island_demo_state.cpp:346–410` (on_enter §A partition) and `src/demo/island_demo_state.cpp:2200–2280` (perform_portal_transition partition)
+
+- [ ] **Step 1: Read current partition**
+
+```bash
+grep -n "bone_index\|persistent_dynamics\|set_persistent_dynamics" src/demo/island_demo_state.cpp
+```
+
+Currently the partition is "bone_index > 0 → dynamic" with PBD-tagged splats (bone_index ∈ [32,63]) staying in the static cloud per the comment at gs_renderer.cpp:3411–3429. Phase 4 changes the partition to also route PBD-tagged into dynamic.
+
+### Task 4.2 — Update partition predicate to include PBD-tagged
+
+- [ ] **Step 1: Modify `on_enter` partition**
+
+In `src/demo/island_demo_state.cpp`'s on_enter §A partition (post-§A merge), change the predicate routing splats into `persistent_dynamics_pending` from "bone_index ∈ [1,31]" to "bone_index ∈ [1,63]" (i.e., any non-zero bone_index goes dynamic):
+
+```cpp
+// Before (pseudocode of current pattern)
+for (const Gaussian& g : merged) {
+    if (g.bone_index == 0) static_cloud.push_back(g);
+    else if (g.bone_index >= 1 && g.bone_index <= 31)
+        persistent_dynamics_pending.push_back(g);  // bone-animated → dynamic
+    // PBD-tagged [32,63] currently falls through to static
+}
+
+// After
+for (const Gaussian& g : merged) {
+    if (g.bone_index == 0) static_cloud.push_back(g);
+    else persistent_dynamics_pending.push_back(g);  // any non-zero → dynamic
+}
+```
+
+- [ ] **Step 2: Mirror the change in `perform_portal_transition`**
+
+Apply the same predicate update at the post-§B re-merge partition (covers both the re-merge and `skip_phase_b_remerge=true` paths).
+
+### Task 4.3 — Remove the now-obsolete static-PBD trade-off comment
+
+**Files:**
+- Modify: `src/engine/gs_renderer.cpp:3411–3429`
+
+- [ ] **Step 1: Delete the comment block**
+
+The comment block at cpp:3411–3429 documents the old "PBD lives in static, don't dirty per-frame" trade-off. With PBD in the dynamic tail, the trade-off no longer applies — delete the block (and the `static_dirty_=true` discussion). Leave the PBD compute dispatch itself in place; just the explanatory comment goes.
+
+### Task 4.4 — Verify PBD + characters render correctly post-Option-A
+
+- [ ] **Step 1: Launch demo**
+
+```bash
+cd build/macos-release-with-diag && ./gseurat_demo &
+sleep 6
+python3 scripts/game_director.py player
+```
+
+- [ ] **Step 2: Confirm PBD wind sway is visible while camera is stationary**
+
+```bash
+python3 scripts/game_director.py screenshot /tmp/phase4_idle1.png
+sleep 1
+python3 scripts/game_director.py screenshot /tmp/phase4_idle2.png
+```
+
+Expected: the two screenshots show slightly different tree poses (wind sway is animating frame-to-frame). With the old static-PBD trade-off, idle screenshots were pose-identical until the camera moved.
+
+- [ ] **Step 3: Walk to dungeon portal and back**
+
+```bash
+python3 scripts/game_director.py walk forward 3
+python3 scripts/game_director.py screenshot /tmp/phase4_postwalk.png
+```
+
+Expected: character renders correctly through the walk. No flicker. No dynamic-tail overflow warning in stderr (`grep "dynamic.*overflow\|exceeded.*headroom" /tmp/<your-demo-log>`).
+
+- [ ] **Step 4: Quit demo**
+
+```bash
+python3 scripts/game_director.py quit
+```
+
+### Task 4.5 — Phase 4 commit
+
+```bash
+git add src/demo/island_demo_state.cpp src/engine/gs_renderer.cpp
+git commit -m "$(cat <<'EOF'
+refactor(demo): Option A — PBD + characters into dynamic tail
+
+With the cross-frame SSBO race fixed (Phases 1-3), restore Option A:
+all non-zero-bone_index splats route into the persistent-dynamic
+prefix. Static cloud now contains only terrain + props (bone_index == 0).
+PBD wind sway is visible while camera is stationary (no longer gated
+on static_dirty_=true).
+
+Removes the obsolete trade-off comment block at gs_renderer.cpp:3411-3429
+describing why PBD-tagged splats had to stay in static.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 5 — Dungeon torch content fix
+
+**Goal:** Dungeon scene's total dynamic count fits under `kDynamicHeadroom` (1 MiB) with comfortable room for PC + NPCs + PBD trees.
+
+### Task 5.1 — Identify the dungeon scene file + torch config
+
+- [ ] **Step 1: Find the dungeon scene**
+
+```bash
+find assets/scenes -name '*dungeon*' 2>&1
+grep -rn "dungeon\|torch_dungeon" assets/scenes/ examples/island_demo/ 2>&1 | head -20
+```
+
+- [ ] **Step 2: Find torch VFX entries**
+
+```bash
+grep -nE "torch_small|torch.*vfx|vfx_preset.*torch" <dungeon scene path>
+```
+
+### Task 5.2 — Measure current dungeon dynamic count
+
+- [ ] **Step 1: Launch demo, walk into dungeon, capture stderr**
+
+```bash
+cd build/macos-release-with-diag && ./gseurat_demo 2> /tmp/dungeon_log.txt &
+sleep 6
+python3 scripts/game_director.py goto <dungeon POI from game-director POI list>
+sleep 2
+python3 scripts/game_director.py quit
+```
+
+- [ ] **Step 2: Inspect dynamic count**
+
+```bash
+grep -E "dyn=|dynamic_count_|dynamic.*overflow" /tmp/dungeon_log.txt | tail -20
+```
+
+Note the steady-state `dyn=...` value and any overflow / cap-hit lines.
+
+### Task 5.3 — Reduce torch particle count
+
+- [ ] **Step 1: Identify the per-torch splat / particle budget**
+
+If torches use a `torch_small.ply` asset, count splats: `wc -l <torch.ply>` (subtract header lines) or `python3 scripts/ply_inspect.py <path>` if that exists. If torches use procedural VFX, find their config (particle count × per-torch instances).
+
+- [ ] **Step 2: Reduce by a measured factor**
+
+Aim for the dungeon's steady-state `dyn` to be ≤ 600 k (leaves ≥ 400 k of headroom in the 1 MiB cap for characters + PBD). Decide between:
+- **Decimate torch PLY:** rerun the PLY generator with a tighter density, or stride-sample at load time (the engine already has `kMaxVfxObjectSplats = 2048` as a fallback cap).
+- **Reduce torch instance count:** drop the number of torches placed in the dungeon scene JSON.
+
+Choose the option that keeps the dungeon visually acceptable. Default: decimate PLY first; only drop instances if decimation looks bad.
+
+- [ ] **Step 3: Re-run measurement**
+
+Repeat Task 5.2's launch + walk + log inspect. Expected: `dyn ≤ 600k`, no overflow warnings.
+
+### Task 5.4 — Verify dungeon renders cleanly
+
+- [ ] **Step 1: Tour the dungeon**
+
+```bash
+cd build/macos-release-with-diag && ./gseurat_demo &
+sleep 6
+python3 scripts/game_director.py tour dungeon
+```
+
+Expected: full tour completes; no flicker; torches still visually present (just lower density).
+
+- [ ] **Step 2: Quit**
+
+```bash
+python3 scripts/game_director.py quit
+```
+
+### Task 5.5 — Phase 5 commit
+
+```bash
+git add <modified scene files / PLY assets>
+git commit -m "$(cat <<'EOF'
+content(scenes): cap dungeon torch density to fit kDynamicHeadroom
+
+Trims dungeon torch particle / instance density so the scene's
+steady-state dynamic GS count stays under 1 MiB (the
+kDynamicHeadroom budget). Pairs with Option A (Phase 4) which
+pushes PC + NPCs + PBD trees into the same dynamic tail. The
+kMaxVfxObjectSplats=2048 engine-side cap remains as a safety net.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final Integration Check
+
+After Phase 5, run the full validation plan from the spec one more time:
+
+- [ ] **30-screenshot flicker regression** — zero blanks across island + dungeon
+- [ ] **`tour` POI walk** — all POIs reached, all triggers fire
+- [ ] **Portal transition** — bridge ↔ dungeon round-trip twice
+- [ ] **VRAM check** — Activity Monitor shows ≈ 400 MB overhead vs. pre-Phase-1
+- [ ] **Frame timing** — `WAIT_SLOW` near-zero in 60 s capture
+- [ ] **Determinism harness** — existing snapshot-diff still passes
+- [ ] **Validation layers** — `macos-debug` 30 s run shows zero SYNC-HAZARDs
+
+If everything passes, the branch is ready for PR review.
+
+---
+
+## Self-review notes
+
+Spec coverage — every spec section is covered:
+- §1 Postmortem → motivates plan, no plan task needed
+- §2 Affected buffers → Phase 1 task tables; descriptor sets → Phase 2
+- §3 Memory budget → flagged in spec, no plan task (verified during runtime check)
+- §4 Phases → Phases 1–5 of this plan match 1:1
+- §5 Validation plan → Phase 3 / Phase 4 / Phase 5 validation gates + Final Integration Check
+- §6 Risks → covered by per-phase validation gates and the "if SYNC-HAZARD found, add buffer to Phase 1" loop
+- §7 Out of scope → no plan tasks (correct)
+- §8 Acceptance → tracked by Final Integration Check
+
+No placeholders. Type / naming consistency: `*_ssbos_` (plural) for arrays; `*_sets_` (plural) for descriptor set arrays; matches across Phase 1 and Phase 2 references.

--- a/docs/superpowers/specs/2026-05-11-cross-frame-ssbo-race-fix-design.md
+++ b/docs/superpowers/specs/2026-05-11-cross-frame-ssbo-race-fix-design.md
@@ -1,0 +1,143 @@
+# Cross-Frame Compute SSBO Double-Buffering + Option A Restore + Dungeon Content Fix
+
+**Date:** 2026-05-11
+**Status:** Draft — pending user review
+**Related:** Postmortem follow-up to PR #420 (`2026-05-09-upfront-merge-single-init-gs-design.md`, §11.1)
+
+## TL;DR
+
+Eliminate the post-merge "every-other-frame blank swapchain image" flicker by **per-frame double-buffering** the compute SSBOs that feed the (already per-frame) `output_images_[f]` slots. With the race fixed, **restore Option A** by moving PBD-tagged and character splats into the dynamic tail, and **content-fix the dungeon** so it stops overflowing the dynamic headroom.
+
+## 1. Postmortem: How the Bug Hid for So Long
+
+The race is **latent, not new.** Recent refactors didn't introduce it; they exposed it:
+
+- **Async PLY parse (PR #417)** and **async portal transition (PR #418)** removed large CPU stalls from main-loop frames, letting the CPU pull ahead of the GPU.
+- **Static/dynamic split (PR #420)** removed the per-frame 2.44 M-splat depth sort, shrinking the GPU frame budget enough that frame N+1's CPU recording can now finish and submit *before* frame N's compute has retired on the GPU.
+- With `kMaxFramesInFlight=2`, two cmdbufs are in flight on the same `VkQueue`. The single-instance compute SSBOs (`projected_ssbo_`, `sort_keys_ssbo_`, `sort_b_ssbo_`, `visible_count_ssbo_`, `dynamic_sort_a/b_`, `counts_ssbo_`) are written by frame N+1's preprocess while frame N's tile-render is still reading them. Result: roughly half the time, frame N's tile-render reads zeros / sentinels / partially-overwritten projected entries → an empty `output_images_[N%2]` → post-process samples an all-zero input → uniform dark-vignette frame.
+
+**Visual evidence (2026-05-11):** Consecutive Game Director screenshots `s7.png` (uniform dark-purple gradient — vignette over zero) and `s8.png` (fully rendered scene). Alternation is near-1:1 in steady state, with some frames also stalling 100–1000 ms on `vkGetQueryPoolResults(WAIT_BIT)` waiting for the previous frame's depth-sort timestamps.
+
+A **partial mitigation** of this class of bug already lives in tree at `gs_renderer.cpp:3490–3508`: the `dynamic_sort_a/b_` fill was moved from CPU mapped-memory writes (which raced CPU-vs-GPU) to GPU-side `vkCmdFillBuffer` with an in-cmdbuf TRANSFER→COMPUTE barrier. That covered the CPU-write-vs-GPU-read race on those two buffers. The **GPU-write-vs-GPU-read race across submits** on the other shared SSBOs remained.
+
+## 2. Affected Buffers
+
+### Must become `std::array<Buffer, kMaxFramesInFlight>`
+
+| Buffer | Role | Per-frame size (≈) |
+|---|---|---|
+| `projected_ssbo_` | Frustum-cull output, one ProjectedGaussian per input splat | `max_total_count` × 80 B |
+| `sort_keys_ssbo_` | Depth-sort key buffer A (ping-pong) | `max_total_count` × 8 B |
+| `sort_b_ssbo_` | Depth-sort key buffer B (ping-pong) | `max_total_count` × 8 B |
+| `visible_count_ssbo_` | Atomic counter after frustum cull | 4 B |
+| `dynamic_sort_a_` | Dynamic-tail sort buffer A | `dynamic_sort_size_` × 8 B |
+| `dynamic_sort_b_` | Dynamic-tail sort buffer B | `dynamic_sort_size_` × 8 B |
+| `counts_ssbo_` | Static / dynamic / merged counts | 12 B |
+| `depth_onesweep_status_` | Onesweep prefix-sum scratch (if shared cross-frame) | varies |
+
+Re-confirm `dynamic_sort_a/b_` during implementation — the GPU-fill mitigation may make per-framing redundant for those two; if so, document and skip.
+
+### Stay single-instance (read-only or static-after-init)
+
+- `gaussian_ssbo_`, `static_gaussian_ssbo_` — read-only after upload / init_gs
+- `static_sort_a_/b_` — written only on `static_dirty_=true` (rare camera-move event); GPU-fenced before swap
+- `bone_ssbo_`, `pbd_state_ssbo_`, `pbd_*` — written CPU-side or by PBD compute; confirm safe in Phase 1 by re-reading their access pattern. If a race is found, per-frame them too.
+
+### Descriptor sets that must become per-frame
+
+- `preprocess_set_` → `preprocess_sets_[kMaxFramesInFlight]`
+- `sort_set_` (legacy) → `sort_sets_[kMaxFramesInFlight]`
+- Depth-onesweep histogram + scatter sets — per-frame variants
+
+`render_sets_[f]` and `post_process_sets_[f]` and the composite `gs_descriptor_sets_[i]` are already per-frame and only need to start binding the per-frame buffers above (no allocation change).
+
+## 3. Memory Budget
+
+`max_total_count ≈ 4 M` (1.7 M static + 0.75 M dynamic + headroom for Option A growth + VFX worst case). Per-frame-slot footprint:
+
+- `projected_ssbo_`: 4 M × 80 B ≈ **320 MB**
+- `sort_keys` + `sort_b`: 4 M × 16 B ≈ 64 MB
+- `dynamic_sort_a/b_`: 1 M × 16 B ≈ 16 MB
+- Counts / visible_count: trivial
+
+Per-slot ≈ **400 MB**. With `kMaxFramesInFlight=2` the duplicate adds ≈ **400 MB** of overhead. **This exceeds the ~200 MB the user initially quoted** — flagging explicitly so the budget is acknowledged before implementation.
+
+If 400 MB is too much, two trim levers exist (both deferred until budget is shown to be a real ceiling):
+1. Tighten `projected_ssbo_` sizing to a frustum-cull worst case rather than `max_total_count` (adds overflow risk, needs runtime guard).
+2. Split projected layout so only the GPU-private fields are per-frame; immutable per-splat data stays single-instance.
+
+Default for this spec: **accept the ~400 MB overhead.** Implementation re-validates and reports actual VRAM use post-Phase 1.
+
+## 4. Implementation Phases
+
+### Phase 1 — Per-frame storage for racing SSBOs
+
+- Change declarations in `gs_renderer.hpp` from `Buffer X_ssbo_` to `std::array<Buffer, kMaxFramesInFlight> X_ssbos_`.
+- Update all create / resize / destroy sites in `gs_renderer.cpp`.
+- Where a buffer is currently accessed by a single getter / member, route through `X_ssbos_[frame_in_flight]`.
+- **Validation gate:** Vulkan validation layers enabled (`macos-debug`) → run demo for 30 s → no `SYNC-HAZARD-*` warnings.
+
+### Phase 2 — Per-frame descriptor sets for compute
+
+- `preprocess_set_` → `preprocess_sets_[f]`; same layout, each set bound to per-frame buffers at the same shader bindings (no shader change).
+- Same treatment for legacy `sort_set_` and the depth-onesweep histogram / scatter sets.
+- `update_descriptors()` writes all per-frame sets at once on init / resize / scene change.
+- **Validation gate:** descriptor pool capacity audit — `gs_pool_` budget must absorb the new sets; double the `kMaxFramesInFlight`-scaled counts in `create_descriptor_pool` if needed.
+
+### Phase 3 — Wire `frame_in_flight` through dispatch
+
+- `dispatch_gpu_compute`, `dispatch_depth_onesweep`, `dispatch_tile_render` already receive `frame_in_flight` from `Renderer::record_gs_prepass`. Bind per-frame sets and use per-frame buffers throughout.
+- Static-tail buffers stay single-instance (`static_sort_a/b_` are GPU-fenced via the existing `static_dirty_` flow).
+- **Validation gate:** Take 30 consecutive Game Director screenshots; zero blank frames.
+
+### Phase 4 — Restore Option A (PBD + characters into dynamic tail)
+
+- `IslandDemoState::on_enter` + `perform_portal_transition`: partition the merged cloud so that PBD-tagged (`bone_index ∈ [32, 63]`) **and** character / NPC bone-animated (`bone_index ∈ [1, 31]`) splats feed `set_persistent_dynamics()`. Only terrain + static props (`bone_index == 0`) stay in the static cloud.
+- `kDynamicHeadroom` is already 1 MiB after PR #420; expected occupancy with Option A:
+  - ~12 PBD trees × ~5 k splats ≈ 60 k
+  - 1 PC × ~50 k ≈ 50 k
+  - N NPCs × ~50 k (bound by manifest)
+  - VFX cap (`kMaxVfxObjectSplats = 2048` × per-frame instances)
+  - Comfortable under 1 M for the island scene; dungeon handled by Phase 5.
+- Remove the trade-off comment at `gs_renderer.cpp:3411–3429` (the "PBD lives in static, don't dirty per-frame" rationale no longer applies — PBD splats now live in the per-frame dynamic sort which is cheap to re-sort).
+- **Validation gate:** PBD wind sway visible while camera is stationary; characters and NPCs render correctly post-merge and post-portal-transition.
+
+### Phase 5 — Dungeon torch content fix
+
+- Identify the dungeon scene's torch VFX (likely under `assets/scenes/` or referenced by a chunk in `world.json`).
+- Reduce per-torch particle count and/or torch instance count so the dungeon's total **dynamic** count fits in `kDynamicHeadroom` with headroom for PC + NPCs + PBD trees.
+- Cross-check with `gs_vfx.cpp` decimation (`kMaxVfxObjectSplats = 2048`) — the cap should remain a safety net, not a load-bearing limit on content.
+- **Validation gate:** Walk into the dungeon; no dynamic-tail overflow warnings in stderr, no flicker, no missing geometry.
+
+## 5. Validation Plan
+
+1. **Flicker regression** — 30 consecutive screenshots, zero blank frames.
+2. **Walk tour** — `python3 scripts/game_director.py tour` reaches every POI; visual inspection shows no flicker, no missing dynamics.
+3. **Portal transition** — Bridge → dungeon → bridge, twice. Characters render through both transitions; no overflow logs.
+4. **VRAM check** — Activity Monitor / Metal HUD before vs after Phase 1. Confirm overhead is in the expected ~400 MB band.
+5. **Frame timing** — Watchdog log over 60 s: `[gs_render/wd/WAIT_SLOW]` lines disappear or fall well below the once-per-30-frames cadence we see today (CPU no longer waits because GPU isn't trailing behind anymore).
+6. **Determinism harness** — Existing snapshot-diff test still passes.
+7. **Validation layers** — `macos-debug` run produces zero `SYNC-HAZARD-*` warnings under steady gameplay.
+
+## 6. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Two prior reverts in this area | Phase-by-phase commits with named validation gates; keep `kMaxFramesInFlight == 2` static_assert. |
+| VRAM overhead exceeds quoted ~200 MB | Document actual measurement post-Phase 1; trim only if a real ceiling appears (`projected_ssbo_` sizing levers exist). |
+| Descriptor pool exhaustion | Audit and re-size `gs_pool_` in Phase 2. |
+| A racing buffer is missed in the per-frame list | Validation-layer SYNC-HAZARD warnings will surface any miss; treat as Phase-1 acceptance criterion. |
+| Option A pushes dungeon over `kDynamicHeadroom` | Phase 5 caps content; add a hard assertion / loud stderr log on overflow so future content authoring fails loud rather than silently truncating. |
+| Mid-implementation discovery that `bone_ssbo_` or PBD buffers also race | Add to the per-frame list in Phase 1 and re-validate. |
+
+## 7. Out of Scope
+
+- Reworking the static-tail invalidation policy (`static_dirty_`).
+- Switching depth sort to a different algorithm.
+- The `loading_monitor` → Warming → Playing edge instrumentation.
+- The §11.3 watchdog removal (already shipped in PR #420; production builds strip it via `GSEURAT_DEBUG_BUILD`).
+- Re-architecting `kMaxFramesInFlight`. Stays 2.
+
+## 8. Acceptance
+
+User reviews and approves this spec. After approval, `writing-plans` produces a phase-by-phase implementation plan; each phase is its own commit on a fresh branch `fix/cross-frame-ssbo-race` off `origin/main`.

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -413,7 +413,11 @@ private:
     void create_compute_pipelines();
     void create_descriptor_resources();
     void update_descriptors();
+    // frame_in_flight selects depth_onesweep_statuses_[f] for the status
+    // clear so frame N+1's fill doesn't stomp frame N's in-flight lookback.
+    // The passed descriptor sets must already bind that same per-frame slot.
     void dispatch_depth_onesweep(VkCommandBuffer cmd, uint32_t sort_size, uint32_t num_workgroups,
+        uint32_t frame_in_flight,
         VkDescriptorSet hist_a, VkDescriptorSet hist_b,
         VkDescriptorSet scatter_ab, VkDescriptorSet scatter_ba);
     // Phase 3: frame_in_flight selects tile_bin_sets_[f] so the per-frame
@@ -693,9 +697,10 @@ private:
     std::array<VkDescriptorSet, kMaxFramesInFlight> tile_render_sets_{};
 
     // Onesweep 2-dispatch sort (histogram+lookback → scatter) — per-frame
-    // (Phase 3.5). Binds racing tile_sort_a/b + tile_indirect_args. The
-    // onesweep_status_ binding is still single-instance (its race is a
-    // separate follow-up item not in this phase's scope).
+    // (Phase 3.5). Binds racing tile_sort_a/b + tile_indirect_args.
+    // onesweep_statuses_ is also per-frame (final cross-frame race fix):
+    // frame N+1's vkCmdFillBuffer would otherwise stomp frame N's in-flight
+    // lookback state.
     VkDescriptorSetLayout onesweep_hist_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout onesweep_hist_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline onesweep_hist_pipeline_ = VK_NULL_HANDLE;
@@ -708,11 +713,19 @@ private:
     std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_scatter_sets_ab_{};  // read A → write B
     std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_scatter_sets_ba_{};  // read B → write A
 
-    Buffer onesweep_status_;    // per-digit lookback status buffer (tile sort, coherent)
+    // Per-digit lookback status buffer (tile sort, coherent). Per-frame:
+    // dispatch_tile_sort zeroes the slot at the start of every per-frame
+    // record and the onesweep compute reads/writes it; with kMaxFramesInFlight
+    // cmdbufs in flight a single-instance buffer would race itself.
+    std::array<Buffer, kMaxFramesInFlight> onesweep_statuses_{};
     uint32_t onesweep_max_wg_ = 0;
 
     // Depth sort Onesweep (reuses same shaders as tile sort)
-    Buffer depth_onesweep_status_;       // per-digit lookback status (depth sort, coherent)
+    // Per-digit lookback status (depth sort, coherent). Per-frame for the
+    // same reason as onesweep_statuses_ — dispatch_depth_onesweep zeroes
+    // this slot at the start of every sort. Shared across static/dynamic/
+    // legacy depth sorts (all three bind frame f's slot).
+    std::array<Buffer, kMaxFramesInFlight> depth_onesweep_statuses_{};
     Buffer depth_sort_params_;           // IndirectArgs-layout buffer for legacy depth sort
     Buffer static_depth_params_;         // IndirectArgs-layout buffer for static depth sort
     Buffer dynamic_depth_params_;        // IndirectArgs-layout buffer for dynamic depth sort
@@ -725,12 +738,14 @@ private:
     std::array<VkDescriptorSet, kMaxFramesInFlight> depth_scatter_sets_ab_{};
     std::array<VkDescriptorSet, kMaxFramesInFlight> depth_scatter_sets_ba_{};
 
-    // Depth sort Onesweep descriptor sets (static path) — single-instance.
-    // These bind only static_sort_a_/b_ which are GPU-fenced via static_dirty_.
-    VkDescriptorSet static_depth_hist_set_a_ = VK_NULL_HANDLE;
-    VkDescriptorSet static_depth_hist_set_b_ = VK_NULL_HANDLE;
-    VkDescriptorSet static_depth_scatter_set_ab_ = VK_NULL_HANDLE;
-    VkDescriptorSet static_depth_scatter_set_ba_ = VK_NULL_HANDLE;
+    // Depth sort Onesweep descriptor sets (static path) — per-frame.
+    // static_sort_a_/b_ themselves are single-instance (GPU-fenced via
+    // static_dirty_), but the bound depth_onesweep_statuses_ slot is now
+    // per-frame, so each slot binds frame f's status buffer.
+    std::array<VkDescriptorSet, kMaxFramesInFlight> static_depth_hist_sets_a_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> static_depth_hist_sets_b_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> static_depth_scatter_sets_ab_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> static_depth_scatter_sets_ba_{};
 
     // Depth sort Onesweep descriptor sets (dynamic path) — per-frame.
     // These bind racing dynamic_sort_as_[f] / dynamic_sort_bs_[f].

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -413,11 +413,7 @@ private:
     void create_compute_pipelines();
     void create_descriptor_resources();
     void update_descriptors();
-    // frame_in_flight selects depth_onesweep_statuses_[f] for the status
-    // clear so frame N+1's fill doesn't stomp frame N's in-flight lookback.
-    // The passed descriptor sets must already bind that same per-frame slot.
     void dispatch_depth_onesweep(VkCommandBuffer cmd, uint32_t sort_size, uint32_t num_workgroups,
-        uint32_t frame_in_flight,
         VkDescriptorSet hist_a, VkDescriptorSet hist_b,
         VkDescriptorSet scatter_ab, VkDescriptorSet scatter_ba);
     // Phase 3: frame_in_flight selects tile_bin_sets_[f] so the per-frame
@@ -697,10 +693,9 @@ private:
     std::array<VkDescriptorSet, kMaxFramesInFlight> tile_render_sets_{};
 
     // Onesweep 2-dispatch sort (histogram+lookback → scatter) — per-frame
-    // (Phase 3.5). Binds racing tile_sort_a/b + tile_indirect_args.
-    // onesweep_statuses_ is also per-frame (final cross-frame race fix):
-    // frame N+1's vkCmdFillBuffer would otherwise stomp frame N's in-flight
-    // lookback state.
+    // (Phase 3.5). Binds racing tile_sort_a/b + tile_indirect_args. The
+    // onesweep_status_ binding is still single-instance (its race is a
+    // separate follow-up item not in this phase's scope).
     VkDescriptorSetLayout onesweep_hist_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout onesweep_hist_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline onesweep_hist_pipeline_ = VK_NULL_HANDLE;
@@ -713,19 +708,11 @@ private:
     std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_scatter_sets_ab_{};  // read A → write B
     std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_scatter_sets_ba_{};  // read B → write A
 
-    // Per-digit lookback status buffer (tile sort, coherent). Per-frame:
-    // dispatch_tile_sort zeroes the slot at the start of every per-frame
-    // record and the onesweep compute reads/writes it; with kMaxFramesInFlight
-    // cmdbufs in flight a single-instance buffer would race itself.
-    std::array<Buffer, kMaxFramesInFlight> onesweep_statuses_{};
+    Buffer onesweep_status_;    // per-digit lookback status buffer (tile sort, coherent)
     uint32_t onesweep_max_wg_ = 0;
 
     // Depth sort Onesweep (reuses same shaders as tile sort)
-    // Per-digit lookback status (depth sort, coherent). Per-frame for the
-    // same reason as onesweep_statuses_ — dispatch_depth_onesweep zeroes
-    // this slot at the start of every sort. Shared across static/dynamic/
-    // legacy depth sorts (all three bind frame f's slot).
-    std::array<Buffer, kMaxFramesInFlight> depth_onesweep_statuses_{};
+    Buffer depth_onesweep_status_;       // per-digit lookback status (depth sort, coherent)
     Buffer depth_sort_params_;           // IndirectArgs-layout buffer for legacy depth sort
     Buffer static_depth_params_;         // IndirectArgs-layout buffer for static depth sort
     Buffer dynamic_depth_params_;        // IndirectArgs-layout buffer for dynamic depth sort
@@ -738,14 +725,12 @@ private:
     std::array<VkDescriptorSet, kMaxFramesInFlight> depth_scatter_sets_ab_{};
     std::array<VkDescriptorSet, kMaxFramesInFlight> depth_scatter_sets_ba_{};
 
-    // Depth sort Onesweep descriptor sets (static path) — per-frame.
-    // static_sort_a_/b_ themselves are single-instance (GPU-fenced via
-    // static_dirty_), but the bound depth_onesweep_statuses_ slot is now
-    // per-frame, so each slot binds frame f's status buffer.
-    std::array<VkDescriptorSet, kMaxFramesInFlight> static_depth_hist_sets_a_{};
-    std::array<VkDescriptorSet, kMaxFramesInFlight> static_depth_hist_sets_b_{};
-    std::array<VkDescriptorSet, kMaxFramesInFlight> static_depth_scatter_sets_ab_{};
-    std::array<VkDescriptorSet, kMaxFramesInFlight> static_depth_scatter_sets_ba_{};
+    // Depth sort Onesweep descriptor sets (static path) — single-instance.
+    // These bind only static_sort_a_/b_ which are GPU-fenced via static_dirty_.
+    VkDescriptorSet static_depth_hist_set_a_ = VK_NULL_HANDLE;
+    VkDescriptorSet static_depth_hist_set_b_ = VK_NULL_HANDLE;
+    VkDescriptorSet static_depth_scatter_set_ab_ = VK_NULL_HANDLE;
+    VkDescriptorSet static_depth_scatter_set_ba_ = VK_NULL_HANDLE;
 
     // Depth sort Onesweep descriptor sets (dynamic path) — per-frame.
     // These bind racing dynamic_sort_as_[f] / dynamic_sort_bs_[f].

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -328,7 +328,10 @@ public:
         return determinism_readback_.allocation();
     }
     VmaAllocation tile_sort_count_allocation() const {
-        return tile_sort_count_ssbo_.allocation();
+        // Phase 3.5: tile_sort_count is per-frame. Return the slot that
+        // dispatch_tile_sort most recently recorded into (matches the
+        // readback the harness reads after the in-flight fence).
+        return tile_sort_count_ssbos_[determinism_last_emitted_frame_].allocation();
     }
     uint32_t tile_sort_capacity() const { return tile_sort_capacity_; }
 
@@ -336,8 +339,11 @@ public:
         return determinism_readback_.mapped();
     }
     uint32_t live_tile_sort_count() const {
-        if (tile_sort_count_ssbo_.mapped() == nullptr) return 0;
-        return *static_cast<const uint32_t*>(tile_sort_count_ssbo_.mapped());
+        // Phase 3.5: tile_sort_count is per-frame. Read the slot that
+        // dispatch_tile_sort most recently emitted (post-fence).
+        const auto& slot = tile_sort_count_ssbos_[determinism_last_emitted_frame_];
+        if (slot.mapped() == nullptr) return 0;
+        return *static_cast<const uint32_t*>(slot.mapped());
     }
 
     // GPU timing averages (populated over kTimestampAvgFrames)
@@ -658,22 +664,26 @@ private:
     // Three-dispatch exclusive prefix-sum (gs_tile_scan.comp). Bindings:
     //   0 per_splat_tile_count[]  1 per_splat_tile_offset[]
     //   2 scan_block_sums[]       3 tile_sort_count
+    // Per-frame (Phase 3.5): binds racing per_splat_*/scan_block_sums/
+    // tile_sort_count buffers, so the set itself is per-frame.
     VkDescriptorSetLayout tile_scan_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout tile_scan_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline tile_scan_pipeline_ = VK_NULL_HANDLE;
-    VkDescriptorSet tile_scan_set_ = VK_NULL_HANDLE;
+    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_scan_sets_{};
 
     // Indirect dispatch preparation
+    // Per-frame (Phase 3.5): binds racing tile_sort_count + tile_indirect_args.
     VkDescriptorSetLayout tile_indirect_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout tile_indirect_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline tile_indirect_pipeline_ = VK_NULL_HANDLE;
-    VkDescriptorSet tile_indirect_set_ = VK_NULL_HANDLE;
+    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_indirect_sets_{};
 
     // Tile range detection pipeline
+    // Per-frame (Phase 3.5): binds racing tile_sort_a + tile_ranges + tile_sort_count.
     VkDescriptorSetLayout tile_ranges_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout tile_ranges_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline tile_ranges_pipeline_ = VK_NULL_HANDLE;
-    VkDescriptorSet tile_ranges_set_ = VK_NULL_HANDLE;
+    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_ranges_sets_{};
 
     // Tile render pipeline (8 bindings)
     VkDescriptorSetLayout tile_render_layout_ = VK_NULL_HANDLE;
@@ -682,18 +692,21 @@ private:
     // tile_render binds output_image + depth_image — per-frame.
     std::array<VkDescriptorSet, kMaxFramesInFlight> tile_render_sets_{};
 
-    // Onesweep 2-dispatch sort (histogram+lookback → scatter)
+    // Onesweep 2-dispatch sort (histogram+lookback → scatter) — per-frame
+    // (Phase 3.5). Binds racing tile_sort_a/b + tile_indirect_args. The
+    // onesweep_status_ binding is still single-instance (its race is a
+    // separate follow-up item not in this phase's scope).
     VkDescriptorSetLayout onesweep_hist_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout onesweep_hist_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline onesweep_hist_pipeline_ = VK_NULL_HANDLE;
-    VkDescriptorSet onesweep_hist_set_a_ = VK_NULL_HANDLE;  // read from A
-    VkDescriptorSet onesweep_hist_set_b_ = VK_NULL_HANDLE;  // read from B
+    std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_hist_sets_a_{};  // read from A
+    std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_hist_sets_b_{};  // read from B
 
     VkDescriptorSetLayout onesweep_scatter_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout onesweep_scatter_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline onesweep_scatter_pipeline_ = VK_NULL_HANDLE;
-    VkDescriptorSet onesweep_scatter_set_ab_ = VK_NULL_HANDLE;  // read A → write B
-    VkDescriptorSet onesweep_scatter_set_ba_ = VK_NULL_HANDLE;  // read B → write A
+    std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_scatter_sets_ab_{};  // read A → write B
+    std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_scatter_sets_ba_{};  // read B → write A
 
     Buffer onesweep_status_;    // per-digit lookback status buffer (tile sort, coherent)
     uint32_t onesweep_max_wg_ = 0;
@@ -726,18 +739,25 @@ private:
     std::array<VkDescriptorSet, kMaxFramesInFlight> dynamic_depth_scatter_sets_ab_{};
     std::array<VkDescriptorSet, kMaxFramesInFlight> dynamic_depth_scatter_sets_ba_{};
 
-    // Tile sort buffers
-    Buffer tile_sort_a_;              // TileSortEntry ping buffer (8 bytes/entry)
-    Buffer tile_sort_b_;              // TileSortEntry pong buffer
-    Buffer tile_sort_count_ssbo_;     // single uint32 — written by gs_tile_scan pass=1
-    Buffer tile_ranges_ssbo_;         // per-tile {start, count}
-    Buffer tile_indirect_args_;       // indirect dispatch args (8 × uint32)
+    // Tile sort buffers — per-frame (Phase 3.5).
+    // All seven buffers below are written every frame on the per-frame
+    // render path (dispatch_tile_sort). With kMaxFramesInFlight cmdbufs
+    // executing concurrently on the same VkQueue, single-instance
+    // buffers would race the same way the projected/sort_keys/visible_count
+    // buffers did pre-Phase-3. Each slot is sized identically (driven by
+    // tile_sort_capacity_ / scan_dispatch_size_).
+    std::array<Buffer, kMaxFramesInFlight> tile_sort_as_{};              // TileSortEntry ping buffer (8 bytes/entry)
+    std::array<Buffer, kMaxFramesInFlight> tile_sort_bs_{};              // TileSortEntry pong buffer
+    std::array<Buffer, kMaxFramesInFlight> tile_sort_count_ssbos_{};     // single uint32 — written by gs_tile_scan pass=1
+    std::array<Buffer, kMaxFramesInFlight> tile_ranges_ssbos_{};         // per-tile {start, count}
+    std::array<Buffer, kMaxFramesInFlight> tile_indirect_args_{};        // indirect dispatch args (8 × uint32)
 
     // Deterministic tile-bin (Fix B) intermediate SSBOs. All sized to the
     // visible-splat upper bound (static_sort_size_ + dynamic_sort_size_).
-    Buffer per_splat_tile_count_ssbo_;   // uint32 × visible_upper
-    Buffer per_splat_tile_offset_ssbo_;  // uint32 × visible_upper (exclusive scan)
-    Buffer scan_block_sums_ssbo_;        // uint32 × ceil(visible_upper / 256)
+    // Per-frame for the same race reason as the tile sort buffers above.
+    std::array<Buffer, kMaxFramesInFlight> per_splat_tile_count_ssbos_{};   // uint32 × visible_upper
+    std::array<Buffer, kMaxFramesInFlight> per_splat_tile_offset_ssbos_{};  // uint32 × visible_upper (exclusive scan)
+    std::array<Buffer, kMaxFramesInFlight> scan_block_sums_ssbos_{};        // uint32 × ceil(visible_upper / 256)
     uint32_t scan_dispatch_size_ = 0;    // visible_upper rounded up to 256
     uint32_t scan_num_blocks_ = 0;       // scan_dispatch_size_ / 256
     // Frame-determinism harness: HOST_VISIBLE copy of the post-Onesweep
@@ -752,6 +772,10 @@ private:
     // before counting a frame so that loading / transition frames where
     // the GS compute path was gated off don't pollute the verdict.
     bool determinism_readback_emitted_ = false;
+    // Phase 3.5: which per-frame slot of tile_sort_count_ssbos_ was the
+    // most recently emitted readback against. The harness uses this to
+    // select the right slot post-fence. Updated inside dispatch_tile_sort.
+    uint32_t determinism_last_emitted_frame_ = 0;
 
     uint32_t tile_sort_capacity_ = 0;    // max entries in tile sort buffers
     uint32_t tile_sort_size_ = 0;        // workgroup-aligned count for radix sort

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -148,8 +148,13 @@ public:
     uint32_t max_dynamic_count() const { return max_dynamic_count_; }
     uint32_t static_count() const { return static_count_; }
     uint32_t dynamic_count() const { return dynamic_count_; }
-    bool static_dirty() const { return static_dirty_; }
-    void set_static_dirty(bool d) { static_dirty_ = d; }
+    bool static_dirty() const { return static_dirty_frames_remaining_ > 0; }
+    // Marks the static head of projected_ssbos_ as dirty for the next
+    // kMaxFramesInFlight frames. Phase 3: with per-frame projected SSBOs,
+    // each frame slot must run static_preprocess once to refresh its slot.
+    void set_static_dirty(bool d) {
+        static_dirty_frames_remaining_ = d ? kMaxFramesInFlight : 0;
+    }
 
     void resize_output(uint32_t width, uint32_t height);
 
@@ -405,7 +410,9 @@ private:
     void dispatch_depth_onesweep(VkCommandBuffer cmd, uint32_t sort_size, uint32_t num_workgroups,
         VkDescriptorSet hist_a, VkDescriptorSet hist_b,
         VkDescriptorSet scatter_ab, VkDescriptorSet scatter_ba);
-    void dispatch_tile_sort(VkCommandBuffer cmd);
+    // Phase 3: frame_in_flight selects tile_bin_sets_[f] so the per-frame
+    // racing projected/merged/counts slots are read correctly.
+    void dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_flight);
     // Drain pending_publications_ and record the metadata writes
     // (page_table, chunk_table) onto `cmd` via vkCmdUpdateBuffer + a
     // TRANSFER_WRITE -> SHADER_READ barrier. Called from poll_transfers
@@ -484,7 +491,11 @@ private:
     uint32_t dynamic_sort_size_ = 0;
     uint32_t static_sort_workgroups_ = 0;
     uint32_t dynamic_sort_workgroups_ = 0;
-    bool static_dirty_ = true;
+    // Static-head refresh countdown. With per-frame projected_ssbos_,
+    // each frame slot must re-run static_preprocess once after a static
+    // mutation. Initialized to kMaxFramesInFlight so the first
+    // kMaxFramesInFlight frames each refresh their own projected slot.
+    uint32_t static_dirty_frames_remaining_ = kMaxFramesInFlight;
 
     // --- Streaming architecture (Phase 2) ---
     StreamingConfig streaming_config_;
@@ -587,7 +598,9 @@ private:
     VkDescriptorSetLayout merge_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout merge_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline merge_pipeline_ = VK_NULL_HANDLE;
-    VkDescriptorSet merge_set_ = VK_NULL_HANDLE;
+    // Per-frame merge sets: merge_sets_[f] binds dynamic_sort_as_[f],
+    // merged_sort_ssbos_[f], counts_ssbos_[f] (all racing per-frame buffers).
+    std::array<VkDescriptorSet, kMaxFramesInFlight> merge_sets_{};
 
     // Static/dynamic preprocess descriptor sets — per-frame (Phase 2 plumbing;
     // dispatch still binds [0] until Phase 3).
@@ -632,7 +645,10 @@ private:
     VkDescriptorSetLayout tile_bin_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout tile_bin_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline tile_bin_pipeline_ = VK_NULL_HANDLE;
-    VkDescriptorSet tile_bin_set_ = VK_NULL_HANDLE;
+    // Per-frame (Phase 3): tile_bin_sets_[f] binds projected_ssbos_[f],
+    // merged_sort_ssbos_[f], counts_ssbos_[f]. Other bindings (per_splat_*,
+    // tile_entries, uniforms) are single-instance.
+    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_bin_sets_{};
 
     // Pre-scatter count pass (gs_tile_count.comp). Shares layout/set with
     // tile_bin_pipeline_ — the binding set is a strict superset of what
@@ -689,23 +705,26 @@ private:
     Buffer dynamic_depth_params_;        // IndirectArgs-layout buffer for dynamic depth sort
     uint32_t depth_onesweep_max_wg_ = 0;
 
-    // Depth sort Onesweep descriptor sets (legacy path)
-    VkDescriptorSet depth_hist_set_a_ = VK_NULL_HANDLE;
-    VkDescriptorSet depth_hist_set_b_ = VK_NULL_HANDLE;
-    VkDescriptorSet depth_scatter_set_ab_ = VK_NULL_HANDLE;
-    VkDescriptorSet depth_scatter_set_ba_ = VK_NULL_HANDLE;
+    // Depth sort Onesweep descriptor sets (legacy path) — per-frame.
+    // These bind racing sort_keys_ssbos_[f] / sort_b_ssbos_[f].
+    std::array<VkDescriptorSet, kMaxFramesInFlight> depth_hist_sets_a_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> depth_hist_sets_b_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> depth_scatter_sets_ab_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> depth_scatter_sets_ba_{};
 
-    // Depth sort Onesweep descriptor sets (static path)
+    // Depth sort Onesweep descriptor sets (static path) — single-instance.
+    // These bind only static_sort_a_/b_ which are GPU-fenced via static_dirty_.
     VkDescriptorSet static_depth_hist_set_a_ = VK_NULL_HANDLE;
     VkDescriptorSet static_depth_hist_set_b_ = VK_NULL_HANDLE;
     VkDescriptorSet static_depth_scatter_set_ab_ = VK_NULL_HANDLE;
     VkDescriptorSet static_depth_scatter_set_ba_ = VK_NULL_HANDLE;
 
-    // Depth sort Onesweep descriptor sets (dynamic path)
-    VkDescriptorSet dynamic_depth_hist_set_a_ = VK_NULL_HANDLE;
-    VkDescriptorSet dynamic_depth_hist_set_b_ = VK_NULL_HANDLE;
-    VkDescriptorSet dynamic_depth_scatter_set_ab_ = VK_NULL_HANDLE;
-    VkDescriptorSet dynamic_depth_scatter_set_ba_ = VK_NULL_HANDLE;
+    // Depth sort Onesweep descriptor sets (dynamic path) — per-frame.
+    // These bind racing dynamic_sort_as_[f] / dynamic_sort_bs_[f].
+    std::array<VkDescriptorSet, kMaxFramesInFlight> dynamic_depth_hist_sets_a_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> dynamic_depth_hist_sets_b_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> dynamic_depth_scatter_sets_ab_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> dynamic_depth_scatter_sets_ba_{};
 
     // Tile sort buffers
     Buffer tile_sort_a_;              // TileSortEntry ping buffer (8 bytes/entry)

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -208,12 +208,12 @@ public:
     uint32_t output_width() const { return output_width_; }
     uint32_t output_height() const { return output_height_; }
     uint32_t visible_count() const {
-        if (counts_ssbo_.mapped()) {
-            auto* c = static_cast<const uint32_t*>(counts_ssbo_.mapped());
+        if (counts_ssbos_[0].mapped()) {
+            auto* c = static_cast<const uint32_t*>(counts_ssbos_[0].mapped());
             return c[0] + c[1];  // static_visible + dynamic_visible
         }
-        if (visible_count_ssbo_.mapped())
-            return *static_cast<const uint32_t*>(visible_count_ssbo_.mapped());
+        if (visible_count_ssbos_[0].mapped())
+            return *static_cast<const uint32_t*>(visible_count_ssbos_[0].mapped());
         return 0;
     }
     void set_shadow_box_params(const glm::vec3& cone_dir, float cone_cos,
@@ -442,12 +442,16 @@ private:
 
     // GPU buffers
     Buffer gaussian_ssbo_;           // Input Gaussians
-    Buffer projected_ssbo_;          // Projected 2D splats
-    Buffer sort_keys_ssbo_;          // Sort buffer A (ping-pong)
-    Buffer sort_b_ssbo_;             // Sort buffer B (ping-pong)
+    // Per-frame racing SSBOs: frame N writes slot [N % kMaxFramesInFlight]
+    // while frame N-1 is still draining. Phase 1 of the cross-frame race
+    // fix converts these to arrays; Phase 3 will wire frame_in_flight into
+    // dispatch sites. For now all consumers access slot [0].
+    std::array<Buffer, kMaxFramesInFlight> projected_ssbos_{};   // Projected 2D splats
+    std::array<Buffer, kMaxFramesInFlight> sort_keys_ssbos_{};   // Sort buffer A (ping-pong)
+    std::array<Buffer, kMaxFramesInFlight> sort_b_ssbos_{};      // Sort buffer B (ping-pong)
 
     Buffer uniform_buffer_;          // Camera + resolution
-    Buffer visible_count_ssbo_;      // Atomic counter: visible Gaussians after frustum cull
+    std::array<Buffer, kMaxFramesInFlight> visible_count_ssbos_{};  // Atomic counter: visible Gaussians after frustum cull
     Buffer bone_ssbo_;               // Bone transforms for character skinning
     uint32_t bone_count_ = 0;
     glm::quat actor_rotation_{1.0f, 0.0f, 0.0f, 0.0f};  // Root motion world rotation
@@ -465,10 +469,11 @@ private:
     Buffer dynamic_gaussian_ssbo_;
     Buffer static_sort_a_;
     Buffer static_sort_b_;
-    Buffer dynamic_sort_a_;
-    Buffer dynamic_sort_b_;
-    Buffer merged_sort_ssbo_;
-    Buffer counts_ssbo_;  // {static_visible, dynamic_visible, merged_visible}
+    // Per-frame racing SSBOs (see comment above projected_ssbos_).
+    std::array<Buffer, kMaxFramesInFlight> dynamic_sort_as_{};
+    std::array<Buffer, kMaxFramesInFlight> dynamic_sort_bs_{};
+    std::array<Buffer, kMaxFramesInFlight> merged_sort_ssbos_{};
+    std::array<Buffer, kMaxFramesInFlight> counts_ssbos_{};  // {static_visible, dynamic_visible, merged_visible}
 
     uint32_t static_count_ = 0;
     uint32_t dynamic_count_ = 0;            // persistent_dyn_count_ + transient

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -575,7 +575,10 @@ private:
     VkDescriptorPool gs_pool_ = VK_NULL_HANDLE;
     VkDescriptorSetLayout preprocess_layout_ = VK_NULL_HANDLE;
     VkDescriptorSetLayout render_layout_ = VK_NULL_HANDLE;
-    VkDescriptorSet preprocess_set_ = VK_NULL_HANDLE;
+    // Per-frame compute sets: preprocess_sets_[f] is bound to *_ssbos_[f].
+    // Phase 2: plumbing only — dispatch sites still use [0]. Phase 3 routes
+    // frame_in_flight to actually use the per-frame slot.
+    std::array<VkDescriptorSet, kMaxFramesInFlight> preprocess_sets_{};
     // render_set_ binds output_image + depth_image — both per-frame —
     // so the set must also be per-frame to point at the right pair.
     std::array<VkDescriptorSet, kMaxFramesInFlight> render_sets_{};
@@ -586,9 +589,10 @@ private:
     VkPipeline merge_pipeline_ = VK_NULL_HANDLE;
     VkDescriptorSet merge_set_ = VK_NULL_HANDLE;
 
-    // Static/dynamic preprocess descriptor sets
-    VkDescriptorSet static_preprocess_set_ = VK_NULL_HANDLE;
-    VkDescriptorSet dynamic_preprocess_set_ = VK_NULL_HANDLE;
+    // Static/dynamic preprocess descriptor sets — per-frame (Phase 2 plumbing;
+    // dispatch still binds [0] until Phase 3).
+    std::array<VkDescriptorSet, kMaxFramesInFlight> static_preprocess_sets_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> dynamic_preprocess_sets_{};
 
     // Compute pipelines
     VkPipelineLayout preprocess_pipeline_layout_ = VK_NULL_HANDLE;
@@ -615,7 +619,8 @@ private:
     VkDescriptorSetLayout sort_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout sort_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline sort_pipeline_ = VK_NULL_HANDLE;
-    VkDescriptorSet sort_set_ = VK_NULL_HANDLE;
+    // Per-frame sort sets (Phase 2 plumbing; dispatch still binds [0]).
+    std::array<VkDescriptorSet, kMaxFramesInFlight> sort_sets_{};
 
     // ── Tile binning pipeline (deterministic count→scan→scatter) ──
     // The combined `tile_bin_layout_` covers both the count and scatter

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -207,14 +207,14 @@ void GsRenderer::create_descriptor_resources() {
     // Phase 2 bumped capacity to absorb the doubled compute-set count
     // (preprocess, sort, static_preprocess, dynamic_preprocess become per-frame).
     VkDescriptorPoolSize pool_sizes[] = {
-        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 320},   // many more for split buffers + Phase 2 per-frame
+        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 384},   // many more for split buffers + Phase 2/3 per-frame
         {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 24},
         {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 48},
     };
 
     VkDescriptorPoolCreateInfo pool_info{};
     pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    pool_info.maxSets = 192;  // expanded for static/dynamic/merge + per-frame compute sets
+    pool_info.maxSets = 216;  // expanded for static/dynamic/merge + per-frame compute sets (Phase 3: +10 racing onesweep/merge/tile_bin sets per frame slot)
     pool_info.poolSizeCount = 3;
     pool_info.pPoolSizes = pool_sizes;
 
@@ -439,13 +439,16 @@ void GsRenderer::create_descriptor_resources() {
     static_assert(kMaxFramesInFlight == 2,
                   "Per-frame descriptor allocation below assumes 2 frames in flight; "
                   "if you change kMaxFramesInFlight, also extend the per-frame slot "
-                  "indices for render/post_process/tile_render at the end of `layouts`.");
+                  "indices for render/post_process/tile_render and the Phase 2/3 "
+                  "per-frame compute sets (preprocess/sort/static_preprocess/"
+                  "dynamic_preprocess/merge/depth_hist/depth_scatter/dynamic_depth_hist/"
+                  "dynamic_depth_scatter) at the end of `layouts`.");
 
     VkDescriptorSetLayout layouts[] = {
         preprocess_layout_, sort_layout_, render_layout_,   // 0-2: legacy preprocess_sets_[0], sort_sets_[0], render_sets_[0]
         post_process_layout_,                               // 3: post-process (post_process_sets_[0])
         preprocess_layout_, preprocess_layout_,             // 4-5: static_preprocess_sets_[0], dynamic_preprocess_sets_[0]
-        merge_layout_,                                      // 6: merge
+        merge_layout_,                                      // 6: merge_sets_[0]
         render_layout_,                                     // 7: merged render
         pbd_layout_,                                        // 8: PBD solver
         // Tile binning sets
@@ -456,12 +459,12 @@ void GsRenderer::create_descriptor_resources() {
         onesweep_hist_layout_, onesweep_hist_layout_,       // 13-14: tile onesweep histogram A, B
         onesweep_scatter_layout_, onesweep_scatter_layout_, // 15-16: tile onesweep scatter A→B, B→A
         // Depth sort Onesweep sets (reusing onesweep layouts)
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 17-18: legacy depth hist A, B
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 19-20: legacy depth scatter AB, BA
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 21-22: static depth hist A, B
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 23-24: static depth scatter AB, BA
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 25-26: dynamic depth hist A, B
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 27-28: dynamic depth scatter AB, BA
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 17-18: legacy depth hist A, B (slot [0])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 19-20: legacy depth scatter AB, BA (slot [0])
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 21-22: static depth hist A, B (single-instance)
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 23-24: static depth scatter AB, BA (single-instance)
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 25-26: dynamic depth hist A, B (slot [0])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 27-28: dynamic depth scatter AB, BA (slot [0])
         tile_scan_layout_,                                  // 29: deterministic tile-bin scan
         // Per-frame [1] copies for sets that bind per-frame images:
         render_layout_,                                     // 30: render_sets_[1]
@@ -469,13 +472,25 @@ void GsRenderer::create_descriptor_resources() {
         tile_render_layout_,                                // 32: tile_render_sets_[1]
         // Phase 2 per-frame [1] copies for compute sets that bind per-frame
         // racing SSBOs (projected, sort_keys, visible_count, counts, dynamic_sort_a).
-        // Dispatch still binds [0]; Phase 3 routes frame_in_flight here.
         preprocess_layout_,                                 // 33: preprocess_sets_[1]
         sort_layout_,                                       // 34: sort_sets_[1]
         preprocess_layout_,                                 // 35: static_preprocess_sets_[1]
         preprocess_layout_,                                 // 36: dynamic_preprocess_sets_[1]
+        // Phase 3 per-frame [1] copies for the racing onesweep/merge sets.
+        // Dispatch binds [frame_in_flight] for these — frame N+1's preprocess
+        // writes its own slot's projected/sort_keys/visible_count without
+        // clobbering frame N's still-active reads.
+        merge_layout_,                                      // 37: merge_sets_[1]
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 38-39: legacy depth hist A, B (slot [1])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 40-41: legacy depth scatter AB, BA (slot [1])
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 42-43: dynamic depth hist A, B (slot [1])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 44-45: dynamic depth scatter AB, BA (slot [1])
+        // tile_bin_set_ reads racing projected/merged/counts — must be per-frame
+        // so tile_bin in frame f reads the slot frame f's preprocess wrote.
+        // (slot [0] is sets[9]; this is the slot [1] copy.)
+        tile_bin_layout_,                                   // 46: tile_bin_sets_[1]
     };
-    constexpr uint32_t kSetCount = 37;
+    constexpr uint32_t kSetCount = 47;
     VkDescriptorSet sets[kSetCount];
     VkDescriptorSetAllocateInfo alloc_info{};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -498,11 +513,13 @@ void GsRenderer::create_descriptor_resources() {
     static_preprocess_sets_[1] = sets[35];
     dynamic_preprocess_sets_[0] = sets[5];
     dynamic_preprocess_sets_[1] = sets[36];
-    merge_set_ = sets[6];
+    merge_sets_[0] = sets[6];
+    merge_sets_[1] = sets[37];
     // sets[7] is the merged render set (render_layout_)
     pbd_set_ = sets[8];
     // Tile binning
-    tile_bin_set_ = sets[9];
+    tile_bin_sets_[0] = sets[9];
+    tile_bin_sets_[1] = sets[46];
     tile_ranges_set_ = sets[10];
     tile_indirect_set_ = sets[11];
     tile_render_sets_[0] = sets[12];
@@ -511,21 +528,29 @@ void GsRenderer::create_descriptor_resources() {
     onesweep_hist_set_b_ = sets[14];
     onesweep_scatter_set_ab_ = sets[15];
     onesweep_scatter_set_ba_ = sets[16];
-    // Depth sort Onesweep (legacy)
-    depth_hist_set_a_ = sets[17];
-    depth_hist_set_b_ = sets[18];
-    depth_scatter_set_ab_ = sets[19];
-    depth_scatter_set_ba_ = sets[20];
-    // Depth sort Onesweep (static)
+    // Depth sort Onesweep (legacy) — per-frame (racing sort_keys/sort_b SSBOs)
+    depth_hist_sets_a_[0] = sets[17];
+    depth_hist_sets_b_[0] = sets[18];
+    depth_scatter_sets_ab_[0] = sets[19];
+    depth_scatter_sets_ba_[0] = sets[20];
+    depth_hist_sets_a_[1] = sets[38];
+    depth_hist_sets_b_[1] = sets[39];
+    depth_scatter_sets_ab_[1] = sets[40];
+    depth_scatter_sets_ba_[1] = sets[41];
+    // Depth sort Onesweep (static) — single-instance (static_sort_a_/b_ GPU-fenced)
     static_depth_hist_set_a_ = sets[21];
     static_depth_hist_set_b_ = sets[22];
     static_depth_scatter_set_ab_ = sets[23];
     static_depth_scatter_set_ba_ = sets[24];
-    // Depth sort Onesweep (dynamic)
-    dynamic_depth_hist_set_a_ = sets[25];
-    dynamic_depth_hist_set_b_ = sets[26];
-    dynamic_depth_scatter_set_ab_ = sets[27];
-    dynamic_depth_scatter_set_ba_ = sets[28];
+    // Depth sort Onesweep (dynamic) — per-frame (racing dynamic_sort_as_/bs_)
+    dynamic_depth_hist_sets_a_[0] = sets[25];
+    dynamic_depth_hist_sets_b_[0] = sets[26];
+    dynamic_depth_scatter_sets_ab_[0] = sets[27];
+    dynamic_depth_scatter_sets_ba_[0] = sets[28];
+    dynamic_depth_hist_sets_a_[1] = sets[42];
+    dynamic_depth_hist_sets_b_[1] = sets[43];
+    dynamic_depth_scatter_sets_ab_[1] = sets[44];
+    dynamic_depth_scatter_sets_ba_[1] = sets[45];
     // Deterministic tile-bin scan
     tile_scan_set_ = sets[29];
 }
@@ -1117,7 +1142,7 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
     }
 
     sort_done_once_ = false;
-    static_dirty_ = true;
+    static_dirty_frames_remaining_ = kMaxFramesInFlight;
 
     // Pre-allocate ALL buffers to full budget size
     max_static_count_ = config.gpu_budget_splats;
@@ -1411,12 +1436,14 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
     chunk_table_ssbo_ = Buffer::create_storage_host_dst(allocator_, 256 * 16);
     std::memset(chunk_table_ssbo_.mapped(), 0, 256 * 16);
 
-    // Zero the counts buffer (Phase 1: slot [0] only; Phase 3 indexes by frame).
-    {
-        auto* counts = static_cast<uint32_t*>(counts_ssbos_[0].mapped());
-        counts[0] = 0;
-        counts[1] = 0;
-        counts[2] = 0;
+    // Zero the counts buffer (Phase 3: every per-frame slot).
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        if (counts_ssbos_[f].mapped()) {
+            auto* counts = static_cast<uint32_t*>(counts_ssbos_[f].mapped());
+            counts[0] = 0;
+            counts[1] = 0;
+            counts[2] = 0;
+        }
     }
 
     active_chunks_.clear();
@@ -1510,7 +1537,7 @@ void GsRenderer::clear_chunks(VkCommandBuffer drain_cmd) {
     gaussian_count_ = 0;
     dynamic_count_ = 0;
     sort_done_once_ = false;
-    static_dirty_ = true;
+    static_dirty_frames_remaining_ = kMaxFramesInFlight;
 
     // Zero the dynamic SSBO so a future over-count of `dynamic_count_`
     // can't surface old-scene gaussians as ghost geometry. memset (not
@@ -1572,11 +1599,15 @@ void GsRenderer::clear_chunks(VkCommandBuffer drain_cmd) {
     // Reset the visibility counts so the first post-portal frame doesn't
     // start by reading {static_visible, dynamic_visible, merged_visible}
     // values left over from the previous scene's last frame.
-    if (counts_ssbos_[0].mapped()) {
-        auto* counts = static_cast<uint32_t*>(counts_ssbos_[0].mapped());
-        counts[0] = 0;
-        counts[1] = 0;
-        counts[2] = 0;
+    // Phase 3: reset every per-frame slot since the next render will pick
+    // whichever slot frame_in_flight points at.
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        if (counts_ssbos_[f].mapped()) {
+            auto* counts = static_cast<uint32_t*>(counts_ssbos_[f].mapped());
+            counts[0] = 0;
+            counts[1] = 0;
+            counts[2] = 0;
+        }
     }
 
     // Zero the static splat data itself. Streaming-path uploads wrote
@@ -1618,13 +1649,36 @@ void GsRenderer::clear_chunks(VkCommandBuffer drain_cmd) {
     // Buffer is HOST_VISIBLE+MAPPED, sized for max_static_count_ +
     // max_dynamic_count_ × sizeof(ProjectedSplat) (48 bytes/entry).
     // vkDeviceWaitIdle above guarantees GPU is idle.
-    if (projected_ssbos_[0].mapped()) {
-        const size_t total = static_cast<size_t>(max_static_count_ + max_dynamic_count_);
-        if (total > 0) {
-            std::memset(projected_ssbos_[0].mapped(), 0,
-                        total * sizeof(ProjectedSplat));
+    // Phase 3: zero every per-frame slot since the next render will pick
+    // whichever slot frame_in_flight points at.
+    const size_t total_projected =
+        static_cast<size_t>(max_static_count_ + max_dynamic_count_);
+    if (total_projected > 0) {
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            if (projected_ssbos_[f].mapped()) {
+                std::memset(projected_ssbos_[f].mapped(), 0,
+                            total_projected * sizeof(ProjectedSplat));
+            }
         }
     }
+
+    // Reset the merged_sort tail to zero across all per-frame slots so the
+    // first post-portal frame's merge sees a clean output buffer.
+    const size_t merged_total =
+        static_cast<size_t>(max_static_count_ + max_dynamic_count_);
+    if (merged_total > 0) {
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            if (merged_sort_ssbos_[f].mapped()) {
+                std::memset(merged_sort_ssbos_[f].mapped(), 0,
+                            merged_total * sizeof(SortEntry));
+            }
+        }
+    }
+
+    // Ensure every per-frame slot's projected static head is refreshed
+    // by static_preprocess once. Phase 3's per-frame routing means each
+    // slot must run static_preprocess at least once after a scene clear.
+    static_dirty_frames_remaining_ = kMaxFramesInFlight;
 }
 
 std::vector<GsRenderer::ChunkInventoryEntry> GsRenderer::chunk_inventory() const {
@@ -2114,7 +2168,7 @@ void GsRenderer::publish_pending_chunks(VkCommandBuffer cmd) {
         for (const auto& c : active_chunks_) static_count_ += c.splat_count;
         total_active_splats_ = static_count_;
         gaussian_count_ = static_count_;
-        static_dirty_ = true;
+        static_dirty_frames_remaining_ = kMaxFramesInFlight;
 
         // Sentinel-fill the static_sort_a_/b_ delta window when this batch
         // shrunk static_count_. The depth sort each frame writes keys for
@@ -2220,9 +2274,13 @@ void GsRenderer::set_persistent_dynamics(const Gaussian* data, uint32_t count) {
     }
 
     // Reinitialize dynamic sort buffers for the active range [0..count).
-    // Phase 1: slot [0] only; Phase 3 will index by frame_in_flight.
-    init_dynamic_sort_buf(dynamic_sort_as_[0], dynamic_sort_size_, count);
-    init_dynamic_sort_buf(dynamic_sort_bs_[0], dynamic_sort_size_, count);
+    // Phase 3: write every per-frame slot. The next render will fill the
+    // active slot via vkCmdFillBuffer, but other slots inherit this init
+    // until their first frame uses them.
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        init_dynamic_sort_buf(dynamic_sort_as_[f], dynamic_sort_size_, count);
+        init_dynamic_sort_buf(dynamic_sort_bs_[f], dynamic_sort_size_, count);
+    }
 
     std::fprintf(stderr,
         "[gs_renderer] persistent dynamics uploaded: %u splats (chars+NPCs+PBD-trees)\n",
@@ -2288,8 +2346,11 @@ void GsRenderer::update_active_gaussians(const Gaussian* data, uint32_t count) {
         }
         std::memcpy(buf.mapped(), staging_sort.data(), sort_size_ * sizeof(SortEntry));
     };
-    init_sort_buf(sort_keys_ssbos_[0]);
-    init_sort_buf(sort_b_ssbos_[0]);
+    // Phase 3: init every per-frame slot. The legacy sort path consumes these.
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        init_sort_buf(sort_keys_ssbos_[f]);
+        init_sort_buf(sort_b_ssbos_[f]);
+    }
 }
 
 void GsRenderer::update_gaussian_data(const Gaussian* data, uint32_t count) {
@@ -2498,14 +2559,16 @@ void GsRenderer::update_descriptors() {
             }
         };
 
-        // Legacy depth sort sets. Phase 2: onesweep sets stay single-instance,
-        // so we bind racing buffer slot [0]. Phase 3 will either make these
-        // per-frame or route around the legacy path entirely.
-        write_depth_onesweep_sets(
-            depth_hist_set_a_, depth_hist_set_b_,
-            depth_scatter_set_ab_, depth_scatter_set_ba_,
-            sort_keys_ssbos_[0].buffer(), sort_b_ssbos_[0].buffer(),
-            depth_onesweep_status_.buffer(), depth_sort_params_.buffer());
+        // Legacy depth sort sets — per-frame (Phase 3). Each frame slot
+        // binds its own sort_keys_ssbos_[f] / sort_b_ssbos_[f] so frame N+1's
+        // dispatch reads its own slot, never frame N's still-in-use slot.
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            write_depth_onesweep_sets(
+                depth_hist_sets_a_[f], depth_hist_sets_b_[f],
+                depth_scatter_sets_ab_[f], depth_scatter_sets_ba_[f],
+                sort_keys_ssbos_[f].buffer(), sort_b_ssbos_[f].buffer(),
+                depth_onesweep_status_.buffer(), depth_sort_params_.buffer());
+        }
     }
 
     // --- Static/dynamic split descriptor sets ---
@@ -2648,31 +2711,36 @@ void GsRenderer::update_descriptors() {
             static_depth_scatter_set_ab_, static_depth_scatter_set_ba_,
             static_sort_a_.buffer(), static_sort_b_.buffer(),
             depth_onesweep_status_.buffer(), static_depth_params_.buffer());
-        // Dynamic depth sort. Phase 2: dynamic depth onesweep sets stay
-        // single-instance, so we bind racing buffer slot [0] (dynamic_sort_as_[0],
-        // dynamic_sort_bs_[0]). Phase 3 will revisit if needed.
-        write_depth_onesweep_sets(
-            dynamic_depth_hist_set_a_, dynamic_depth_hist_set_b_,
-            dynamic_depth_scatter_set_ab_, dynamic_depth_scatter_set_ba_,
-            dynamic_sort_as_[0].buffer(), dynamic_sort_bs_[0].buffer(),
-            depth_onesweep_status_.buffer(), dynamic_depth_params_.buffer());
+        // Dynamic depth sort — per-frame (Phase 3). Each frame slot binds
+        // its own dynamic_sort_as_[f] / dynamic_sort_bs_[f] so frame N+1's
+        // dispatch reads its own slot.
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            write_depth_onesweep_sets(
+                dynamic_depth_hist_sets_a_[f], dynamic_depth_hist_sets_b_[f],
+                dynamic_depth_scatter_sets_ab_[f], dynamic_depth_scatter_sets_ba_[f],
+                dynamic_sort_as_[f].buffer(), dynamic_sort_bs_[f].buffer(),
+                depth_onesweep_status_.buffer(), dynamic_depth_params_.buffer());
+        }
     }
 
     // Merge set: static_sort_a(0), dynamic_sort_a(1), merged_sort(2), counts(3)
-    {
+    // Per-frame (Phase 3): merge_sets_[f] binds dynamic_sort_as_[f],
+    // merged_sort_ssbos_[f], counts_ssbos_[f]. static_sort_a_ is single-instance.
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
         VkDescriptorBufferInfo static_info{static_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo dynamic_info{dynamic_sort_as_[0].buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo merged_info{merged_sort_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo counts_info{counts_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo dynamic_info{dynamic_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo merged_info{merged_sort_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo counts_info{counts_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
 
+        VkDescriptorSet merge_set = merge_sets_[f];
         VkWriteDescriptorSet writes[] = {
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, merge_set_, 0, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, merge_set, 0, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &static_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, merge_set_, 1, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, merge_set, 1, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &dynamic_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, merge_set_, 2, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, merge_set, 2, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &merged_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, merge_set_, 3, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, merge_set, 3, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &counts_info, nullptr},
         };
         vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
@@ -2717,29 +2785,36 @@ void GsRenderer::update_descriptors() {
         //   4 per_splat_offset (scatter reads here)
         //   5 tile_entries (scatter writes here)
         //   6 uniforms
-        {
-            VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo merged_info{merged_sort_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo counts_info{counts_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        //
+        // Per-frame (Phase 3): tile_bin_sets_[f] binds the per-frame
+        // projected/merged/counts slots so tile_bin in frame f reads the
+        // data frame f's preprocess+merge wrote earlier in the same
+        // command buffer. Frame N+1's tile_bin no longer reads frame N's
+        // slot. per_splat_*, tile_entries, uniforms remain single-instance.
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            VkDescriptorBufferInfo projected_info{projected_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo merged_info{merged_sort_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo counts_info{counts_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo per_splat_count_info{per_splat_tile_count_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo per_splat_offset_info{per_splat_tile_offset_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo tile_entries_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
 
+            VkDescriptorSet tile_bin_set = tile_bin_sets_[f];
             VkWriteDescriptorSet writes[] = {
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set_, 0, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 0, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &projected_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set_, 1, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 1, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &merged_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set_, 2, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 2, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &counts_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set_, 3, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 3, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &per_splat_count_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set_, 4, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 4, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &per_splat_offset_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set_, 5, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 5, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &tile_entries_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set_, 6, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 6, 0, 1,
                  VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
             };
             vkUpdateDescriptorSets(device_, 7, writes, 0, nullptr);
@@ -2863,9 +2938,12 @@ void GsRenderer::update_descriptors() {
         }
 
         // Tile render set: projected(0), tile_entries(1), uniforms(2), output_image(3), tile_ranges(4), depth_image(5)
-        // Per-frame: each tile_render_sets_[i] binds frame i's output and depth views.
+        // Per-frame (Phase 3): each tile_render_sets_[f] binds frame f's
+        // output/depth views AND frame f's projected_ssbos_[f]. The tile_render
+        // dispatch runs in frame f's command buffer and reads projected data
+        // that frame f's preprocess wrote earlier in the same command buffer.
         for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-            VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo projected_info{projected_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo tile_entries_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
             VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_views_[f], VK_IMAGE_LAYOUT_GENERAL};
@@ -3053,7 +3131,7 @@ void GsRenderer::dispatch_depth_onesweep(
     // After even number of passes, sorted result is in buffer A
 }
 
-void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd) {
+void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_flight) {
     // Reset the per-frame "did we record a readback?" flag at the start of
     // every dispatch attempt. The harness in Renderer::draw_scene reads
     // this flag after the in-flight fence to decide whether the captured
@@ -3100,7 +3178,7 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd) {
     {
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_count_pipeline_);
         vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                tile_bin_pipeline_layout_, 0, 1, &tile_bin_set_, 0, nullptr);
+                                tile_bin_pipeline_layout_, 0, 1, &tile_bin_sets_[frame_in_flight], 0, nullptr);
         // Push range allocated for the scatter; count shader has no push,
         // but Vulkan permits leaving the range untouched.
         uint32_t push_data[1] = {tile_sort_capacity_};
@@ -3143,7 +3221,7 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd) {
     {
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_bin_pipeline_);
         vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                tile_bin_pipeline_layout_, 0, 1, &tile_bin_set_, 0, nullptr);
+                                tile_bin_pipeline_layout_, 0, 1, &tile_bin_sets_[frame_in_flight], 0, nullptr);
         uint32_t push_data[1] = {tile_sort_capacity_};
         vkCmdPushConstants(cmd, tile_bin_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
                            0, 4, push_data);
@@ -3524,12 +3602,15 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
             // Reset counts that will be written this frame
             // counts[0]=static_visible (reset if static dirty), counts[1]=dynamic_visible (always reset)
             // vkCmdFillBuffer requires offset/size to be multiples of 4 (satisfied)
-            if (static_dirty_ && static_count_ > 0) {
+            // Phase 3: writes go to frame_in_flight's per-frame slot.
+            const bool static_dirty_this_frame =
+                static_dirty_frames_remaining_ > 0 && static_count_ > 0;
+            if (static_dirty_this_frame) {
                 // Reset all 3 counts (static + dynamic + merged)
-                vkCmdFillBuffer(cmd, counts_ssbos_[0].buffer(), 0, 12, 0);
+                vkCmdFillBuffer(cmd, counts_ssbos_[frame_in_flight].buffer(), 0, 12, 0);
             } else {
                 // Reset only dynamic visible count (counts[1]) and merged (counts[2])
-                vkCmdFillBuffer(cmd, counts_ssbos_[0].buffer(), 4, 8, 0);
+                vkCmdFillBuffer(cmd, counts_ssbos_[frame_in_flight].buffer(), 4, 8, 0);
             }
 
             // Per-frame GPU-side init of dynamic sort buffers.
@@ -3551,11 +3632,12 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
             // [0..0xFFFE] for visible, 0xFFFF for culled) and indices, so the
             // active range is fresh. Inactive slots keep 0xFFFFFFFF, sorting
             // them past 0xFFFF and out of the counts[1] visible window.
-            if (dynamic_count_ > 0 && dynamic_sort_as_[0].buffer() && dynamic_sort_bs_[0].buffer()) {
+            // Phase 3: fill frame_in_flight's per-frame slot.
+            if (dynamic_count_ > 0 && dynamic_sort_as_[frame_in_flight].buffer() && dynamic_sort_bs_[frame_in_flight].buffer()) {
                 const VkDeviceSize dyn_sort_bytes =
                     static_cast<VkDeviceSize>(dynamic_sort_size_) * sizeof(SortEntry);
-                vkCmdFillBuffer(cmd, dynamic_sort_as_[0].buffer(), 0, dyn_sort_bytes, 0xFFFFFFFFu);
-                vkCmdFillBuffer(cmd, dynamic_sort_bs_[0].buffer(), 0, dyn_sort_bytes, 0xFFFFFFFFu);
+                vkCmdFillBuffer(cmd, dynamic_sort_as_[frame_in_flight].buffer(), 0, dyn_sort_bytes, 0xFFFFFFFFu);
+                vkCmdFillBuffer(cmd, dynamic_sort_bs_[frame_in_flight].buffer(), 0, dyn_sort_bytes, 0xFFFFFFFFu);
             }
             {
                 VkMemoryBarrier fill_barrier{};
@@ -3577,9 +3659,9 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
             // === Phase 1: Dynamic preprocess + sort (every frame, if dynamic_count_ > 0) ===
             if (dynamic_count_ > 0) {
                 vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, preprocess_pipeline_);
-                // Phase 2: still binding slot [0]; Phase 3 routes frame_in_flight here.
+                // Phase 3: bind frame_in_flight's per-frame slot.
                 vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                        preprocess_pipeline_layout_, 0, 1, &dynamic_preprocess_sets_[0], 0, nullptr);
+                                        preprocess_pipeline_layout_, 0, 1, &dynamic_preprocess_sets_[frame_in_flight], 0, nullptr);
                 GsPreprocessPush dyn_push{max_static_count_, dynamic_count_, 1};
                 vkCmdPushConstants(cmd, preprocess_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
                                    0, sizeof(GsPreprocessPush), &dyn_push);
@@ -3587,18 +3669,23 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
 
                 insert_compute_barrier(cmd);
 
-                // Sort dynamic (Onesweep)
+                // Sort dynamic (Onesweep) — Phase 3: per-frame sets read this
+                // frame's dynamic_sort_as_[f]/bs_[f].
                 dispatch_depth_onesweep(cmd, dynamic_sort_size_, dynamic_sort_workgroups_,
-                    dynamic_depth_hist_set_a_, dynamic_depth_hist_set_b_,
-                    dynamic_depth_scatter_set_ab_, dynamic_depth_scatter_set_ba_);
+                    dynamic_depth_hist_sets_a_[frame_in_flight], dynamic_depth_hist_sets_b_[frame_in_flight],
+                    dynamic_depth_scatter_sets_ab_[frame_in_flight], dynamic_depth_scatter_sets_ba_[frame_in_flight]);
             }
 
             // === Phase 2: Static preprocess + sort (only when static_dirty_) ===
-            if (static_dirty_ && static_count_ > 0) {
+            // Phase 3: static_dirty_frames_remaining_ tracks per-frame slots
+            // that still need a refresh after the last static mutation.
+            if (static_dirty_frames_remaining_ > 0 && static_count_ > 0) {
                 vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, preprocess_pipeline_);
-                // Phase 2: still binding slot [0]; Phase 3 routes frame_in_flight here.
+                // Phase 3: bind frame_in_flight's per-frame slot. The static
+                // head of projected_ssbos_[f] is refreshed once per slot per
+                // dirty cycle.
                 vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                        preprocess_pipeline_layout_, 0, 1, &static_preprocess_sets_[0], 0, nullptr);
+                                        preprocess_pipeline_layout_, 0, 1, &static_preprocess_sets_[frame_in_flight], 0, nullptr);
                 GsPreprocessPush stat_push{0, static_count_, 0};
                 vkCmdPushConstants(cmd, preprocess_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
                                    0, sizeof(GsPreprocessPush), &stat_push);
@@ -3606,12 +3693,13 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
 
                 insert_compute_barrier(cmd);
 
-                // Sort static (Onesweep)
+                // Sort static (Onesweep) — static_*_set_ are single-instance
+                // (static_sort_a_/b_ are GPU-fenced via this dirty flow).
                 dispatch_depth_onesweep(cmd, static_sort_size_, static_sort_workgroups_,
                     static_depth_hist_set_a_, static_depth_hist_set_b_,
                     static_depth_scatter_set_ab_, static_depth_scatter_set_ba_);
 
-                static_dirty_ = false;
+                static_dirty_frames_remaining_--;
             }
 
             // === Phase 3: Merge (every frame) ===
@@ -3619,8 +3707,9 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
             // Thread 0 computes merged_visible_count = static_count + dynamic_count
             {
                 vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, merge_pipeline_);
+                // Phase 3: bind frame_in_flight's per-frame merge set.
                 vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                        merge_pipeline_layout_, 0, 1, &merge_set_, 0, nullptr);
+                                        merge_pipeline_layout_, 0, 1, &merge_sets_[frame_in_flight], 0, nullptr);
                 // Dispatch enough threads to cover possible visible count
                 // Use sort sizes as upper bound (actual count determined by shader from counts SSBO)
                 uint32_t total = static_sort_size_ + dynamic_sort_size_;
@@ -3640,7 +3729,7 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
                 vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
                                    timestamp_pool_, 2);  // tile_sort_begin
             }
-            dispatch_tile_sort(cmd);
+            dispatch_tile_sort(cmd, frame_in_flight);
             if (timestamp_pool_) {
                 vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
                                    timestamp_pool_, 3);  // tile_sort_end

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1138,11 +1138,7 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
 
     // Destroy ALL old buffers (legacy + split)
     gaussian_ssbo_.destroy(allocator_);
-    projected_ssbo_.destroy(allocator_);
-    sort_keys_ssbo_.destroy(allocator_);
-    sort_b_ssbo_.destroy(allocator_);
     uniform_buffer_.destroy(allocator_);
-    visible_count_ssbo_.destroy(allocator_);
     bone_ssbo_.destroy(allocator_);
     pbd_state_ssbo_.destroy(allocator_);
     pbd_params_ssbo_.destroy(allocator_);
@@ -1152,10 +1148,17 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
     dynamic_gaussian_ssbo_.destroy(allocator_);
     static_sort_a_.destroy(allocator_);
     static_sort_b_.destroy(allocator_);
-    dynamic_sort_a_.destroy(allocator_);
-    dynamic_sort_b_.destroy(allocator_);
-    merged_sort_ssbo_.destroy(allocator_);
-    counts_ssbo_.destroy(allocator_);
+    // Per-frame racing SSBOs: destroy every slot.
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        projected_ssbos_[f].destroy(allocator_);
+        sort_keys_ssbos_[f].destroy(allocator_);
+        sort_b_ssbos_[f].destroy(allocator_);
+        visible_count_ssbos_[f].destroy(allocator_);
+        dynamic_sort_as_[f].destroy(allocator_);
+        dynamic_sort_bs_[f].destroy(allocator_);
+        merged_sort_ssbos_[f].destroy(allocator_);
+        counts_ssbos_[f].destroy(allocator_);
+    }
     page_table_ssbo_.destroy(allocator_);
     chunk_table_ssbo_.destroy(allocator_);
     tile_sort_a_.destroy(allocator_);
@@ -1177,23 +1180,33 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
     // surface as "ghost geometry from initial spawn state".
     static_gaussian_ssbo_ = Buffer::create_storage_host_dst(allocator_, static_gauss_size);
     dynamic_gaussian_ssbo_ = Buffer::create_storage(allocator_, dynamic_gauss_size);
-    projected_ssbo_ = Buffer::create_storage(allocator_, projected_buf_size);
     // host_dst flag = TRANSFER_DST_BIT, required for the per-frame
     // vkCmdFillBuffer in publish_pending_chunks that sentinel-fills the
     // [new_count, prev_count) tail when streaming Unloads shrink static_count_.
     static_sort_a_ = Buffer::create_storage_host_dst(allocator_, static_sort_buf_size);
     static_sort_b_ = Buffer::create_storage_host_dst(allocator_, static_sort_buf_size);
+    uniform_buffer_ = Buffer::create_uniform(allocator_, sizeof(GsUniforms));
+
+    // Per-frame racing SSBOs: create one slot per frame in flight. Phase 1
+    // of the cross-frame race fix; all consumers still index slot [0] for
+    // now, so behavior is unchanged. Phase 3 wires frame_in_flight into
+    // dispatch sites to actually use the per-frame slots.
+    //
     // Dynamic sort buffers also need TRANSFER_DST_BIT — render() issues a
     // per-frame vkCmdFillBuffer against them to GPU-side init the sentinel
     // keys before the dynamic preprocess overwrites the active range.
     // Without TRANSFER_DST the fillbuffer is a Vulkan-spec violation
     // (validation error / UB). Codex review on PR #420 flagged this.
-    dynamic_sort_a_ = Buffer::create_storage_host_dst(allocator_, dynamic_sort_buf_size);
-    dynamic_sort_b_ = Buffer::create_storage_host_dst(allocator_, dynamic_sort_buf_size);
-    merged_sort_ssbo_ = Buffer::create_storage(allocator_, merged_sort_buf_size);
-    counts_ssbo_ = Buffer::create_storage_readback(allocator_, 3 * sizeof(uint32_t));
-    uniform_buffer_ = Buffer::create_uniform(allocator_, sizeof(GsUniforms));
-    visible_count_ssbo_ = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        projected_ssbos_[f]     = Buffer::create_storage(allocator_, projected_buf_size);
+        sort_keys_ssbos_[f]     = Buffer::create_storage(allocator_, static_sort_buf_size);
+        sort_b_ssbos_[f]        = Buffer::create_storage(allocator_, static_sort_buf_size);
+        visible_count_ssbos_[f] = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
+        dynamic_sort_as_[f]     = Buffer::create_storage_host_dst(allocator_, dynamic_sort_buf_size);
+        dynamic_sort_bs_[f]     = Buffer::create_storage_host_dst(allocator_, dynamic_sort_buf_size);
+        counts_ssbos_[f]        = Buffer::create_storage_readback(allocator_, 3 * sizeof(uint32_t));
+        merged_sort_ssbos_[f]   = Buffer::create_storage(allocator_, merged_sort_buf_size);
+    }
 
     // Defense in depth: zero/sentinel-fill all splat-related buffers at init.
     // VMA does not guarantee zero-init for new allocations, so the bytes
@@ -1208,9 +1221,6 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
                 static_cast<size_t>(max_static_count_) * sizeof(GpuGaussian));
     std::memset(dynamic_gaussian_ssbo_.mapped(), 0,
                 static_cast<size_t>(max_dynamic_count_) * sizeof(GpuGaussian));
-    std::memset(projected_ssbo_.mapped(), 0,
-                static_cast<size_t>(max_static_count_ + max_dynamic_count_)
-                    * sizeof(ProjectedSplat));
     {
         // Sentinel-fill sort buffers: key=0xFFFFFFFF sorts to the tail and
         // is never read by the merge's [0, count) window. index=0 is a
@@ -1227,21 +1237,25 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
         };
         sentinel_fill_sort(static_sort_a_, static_sort_size_);
         sentinel_fill_sort(static_sort_b_, static_sort_size_);
-        sentinel_fill_sort(dynamic_sort_a_, dynamic_sort_size_);
-        sentinel_fill_sort(dynamic_sort_b_, dynamic_sort_size_);
-        // merged_sort_ssbo_ is rewritten by the merge stage every frame
-        // for [0, total_count); tile_bin reads only that range. No
-        // sentinel needed here, but zero it for cleanliness.
-        std::memset(merged_sort_ssbo_.mapped(), 0,
-                    static_cast<size_t>(max_static_count_ + max_dynamic_count_)
-                        * sizeof(SortEntry));
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            std::memset(projected_ssbos_[f].mapped(), 0,
+                        static_cast<size_t>(max_static_count_ + max_dynamic_count_)
+                            * sizeof(ProjectedSplat));
+            sentinel_fill_sort(dynamic_sort_as_[f], dynamic_sort_size_);
+            sentinel_fill_sort(dynamic_sort_bs_[f], dynamic_sort_size_);
+            // merged_sort_ssbos_ is rewritten by the merge stage every frame
+            // for [0, total_count); tile_bin reads only that range. No
+            // sentinel needed here, but zero it for cleanliness.
+            std::memset(merged_sort_ssbos_[f].mapped(), 0,
+                        static_cast<size_t>(max_static_count_ + max_dynamic_count_)
+                            * sizeof(SortEntry));
+        }
     }
 
-    // Legacy buffers (same sizes as static counterparts for backward compat)
+    // Legacy buffers (same sizes as static counterparts for backward compat).
+    // sort_keys/sort_b are now per-frame and created in the loop above.
     gaussian_ssbo_ = Buffer::create_storage(allocator_,
         static_cast<VkDeviceSize>(max_gaussian_count_) * sizeof(GpuGaussian));
-    sort_keys_ssbo_ = Buffer::create_storage(allocator_, static_sort_buf_size);
-    sort_b_ssbo_ = Buffer::create_storage(allocator_, static_sort_buf_size);
 
     // Bone transform SSBO
     bone_ssbo_ = Buffer::create_storage(allocator_, kMaxBones * sizeof(glm::mat4));
@@ -1384,9 +1398,9 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
     chunk_table_ssbo_ = Buffer::create_storage_host_dst(allocator_, 256 * 16);
     std::memset(chunk_table_ssbo_.mapped(), 0, 256 * 16);
 
-    // Zero the counts buffer
+    // Zero the counts buffer (Phase 1: slot [0] only; Phase 3 indexes by frame).
     {
-        auto* counts = static_cast<uint32_t*>(counts_ssbo_.mapped());
+        auto* counts = static_cast<uint32_t*>(counts_ssbos_[0].mapped());
         counts[0] = 0;
         counts[1] = 0;
         counts[2] = 0;
@@ -1545,8 +1559,8 @@ void GsRenderer::clear_chunks(VkCommandBuffer drain_cmd) {
     // Reset the visibility counts so the first post-portal frame doesn't
     // start by reading {static_visible, dynamic_visible, merged_visible}
     // values left over from the previous scene's last frame.
-    if (counts_ssbo_.mapped()) {
-        auto* counts = static_cast<uint32_t*>(counts_ssbo_.mapped());
+    if (counts_ssbos_[0].mapped()) {
+        auto* counts = static_cast<uint32_t*>(counts_ssbos_[0].mapped());
         counts[0] = 0;
         counts[1] = 0;
         counts[2] = 0;
@@ -1591,10 +1605,10 @@ void GsRenderer::clear_chunks(VkCommandBuffer drain_cmd) {
     // Buffer is HOST_VISIBLE+MAPPED, sized for max_static_count_ +
     // max_dynamic_count_ × sizeof(ProjectedSplat) (48 bytes/entry).
     // vkDeviceWaitIdle above guarantees GPU is idle.
-    if (projected_ssbo_.mapped()) {
+    if (projected_ssbos_[0].mapped()) {
         const size_t total = static_cast<size_t>(max_static_count_ + max_dynamic_count_);
         if (total > 0) {
-            std::memset(projected_ssbo_.mapped(), 0,
+            std::memset(projected_ssbos_[0].mapped(), 0,
                         total * sizeof(ProjectedSplat));
         }
     }
@@ -1817,8 +1831,8 @@ void GsRenderer::diag_streaming_dump(uint64_t frame) {
     // If sort indirection is bounding correctly, the rasterizer should
     // never reach these — but if real-looking projections sit here AND
     // the ghost still renders, something downstream is reading past count.
-    if (projected_ssbo_.mapped() && static_count_ < max_static_count_) {
-        const auto* p = static_cast<const ProjectedSplat*>(projected_ssbo_.mapped());
+    if (projected_ssbos_[0].mapped() && static_count_ < max_static_count_) {
+        const auto* p = static_cast<const ProjectedSplat*>(projected_ssbos_[0].mapped());
         const uint32_t scan_start = static_count_;
         const uint32_t scan_end =
             std::min<uint32_t>(static_count_ + 2048u, max_static_count_);
@@ -1854,8 +1868,8 @@ void GsRenderer::diag_streaming_dump(uint64_t frame) {
     // merged_sort_ssbo_: indices the rasterizer WILL read, bounded by
     // total_active_splats_. If max_idx >= max_static + max_dynamic that's
     // an out-of-bounds index — direct evidence of a bound bug.
-    if (merged_sort_ssbo_.mapped() && total_active_splats_ > 0) {
-        const auto* m = static_cast<const SortEntry*>(merged_sort_ssbo_.mapped());
+    if (merged_sort_ssbos_[0].mapped() && total_active_splats_ > 0) {
+        const auto* m = static_cast<const SortEntry*>(merged_sort_ssbos_[0].mapped());
         const uint32_t total_max = max_static_count_ + max_dynamic_count_;
         const uint32_t merge_count = total_active_splats_;
         uint32_t max_idx = 0;
@@ -2192,9 +2206,10 @@ void GsRenderer::set_persistent_dynamics(const Gaussian* data, uint32_t count) {
                     count * sizeof(GpuGaussian));
     }
 
-    // Reinitialize dynamic sort buffers for the active range [0..count)
-    init_dynamic_sort_buf(dynamic_sort_a_, dynamic_sort_size_, count);
-    init_dynamic_sort_buf(dynamic_sort_b_, dynamic_sort_size_, count);
+    // Reinitialize dynamic sort buffers for the active range [0..count).
+    // Phase 1: slot [0] only; Phase 3 will index by frame_in_flight.
+    init_dynamic_sort_buf(dynamic_sort_as_[0], dynamic_sort_size_, count);
+    init_dynamic_sort_buf(dynamic_sort_bs_[0], dynamic_sort_size_, count);
 
     std::fprintf(stderr,
         "[gs_renderer] persistent dynamics uploaded: %u splats (chars+NPCs+PBD-trees)\n",
@@ -2260,8 +2275,8 @@ void GsRenderer::update_active_gaussians(const Gaussian* data, uint32_t count) {
         }
         std::memcpy(buf.mapped(), staging_sort.data(), sort_size_ * sizeof(SortEntry));
     };
-    init_sort_buf(sort_keys_ssbo_);
-    init_sort_buf(sort_b_ssbo_);
+    init_sort_buf(sort_keys_ssbos_[0]);
+    init_sort_buf(sort_b_ssbos_[0]);
 }
 
 void GsRenderer::update_gaussian_data(const Gaussian* data, uint32_t count) {
@@ -2311,10 +2326,10 @@ void GsRenderer::update_descriptors() {
     // Preprocess set: gaussians(0), projected(1), sort_keys_A(2), uniforms(3), visible_count(4), bones(5), pbd(6), page_table(8)
     {
         VkDescriptorBufferInfo gaussian_info{gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo sort_info{sort_keys_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo sort_info{sort_keys_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
-        VkDescriptorBufferInfo visible_count_info{visible_count_ssbo_.buffer(), 0, sizeof(uint32_t)};
+        VkDescriptorBufferInfo visible_count_info{visible_count_ssbos_[0].buffer(), 0, sizeof(uint32_t)};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo pbd_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo page_table_info{page_table_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
@@ -2342,7 +2357,7 @@ void GsRenderer::update_descriptors() {
 
     // Legacy sort set
     {
-        VkDescriptorBufferInfo sort_info{sort_keys_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo sort_info{sort_keys_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
         VkWriteDescriptorSet writes[] = {
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, sort_set_, 0, 0, 1,
@@ -2356,11 +2371,11 @@ void GsRenderer::update_descriptors() {
     // Render set: projected(0), sort_keys_A(1), uniforms(2), output_image(3), visible_count(4), depth_image(5)
     // Per-frame: each render_sets_[i] binds output_views_[i] / depth_views_[i].
     for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-        VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo sort_info{sort_keys_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo sort_info{sort_keys_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
         VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_views_[f], VK_IMAGE_LAYOUT_GENERAL};
-        VkDescriptorBufferInfo visible_count_info{visible_count_ssbo_.buffer(), 0, sizeof(uint32_t)};
+        VkDescriptorBufferInfo visible_count_info{visible_count_ssbos_[0].buffer(), 0, sizeof(uint32_t)};
         VkDescriptorImageInfo depth_img_info{VK_NULL_HANDLE, depth_views_[f], VK_IMAGE_LAYOUT_GENERAL};
 
         VkDescriptorSet set = render_sets_[f];
@@ -2468,21 +2483,21 @@ void GsRenderer::update_descriptors() {
         write_depth_onesweep_sets(
             depth_hist_set_a_, depth_hist_set_b_,
             depth_scatter_set_ab_, depth_scatter_set_ba_,
-            sort_keys_ssbo_.buffer(), sort_b_ssbo_.buffer(),
+            sort_keys_ssbos_[0].buffer(), sort_b_ssbos_[0].buffer(),
             depth_onesweep_status_.buffer(), depth_sort_params_.buffer());
     }
 
     // --- Static/dynamic split descriptor sets ---
     // Only write these if the split buffers have been allocated
-    if (!static_gaussian_ssbo_.buffer() || !counts_ssbo_.buffer()) return;
+    if (!static_gaussian_ssbo_.buffer() || !counts_ssbos_[0].buffer()) return;
 
     // Static preprocess set: static_gaussian(0), projected(1), static_sort_a(2), uniforms(3), counts[0](4), bones(5), pbd(6), page_table(8)
     {
         VkDescriptorBufferInfo gaussian_info{static_gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo sort_info{static_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
-        VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo counts_info{counts_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo pbd_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo page_table_info{page_table_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
@@ -2511,10 +2526,10 @@ void GsRenderer::update_descriptors() {
     // Dynamic preprocess set: dynamic_gaussian(0), projected(1), dynamic_sort_a(2), uniforms(3), counts[1](4), bones(5), pbd(6), page_table(8)
     {
         VkDescriptorBufferInfo gaussian_info{dynamic_gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo sort_info{dynamic_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo sort_info{dynamic_sort_as_[0].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
-        VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo counts_info{counts_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo pbd_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo page_table_info{page_table_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
@@ -2610,16 +2625,16 @@ void GsRenderer::update_descriptors() {
         write_depth_onesweep_sets(
             dynamic_depth_hist_set_a_, dynamic_depth_hist_set_b_,
             dynamic_depth_scatter_set_ab_, dynamic_depth_scatter_set_ba_,
-            dynamic_sort_a_.buffer(), dynamic_sort_b_.buffer(),
+            dynamic_sort_as_[0].buffer(), dynamic_sort_bs_[0].buffer(),
             depth_onesweep_status_.buffer(), dynamic_depth_params_.buffer());
     }
 
     // Merge set: static_sort_a(0), dynamic_sort_a(1), merged_sort(2), counts(3)
     {
         VkDescriptorBufferInfo static_info{static_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo dynamic_info{dynamic_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo merged_info{merged_sort_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo dynamic_info{dynamic_sort_as_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo merged_info{merged_sort_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo counts_info{counts_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
 
         VkWriteDescriptorSet writes[] = {
             {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, merge_set_, 0, 0, 1,
@@ -2639,11 +2654,11 @@ void GsRenderer::update_descriptors() {
     // counts_ssbo, replacing the legacy bindings written above. Each
     // frame's set still references its frame-i image views.
     for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-        VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo merged_info{merged_sort_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo merged_info{merged_sort_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
         VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_views_[f], VK_IMAGE_LAYOUT_GENERAL};
-        VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo counts_info{counts_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorImageInfo depth_img_info{VK_NULL_HANDLE, depth_views_[f], VK_IMAGE_LAYOUT_GENERAL};
 
         VkDescriptorSet set = render_sets_[f];
@@ -2673,9 +2688,9 @@ void GsRenderer::update_descriptors() {
         //   5 tile_entries (scatter writes here)
         //   6 uniforms
         {
-            VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo merged_info{merged_sort_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo counts_info{counts_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo merged_info{merged_sort_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo counts_info{counts_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo per_splat_count_info{per_splat_tile_count_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo per_splat_offset_info{per_splat_tile_offset_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo tile_entries_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
@@ -2820,7 +2835,7 @@ void GsRenderer::update_descriptors() {
         // Tile render set: projected(0), tile_entries(1), uniforms(2), output_image(3), tile_ranges(4), depth_image(5)
         // Per-frame: each tile_render_sets_[i] binds frame i's output and depth views.
         for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-            VkDescriptorBufferInfo projected_info{projected_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo tile_entries_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
             VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_views_[f], VK_IMAGE_LAYOUT_GENERAL};
@@ -3472,7 +3487,7 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
         // Streaming-strict invariant: split buffers are always allocated
         // post-init. The wrapper remains for code-locality; collapsing it
         // is part of the post-1c descriptor-state cleanup (issue #397).
-        bool use_split = static_gaussian_ssbo_.buffer() && counts_ssbo_.buffer();
+        bool use_split = static_gaussian_ssbo_.buffer() && counts_ssbos_[0].buffer();
         assert(use_split && "render: split buffers must be allocated in streaming-strict mode");
 
         if (use_split) {
@@ -3481,10 +3496,10 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
             // vkCmdFillBuffer requires offset/size to be multiples of 4 (satisfied)
             if (static_dirty_ && static_count_ > 0) {
                 // Reset all 3 counts (static + dynamic + merged)
-                vkCmdFillBuffer(cmd, counts_ssbo_.buffer(), 0, 12, 0);
+                vkCmdFillBuffer(cmd, counts_ssbos_[0].buffer(), 0, 12, 0);
             } else {
                 // Reset only dynamic visible count (counts[1]) and merged (counts[2])
-                vkCmdFillBuffer(cmd, counts_ssbo_.buffer(), 4, 8, 0);
+                vkCmdFillBuffer(cmd, counts_ssbos_[0].buffer(), 4, 8, 0);
             }
 
             // Per-frame GPU-side init of dynamic sort buffers.
@@ -3506,11 +3521,11 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
             // [0..0xFFFE] for visible, 0xFFFF for culled) and indices, so the
             // active range is fresh. Inactive slots keep 0xFFFFFFFF, sorting
             // them past 0xFFFF and out of the counts[1] visible window.
-            if (dynamic_count_ > 0 && dynamic_sort_a_.buffer() && dynamic_sort_b_.buffer()) {
+            if (dynamic_count_ > 0 && dynamic_sort_as_[0].buffer() && dynamic_sort_bs_[0].buffer()) {
                 const VkDeviceSize dyn_sort_bytes =
                     static_cast<VkDeviceSize>(dynamic_sort_size_) * sizeof(SortEntry);
-                vkCmdFillBuffer(cmd, dynamic_sort_a_.buffer(), 0, dyn_sort_bytes, 0xFFFFFFFFu);
-                vkCmdFillBuffer(cmd, dynamic_sort_b_.buffer(), 0, dyn_sort_bytes, 0xFFFFFFFFu);
+                vkCmdFillBuffer(cmd, dynamic_sort_as_[0].buffer(), 0, dyn_sort_bytes, 0xFFFFFFFFu);
+                vkCmdFillBuffer(cmd, dynamic_sort_bs_[0].buffer(), 0, dyn_sort_bytes, 0xFFFFFFFFu);
             }
             {
                 VkMemoryBarrier fill_barrier{};
@@ -3801,11 +3816,7 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
 
     // Legacy buffers
     gaussian_ssbo_.destroy(allocator);
-    projected_ssbo_.destroy(allocator);
-    sort_keys_ssbo_.destroy(allocator);
-    sort_b_ssbo_.destroy(allocator);
     uniform_buffer_.destroy(allocator);
-    visible_count_ssbo_.destroy(allocator);
     bone_ssbo_.destroy(allocator);
     pbd_state_ssbo_.destroy(allocator);
     pbd_params_ssbo_.destroy(allocator);
@@ -3817,10 +3828,17 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     dynamic_gaussian_ssbo_.destroy(allocator);
     static_sort_a_.destroy(allocator);
     static_sort_b_.destroy(allocator);
-    dynamic_sort_a_.destroy(allocator);
-    dynamic_sort_b_.destroy(allocator);
-    merged_sort_ssbo_.destroy(allocator);
-    counts_ssbo_.destroy(allocator);
+    // Per-frame racing SSBOs.
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        projected_ssbos_[f].destroy(allocator);
+        sort_keys_ssbos_[f].destroy(allocator);
+        sort_b_ssbos_[f].destroy(allocator);
+        visible_count_ssbos_[f].destroy(allocator);
+        dynamic_sort_as_[f].destroy(allocator);
+        dynamic_sort_bs_[f].destroy(allocator);
+        merged_sort_ssbos_[f].destroy(allocator);
+        counts_ssbos_[f].destroy(allocator);
+    }
 
     // Tile binning buffers
     tile_sort_a_.destroy(allocator);

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -203,16 +203,18 @@ void GsRenderer::create_output_image(uint32_t width, uint32_t height) {
 }
 
 void GsRenderer::create_descriptor_resources() {
-    // Descriptor pool — enough for all sets (including post-process + static/dynamic split)
+    // Descriptor pool — enough for all sets (including post-process + static/dynamic split).
+    // Phase 2 bumped capacity to absorb the doubled compute-set count
+    // (preprocess, sort, static_preprocess, dynamic_preprocess become per-frame).
     VkDescriptorPoolSize pool_sizes[] = {
-        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 256},   // many more for split buffers
+        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 320},   // many more for split buffers + Phase 2 per-frame
         {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 24},
-        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 32},
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 48},
     };
 
     VkDescriptorPoolCreateInfo pool_info{};
     pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    pool_info.maxSets = 160;  // expanded for static/dynamic/merge + per-frame sets
+    pool_info.maxSets = 192;  // expanded for static/dynamic/merge + per-frame compute sets
     pool_info.poolSizeCount = 3;
     pool_info.pPoolSizes = pool_sizes;
 
@@ -440,9 +442,9 @@ void GsRenderer::create_descriptor_resources() {
                   "indices for render/post_process/tile_render at the end of `layouts`.");
 
     VkDescriptorSetLayout layouts[] = {
-        preprocess_layout_, sort_layout_, render_layout_,   // 0-2: legacy (render_sets_[0])
+        preprocess_layout_, sort_layout_, render_layout_,   // 0-2: legacy preprocess_sets_[0], sort_sets_[0], render_sets_[0]
         post_process_layout_,                               // 3: post-process (post_process_sets_[0])
-        preprocess_layout_, preprocess_layout_,             // 4-5: static + dynamic preprocess
+        preprocess_layout_, preprocess_layout_,             // 4-5: static_preprocess_sets_[0], dynamic_preprocess_sets_[0]
         merge_layout_,                                      // 6: merge
         render_layout_,                                     // 7: merged render
         pbd_layout_,                                        // 8: PBD solver
@@ -465,8 +467,15 @@ void GsRenderer::create_descriptor_resources() {
         render_layout_,                                     // 30: render_sets_[1]
         post_process_layout_,                               // 31: post_process_sets_[1]
         tile_render_layout_,                                // 32: tile_render_sets_[1]
+        // Phase 2 per-frame [1] copies for compute sets that bind per-frame
+        // racing SSBOs (projected, sort_keys, visible_count, counts, dynamic_sort_a).
+        // Dispatch still binds [0]; Phase 3 routes frame_in_flight here.
+        preprocess_layout_,                                 // 33: preprocess_sets_[1]
+        sort_layout_,                                       // 34: sort_sets_[1]
+        preprocess_layout_,                                 // 35: static_preprocess_sets_[1]
+        preprocess_layout_,                                 // 36: dynamic_preprocess_sets_[1]
     };
-    constexpr uint32_t kSetCount = 33;
+    constexpr uint32_t kSetCount = 37;
     VkDescriptorSet sets[kSetCount];
     VkDescriptorSetAllocateInfo alloc_info{};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -475,16 +484,20 @@ void GsRenderer::create_descriptor_resources() {
     alloc_info.pSetLayouts = layouts;
     vkAllocateDescriptorSets(device_, &alloc_info, sets);
 
-    // Legacy sets
-    preprocess_set_ = sets[0];
-    sort_set_ = sets[1];
+    // Legacy sets (per-frame Phase 2)
+    preprocess_sets_[0] = sets[0];
+    preprocess_sets_[1] = sets[33];
+    sort_sets_[0] = sets[1];
+    sort_sets_[1] = sets[34];
     render_sets_[0] = sets[2];
     render_sets_[1] = sets[30];
     post_process_sets_[0] = sets[3];
     post_process_sets_[1] = sets[31];
-    // Static/dynamic preprocess
-    static_preprocess_set_ = sets[4];
-    dynamic_preprocess_set_ = sets[5];
+    // Static/dynamic preprocess (per-frame Phase 2)
+    static_preprocess_sets_[0] = sets[4];
+    static_preprocess_sets_[1] = sets[35];
+    dynamic_preprocess_sets_[0] = sets[5];
+    dynamic_preprocess_sets_[1] = sets[36];
     merge_set_ = sets[6];
     // sets[7] is the merged render set (render_layout_)
     pbd_set_ = sets[8];
@@ -2324,58 +2337,64 @@ void GsRenderer::clear_bone_transforms() {
 
 void GsRenderer::update_descriptors() {
     // Preprocess set: gaussians(0), projected(1), sort_keys_A(2), uniforms(3), visible_count(4), bones(5), pbd(6), page_table(8)
-    {
+    // Per-frame: preprocess_sets_[f] binds *_ssbos_[f]. Dispatch still uses [0]
+    // until Phase 3. Single-instance buffers (gaussian, bone, pbd, page_table,
+    // uniform) are shared across frames.
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
         VkDescriptorBufferInfo gaussian_info{gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo sort_info{sort_keys_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo projected_info{projected_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo sort_info{sort_keys_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
-        VkDescriptorBufferInfo visible_count_info{visible_count_ssbos_[0].buffer(), 0, sizeof(uint32_t)};
+        VkDescriptorBufferInfo visible_count_info{visible_count_ssbos_[f].buffer(), 0, sizeof(uint32_t)};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo pbd_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo page_table_info{page_table_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
+        VkDescriptorSet set = preprocess_sets_[f];
         VkWriteDescriptorSet writes[] = {
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 0, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &gaussian_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 1, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &projected_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 2, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &sort_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 3, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 4, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 4, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &visible_count_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 5, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 5, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &bone_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 6, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 6, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, preprocess_set_, 8, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 8, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &page_table_info, nullptr},
         };
         vkUpdateDescriptorSets(device_, 8, writes, 0, nullptr);
     }
 
-    // Legacy sort set
-    {
-        VkDescriptorBufferInfo sort_info{sort_keys_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+    // Legacy sort set — per-frame (binds racing sort_keys_ssbos_[f]).
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        VkDescriptorBufferInfo sort_info{sort_keys_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
+        VkDescriptorSet set = sort_sets_[f];
         VkWriteDescriptorSet writes[] = {
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, sort_set_, 0, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &sort_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, sort_set_, 1, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
         };
         vkUpdateDescriptorSets(device_, 2, writes, 0, nullptr);
     }
 
     // Render set: projected(0), sort_keys_A(1), uniforms(2), output_image(3), visible_count(4), depth_image(5)
-    // Per-frame: each render_sets_[i] binds output_views_[i] / depth_views_[i].
+    // Per-frame: each render_sets_[i] binds output_views_[i] / depth_views_[i]
+    // and racing SSBO slot [f].
     for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-        VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo sort_info{sort_keys_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo projected_info{projected_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo sort_info{sort_keys_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
         VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_views_[f], VK_IMAGE_LAYOUT_GENERAL};
-        VkDescriptorBufferInfo visible_count_info{visible_count_ssbos_[0].buffer(), 0, sizeof(uint32_t)};
+        VkDescriptorBufferInfo visible_count_info{visible_count_ssbos_[f].buffer(), 0, sizeof(uint32_t)};
         VkDescriptorImageInfo depth_img_info{VK_NULL_HANDLE, depth_views_[f], VK_IMAGE_LAYOUT_GENERAL};
 
         VkDescriptorSet set = render_sets_[f];
@@ -2479,7 +2498,9 @@ void GsRenderer::update_descriptors() {
             }
         };
 
-        // Legacy depth sort sets
+        // Legacy depth sort sets. Phase 2: onesweep sets stay single-instance,
+        // so we bind racing buffer slot [0]. Phase 3 will either make these
+        // per-frame or route around the legacy path entirely.
         write_depth_onesweep_sets(
             depth_hist_set_a_, depth_hist_set_b_,
             depth_scatter_set_ab_, depth_scatter_set_ba_,
@@ -2492,64 +2513,70 @@ void GsRenderer::update_descriptors() {
     if (!static_gaussian_ssbo_.buffer() || !counts_ssbos_[0].buffer()) return;
 
     // Static preprocess set: static_gaussian(0), projected(1), static_sort_a(2), uniforms(3), counts[0](4), bones(5), pbd(6), page_table(8)
-    {
+    // Per-frame: static_preprocess_sets_[f] binds projected_ssbos_[f] and counts_ssbos_[f].
+    // (static_sort_a_ is single-instance — not in the racing set.)
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
         VkDescriptorBufferInfo gaussian_info{static_gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo projected_info{projected_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo sort_info{static_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
-        VkDescriptorBufferInfo counts_info{counts_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo counts_info{counts_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo pbd_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo page_table_info{page_table_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
+        VkDescriptorSet set = static_preprocess_sets_[f];
         VkWriteDescriptorSet writes[] = {
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 0, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &gaussian_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 1, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &projected_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 2, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &sort_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 3, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 4, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 4, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &counts_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 5, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 5, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &bone_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 6, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 6, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, static_preprocess_set_, 8, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 8, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &page_table_info, nullptr},
         };
         vkUpdateDescriptorSets(device_, 8, writes, 0, nullptr);
     }
 
     // Dynamic preprocess set: dynamic_gaussian(0), projected(1), dynamic_sort_a(2), uniforms(3), counts[1](4), bones(5), pbd(6), page_table(8)
-    {
+    // Per-frame: dynamic_preprocess_sets_[f] binds projected_ssbos_[f],
+    // dynamic_sort_as_[f], and counts_ssbos_[f].
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
         VkDescriptorBufferInfo gaussian_info{dynamic_gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo sort_info{dynamic_sort_as_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo projected_info{projected_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo sort_info{dynamic_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
-        VkDescriptorBufferInfo counts_info{counts_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo counts_info{counts_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo bone_info{bone_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo pbd_info{pbd_state_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo page_table_info{page_table_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
+        VkDescriptorSet set = dynamic_preprocess_sets_[f];
         VkWriteDescriptorSet writes[] = {
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 0, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &gaussian_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 1, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &projected_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 2, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &sort_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 3, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 4, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 4, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &counts_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 5, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 5, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &bone_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 6, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 6, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &pbd_info, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, dynamic_preprocess_set_, 8, 0, 1,
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 8, 0, 1,
              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &page_table_info, nullptr},
         };
         vkUpdateDescriptorSets(device_, 8, writes, 0, nullptr);
@@ -2615,13 +2642,15 @@ void GsRenderer::update_descriptors() {
               }; vkUpdateDescriptorSets(device_, 4, w, 0, nullptr); }
         };
 
-        // Static depth sort
+        // Static depth sort (static_sort_a_/b_ are single-instance — not racing).
         write_depth_onesweep_sets(
             static_depth_hist_set_a_, static_depth_hist_set_b_,
             static_depth_scatter_set_ab_, static_depth_scatter_set_ba_,
             static_sort_a_.buffer(), static_sort_b_.buffer(),
             depth_onesweep_status_.buffer(), static_depth_params_.buffer());
-        // Dynamic depth sort
+        // Dynamic depth sort. Phase 2: dynamic depth onesweep sets stay
+        // single-instance, so we bind racing buffer slot [0] (dynamic_sort_as_[0],
+        // dynamic_sort_bs_[0]). Phase 3 will revisit if needed.
         write_depth_onesweep_sets(
             dynamic_depth_hist_set_a_, dynamic_depth_hist_set_b_,
             dynamic_depth_scatter_set_ab_, dynamic_depth_scatter_set_ba_,
@@ -2652,13 +2681,14 @@ void GsRenderer::update_descriptors() {
     // Render set (uses merged_sort and counts) — per-frame.
     // Re-binds render_sets_[i] to point at the merged_sort buffer and
     // counts_ssbo, replacing the legacy bindings written above. Each
-    // frame's set still references its frame-i image views.
+    // frame's set still references its frame-i image views and racing
+    // SSBO slot [f].
     for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-        VkDescriptorBufferInfo projected_info{projected_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
-        VkDescriptorBufferInfo merged_info{merged_sort_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo projected_info{projected_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo merged_info{merged_sort_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
         VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_views_[f], VK_IMAGE_LAYOUT_GENERAL};
-        VkDescriptorBufferInfo counts_info{counts_ssbos_[0].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo counts_info{counts_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
         VkDescriptorImageInfo depth_img_info{VK_NULL_HANDLE, depth_views_[f], VK_IMAGE_LAYOUT_GENERAL};
 
         VkDescriptorSet set = render_sets_[f];
@@ -3547,8 +3577,9 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
             // === Phase 1: Dynamic preprocess + sort (every frame, if dynamic_count_ > 0) ===
             if (dynamic_count_ > 0) {
                 vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, preprocess_pipeline_);
+                // Phase 2: still binding slot [0]; Phase 3 routes frame_in_flight here.
                 vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                        preprocess_pipeline_layout_, 0, 1, &dynamic_preprocess_set_, 0, nullptr);
+                                        preprocess_pipeline_layout_, 0, 1, &dynamic_preprocess_sets_[0], 0, nullptr);
                 GsPreprocessPush dyn_push{max_static_count_, dynamic_count_, 1};
                 vkCmdPushConstants(cmd, preprocess_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
                                    0, sizeof(GsPreprocessPush), &dyn_push);
@@ -3565,8 +3596,9 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
             // === Phase 2: Static preprocess + sort (only when static_dirty_) ===
             if (static_dirty_ && static_count_ > 0) {
                 vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, preprocess_pipeline_);
+                // Phase 2: still binding slot [0]; Phase 3 routes frame_in_flight here.
                 vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                        preprocess_pipeline_layout_, 0, 1, &static_preprocess_set_, 0, nullptr);
+                                        preprocess_pipeline_layout_, 0, 1, &static_preprocess_sets_[0], 0, nullptr);
                 GsPreprocessPush stat_push{0, static_count_, 0};
                 vkCmdPushConstants(cmd, preprocess_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
                                    0, sizeof(GsPreprocessPush), &stat_push);

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -89,17 +89,21 @@ void GsRenderer::init(VkDevice device, VkPhysicalDevice physical_device,
 
     // Create initial tile buffers (zeroed) for valid descriptor bindings.
     // init_streaming() will recreate them at proper size when a scene loads.
+    // Phase 3.5: per-frame — every slot must be populated so the descriptor
+    // writes for both tile_*_sets_[f] slots have a valid buffer handle.
     {
         static constexpr uint32_t kMaxTiles = 256 * 144;  // supports up to 4096×2304
-        tile_ranges_ssbo_ = Buffer::create_storage_gpu_only(allocator_,
-            static_cast<VkDeviceSize>(kMaxTiles) * 2 * sizeof(uint32_t));
-        // GPU-only: zeroed by vkCmdFillBuffer at dispatch time
-        // Tiny dummy tile sort buffer (8 bytes) — just for descriptor binding validity
-        tile_sort_a_ = Buffer::create_storage_gpu_only(allocator_, 8);
-        tile_sort_count_ssbo_ = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
-        std::memset(tile_sort_count_ssbo_.mapped(), 0, sizeof(uint32_t));
-        tile_indirect_args_ = Buffer::create_storage_indirect(allocator_, 8 * sizeof(uint32_t));
-        std::memset(tile_indirect_args_.mapped(), 0, 8 * sizeof(uint32_t));
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            tile_ranges_ssbos_[f] = Buffer::create_storage_gpu_only(allocator_,
+                static_cast<VkDeviceSize>(kMaxTiles) * 2 * sizeof(uint32_t));
+            // GPU-only: zeroed by vkCmdFillBuffer at dispatch time
+            // Tiny dummy tile sort buffer (8 bytes) — just for descriptor binding validity
+            tile_sort_as_[f] = Buffer::create_storage_gpu_only(allocator_, 8);
+            tile_sort_count_ssbos_[f] = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
+            std::memset(tile_sort_count_ssbos_[f].mapped(), 0, sizeof(uint32_t));
+            tile_indirect_args_[f] = Buffer::create_storage_indirect(allocator_, 8 * sizeof(uint32_t));
+            std::memset(tile_indirect_args_[f].mapped(), 0, 8 * sizeof(uint32_t));
+        }
     }
 
     create_descriptor_resources();
@@ -207,14 +211,17 @@ void GsRenderer::create_descriptor_resources() {
     // Phase 2 bumped capacity to absorb the doubled compute-set count
     // (preprocess, sort, static_preprocess, dynamic_preprocess become per-frame).
     VkDescriptorPoolSize pool_sizes[] = {
-        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 384},   // many more for split buffers + Phase 2/3 per-frame
+        // Phase 3.5: +32 STORAGE_BUFFER for 7 newly-per-frame tile-pipeline
+        // sets (tile_scan/tile_indirect/tile_ranges + onesweep hist_a/hist_b/
+        // scatter_ab/scatter_ba) × ~3-4 SSBO bindings × 1 extra slot.
+        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 416},   // many more for split buffers + Phase 2/3 per-frame
         {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 24},
         {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 48},
     };
 
     VkDescriptorPoolCreateInfo pool_info{};
     pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    pool_info.maxSets = 216;  // expanded for static/dynamic/merge + per-frame compute sets (Phase 3: +10 racing onesweep/merge/tile_bin sets per frame slot)
+    pool_info.maxSets = 232;  // expanded for static/dynamic/merge + per-frame compute sets (Phase 3: +10 racing onesweep/merge/tile_bin sets per frame slot; Phase 3.5: +16 for per-frame tile_scan/tile_indirect/tile_ranges + onesweep tile sort sets)
     pool_info.poolSizeCount = 3;
     pool_info.pPoolSizes = pool_sizes;
 
@@ -453,11 +460,11 @@ void GsRenderer::create_descriptor_resources() {
         pbd_layout_,                                        // 8: PBD solver
         // Tile binning sets
         tile_bin_layout_,                                   // 9: tile bin (count + scatter)
-        tile_ranges_layout_,                                // 10: tile range detection
-        tile_indirect_layout_,                              // 11: indirect dispatch prep
+        tile_ranges_layout_,                                // 10: tile range detection (slot [0])
+        tile_indirect_layout_,                              // 11: indirect dispatch prep (slot [0])
         tile_render_layout_,                                // 12: tile render (tile_render_sets_[0])
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 13-14: tile onesweep histogram A, B
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 15-16: tile onesweep scatter A→B, B→A
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 13-14: tile onesweep histogram A, B (slot [0])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 15-16: tile onesweep scatter A→B, B→A (slot [0])
         // Depth sort Onesweep sets (reusing onesweep layouts)
         onesweep_hist_layout_, onesweep_hist_layout_,       // 17-18: legacy depth hist A, B (slot [0])
         onesweep_scatter_layout_, onesweep_scatter_layout_, // 19-20: legacy depth scatter AB, BA (slot [0])
@@ -465,7 +472,7 @@ void GsRenderer::create_descriptor_resources() {
         onesweep_scatter_layout_, onesweep_scatter_layout_, // 23-24: static depth scatter AB, BA (single-instance)
         onesweep_hist_layout_, onesweep_hist_layout_,       // 25-26: dynamic depth hist A, B (slot [0])
         onesweep_scatter_layout_, onesweep_scatter_layout_, // 27-28: dynamic depth scatter AB, BA (slot [0])
-        tile_scan_layout_,                                  // 29: deterministic tile-bin scan
+        tile_scan_layout_,                                  // 29: deterministic tile-bin scan (slot [0])
         // Per-frame [1] copies for sets that bind per-frame images:
         render_layout_,                                     // 30: render_sets_[1]
         post_process_layout_,                               // 31: post_process_sets_[1]
@@ -489,8 +496,18 @@ void GsRenderer::create_descriptor_resources() {
         // so tile_bin in frame f reads the slot frame f's preprocess wrote.
         // (slot [0] is sets[9]; this is the slot [1] copy.)
         tile_bin_layout_,                                   // 46: tile_bin_sets_[1]
+        // Phase 3.5 per-frame [1] copies for the racing tile-pipeline sets:
+        // tile_scan/tile_indirect/tile_ranges + tile onesweep hist/scatter.
+        // Each binds at least one of the newly per-frame tile buffers
+        // (tile_sort_a/b, tile_sort_count, tile_ranges, tile_indirect_args,
+        // per_splat_tile_count/offset, scan_block_sums).
+        tile_scan_layout_,                                  // 47: tile_scan_sets_[1]
+        tile_indirect_layout_,                              // 48: tile_indirect_sets_[1]
+        tile_ranges_layout_,                                // 49: tile_ranges_sets_[1]
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 50-51: tile onesweep hist A, B (slot [1])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 52-53: tile onesweep scatter AB, BA (slot [1])
     };
-    constexpr uint32_t kSetCount = 47;
+    constexpr uint32_t kSetCount = 54;
     VkDescriptorSet sets[kSetCount];
     VkDescriptorSetAllocateInfo alloc_info{};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -520,14 +537,21 @@ void GsRenderer::create_descriptor_resources() {
     // Tile binning
     tile_bin_sets_[0] = sets[9];
     tile_bin_sets_[1] = sets[46];
-    tile_ranges_set_ = sets[10];
-    tile_indirect_set_ = sets[11];
+    // Phase 3.5: per-frame tile_ranges / tile_indirect / tile_scan + tile onesweep
+    tile_ranges_sets_[0] = sets[10];
+    tile_ranges_sets_[1] = sets[49];
+    tile_indirect_sets_[0] = sets[11];
+    tile_indirect_sets_[1] = sets[48];
     tile_render_sets_[0] = sets[12];
     tile_render_sets_[1] = sets[32];
-    onesweep_hist_set_a_ = sets[13];
-    onesweep_hist_set_b_ = sets[14];
-    onesweep_scatter_set_ab_ = sets[15];
-    onesweep_scatter_set_ba_ = sets[16];
+    onesweep_hist_sets_a_[0] = sets[13];
+    onesweep_hist_sets_b_[0] = sets[14];
+    onesweep_scatter_sets_ab_[0] = sets[15];
+    onesweep_scatter_sets_ba_[0] = sets[16];
+    onesweep_hist_sets_a_[1] = sets[50];
+    onesweep_hist_sets_b_[1] = sets[51];
+    onesweep_scatter_sets_ab_[1] = sets[52];
+    onesweep_scatter_sets_ba_[1] = sets[53];
     // Depth sort Onesweep (legacy) — per-frame (racing sort_keys/sort_b SSBOs)
     depth_hist_sets_a_[0] = sets[17];
     depth_hist_sets_b_[0] = sets[18];
@@ -551,8 +575,9 @@ void GsRenderer::create_descriptor_resources() {
     dynamic_depth_hist_sets_b_[1] = sets[43];
     dynamic_depth_scatter_sets_ab_[1] = sets[44];
     dynamic_depth_scatter_sets_ba_[1] = sets[45];
-    // Deterministic tile-bin scan
-    tile_scan_set_ = sets[29];
+    // Deterministic tile-bin scan — per-frame (Phase 3.5)
+    tile_scan_sets_[0] = sets[29];
+    tile_scan_sets_[1] = sets[47];
 }
 
 void GsRenderer::create_compute_pipelines() {
@@ -1199,10 +1224,15 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
     }
     page_table_ssbo_.destroy(allocator_);
     chunk_table_ssbo_.destroy(allocator_);
-    tile_sort_a_.destroy(allocator_);
-    tile_sort_b_.destroy(allocator_);
-    tile_sort_count_ssbo_.destroy(allocator_);
-    tile_ranges_ssbo_.destroy(allocator_);
+    // Phase 3.5: per-frame tile buffers — destroy every slot.
+    // (tile_indirect_args_, per_splat_tile_count_ssbos_, per_splat_tile_offset_ssbos_,
+    //  scan_block_sums_ssbos_ are destroyed inside the tile-sort recreate block below.)
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        tile_sort_as_[f].destroy(allocator_);
+        tile_sort_bs_[f].destroy(allocator_);
+        tile_sort_count_ssbos_[f].destroy(allocator_);
+        tile_ranges_ssbos_[f].destroy(allocator_);
+    }
     pp_ubo_buffer_.destroy(allocator_);
     depth_onesweep_status_.destroy(allocator_);
     depth_sort_params_.destroy(allocator_);
@@ -1357,27 +1387,34 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
         VkDeviceSize block_sums_buf_size =
             static_cast<VkDeviceSize>(scan_num_blocks_) * sizeof(uint32_t);
 
-        tile_sort_a_.destroy(allocator_);
-        tile_sort_b_.destroy(allocator_);
-        tile_sort_count_ssbo_.destroy(allocator_);
-        tile_ranges_ssbo_.destroy(allocator_);
-        tile_indirect_args_.destroy(allocator_);
-        per_splat_tile_count_ssbo_.destroy(allocator_);
-        per_splat_tile_offset_ssbo_.destroy(allocator_);
-        scan_block_sums_ssbo_.destroy(allocator_);
+        // Phase 3.5: per-frame — destroy + recreate every slot at the new
+        // capacity. All seven buffers are racing across cmdbufs and must
+        // exist in kMaxFramesInFlight independent allocations.
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            tile_sort_as_[f].destroy(allocator_);
+            tile_sort_bs_[f].destroy(allocator_);
+            tile_sort_count_ssbos_[f].destroy(allocator_);
+            tile_ranges_ssbos_[f].destroy(allocator_);
+            tile_indirect_args_[f].destroy(allocator_);
+            per_splat_tile_count_ssbos_[f].destroy(allocator_);
+            per_splat_tile_offset_ssbos_[f].destroy(allocator_);
+            scan_block_sums_ssbos_[f].destroy(allocator_);
+        }
         determinism_readback_.destroy(allocator_);
 
-        tile_sort_a_ = Buffer::create_storage_gpu_only(allocator_, entry_buf_size);
-        tile_sort_b_ = Buffer::create_storage_gpu_only(allocator_, entry_buf_size);
-        tile_sort_count_ssbo_ = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
-        tile_ranges_ssbo_ = Buffer::create_storage_gpu_only(allocator_, ranges_buf_size);
-        tile_indirect_args_ = Buffer::create_storage_indirect(allocator_, 8 * sizeof(uint32_t));
-        per_splat_tile_count_ssbo_ =
-            Buffer::create_storage_gpu_only(allocator_, per_splat_buf_size);
-        per_splat_tile_offset_ssbo_ =
-            Buffer::create_storage_gpu_only(allocator_, per_splat_buf_size);
-        scan_block_sums_ssbo_ =
-            Buffer::create_storage_gpu_only(allocator_, block_sums_buf_size);
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            tile_sort_as_[f] = Buffer::create_storage_gpu_only(allocator_, entry_buf_size);
+            tile_sort_bs_[f] = Buffer::create_storage_gpu_only(allocator_, entry_buf_size);
+            tile_sort_count_ssbos_[f] = Buffer::create_storage_readback(allocator_, sizeof(uint32_t));
+            tile_ranges_ssbos_[f] = Buffer::create_storage_gpu_only(allocator_, ranges_buf_size);
+            tile_indirect_args_[f] = Buffer::create_storage_indirect(allocator_, 8 * sizeof(uint32_t));
+            per_splat_tile_count_ssbos_[f] =
+                Buffer::create_storage_gpu_only(allocator_, per_splat_buf_size);
+            per_splat_tile_offset_ssbos_[f] =
+                Buffer::create_storage_gpu_only(allocator_, per_splat_buf_size);
+            scan_block_sums_ssbos_[f] =
+                Buffer::create_storage_gpu_only(allocator_, block_sums_buf_size);
+        }
         determinism_readback_ = Buffer::create_readback(allocator_, entry_buf_size);
         determinism_readback_size_ = entry_buf_size;
 
@@ -2778,7 +2815,7 @@ void GsRenderer::update_descriptors() {
     }
 
     // ── Tile binning descriptor sets ──
-    if (tile_sort_a_.buffer()) {
+    if (tile_sort_as_[0].buffer()) {
         // Tile bin set (count + scatter share this layout):
         //   0 projected  1 merged_sort  2 counts (ro)
         //   3 per_splat_count (count writes here)
@@ -2790,14 +2827,16 @@ void GsRenderer::update_descriptors() {
         // projected/merged/counts slots so tile_bin in frame f reads the
         // data frame f's preprocess+merge wrote earlier in the same
         // command buffer. Frame N+1's tile_bin no longer reads frame N's
-        // slot. per_splat_*, tile_entries, uniforms remain single-instance.
+        // slot.
+        // Phase 3.5: per_splat_count/offset, tile_entries are now per-frame
+        // too — bind frame f's slot.
         for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
             VkDescriptorBufferInfo projected_info{projected_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo merged_info{merged_sort_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo counts_info{counts_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo per_splat_count_info{per_splat_tile_count_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo per_splat_offset_info{per_splat_tile_offset_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo tile_entries_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo per_splat_count_info{per_splat_tile_count_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo per_splat_offset_info{per_splat_tile_offset_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo tile_entries_info{tile_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
 
             VkDescriptorSet tile_bin_set = tile_bin_sets_[f];
@@ -2822,118 +2861,132 @@ void GsRenderer::update_descriptors() {
 
         // Tile scan set: per_splat_count(0), per_splat_offset(1),
         //                scan_block_sums(2), tile_sort_count(3)
-        {
-            VkDescriptorBufferInfo count_info{per_splat_tile_count_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo offset_info{per_splat_tile_offset_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo block_sums_info{scan_block_sums_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo total_info{tile_sort_count_ssbo_.buffer(), 0, sizeof(uint32_t)};
+        // Phase 3.5: per-frame.
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            VkDescriptorBufferInfo count_info{per_splat_tile_count_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo offset_info{per_splat_tile_offset_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo block_sums_info{scan_block_sums_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo total_info{tile_sort_count_ssbos_[f].buffer(), 0, sizeof(uint32_t)};
+            VkDescriptorSet scan_set = tile_scan_sets_[f];
             VkWriteDescriptorSet writes[] = {
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_scan_set_, 0, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scan_set, 0, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &count_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_scan_set_, 1, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scan_set, 1, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &offset_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_scan_set_, 2, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scan_set, 2, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &block_sums_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_scan_set_, 3, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scan_set, 3, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &total_info, nullptr},
             };
             vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
         }
 
         // Tile range detection set: sorted_entries(0), tile_ranges(1), tile_count(2)
-        {
-            VkDescriptorBufferInfo sorted_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo ranges_info{tile_ranges_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo count_info{tile_sort_count_ssbo_.buffer(), 0, sizeof(uint32_t)};
+        // Phase 3.5: per-frame.
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            VkDescriptorBufferInfo sorted_info{tile_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo ranges_info{tile_ranges_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo count_info{tile_sort_count_ssbos_[f].buffer(), 0, sizeof(uint32_t)};
+            VkDescriptorSet ranges_set = tile_ranges_sets_[f];
 
             VkWriteDescriptorSet writes[] = {
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_ranges_set_, 0, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, ranges_set, 0, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &sorted_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_ranges_set_, 1, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, ranges_set, 1, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &ranges_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_ranges_set_, 2, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, ranges_set, 2, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &count_info, nullptr},
             };
             vkUpdateDescriptorSets(device_, 3, writes, 0, nullptr);
         }
 
         // Tile indirect set: tile_sort_count(0), indirect_args(1)
-        {
-            VkDescriptorBufferInfo count_info{tile_sort_count_ssbo_.buffer(), 0, sizeof(uint32_t)};
-            VkDescriptorBufferInfo args_info{tile_indirect_args_.buffer(), 0, VK_WHOLE_SIZE};
+        // Phase 3.5: per-frame.
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            VkDescriptorBufferInfo count_info{tile_sort_count_ssbos_[f].buffer(), 0, sizeof(uint32_t)};
+            VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorSet indirect_set = tile_indirect_sets_[f];
             VkWriteDescriptorSet writes[] = {
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_indirect_set_, 0, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, indirect_set, 0, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &count_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_indirect_set_, 1, 0, 1,
+                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, indirect_set, 1, 0, 1,
                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
             };
             vkUpdateDescriptorSets(device_, 2, writes, 0, nullptr);
         }
 
         // Onesweep histogram descriptor sets (read-only input + status + args)
+        // Phase 3.5: per-frame. onesweep_status_ stays single-instance (its
+        // race is out of scope for this phase).
         if (onesweep_status_.buffer()) {
-            {
-                VkDescriptorBufferInfo in_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
-                VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
-                VkDescriptorBufferInfo args_info{tile_indirect_args_.buffer(), 0, VK_WHOLE_SIZE};
-                VkWriteDescriptorSet writes[] = {
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_hist_set_a_, 0, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_hist_set_a_, 1, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_hist_set_a_, 2, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
-                };
-                vkUpdateDescriptorSets(device_, 3, writes, 0, nullptr);
-            }
-            {
-                VkDescriptorBufferInfo in_info{tile_sort_b_.buffer(), 0, VK_WHOLE_SIZE};
-                VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
-                VkDescriptorBufferInfo args_info{tile_indirect_args_.buffer(), 0, VK_WHOLE_SIZE};
-                VkWriteDescriptorSet writes[] = {
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_hist_set_b_, 0, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_hist_set_b_, 1, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_hist_set_b_, 2, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
-                };
-                vkUpdateDescriptorSets(device_, 3, writes, 0, nullptr);
-            }
-            // Onesweep scatter descriptor sets (input + output + status + args)
-            {
-                VkDescriptorBufferInfo in_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
-                VkDescriptorBufferInfo out_info{tile_sort_b_.buffer(), 0, VK_WHOLE_SIZE};
-                VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
-                VkDescriptorBufferInfo args_info{tile_indirect_args_.buffer(), 0, VK_WHOLE_SIZE};
-                VkWriteDescriptorSet writes[] = {
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_scatter_set_ab_, 0, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_scatter_set_ab_, 1, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &out_info, nullptr},
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_scatter_set_ab_, 2, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_scatter_set_ab_, 3, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
-                };
-                vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
-            }
-            {
-                VkDescriptorBufferInfo in_info{tile_sort_b_.buffer(), 0, VK_WHOLE_SIZE};
-                VkDescriptorBufferInfo out_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
-                VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
-                VkDescriptorBufferInfo args_info{tile_indirect_args_.buffer(), 0, VK_WHOLE_SIZE};
-                VkWriteDescriptorSet writes[] = {
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_scatter_set_ba_, 0, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_scatter_set_ba_, 1, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &out_info, nullptr},
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_scatter_set_ba_, 2, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
-                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, onesweep_scatter_set_ba_, 3, 0, 1,
-                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
-                };
-                vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
+            for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+                {
+                    VkDescriptorBufferInfo in_info{tile_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorSet hist_a = onesweep_hist_sets_a_[f];
+                    VkWriteDescriptorSet writes[] = {
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, hist_a, 0, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, hist_a, 1, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, hist_a, 2, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
+                    };
+                    vkUpdateDescriptorSets(device_, 3, writes, 0, nullptr);
+                }
+                {
+                    VkDescriptorBufferInfo in_info{tile_sort_bs_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorSet hist_b = onesweep_hist_sets_b_[f];
+                    VkWriteDescriptorSet writes[] = {
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, hist_b, 0, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, hist_b, 1, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, hist_b, 2, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
+                    };
+                    vkUpdateDescriptorSets(device_, 3, writes, 0, nullptr);
+                }
+                // Onesweep scatter descriptor sets (input + output + status + args)
+                {
+                    VkDescriptorBufferInfo in_info{tile_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo out_info{tile_sort_bs_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorSet scatter_ab = onesweep_scatter_sets_ab_[f];
+                    VkWriteDescriptorSet writes[] = {
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ab, 0, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ab, 1, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &out_info, nullptr},
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ab, 2, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ab, 3, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
+                    };
+                    vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
+                }
+                {
+                    VkDescriptorBufferInfo in_info{tile_sort_bs_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo out_info{tile_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorSet scatter_ba = onesweep_scatter_sets_ba_[f];
+                    VkWriteDescriptorSet writes[] = {
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ba, 0, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ba, 1, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &out_info, nullptr},
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ba, 2, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
+                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ba, 3, 0, 1,
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
+                    };
+                    vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
+                }
             }
         }
 
@@ -2942,12 +2995,14 @@ void GsRenderer::update_descriptors() {
         // output/depth views AND frame f's projected_ssbos_[f]. The tile_render
         // dispatch runs in frame f's command buffer and reads projected data
         // that frame f's preprocess wrote earlier in the same command buffer.
+        // Phase 3.5: tile_entries (tile_sort_a) and tile_ranges are also
+        // per-frame — bind frame f's slot.
         for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
             VkDescriptorBufferInfo projected_info{projected_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo tile_entries_info{tile_sort_a_.buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo tile_entries_info{tile_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorBufferInfo uniform_info{uniform_buffer_.buffer(), 0, sizeof(GsUniforms)};
             VkDescriptorImageInfo image_info{VK_NULL_HANDLE, output_views_[f], VK_IMAGE_LAYOUT_GENERAL};
-            VkDescriptorBufferInfo tile_ranges_info{tile_ranges_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo tile_ranges_info{tile_ranges_ssbos_[f].buffer(), 0, VK_WHOLE_SIZE};
             VkDescriptorImageInfo depth_img_info{VK_NULL_HANDLE, depth_views_[f], VK_IMAGE_LAYOUT_GENERAL};
 
             VkDescriptorSet set = tile_render_sets_[f];
@@ -3137,7 +3192,7 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_fligh
     // this flag after the in-flight fence to decide whether the captured
     // frame represents a real measurement.
     determinism_readback_emitted_ = false;
-    assert(tile_sort_a_.buffer() && tile_sort_capacity_ > 0 &&
+    assert(tile_sort_as_[frame_in_flight].buffer() && tile_sort_capacity_ > 0 &&
            "dispatch_tile_sort: tile sort buffers must be allocated before first dispatch");
 
     uint32_t width = output_width_;
@@ -3151,13 +3206,15 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_fligh
     // pass only writes [0, total). Slots in [total, tile_sort_size_)
     // need 0xFFFFFFFF keys so the sort routes them to the tail and
     // keeps real entries contiguous at [0, total).
-    vkCmdFillBuffer(cmd, tile_sort_count_ssbo_.buffer(), 0, sizeof(uint32_t), 0);
-    vkCmdFillBuffer(cmd, tile_sort_a_.buffer(), 0,
+    // Phase 3.5: per-frame — fills target frame f's slot, not the shared
+    // singleton, so cmdbuf f and cmdbuf f+1 don't stomp on each other.
+    vkCmdFillBuffer(cmd, tile_sort_count_ssbos_[frame_in_flight].buffer(), 0, sizeof(uint32_t), 0);
+    vkCmdFillBuffer(cmd, tile_sort_as_[frame_in_flight].buffer(), 0,
                     static_cast<VkDeviceSize>(tile_sort_size_) * 8, 0xFFFFFFFF);
     // per_splat_tile_count_ must be zeroed before the count dispatch so the
     // tail (gid >= visible) reads 0 in the scan; the count shader doesn't
     // touch those slots.
-    vkCmdFillBuffer(cmd, per_splat_tile_count_ssbo_.buffer(), 0,
+    vkCmdFillBuffer(cmd, per_splat_tile_count_ssbos_[frame_in_flight].buffer(), 0,
                     static_cast<VkDeviceSize>(scan_dispatch_size_) * sizeof(uint32_t), 0);
 
     {
@@ -3193,7 +3250,7 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_fligh
         struct ScanPush { uint32_t pass; uint32_t num_elements; uint32_t num_blocks; };
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_scan_pipeline_);
         vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                tile_scan_pipeline_layout_, 0, 1, &tile_scan_set_, 0, nullptr);
+                                tile_scan_pipeline_layout_, 0, 1, &tile_scan_sets_[frame_in_flight], 0, nullptr);
 
         // Pass 0: per-block local exclusive scan + write block sums.
         ScanPush p0{0u, scan_dispatch_size_, scan_num_blocks_};
@@ -3234,7 +3291,7 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_fligh
     {
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_indirect_pipeline_);
         vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                tile_indirect_pipeline_layout_, 0, 1, &tile_indirect_set_, 0, nullptr);
+                                tile_indirect_pipeline_layout_, 0, 1, &tile_indirect_sets_[frame_in_flight], 0, nullptr);
         vkCmdPushConstants(cmd, tile_indirect_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
                            0, 4, &tile_sort_capacity_);
         vkCmdDispatch(cmd, 1, 1, 1);
@@ -3271,27 +3328,30 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_fligh
             bool read_from_a = (pass % 2 == 0);
 
             // Dispatch 1: histogram + decoupled lookback
+            // Phase 3.5: per-frame onesweep sets bind racing tile_sort_a/b + indirect_args.
             {
-                VkDescriptorSet hist_set = read_from_a ? onesweep_hist_set_a_ : onesweep_hist_set_b_;
+                VkDescriptorSet hist_set = read_from_a ? onesweep_hist_sets_a_[frame_in_flight]
+                                                       : onesweep_hist_sets_b_[frame_in_flight];
                 vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, onesweep_hist_pipeline_);
                 vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
                                         onesweep_hist_pipeline_layout_, 0, 1, &hist_set, 0, nullptr);
                 vkCmdPushConstants(cmd, onesweep_hist_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
                                    0, 4, push_data);
-                vkCmdDispatchIndirect(cmd, tile_indirect_args_.buffer(), 0);
+                vkCmdDispatchIndirect(cmd, tile_indirect_args_[frame_in_flight].buffer(), 0);
             }
 
             insert_compute_barrier(cmd);
 
             // Dispatch 2: read status buffer, compute prefix, scatter
             {
-                VkDescriptorSet scatter_set = read_from_a ? onesweep_scatter_set_ab_ : onesweep_scatter_set_ba_;
+                VkDescriptorSet scatter_set = read_from_a ? onesweep_scatter_sets_ab_[frame_in_flight]
+                                                          : onesweep_scatter_sets_ba_[frame_in_flight];
                 vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, onesweep_scatter_pipeline_);
                 vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
                                         onesweep_scatter_pipeline_layout_, 0, 1, &scatter_set, 0, nullptr);
                 vkCmdPushConstants(cmd, onesweep_scatter_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
                                    0, 4, push_data);
-                vkCmdDispatchIndirect(cmd, tile_indirect_args_.buffer(), 0);
+                vkCmdDispatchIndirect(cmd, tile_indirect_args_[frame_in_flight].buffer(), 0);
             }
 
             insert_compute_barrier(cmd);
@@ -3303,6 +3363,9 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_fligh
     // When the harness is active, copy tile_sort_a_ into a host-visible
     // readback buffer so the CPU can hash the live entry range and detect
     // order-instability across frames with frozen inputs.
+    // Phase 3.5: tile_sort_a is per-frame; source from frame f's slot.
+    // determinism_readback_ stays single-instance — only one frame emits at
+    // a time, and the harness waits on the in-flight fence before reading.
     if (determinism_test_active_ && determinism_readback_.buffer() != VK_NULL_HANDLE
         && determinism_readback_size_ > 0) {
         VkBufferMemoryBarrier src_barrier{};
@@ -3311,7 +3374,7 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_fligh
         src_barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
         src_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         src_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        src_barrier.buffer = tile_sort_a_.buffer();
+        src_barrier.buffer = tile_sort_as_[frame_in_flight].buffer();
         src_barrier.offset = 0;
         src_barrier.size = determinism_readback_size_;
         vkCmdPipelineBarrier(cmd,
@@ -3323,7 +3386,7 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_fligh
         region.srcOffset = 0;
         region.dstOffset = 0;
         region.size = determinism_readback_size_;
-        vkCmdCopyBuffer(cmd, tile_sort_a_.buffer(),
+        vkCmdCopyBuffer(cmd, tile_sort_as_[frame_in_flight].buffer(),
                         determinism_readback_.buffer(), 1, &region);
 
         VkBufferMemoryBarrier dst_barrier{};
@@ -3340,12 +3403,16 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_fligh
             VK_PIPELINE_STAGE_HOST_BIT,
             0, 0, nullptr, 1, &dst_barrier, 0, nullptr);
         determinism_readback_emitted_ = true;
+        // Phase 3.5: remember which per-frame slot of tile_sort_count_ssbos_
+        // the harness should sample post-fence.
+        determinism_last_emitted_frame_ = frame_in_flight;
     }
 
     // === Tile range detection ===
+    // Phase 3.5: tile_ranges per-frame — fill frame f's slot.
     {
         uint32_t num_tiles = tiles_x * tiles_y;
-        vkCmdFillBuffer(cmd, tile_ranges_ssbo_.buffer(), 0,
+        vkCmdFillBuffer(cmd, tile_ranges_ssbos_[frame_in_flight].buffer(), 0,
                         static_cast<VkDeviceSize>(num_tiles) * 2 * sizeof(uint32_t), 0);
 
         VkMemoryBarrier fill_barrier{};
@@ -3363,10 +3430,10 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_fligh
         uint32_t push_data[2] = {num_tiles, tile_sort_capacity_};
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_ranges_pipeline_);
         vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                tile_ranges_pipeline_layout_, 0, 1, &tile_ranges_set_, 0, nullptr);
+                                tile_ranges_pipeline_layout_, 0, 1, &tile_ranges_sets_[frame_in_flight], 0, nullptr);
         vkCmdPushConstants(cmd, tile_ranges_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
                            0, 8, push_data);
-        vkCmdDispatchIndirect(cmd, tile_indirect_args_.buffer(), 3 * sizeof(uint32_t));
+        vkCmdDispatchIndirect(cmd, tile_indirect_args_[frame_in_flight].buffer(), 3 * sizeof(uint32_t));
     }
 
     insert_compute_barrier(cmd);
@@ -3737,7 +3804,7 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
 
             // === Phase 4: Tile-based rasterization ===
             {
-                assert(tile_sort_a_.buffer() && tile_sort_capacity_ > 0 &&
+                assert(tile_sort_as_[frame_in_flight].buffer() && tile_sort_capacity_ > 0 &&
                        "tile render: tile sort buffers must be allocated post-init");
                 vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_render_pipeline_);
                 vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
@@ -3961,16 +4028,18 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
         counts_ssbos_[f].destroy(allocator);
     }
 
-    // Tile binning buffers
-    tile_sort_a_.destroy(allocator);
-    tile_sort_b_.destroy(allocator);
-    tile_sort_count_ssbo_.destroy(allocator);
-    tile_ranges_ssbo_.destroy(allocator);
-    tile_indirect_args_.destroy(allocator);
+    // Tile binning buffers (Phase 3.5: per-frame — destroy every slot).
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        tile_sort_as_[f].destroy(allocator);
+        tile_sort_bs_[f].destroy(allocator);
+        tile_sort_count_ssbos_[f].destroy(allocator);
+        tile_ranges_ssbos_[f].destroy(allocator);
+        tile_indirect_args_[f].destroy(allocator);
+        per_splat_tile_count_ssbos_[f].destroy(allocator);
+        per_splat_tile_offset_ssbos_[f].destroy(allocator);
+        scan_block_sums_ssbos_[f].destroy(allocator);
+    }
     onesweep_status_.destroy(allocator);
-    per_splat_tile_count_ssbo_.destroy(allocator);
-    per_splat_tile_offset_ssbo_.destroy(allocator);
-    scan_block_sums_ssbo_.destroy(allocator);
     determinism_readback_.destroy(allocator);
 
     // Depth sort Onesweep buffers

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -221,7 +221,7 @@ void GsRenderer::create_descriptor_resources() {
 
     VkDescriptorPoolCreateInfo pool_info{};
     pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    pool_info.maxSets = 232;  // expanded for static/dynamic/merge + per-frame compute sets (Phase 3: +10 racing onesweep/merge/tile_bin sets per frame slot; Phase 3.5: +16 for per-frame tile_scan/tile_indirect/tile_ranges + onesweep tile sort sets)
+    pool_info.maxSets = 236;  // expanded for static/dynamic/merge + per-frame compute sets (Phase 3: +10 racing onesweep/merge/tile_bin sets per frame slot; Phase 3.5: +16 for per-frame tile_scan/tile_indirect/tile_ranges + onesweep tile sort sets; per-frame onesweep status fix: +4 for static depth onesweep slot [1])
     pool_info.poolSizeCount = 3;
     pool_info.pPoolSizes = pool_sizes;
 
@@ -506,8 +506,12 @@ void GsRenderer::create_descriptor_resources() {
         tile_ranges_layout_,                                // 49: tile_ranges_sets_[1]
         onesweep_hist_layout_, onesweep_hist_layout_,       // 50-51: tile onesweep hist A, B (slot [1])
         onesweep_scatter_layout_, onesweep_scatter_layout_, // 52-53: tile onesweep scatter AB, BA (slot [1])
+        // Phase: per-frame onesweep status fix — static depth onesweep sets
+        // become per-frame so they can bind depth_onesweep_statuses_[f].
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 54-55: static depth hist A, B (slot [1])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 56-57: static depth scatter AB, BA (slot [1])
     };
-    constexpr uint32_t kSetCount = 54;
+    constexpr uint32_t kSetCount = 58;
     VkDescriptorSet sets[kSetCount];
     VkDescriptorSetAllocateInfo alloc_info{};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -561,11 +565,17 @@ void GsRenderer::create_descriptor_resources() {
     depth_hist_sets_b_[1] = sets[39];
     depth_scatter_sets_ab_[1] = sets[40];
     depth_scatter_sets_ba_[1] = sets[41];
-    // Depth sort Onesweep (static) — single-instance (static_sort_a_/b_ GPU-fenced)
-    static_depth_hist_set_a_ = sets[21];
-    static_depth_hist_set_b_ = sets[22];
-    static_depth_scatter_set_ab_ = sets[23];
-    static_depth_scatter_set_ba_ = sets[24];
+    // Depth sort Onesweep (static) — per-frame so each slot can bind frame
+    // f's depth_onesweep_statuses_[f]. static_sort_a_/b_ stay single-instance
+    // (GPU-fenced via static_dirty_).
+    static_depth_hist_sets_a_[0] = sets[21];
+    static_depth_hist_sets_b_[0] = sets[22];
+    static_depth_scatter_sets_ab_[0] = sets[23];
+    static_depth_scatter_sets_ba_[0] = sets[24];
+    static_depth_hist_sets_a_[1] = sets[54];
+    static_depth_hist_sets_b_[1] = sets[55];
+    static_depth_scatter_sets_ab_[1] = sets[56];
+    static_depth_scatter_sets_ba_[1] = sets[57];
     // Depth sort Onesweep (dynamic) — per-frame (racing dynamic_sort_as_/bs_)
     dynamic_depth_hist_sets_a_[0] = sets[25];
     dynamic_depth_hist_sets_b_[0] = sets[26];
@@ -1234,7 +1244,9 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
         tile_ranges_ssbos_[f].destroy(allocator_);
     }
     pp_ubo_buffer_.destroy(allocator_);
-    depth_onesweep_status_.destroy(allocator_);
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        depth_onesweep_statuses_[f].destroy(allocator_);
+    }
     depth_sort_params_.destroy(allocator_);
     static_depth_params_.destroy(allocator_);
     dynamic_depth_params_.destroy(allocator_);
@@ -1425,21 +1437,30 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
                      static_cast<float>(entry_buf_size * 2) / (1024.0f * 1024.0f),
                      scan_dispatch_size_, scan_num_blocks_);
 
-        // Onesweep status buffer: 4 passes × 256 digits × max_workgroups
-        onesweep_status_.destroy(allocator_);
+        // Onesweep status buffer: 4 passes × 256 digits × max_workgroups.
+        // Per-frame so each in-flight cmdbuf clears + reads its own slot
+        // without racing the other cmdbuf's in-progress onesweep lookback.
         onesweep_max_wg_ = (tile_sort_capacity_ + 2047) / 2048;
         if (onesweep_max_wg_ == 0) onesweep_max_wg_ = 1;
         VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
-        onesweep_status_ = Buffer::create_storage_gpu_only(allocator_, status_size);
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            onesweep_statuses_[f].destroy(allocator_);
+            onesweep_statuses_[f] = Buffer::create_storage_gpu_only(allocator_, status_size);
+        }
     }
 
     // ── Depth sort Onesweep buffers ──
     {
-        // Status buffer: num_sort_passes × 256 digits × max_wg (shared across static/dynamic/legacy)
+        // Status buffer: num_sort_passes × 256 digits × max_wg (shared across
+        // static/dynamic/legacy depth sorts). Per-frame so the per-cmdbuf
+        // status clears don't race in-flight onesweep lookback on the other
+        // cmdbuf.
         depth_onesweep_max_wg_ = std::max({static_sort_workgroups_, dynamic_sort_workgroups_, num_sort_workgroups_});
         VkDeviceSize depth_status_size = static_cast<VkDeviceSize>(num_sort_passes_) * 256ull
                                          * depth_onesweep_max_wg_ * sizeof(uint32_t);
-        depth_onesweep_status_ = Buffer::create_storage_gpu_only(allocator_, depth_status_size);
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            depth_onesweep_statuses_[f] = Buffer::create_storage_gpu_only(allocator_, depth_status_size);
+        }
 
         // Params buffers (IndirectArgs layout: {wg_x, 1, 1, 0, 0, 0, entry_count, 0})
         auto fill_sort_params = [&](Buffer& buf, uint32_t wg_count, uint32_t entry_count) {
@@ -2536,7 +2557,7 @@ void GsRenderer::update_descriptors() {
     }
 
     // Depth Onesweep descriptor sets (legacy path) — same layout as tile Onesweep
-    if (depth_onesweep_status_.buffer() && depth_sort_params_.buffer()) {
+    if (depth_onesweep_statuses_[0].buffer() && depth_sort_params_.buffer()) {
         auto write_depth_onesweep_sets = [&](
             VkDescriptorSet hist_a, VkDescriptorSet hist_b,
             VkDescriptorSet scatter_ab, VkDescriptorSet scatter_ba,
@@ -2599,12 +2620,15 @@ void GsRenderer::update_descriptors() {
         // Legacy depth sort sets — per-frame (Phase 3). Each frame slot
         // binds its own sort_keys_ssbos_[f] / sort_b_ssbos_[f] so frame N+1's
         // dispatch reads its own slot, never frame N's still-in-use slot.
+        // depth_onesweep_statuses_[f] is also per-frame so the status fill
+        // at the start of dispatch_depth_onesweep doesn't race the other
+        // cmdbuf's in-flight lookback.
         for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
             write_depth_onesweep_sets(
                 depth_hist_sets_a_[f], depth_hist_sets_b_[f],
                 depth_scatter_sets_ab_[f], depth_scatter_sets_ba_[f],
                 sort_keys_ssbos_[f].buffer(), sort_b_ssbos_[f].buffer(),
-                depth_onesweep_status_.buffer(), depth_sort_params_.buffer());
+                depth_onesweep_statuses_[f].buffer(), depth_sort_params_.buffer());
         }
     }
 
@@ -2702,7 +2726,7 @@ void GsRenderer::update_descriptors() {
     }
 
     // Static/dynamic depth Onesweep descriptor sets (reuse lambda from above if available)
-    if (depth_onesweep_status_.buffer() && static_depth_params_.buffer()) {
+    if (depth_onesweep_statuses_[0].buffer() && static_depth_params_.buffer()) {
         auto write_depth_onesweep_sets = [&](
             VkDescriptorSet hist_a, VkDescriptorSet hist_b,
             VkDescriptorSet scatter_ab, VkDescriptorSet scatter_ba,
@@ -2742,12 +2766,16 @@ void GsRenderer::update_descriptors() {
               }; vkUpdateDescriptorSets(device_, 4, w, 0, nullptr); }
         };
 
-        // Static depth sort (static_sort_a_/b_ are single-instance — not racing).
-        write_depth_onesweep_sets(
-            static_depth_hist_set_a_, static_depth_hist_set_b_,
-            static_depth_scatter_set_ab_, static_depth_scatter_set_ba_,
-            static_sort_a_.buffer(), static_sort_b_.buffer(),
-            depth_onesweep_status_.buffer(), static_depth_params_.buffer());
+        // Static depth sort: static_sort_a_/b_ are single-instance
+        // (GPU-fenced via static_dirty_), but the bound status buffer is
+        // per-frame so we still need per-frame descriptor sets here.
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            write_depth_onesweep_sets(
+                static_depth_hist_sets_a_[f], static_depth_hist_sets_b_[f],
+                static_depth_scatter_sets_ab_[f], static_depth_scatter_sets_ba_[f],
+                static_sort_a_.buffer(), static_sort_b_.buffer(),
+                depth_onesweep_statuses_[f].buffer(), static_depth_params_.buffer());
+        }
         // Dynamic depth sort — per-frame (Phase 3). Each frame slot binds
         // its own dynamic_sort_as_[f] / dynamic_sort_bs_[f] so frame N+1's
         // dispatch reads its own slot.
@@ -2756,7 +2784,7 @@ void GsRenderer::update_descriptors() {
                 dynamic_depth_hist_sets_a_[f], dynamic_depth_hist_sets_b_[f],
                 dynamic_depth_scatter_sets_ab_[f], dynamic_depth_scatter_sets_ba_[f],
                 dynamic_sort_as_[f].buffer(), dynamic_sort_bs_[f].buffer(),
-                depth_onesweep_status_.buffer(), dynamic_depth_params_.buffer());
+                depth_onesweep_statuses_[f].buffer(), dynamic_depth_params_.buffer());
         }
     }
 
@@ -2916,13 +2944,13 @@ void GsRenderer::update_descriptors() {
         }
 
         // Onesweep histogram descriptor sets (read-only input + status + args)
-        // Phase 3.5: per-frame. onesweep_status_ stays single-instance (its
-        // race is out of scope for this phase).
-        if (onesweep_status_.buffer()) {
+        // Phase 3.5 + onesweep status fix: every binding is per-frame, so
+        // each frame f's onesweep dispatch reads/writes only its own slot.
+        if (onesweep_statuses_[0].buffer()) {
             for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
                 {
                     VkDescriptorBufferInfo in_info{tile_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo status_info{onesweep_statuses_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorSet hist_a = onesweep_hist_sets_a_[f];
                     VkWriteDescriptorSet writes[] = {
@@ -2937,7 +2965,7 @@ void GsRenderer::update_descriptors() {
                 }
                 {
                     VkDescriptorBufferInfo in_info{tile_sort_bs_[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo status_info{onesweep_statuses_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorSet hist_b = onesweep_hist_sets_b_[f];
                     VkWriteDescriptorSet writes[] = {
@@ -2954,7 +2982,7 @@ void GsRenderer::update_descriptors() {
                 {
                     VkDescriptorBufferInfo in_info{tile_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorBufferInfo out_info{tile_sort_bs_[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo status_info{onesweep_statuses_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorSet scatter_ab = onesweep_scatter_sets_ab_[f];
                     VkWriteDescriptorSet writes[] = {
@@ -2972,7 +3000,7 @@ void GsRenderer::update_descriptors() {
                 {
                     VkDescriptorBufferInfo in_info{tile_sort_bs_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorBufferInfo out_info{tile_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo status_info{onesweep_statuses_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorSet scatter_ba = onesweep_scatter_sets_ba_[f];
                     VkWriteDescriptorSet writes[] = {
@@ -3136,13 +3164,15 @@ void GsRenderer::init_output_layouts(VkCommandBuffer cmd) {
 
 void GsRenderer::dispatch_depth_onesweep(
     VkCommandBuffer cmd, uint32_t sort_size, uint32_t num_workgroups,
+    uint32_t frame_in_flight,
     VkDescriptorSet hist_a, VkDescriptorSet hist_b,
     VkDescriptorSet scatter_ab, VkDescriptorSet scatter_ba)
 {
-    // Clear shared status buffer before sort
+    // Clear the per-frame status buffer slot before sort. The descriptor
+    // sets passed in must already bind depth_onesweep_statuses_[frame_in_flight].
     VkDeviceSize status_clear_size = static_cast<VkDeviceSize>(num_sort_passes_) * 256ull
                                      * depth_onesweep_max_wg_ * sizeof(uint32_t);
-    vkCmdFillBuffer(cmd, depth_onesweep_status_.buffer(), 0, status_clear_size, 0);
+    vkCmdFillBuffer(cmd, depth_onesweep_statuses_[frame_in_flight].buffer(), 0, status_clear_size, 0);
     {
         VkMemoryBarrier sb{};
         sb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
@@ -3310,9 +3340,11 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_fligh
     }
 
     // === Onesweep 2-dispatch: clear status buffer once ===
+    // Per-frame: fill frame f's slot so cmdbuf f+1's clear doesn't stomp
+    // cmdbuf f's still-in-progress onesweep lookback state.
     {
         VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
-        vkCmdFillBuffer(cmd, onesweep_status_.buffer(), 0, status_size, 0);
+        vkCmdFillBuffer(cmd, onesweep_statuses_[frame_in_flight].buffer(), 0, status_size, 0);
         {
             VkMemoryBarrier sb{};
             sb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
@@ -3737,8 +3769,10 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
                 insert_compute_barrier(cmd);
 
                 // Sort dynamic (Onesweep) — Phase 3: per-frame sets read this
-                // frame's dynamic_sort_as_[f]/bs_[f].
+                // frame's dynamic_sort_as_[f]/bs_[f]. frame_in_flight also
+                // selects this frame's slot of depth_onesweep_statuses_.
                 dispatch_depth_onesweep(cmd, dynamic_sort_size_, dynamic_sort_workgroups_,
+                    frame_in_flight,
                     dynamic_depth_hist_sets_a_[frame_in_flight], dynamic_depth_hist_sets_b_[frame_in_flight],
                     dynamic_depth_scatter_sets_ab_[frame_in_flight], dynamic_depth_scatter_sets_ba_[frame_in_flight]);
             }
@@ -3760,11 +3794,13 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
 
                 insert_compute_barrier(cmd);
 
-                // Sort static (Onesweep) — static_*_set_ are single-instance
-                // (static_sort_a_/b_ are GPU-fenced via this dirty flow).
+                // Sort static (Onesweep) — static_sort_a_/b_ are GPU-fenced
+                // via static_dirty_, but the bound depth_onesweep_statuses_
+                // slot is per-frame, so the descriptor sets are per-frame too.
                 dispatch_depth_onesweep(cmd, static_sort_size_, static_sort_workgroups_,
-                    static_depth_hist_set_a_, static_depth_hist_set_b_,
-                    static_depth_scatter_set_ab_, static_depth_scatter_set_ba_);
+                    frame_in_flight,
+                    static_depth_hist_sets_a_[frame_in_flight], static_depth_hist_sets_b_[frame_in_flight],
+                    static_depth_scatter_sets_ab_[frame_in_flight], static_depth_scatter_sets_ba_[frame_in_flight]);
 
                 static_dirty_frames_remaining_--;
             }
@@ -4039,11 +4075,15 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
         per_splat_tile_offset_ssbos_[f].destroy(allocator);
         scan_block_sums_ssbos_[f].destroy(allocator);
     }
-    onesweep_status_.destroy(allocator);
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        onesweep_statuses_[f].destroy(allocator);
+    }
     determinism_readback_.destroy(allocator);
 
-    // Depth sort Onesweep buffers
-    depth_onesweep_status_.destroy(allocator);
+    // Depth sort Onesweep buffers — per-frame status, single-instance params.
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        depth_onesweep_statuses_[f].destroy(allocator);
+    }
     depth_sort_params_.destroy(allocator);
     static_depth_params_.destroy(allocator);
     dynamic_depth_params_.destroy(allocator);

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -3598,25 +3598,14 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
         vkCmdClearColorImage(cmd, depth_img, VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &range);
 
         // === PBD solver dispatch (before any preprocess) ===
-        // PBD-tagged gaussians live in the static buffer, but we deliberately do
-        // NOT force static_dirty_=true here. The static depth sort cost
-        // (~2.44M splats with the island scene) is too high to absorb every
-        // frame just to keep tree wind-sway frame-current. Instead the cached
-        // static sort is reused while the camera is stationary; trees freeze
-        // at their last-cached pose between camera-dirty events. Wind sway
-        // becomes visible whenever the camera moves (which arms
-        // `set_static_dirty(true)` upstream in Renderer::record_gs_prepass and
-        // re-runs static preprocess + sort, picking up the current
-        // pbd_state_ssbo_ contents).
-        //
-        // The PBD solver compute dispatch below still runs every frame to keep
-        // pbd_state_ssbo_ current — without that the rotation values trees
-        // pick up at the next camera move would themselves be stale.
-        //
-        // Trade-off accepted: stationary trees while camera is still vs.
-        // eliminating a per-frame 100-200ms (foreground) / 5-90s (M5
-        // background-throttled) sort cost that surfaces as a CPU freeze
-        // through vkGetQueryPoolResults's VK_QUERY_RESULT_WAIT_BIT.
+        // Option A (2026-05-11 cross-frame race fix): PBD-tagged gaussians live
+        // in the persistent-dynamic prefix alongside bone-animated characters
+        // and NPCs. The dynamic preprocess re-applies bone+PBD transforms every
+        // frame, so wind sway is visible while the camera is stationary — the
+        // static depth sort no longer needs to be re-armed to refresh tree
+        // poses. Static cloud retains only terrain + non-animated props
+        // (bone_index == 0) and its sort can stay cached until the camera
+        // actually moves.
         //
         // Determinism harness: PBD uses a hardcoded 1/60s step rather than
         // the engine dt, so the upstream draw_scene `dt = 0` freeze is not

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -221,7 +221,7 @@ void GsRenderer::create_descriptor_resources() {
 
     VkDescriptorPoolCreateInfo pool_info{};
     pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    pool_info.maxSets = 236;  // expanded for static/dynamic/merge + per-frame compute sets (Phase 3: +10 racing onesweep/merge/tile_bin sets per frame slot; Phase 3.5: +16 for per-frame tile_scan/tile_indirect/tile_ranges + onesweep tile sort sets; per-frame onesweep status fix: +4 for static depth onesweep slot [1])
+    pool_info.maxSets = 232;  // expanded for static/dynamic/merge + per-frame compute sets (Phase 3: +10 racing onesweep/merge/tile_bin sets per frame slot; Phase 3.5: +16 for per-frame tile_scan/tile_indirect/tile_ranges + onesweep tile sort sets)
     pool_info.poolSizeCount = 3;
     pool_info.pPoolSizes = pool_sizes;
 
@@ -506,12 +506,8 @@ void GsRenderer::create_descriptor_resources() {
         tile_ranges_layout_,                                // 49: tile_ranges_sets_[1]
         onesweep_hist_layout_, onesweep_hist_layout_,       // 50-51: tile onesweep hist A, B (slot [1])
         onesweep_scatter_layout_, onesweep_scatter_layout_, // 52-53: tile onesweep scatter AB, BA (slot [1])
-        // Phase: per-frame onesweep status fix — static depth onesweep sets
-        // become per-frame so they can bind depth_onesweep_statuses_[f].
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 54-55: static depth hist A, B (slot [1])
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 56-57: static depth scatter AB, BA (slot [1])
     };
-    constexpr uint32_t kSetCount = 58;
+    constexpr uint32_t kSetCount = 54;
     VkDescriptorSet sets[kSetCount];
     VkDescriptorSetAllocateInfo alloc_info{};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -565,17 +561,11 @@ void GsRenderer::create_descriptor_resources() {
     depth_hist_sets_b_[1] = sets[39];
     depth_scatter_sets_ab_[1] = sets[40];
     depth_scatter_sets_ba_[1] = sets[41];
-    // Depth sort Onesweep (static) — per-frame so each slot can bind frame
-    // f's depth_onesweep_statuses_[f]. static_sort_a_/b_ stay single-instance
-    // (GPU-fenced via static_dirty_).
-    static_depth_hist_sets_a_[0] = sets[21];
-    static_depth_hist_sets_b_[0] = sets[22];
-    static_depth_scatter_sets_ab_[0] = sets[23];
-    static_depth_scatter_sets_ba_[0] = sets[24];
-    static_depth_hist_sets_a_[1] = sets[54];
-    static_depth_hist_sets_b_[1] = sets[55];
-    static_depth_scatter_sets_ab_[1] = sets[56];
-    static_depth_scatter_sets_ba_[1] = sets[57];
+    // Depth sort Onesweep (static) — single-instance (static_sort_a_/b_ GPU-fenced)
+    static_depth_hist_set_a_ = sets[21];
+    static_depth_hist_set_b_ = sets[22];
+    static_depth_scatter_set_ab_ = sets[23];
+    static_depth_scatter_set_ba_ = sets[24];
     // Depth sort Onesweep (dynamic) — per-frame (racing dynamic_sort_as_/bs_)
     dynamic_depth_hist_sets_a_[0] = sets[25];
     dynamic_depth_hist_sets_b_[0] = sets[26];
@@ -1244,9 +1234,7 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
         tile_ranges_ssbos_[f].destroy(allocator_);
     }
     pp_ubo_buffer_.destroy(allocator_);
-    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-        depth_onesweep_statuses_[f].destroy(allocator_);
-    }
+    depth_onesweep_status_.destroy(allocator_);
     depth_sort_params_.destroy(allocator_);
     static_depth_params_.destroy(allocator_);
     dynamic_depth_params_.destroy(allocator_);
@@ -1437,30 +1425,21 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
                      static_cast<float>(entry_buf_size * 2) / (1024.0f * 1024.0f),
                      scan_dispatch_size_, scan_num_blocks_);
 
-        // Onesweep status buffer: 4 passes × 256 digits × max_workgroups.
-        // Per-frame so each in-flight cmdbuf clears + reads its own slot
-        // without racing the other cmdbuf's in-progress onesweep lookback.
+        // Onesweep status buffer: 4 passes × 256 digits × max_workgroups
+        onesweep_status_.destroy(allocator_);
         onesweep_max_wg_ = (tile_sort_capacity_ + 2047) / 2048;
         if (onesweep_max_wg_ == 0) onesweep_max_wg_ = 1;
         VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
-        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-            onesweep_statuses_[f].destroy(allocator_);
-            onesweep_statuses_[f] = Buffer::create_storage_gpu_only(allocator_, status_size);
-        }
+        onesweep_status_ = Buffer::create_storage_gpu_only(allocator_, status_size);
     }
 
     // ── Depth sort Onesweep buffers ──
     {
-        // Status buffer: num_sort_passes × 256 digits × max_wg (shared across
-        // static/dynamic/legacy depth sorts). Per-frame so the per-cmdbuf
-        // status clears don't race in-flight onesweep lookback on the other
-        // cmdbuf.
+        // Status buffer: num_sort_passes × 256 digits × max_wg (shared across static/dynamic/legacy)
         depth_onesweep_max_wg_ = std::max({static_sort_workgroups_, dynamic_sort_workgroups_, num_sort_workgroups_});
         VkDeviceSize depth_status_size = static_cast<VkDeviceSize>(num_sort_passes_) * 256ull
                                          * depth_onesweep_max_wg_ * sizeof(uint32_t);
-        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-            depth_onesweep_statuses_[f] = Buffer::create_storage_gpu_only(allocator_, depth_status_size);
-        }
+        depth_onesweep_status_ = Buffer::create_storage_gpu_only(allocator_, depth_status_size);
 
         // Params buffers (IndirectArgs layout: {wg_x, 1, 1, 0, 0, 0, entry_count, 0})
         auto fill_sort_params = [&](Buffer& buf, uint32_t wg_count, uint32_t entry_count) {
@@ -2557,7 +2536,7 @@ void GsRenderer::update_descriptors() {
     }
 
     // Depth Onesweep descriptor sets (legacy path) — same layout as tile Onesweep
-    if (depth_onesweep_statuses_[0].buffer() && depth_sort_params_.buffer()) {
+    if (depth_onesweep_status_.buffer() && depth_sort_params_.buffer()) {
         auto write_depth_onesweep_sets = [&](
             VkDescriptorSet hist_a, VkDescriptorSet hist_b,
             VkDescriptorSet scatter_ab, VkDescriptorSet scatter_ba,
@@ -2620,15 +2599,12 @@ void GsRenderer::update_descriptors() {
         // Legacy depth sort sets — per-frame (Phase 3). Each frame slot
         // binds its own sort_keys_ssbos_[f] / sort_b_ssbos_[f] so frame N+1's
         // dispatch reads its own slot, never frame N's still-in-use slot.
-        // depth_onesweep_statuses_[f] is also per-frame so the status fill
-        // at the start of dispatch_depth_onesweep doesn't race the other
-        // cmdbuf's in-flight lookback.
         for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
             write_depth_onesweep_sets(
                 depth_hist_sets_a_[f], depth_hist_sets_b_[f],
                 depth_scatter_sets_ab_[f], depth_scatter_sets_ba_[f],
                 sort_keys_ssbos_[f].buffer(), sort_b_ssbos_[f].buffer(),
-                depth_onesweep_statuses_[f].buffer(), depth_sort_params_.buffer());
+                depth_onesweep_status_.buffer(), depth_sort_params_.buffer());
         }
     }
 
@@ -2726,7 +2702,7 @@ void GsRenderer::update_descriptors() {
     }
 
     // Static/dynamic depth Onesweep descriptor sets (reuse lambda from above if available)
-    if (depth_onesweep_statuses_[0].buffer() && static_depth_params_.buffer()) {
+    if (depth_onesweep_status_.buffer() && static_depth_params_.buffer()) {
         auto write_depth_onesweep_sets = [&](
             VkDescriptorSet hist_a, VkDescriptorSet hist_b,
             VkDescriptorSet scatter_ab, VkDescriptorSet scatter_ba,
@@ -2766,16 +2742,12 @@ void GsRenderer::update_descriptors() {
               }; vkUpdateDescriptorSets(device_, 4, w, 0, nullptr); }
         };
 
-        // Static depth sort: static_sort_a_/b_ are single-instance
-        // (GPU-fenced via static_dirty_), but the bound status buffer is
-        // per-frame so we still need per-frame descriptor sets here.
-        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-            write_depth_onesweep_sets(
-                static_depth_hist_sets_a_[f], static_depth_hist_sets_b_[f],
-                static_depth_scatter_sets_ab_[f], static_depth_scatter_sets_ba_[f],
-                static_sort_a_.buffer(), static_sort_b_.buffer(),
-                depth_onesweep_statuses_[f].buffer(), static_depth_params_.buffer());
-        }
+        // Static depth sort (static_sort_a_/b_ are single-instance — not racing).
+        write_depth_onesweep_sets(
+            static_depth_hist_set_a_, static_depth_hist_set_b_,
+            static_depth_scatter_set_ab_, static_depth_scatter_set_ba_,
+            static_sort_a_.buffer(), static_sort_b_.buffer(),
+            depth_onesweep_status_.buffer(), static_depth_params_.buffer());
         // Dynamic depth sort — per-frame (Phase 3). Each frame slot binds
         // its own dynamic_sort_as_[f] / dynamic_sort_bs_[f] so frame N+1's
         // dispatch reads its own slot.
@@ -2784,7 +2756,7 @@ void GsRenderer::update_descriptors() {
                 dynamic_depth_hist_sets_a_[f], dynamic_depth_hist_sets_b_[f],
                 dynamic_depth_scatter_sets_ab_[f], dynamic_depth_scatter_sets_ba_[f],
                 dynamic_sort_as_[f].buffer(), dynamic_sort_bs_[f].buffer(),
-                depth_onesweep_statuses_[f].buffer(), dynamic_depth_params_.buffer());
+                depth_onesweep_status_.buffer(), dynamic_depth_params_.buffer());
         }
     }
 
@@ -2944,13 +2916,13 @@ void GsRenderer::update_descriptors() {
         }
 
         // Onesweep histogram descriptor sets (read-only input + status + args)
-        // Phase 3.5 + onesweep status fix: every binding is per-frame, so
-        // each frame f's onesweep dispatch reads/writes only its own slot.
-        if (onesweep_statuses_[0].buffer()) {
+        // Phase 3.5: per-frame. onesweep_status_ stays single-instance (its
+        // race is out of scope for this phase).
+        if (onesweep_status_.buffer()) {
             for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
                 {
                     VkDescriptorBufferInfo in_info{tile_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo status_info{onesweep_statuses_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorSet hist_a = onesweep_hist_sets_a_[f];
                     VkWriteDescriptorSet writes[] = {
@@ -2965,7 +2937,7 @@ void GsRenderer::update_descriptors() {
                 }
                 {
                     VkDescriptorBufferInfo in_info{tile_sort_bs_[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo status_info{onesweep_statuses_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorSet hist_b = onesweep_hist_sets_b_[f];
                     VkWriteDescriptorSet writes[] = {
@@ -2982,7 +2954,7 @@ void GsRenderer::update_descriptors() {
                 {
                     VkDescriptorBufferInfo in_info{tile_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorBufferInfo out_info{tile_sort_bs_[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo status_info{onesweep_statuses_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorSet scatter_ab = onesweep_scatter_sets_ab_[f];
                     VkWriteDescriptorSet writes[] = {
@@ -3000,7 +2972,7 @@ void GsRenderer::update_descriptors() {
                 {
                     VkDescriptorBufferInfo in_info{tile_sort_bs_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorBufferInfo out_info{tile_sort_as_[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo status_info{onesweep_statuses_[f].buffer(), 0, VK_WHOLE_SIZE};
+                    VkDescriptorBufferInfo status_info{onesweep_status_.buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorBufferInfo args_info{tile_indirect_args_[f].buffer(), 0, VK_WHOLE_SIZE};
                     VkDescriptorSet scatter_ba = onesweep_scatter_sets_ba_[f];
                     VkWriteDescriptorSet writes[] = {
@@ -3164,15 +3136,13 @@ void GsRenderer::init_output_layouts(VkCommandBuffer cmd) {
 
 void GsRenderer::dispatch_depth_onesweep(
     VkCommandBuffer cmd, uint32_t sort_size, uint32_t num_workgroups,
-    uint32_t frame_in_flight,
     VkDescriptorSet hist_a, VkDescriptorSet hist_b,
     VkDescriptorSet scatter_ab, VkDescriptorSet scatter_ba)
 {
-    // Clear the per-frame status buffer slot before sort. The descriptor
-    // sets passed in must already bind depth_onesweep_statuses_[frame_in_flight].
+    // Clear shared status buffer before sort
     VkDeviceSize status_clear_size = static_cast<VkDeviceSize>(num_sort_passes_) * 256ull
                                      * depth_onesweep_max_wg_ * sizeof(uint32_t);
-    vkCmdFillBuffer(cmd, depth_onesweep_statuses_[frame_in_flight].buffer(), 0, status_clear_size, 0);
+    vkCmdFillBuffer(cmd, depth_onesweep_status_.buffer(), 0, status_clear_size, 0);
     {
         VkMemoryBarrier sb{};
         sb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
@@ -3340,11 +3310,9 @@ void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_fligh
     }
 
     // === Onesweep 2-dispatch: clear status buffer once ===
-    // Per-frame: fill frame f's slot so cmdbuf f+1's clear doesn't stomp
-    // cmdbuf f's still-in-progress onesweep lookback state.
     {
         VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
-        vkCmdFillBuffer(cmd, onesweep_statuses_[frame_in_flight].buffer(), 0, status_size, 0);
+        vkCmdFillBuffer(cmd, onesweep_status_.buffer(), 0, status_size, 0);
         {
             VkMemoryBarrier sb{};
             sb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
@@ -3769,10 +3737,8 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
                 insert_compute_barrier(cmd);
 
                 // Sort dynamic (Onesweep) — Phase 3: per-frame sets read this
-                // frame's dynamic_sort_as_[f]/bs_[f]. frame_in_flight also
-                // selects this frame's slot of depth_onesweep_statuses_.
+                // frame's dynamic_sort_as_[f]/bs_[f].
                 dispatch_depth_onesweep(cmd, dynamic_sort_size_, dynamic_sort_workgroups_,
-                    frame_in_flight,
                     dynamic_depth_hist_sets_a_[frame_in_flight], dynamic_depth_hist_sets_b_[frame_in_flight],
                     dynamic_depth_scatter_sets_ab_[frame_in_flight], dynamic_depth_scatter_sets_ba_[frame_in_flight]);
             }
@@ -3794,13 +3760,11 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
 
                 insert_compute_barrier(cmd);
 
-                // Sort static (Onesweep) — static_sort_a_/b_ are GPU-fenced
-                // via static_dirty_, but the bound depth_onesweep_statuses_
-                // slot is per-frame, so the descriptor sets are per-frame too.
+                // Sort static (Onesweep) — static_*_set_ are single-instance
+                // (static_sort_a_/b_ are GPU-fenced via this dirty flow).
                 dispatch_depth_onesweep(cmd, static_sort_size_, static_sort_workgroups_,
-                    frame_in_flight,
-                    static_depth_hist_sets_a_[frame_in_flight], static_depth_hist_sets_b_[frame_in_flight],
-                    static_depth_scatter_sets_ab_[frame_in_flight], static_depth_scatter_sets_ba_[frame_in_flight]);
+                    static_depth_hist_set_a_, static_depth_hist_set_b_,
+                    static_depth_scatter_set_ab_, static_depth_scatter_set_ba_);
 
                 static_dirty_frames_remaining_--;
             }
@@ -4075,15 +4039,11 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
         per_splat_tile_offset_ssbos_[f].destroy(allocator);
         scan_block_sums_ssbos_[f].destroy(allocator);
     }
-    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-        onesweep_statuses_[f].destroy(allocator);
-    }
+    onesweep_status_.destroy(allocator);
     determinism_readback_.destroy(allocator);
 
-    // Depth sort Onesweep buffers — per-frame status, single-instance params.
-    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-        depth_onesweep_statuses_[f].destroy(allocator);
-    }
+    // Depth sort Onesweep buffers
+    depth_onesweep_status_.destroy(allocator);
     depth_sort_params_.destroy(allocator);
     static_depth_params_.destroy(allocator);
     dynamic_depth_params_.destroy(allocator);

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -1275,9 +1275,11 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
         // Phase 1 (dynamic preprocess+sort) and Phase 2 (static preprocess+sort)
         // touch disjoint regions; Phase 3 (merge) reads both and is re-run every
         // frame, so dropping the static rebuild while a VFX is alive is safe.
-        // PBD-on-static still self-arms `static_dirty_` from inside
-        // GsRenderer::render() because PBD-tagged splats live in the static
-        // buffer and mutate every frame; that path stays.
+        // Option A (2026-05-11): PBD-tagged splats now live in the dynamic
+        // prefix alongside characters/NPCs. The dynamic preprocess runs every
+        // frame anyway, so PBD wind sway is visible without arming
+        // `static_dirty_` — and the static sort can stay cached until the
+        // camera actually moves.
 
         // Determinism harness: hold the LOD/chunk-gather selection across
         // frames so the pre-sort input set itself is bit-identical. Any
@@ -1290,11 +1292,12 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
 
         // Camera-dirty refresh: arm the per-frame static preprocess gate.
         // GsRenderer::render() gates static preprocess on `static_dirty_`.
-        // Only chunk publications and PBD physics dispatches re-arm it
-        // automatically — so a streamed scene with no PBD elements would
-        // freeze static projections between chunk events as the camera
-        // moves. Force the flag on every camera-dirty frame so streaming
-        // scenes stay responsive. Source: codex P1 review on PR #388.
+        // Only chunk publications re-arm it automatically (PBD now lives in
+        // dynamic under Option A and no longer touches `static_dirty_`) — so
+        // a streamed scene would freeze static projections between chunk
+        // events as the camera moves. Force the flag on every camera-dirty
+        // frame so streaming scenes stay responsive. Source: codex P1 review
+        // on PR #388.
         if (camera_dirty) {
             gs_renderer_.set_static_dirty(true);
             gs_prev_view_ = gs_view_;


### PR DESCRIPTION
## Summary

- Eliminates the every-other-frame blank-vignette flicker by per-framing the GS compute pipeline's racing SSBOs and descriptor sets across `kMaxFramesInFlight` slots, and routing `frame_in_flight` through every dispatch on the per-frame render path.
- Restores Option A: PBD-tagged and character/NPC bone-animated splats now ride in the dynamic tail (in-tree since `87422f4a`; this branch cleans up the now-obsolete static-PBD trade-off comments).
- Residual race on `onesweep_status_` / `depth_onesweep_status_` is documented as tech debt — see `docs/superpowers/issues/onesweep_status_double_buffering_hang.md`.

## What changed (commits)

| Phase | Commit | Description |
|---|---|---|
| Spec | `6b62fe90` | docs(spec) — cross-frame compute SSBO race fix + Option A restore design |
| Plan | `fad84b02` | docs(plan) — phase-by-phase implementation plan |
| 1 | `3d746ee2` | 8 racing buffers → `std::array<Buffer, kMaxFramesInFlight>`, all consumers on slot `[0]` (no behavior change) |
| 2 | `33652933` | preprocess/sort/static_preprocess/dynamic_preprocess descriptor sets → per-frame arrays |
| 3 | `690ee1ef` | `frame_in_flight` routing through dispatch + per-frame onesweep/merge/tile_bin sets |
| 3.5 | `506af492` | Per-frame tile-pipeline buffers (runtime-discovered miss: `tile_sort_a/b_`, `tile_sort_count_ssbo_`, `per_splat_tile_count/offset_ssbo_`, `scan_block_sums_ssbo_`, `tile_indirect_args_`, `tile_ranges_ssbo_`) |
| — | `354479b0` | Attempted per-framing of `onesweep_status_` / `depth_onesweep_status_` … |
| — | `8251f05c` | … **reverted** — regressed the `LoadingMonitor` transition, engine got stuck in Warming. Tracked as tech debt. |
| 4 | `496cafc9` | Option A doc cleanup (partition logic was already non-zero-bone_index → dynamic from `87422f4a`) |
| Issue | `164e5887` | docs(issues) — full postmortem of the Phase 3.6 hang with five candidate hypotheses for the next attempt |

Net: `include/gseurat/engine/gs_renderer.hpp` and `src/engine/gs_renderer.cpp` are the bulk of the diff. `src/demo/island_demo_state.cpp` and `src/engine/renderer.cpp` get small comment cleanups. New design / plan / issue docs under `docs/superpowers/`.

## Race-fix scope

**Now per-frame** (each frame N writes / reads its own `[N % kMaxFramesInFlight]` slot):

- Compute SSBOs: `projected`, `sort_keys`, `sort_b`, `visible_count`, `dynamic_sort_a/b`, `counts`, `merged_sort` (Phase 1)
- Tile-pipeline buffers: `tile_sort_a/b`, `tile_sort_count`, `per_splat_tile_count`, `per_splat_tile_offset`, `scan_block_sums`, `tile_indirect_args`, `tile_ranges` (Phase 3.5)
- Compute descriptor sets: `preprocess`, `sort`, `static_preprocess`, `dynamic_preprocess`, `merge`, `tile_bin`, depth & dynamic-depth onesweep hist/scatter (Phase 2 + Phase 3)

**Still single-instance** (not raced or rare-write only):

- `gaussian_ssbo_`, `static_gaussian_ssbo_`, `dynamic_gaussian_ssbo_` (read-only after upload)
- `static_sort_a/b_` (mutated only during `static_dirty_frames_remaining_` countdown; see tech-debt note)
- `bone_ssbo_`, `pbd_state_ssbo_`, `pbd_*` (CPU-written per frame but on a different sync path)
- `uniform_buffer_`, `tile_scan_pipeline`'s scan-related sets bound to single-instance buffers
- `onesweep_status_`, `depth_onesweep_status_` — **known residual race, documented in tech-debt doc**

## Memory overhead

Per spec §3 estimate: ~400 MB of additional VRAM for the per-frame buffer duplication on an M5 with `kMaxFramesInFlight=2`. Accepted by the user pre-implementation given unified memory and stability priorities. Not measured precisely post-merge; recommend tracking VRAM usage if a future hardware target is more memory-constrained.

## Validation

Manual Game Director screenshot batches on M-series macOS:

- **Pre-branch baseline:** ~50% strict every-other-frame blank-vignette alternation in steady-state gameplay; ≥1 s `vkQueueSubmit` stalls observed in watchdog traces.
- **Branch tip (`164e5887`, this PR):** No observable steady-state blank flicker. The few "blank-sized" screenshots in the 15-shot validation batch were the engine's **WARMING UP / PREPARING SCENE** overlay at full swapchain resolution, not actual GS-output blanks. Vulkan validation layer (`macos-debug` build) reports zero `SYNC-HAZARD-*` warnings on the per-frame compute paths.
- **Performance:** Watchdog `WAIT_SLOW` lines dropped from ~once per 30 frames to near-zero across a 60 s capture.
- **Determinism harness:** existing snapshot-diff test still passes (no regression observed in the pre-merge harness runs).

Two macOS WindowServer kernel restarts occurred during this branch's validation cycle, both correlated with the Phase 3.6 attempt's GPU pattern. Phase 3.5 alone (current branch tip) has not reproduced this. Documented in the tech-debt doc.

## Known residual issue

`onesweep_status_` / `depth_onesweep_status_` are still single-instance and filled at the start of every per-frame dispatch. On paper the race is real; in practice it does not appear visually disruptive at current dynamic-tail sizes (~450 k splats steady-state, well under the buffer-size threshold where the race manifests). The Phase 3.6 attempt to per-frame these buffers regressed the LoadingMonitor transition; the postmortem at `docs/superpowers/issues/onesweep_status_double_buffering_hang.md` captures five candidate root causes and a prioritized investigation path for the next attempt.

## Test plan

- [ ] Reviewer runs the island demo on M-series hardware and confirms no flicker / no engine hang in steady-state gameplay.
- [ ] Reviewer walks through the bridge → forest → dungeon round-trip and confirms no flicker on either side of the portal.
- [ ] Reviewer runs `macos-debug` for ~30 s and confirms zero `SYNC-HAZARD-*` validation warnings.
- [ ] Reviewer reads `docs/superpowers/issues/onesweep_status_double_buffering_hang.md` and either accepts the tech debt or flags concerns about the residual race.
- [ ] Existing regression harness passes in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)