### PR TITLE
build: bake GSVX from PLY at build time (M1 PR-1 / #396)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,53 @@ if(GSEURAT_BUILD_TOOLS)
 add_subdirectory(tools/ply_importer)
 endif() # GSEURAT_BUILD_TOOLS
 
+# --- GSVX baking ------------------------------------------------------------
+# Pre-convert all bundled .ply assets to GSVX at build time, so the runtime
+# always hits the GSVX fast path in GaussianCloud::load_with_gsvx_first and
+# never falls back to runtime PLY parsing. Required for #396 / M1 — once every
+# asset has a sibling .gsvx in the build dir, the PLY parser can be removed
+# from gseurat_core entirely (PR-2).
+
+if(GSEURAT_BUILD_EXAMPLES AND GSEURAT_BUILD_TOOLS)
+    file(GLOB_RECURSE GSEURAT_PLY_ASSETS
+        CONFIGURE_DEPENDS
+        RELATIVE "${GSEURAT_EXAMPLE_DIR}/assets"
+        "${GSEURAT_EXAMPLE_DIR}/assets/*.ply")
+
+    set(GSEURAT_GSVX_OUTPUTS)
+    foreach(rel_ply IN LISTS GSEURAT_PLY_ASSETS)
+        set(src_ply  "${GSEURAT_EXAMPLE_DIR}/assets/${rel_ply}")
+        # Skip test fixtures that are not valid PLYs (e.g. tests/ scene-loader
+        # path-resolution stubs). Real PLY files start with "ply\n"; check the
+        # first three bytes against the magic.
+        file(READ "${src_ply}" GSEURAT_PLY_MAGIC LIMIT 3 HEX)
+        if(NOT GSEURAT_PLY_MAGIC STREQUAL "706c79")
+            message(STATUS "GSeurat: skipping non-PLY file assets/${rel_ply}")
+            continue()
+        endif()
+        string(REGEX REPLACE "\\.ply$" ".gsvx" rel_gsvx "${rel_ply}")
+        set(dst_gsvx "${CMAKE_CURRENT_BINARY_DIR}/assets/${rel_gsvx}")
+        get_filename_component(dst_dir "${dst_gsvx}" DIRECTORY)
+        add_custom_command(
+            OUTPUT  "${dst_gsvx}"
+            DEPENDS "${src_ply}" ply_importer
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${dst_dir}"
+            COMMAND $<TARGET_FILE:ply_importer> "${src_ply}" "${dst_gsvx}"
+            COMMENT "Baking GSVX: ${rel_gsvx}"
+            VERBATIM
+        )
+        list(APPEND GSEURAT_GSVX_OUTPUTS "${dst_gsvx}")
+    endforeach()
+
+    list(LENGTH GSEURAT_GSVX_OUTPUTS GSEURAT_GSVX_COUNT)
+    if(GSEURAT_GSVX_COUNT GREATER 0)
+        add_custom_target(bake_gsvx ALL DEPENDS ${GSEURAT_GSVX_OUTPUTS})
+        add_dependencies(gseurat_demo bake_gsvx)
+        add_dependencies(gseurat_staging bake_gsvx)
+        message(STATUS "GSeurat: GSVX baking enabled for ${GSEURAT_GSVX_COUNT} PLY assets")
+    endif()
+endif()
+
 # --- Tests ------------------------------------------------------------------
 
 if(GSEURAT_BUILD_TESTS)


### PR DESCRIPTION
## Summary

PR-1 of two for closing **M1 (Phase 1 end / #396)** — *severing the runtime PLY parser*.

This PR is pure build-system: it adds a CMake step that runs the standalone `ply_importer` tool over every bundled `.ply` asset, producing a sibling `.gsvx` in the build dir. The runtime's `GaussianCloud::load_with_gsvx_first` already prefers GSVX and falls back to PLY only when no sibling exists — once every PLY has a baked GSVX, the fallback never fires.

No runtime code is modified. PR-2 (follow-up) will delete `GaussianCloud::load_ply` and remove the fallback now that the bake guarantees coverage.

## Why this and not a "bone sidecar"

The status memory pointer described this as needing a `character.bones.json` sidecar from the importer. Code audit during planning found that's already moot:

- Per-Gaussian `bone_index` is already encoded into GSVX (`scale_pad.w`, `tools/ply_importer/ply_parse.hpp:25`).
- Runtime `bone_count` comes from `BoneAnimated.manifest` JSON, not from any PLY parse (`src/engine/gs_scene_loader.cpp:67-86`).
- The only blocker to retiring `load_ply` was that **0 of 57 PLY assets had a sibling GSVX**, so the fallback at `gaussian_cloud.cpp:593` fired for every load. This PR makes that path unreachable for bundled assets.

## Implementation

- `file(GLOB_RECURSE ... CONFIGURE_DEPENDS)` over `examples/island_demo/assets/*.ply` (57 files).
- 3-byte `ply\n` magic-header check skips non-PLY stubs (e.g. `characters/test/test.ply` — a 4-byte fixture for scene-loader path-resolution unit tests).
- Per-PLY `add_custom_command` invokes `$<TARGET_FILE:ply_importer>` with the PLY input and a build-tree GSVX output; `make_directory` first to handle nested asset folders.
- `bake_gsvx` aggregate target wired as a hard dep of `gseurat_demo` and `gseurat_staging`.
- Gated on `GSEURAT_BUILD_EXAMPLES AND GSEURAT_BUILD_TOOLS` so submodule consumers see no behavior change.

## Validation

- Configure: `-- GSeurat: GSVX baking enabled for 56 PLY assets` (1 skipped fixture).
- `cmake --build --preset macos-debug --target bake_gsvx` → 56 sibling `.gsvx` files emitted under `build/macos-debug/assets/`.
- `cmake --build --preset macos-debug --target gseurat_demo` → links cleanly, transitively builds the bake.

## Test plan

- [ ] CI green
- [ ] Local: `cmake --build --preset macos-debug --target gseurat_demo` succeeds; `find build/macos-debug/assets -name '*.gsvx' | wc -l` returns 56
- [ ] Local: launch `./build/macos-debug/gseurat_demo`, walk the demo scene, verify no `[gaussian_cloud] sibling .gsvx failed` lines in stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
