### PR TITLE
fix(engine): refresh descriptors after resize_output regardless of count

### DIFF
--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -3129,7 +3129,20 @@ void GsRenderer::resize_output(uint32_t width, uint32_t height) {
 
     create_output_image(width, height);
 
-    if (gaussian_count_ > 0) {
+    // Descriptors hold raw VkImageView handles into the just-destroyed
+    // output_views_/depth_views_/processed_views_ arrays. They must be
+    // refreshed against the new views before any GS dispatch, regardless
+    // of whether splats have been uploaded yet — gaussian_count_ > 0
+    // gates whether the resulting frame is meaningful, not whether the
+    // descriptor handles are valid. (Without this, the first dispatch
+    // after a resize-before-load reports VkImageView 0x0 and the slot's
+    // post-process writes nothing — the symptom user-visible as alternating
+    // blank frames after a cold scene load.)
+    //
+    // update_descriptors has its own internal guard for the static/dynamic
+    // split sets that early-returns when split buffers aren't allocated
+    // yet (pre-init_streaming).
+    if (streaming_initialized_) {
         update_descriptors();
     }
 }


### PR DESCRIPTION
## Summary

Eliminates the alternating-blank-frame symptom the user reported and reproduced via screen recording + `scripts/repro_alternating_blank.sh`.

`resize_output` destroys `output_views_`/`depth_views_`/`processed_views_` and rebuilds them via `create_output_image`, but only re-ran `update_descriptors()` when `gaussian_count_ > 0`. The startup ordering is:

1. Constructor → `create_output_image(320, 240)` (placeholder views)
2. Renderer → `init_streaming()` which calls `update_descriptors()` → per-frame `render_sets_`/`post_process_sets_`/`tile_render_sets_` now bind the 320×240 view handles
3. Renderer → `resize_output(actual_swapchain_size)` → destroys the 320×240 views, creates new ones, **skips `update_descriptors`** because `gaussian_count_` is still 0 (`load_cloud_async` hasn't completed)
4. `load_cloud_async` finishes → `gaussian_count_ = 1_698_939` — nobody re-runs `update_descriptors`
5. First GS dispatch → Vulkan validation reports `VkImageView 0x0 that is invalid or has been destroyed` on `output_image` / `depth_image` / `input_image`; that slot's post-process writes nothing; with `kMaxFramesInFlight=2` every other presented frame is the dark-vignette blank.

## Fix

Replace the `gaussian_count_ > 0` gate with `streaming_initialized_`. The image-view bindings need refreshing whenever the views change, independent of splat count. `update_descriptors()` already has an internal early-return for the static/dynamic split sets when those buffers aren't allocated, so calling it pre-load is safe.

One-line change (plus comment explaining why):

\`\`\`cpp
-    if (gaussian_count_ > 0) {
+    if (streaming_initialized_) {
         update_descriptors();
     }
\`\`\`

## Test plan

- [x] `cmake --build --preset macos-debug` clean
- [x] `bash scripts/repro_alternating_blank.sh 30`:
  - **Before**: 10 `VkImageView 0x0` validation errors; Game Director shots split into a 410339-byte broken cluster (every other shot) and a 270-280 KB good cluster
  - **After**: 0 validation errors; shots uniformly 240-305 KB across all 30 samples; no alternation; gameplay rendered every frame
- [x] Visually verified rendered frames look correct (player, NPCs, terrain, lighting all present)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)