### PR TITLE
refactor(engine): retire runtime PLY parser (M1 close / #396)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,7 +360,7 @@ add_custom_target(sync_assets ALL
 )
 
 add_executable(ply2heightmap src/tools/ply2heightmap.cpp
-    src/engine/gaussian_cloud.cpp
+    src/engine/gaussian_cloud.cpp src/engine/gaussian_cloud_ply.cpp
     src/engine/project_root.cpp)
 target_include_directories(ply2heightmap PRIVATE
     ${PROJECT_SOURCE_DIR}/include
@@ -458,13 +458,13 @@ add_gseurat_test(test_sort_hash)
 add_gseurat_test(test_engine_loading_monitor  src/engine/engine_state.cpp)
 add_gseurat_test(test_async_loader     src/engine/async_loader.cpp)
 add_gseurat_test(test_character_data   src/engine/character_data.cpp)
-add_gseurat_test(test_gaussian_cloud   src/engine/gaussian_cloud.cpp src/engine/collision_gen.cpp
+add_gseurat_test(test_gaussian_cloud   src/engine/gaussian_cloud.cpp src/engine/gaussian_cloud_ply.cpp src/engine/collision_gen.cpp
                                        src/engine/scene_loader.cpp src/engine/tilemap.cpp
                                        src/engine/gs_particle.cpp src/engine/gs_spline.cpp
                                        src/engine/gs_animator.cpp src/engine/project_root.cpp)
 add_gseurat_test(test_transition_system  src/engine/systems/transition_system.cpp
                                           src/engine/systems/portal_trigger_handler.cpp)
-add_gseurat_test(test_gs_chunk_streamer src/engine/gs_chunk_streamer.cpp src/engine/gaussian_cloud.cpp
+add_gseurat_test(test_gs_chunk_streamer src/engine/gs_chunk_streamer.cpp src/engine/gaussian_cloud.cpp src/engine/gaussian_cloud_ply.cpp
                                         src/engine/async_loader.cpp
                                         src/engine/project_root.cpp)
 add_gseurat_test(test_gs_parallax_camera src/engine/gs_parallax_camera.cpp)
@@ -472,22 +472,22 @@ add_gseurat_test(test_screenshot       src/engine/screenshot.cpp)
 add_gseurat_test(test_staging_uploader src/engine/staging_uploader.cpp)
 add_gseurat_test(test_tilemap          src/engine/tilemap.cpp)
 add_gseurat_test(test_gs_point_lights)
-add_gseurat_test(test_gs_emission     src/engine/gaussian_cloud.cpp
+add_gseurat_test(test_gs_emission     src/engine/gaussian_cloud.cpp src/engine/gaussian_cloud_ply.cpp
                                        src/engine/project_root.cpp)
 add_gseurat_test(test_gs_particle    src/engine/gs_particle.cpp src/engine/gs_animator.cpp
-                                      src/engine/gaussian_cloud.cpp src/engine/scene_loader.cpp
+                                      src/engine/gaussian_cloud.cpp src/engine/gaussian_cloud_ply.cpp src/engine/scene_loader.cpp
                                       src/engine/gs_spline.cpp src/engine/project_root.cpp)
 add_gseurat_test(test_scene_loading  src/engine/scene_loader.cpp src/engine/tilemap.cpp
                                       src/engine/gs_particle.cpp src/engine/gs_animator.cpp
-                                      src/engine/gaussian_cloud.cpp src/engine/gs_vfx.cpp
+                                      src/engine/gaussian_cloud.cpp src/engine/gaussian_cloud_ply.cpp src/engine/gs_vfx.cpp
                                       src/engine/gs_spline.cpp src/engine/coordinate.cpp
                                       src/engine/project_root.cpp)
 add_gseurat_test(test_incremental_sync src/engine/scene_loader.cpp src/engine/tilemap.cpp
-                                        src/engine/gaussian_cloud.cpp src/engine/gs_particle.cpp
+                                        src/engine/gaussian_cloud.cpp src/engine/gaussian_cloud_ply.cpp src/engine/gs_particle.cpp
                                         src/engine/gs_animator.cpp src/engine/gs_spline.cpp
                                         src/engine/coordinate.cpp src/engine/project_root.cpp)
 add_gseurat_test(test_vfx_lights_rotation src/engine/gs_vfx.cpp src/engine/gs_particle.cpp
-                                           src/engine/gs_animator.cpp src/engine/gaussian_cloud.cpp
+                                           src/engine/gs_animator.cpp src/engine/gaussian_cloud.cpp src/engine/gaussian_cloud_ply.cpp
                                            src/engine/scene_loader.cpp src/engine/tilemap.cpp
                                            src/engine/gs_spline.cpp src/engine/project_root.cpp)
 add_gseurat_test(test_gs_spline src/engine/gs_spline.cpp)
@@ -518,8 +518,8 @@ add_gseurat_test(test_camera_review_state src/staging/camera_review_state.cpp
 target_link_libraries(test_camera_review_state PRIVATE glfw imgui_lib)
 add_gseurat_test(test_visual_state  src/staging/visual_state.cpp)
 add_gseurat_test(test_project_root  src/engine/project_root.cpp)
-add_gseurat_test(test_ply_path_resolution  src/engine/project_root.cpp src/engine/gaussian_cloud.cpp)
-add_gseurat_test(test_bridge_reconnect_root  src/engine/project_root.cpp src/engine/gaussian_cloud.cpp)
+add_gseurat_test(test_ply_path_resolution  src/engine/project_root.cpp src/engine/gaussian_cloud.cpp src/engine/gaussian_cloud_ply.cpp)
+add_gseurat_test(test_bridge_reconnect_root  src/engine/project_root.cpp src/engine/gaussian_cloud.cpp src/engine/gaussian_cloud_ply.cpp)
 add_gseurat_test(test_slab_allocator src/engine/slab_allocator.cpp)
 add_gseurat_test(test_world_manifest src/engine/world_manifest.cpp)
 add_gseurat_test(test_world_streamer src/engine/world_streamer.cpp src/engine/world_manifest.cpp)
@@ -606,7 +606,7 @@ add_gseurat_test(test_audio_effect_chain
 target_include_directories(test_audio_effect_chain PRIVATE ${PROJECT_SOURCE_DIR}/src/engine/audio)
 
 add_gseurat_test(test_ply2heightmap
-    src/engine/gaussian_cloud.cpp
+    src/engine/gaussian_cloud.cpp src/engine/gaussian_cloud_ply.cpp
     src/engine/project_root.cpp)
 
 add_gseurat_test(test_debug

--- a/include/gseurat/engine/gaussian_cloud.hpp
+++ b/include/gseurat/engine/gaussian_cloud.hpp
@@ -97,16 +97,19 @@ struct GsvxPayload {
 
 class GaussianCloud {
 public:
+    /// Parse a binary_little_endian PLY file. Compiled into offline tools
+    /// (ply2heightmap) and tests only; the runtime engine does NOT link
+    /// this. The runtime uses `load_with_gsvx_first`, which requires a
+    /// build-baked sibling .gsvx (see CMakeLists.txt `bake_gsvx`).
     static GaussianCloud load_ply(const std::string& path,
                                    CoordinateSystem coords = CoordinateSystem::kYUp);
     /// Load a pre-baked .gsvx binary file (zero-copy GPU format).
     static GsvxPayload load_gsvx(const std::string& path);
-    /// Try a sibling `.gsvx` first (path with `.ply` swapped for `.gsvx`);
-    /// fall back to `load_ply` on any failure (no file, bad header,
-    /// truncated, etc.). The returned cloud is field-equivalent to
-    /// `load_ply` within float epsilon. `coords` is applied symmetrically
-    /// on either path. Drop-in replacement for runtime `load_ply` callers
-    /// (PR-A of #396).
+    /// Resolve the sibling `.gsvx` for a `.ply` path and load it. Throws
+    /// `std::runtime_error` if the sibling is missing or unreadable; this
+    /// is the runtime cloud-load path and there is no PLY fallback. Every
+    /// bundled .ply is converted to .gsvx by the `bake_gsvx` build target
+    /// (M1 of #396).
     static GaussianCloud load_with_gsvx_first(
         const std::string& ply_path,
         CoordinateSystem coords = CoordinateSystem::kYUp);

--- a/include/gseurat/engine/gaussian_cloud.hpp
+++ b/include/gseurat/engine/gaussian_cloud.hpp
@@ -97,12 +97,6 @@ struct GsvxPayload {
 
 class GaussianCloud {
 public:
-    /// Parse a binary_little_endian PLY file. Compiled into offline tools
-    /// (ply2heightmap) and tests only; the runtime engine does NOT link
-    /// this. The runtime uses `load_with_gsvx_first`, which requires a
-    /// build-baked sibling .gsvx (see CMakeLists.txt `bake_gsvx`).
-    static GaussianCloud load_ply(const std::string& path,
-                                   CoordinateSystem coords = CoordinateSystem::kYUp);
     /// Load a pre-baked .gsvx binary file (zero-copy GPU format).
     static GsvxPayload load_gsvx(const std::string& path);
     /// Resolve the sibling `.gsvx` for a `.ply` path and load it. Throws
@@ -115,10 +109,10 @@ public:
         CoordinateSystem coords = CoordinateSystem::kYUp);
     static GaussianCloud from_gaussians(std::vector<Gaussian> gaussians);
 
-    // Write Gaussians to a binary little-endian PLY file.
-    // Data is stored in the same format load_ply() expects (log-scale, logit-opacity, SH DC color).
-    static void write_ply(const std::string& path, const std::vector<Gaussian>& gaussians,
-                          CoordinateSystem coords = CoordinateSystem::kYUp);
+    // PLY load/write live in <gseurat/engine/gaussian_cloud_ply.hpp> as
+    // `gseurat::ply::load` / `gseurat::ply::write`. They are offline-only —
+    // not linked into gseurat_core. Callers must add
+    // `src/engine/gaussian_cloud_ply.cpp` to their build target.
 
     const std::vector<Gaussian>& gaussians() const { return gaussians_; }
     const AABB& bounds() const { return bounds_; }

--- a/include/gseurat/engine/gaussian_cloud_ply.hpp
+++ b/include/gseurat/engine/gaussian_cloud_ply.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+// Offline-only PLY I/O for GaussianCloud.
+//
+// This header is NOT part of the public `gseurat_core` ABI. The runtime
+// engine library does not compile `gaussian_cloud_ply.cpp` and does not
+// link these symbols — calling them from a downstream submodule consumer
+// would fail at link time.
+//
+// Only offline tools (e.g. ply2heightmap) and tests include this header
+// and add `src/engine/gaussian_cloud_ply.cpp` to their build. The runtime
+// path goes through `GaussianCloud::load_with_gsvx_first`, which requires
+// a sibling `.gsvx` baked by the `bake_gsvx` CMake target.
+//
+// Closes Codex P2 on PR #425: header surface now matches link surface.
+
+#include "gseurat/engine/gaussian_cloud.hpp"
+
+#include <string>
+#include <vector>
+
+namespace gseurat::ply {
+
+/// Parse a binary_little_endian PLY file. Throws `std::runtime_error` on any
+/// parse failure. Offline-only — see header comment.
+GaussianCloud load(const std::string& path,
+                   CoordinateSystem coords = CoordinateSystem::kYUp);
+
+/// Write Gaussians to a binary_little_endian PLY file. Round-trips through
+/// `ply::load` within float epsilon. Offline-only — see header comment.
+void write(const std::string& path,
+           const std::vector<Gaussian>& gaussians,
+           CoordinateSystem coords = CoordinateSystem::kYUp);
+
+}  // namespace gseurat::ply

--- a/src/engine/gaussian_cloud.cpp
+++ b/src/engine/gaussian_cloud.cpp
@@ -3,324 +3,18 @@
 #include "gseurat/engine/project_root.hpp"
 
 #include <algorithm>
-#include <cmath>
-#include <cstdio>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
-#include <sstream>
 #include <stdexcept>
 #include <system_error>
-#include <unordered_map>
 
 namespace gseurat {
 
-namespace {
-
-// SH coefficient C0 for converting DC spherical harmonic to RGB
-constexpr float kSH_C0 = 0.28209479177387814f;  // 1 / (2 * sqrt(pi))
-
-struct PlyProperty {
-    std::string name;
-    std::string type;
-    size_t offset = 0;
-    size_t size = 0;
-};
-
-size_t type_size(const std::string& type) {
-    if (type == "float" || type == "float32") return 4;
-    if (type == "double" || type == "float64") return 8;
-    if (type == "uchar" || type == "uint8") return 1;
-    if (type == "char" || type == "int8") return 1;
-    if (type == "int" || type == "int32") return 4;
-    if (type == "uint" || type == "uint32") return 4;
-    if (type == "short" || type == "int16") return 2;
-    if (type == "ushort" || type == "uint16") return 2;
-    return 0;
-}
-
-float read_float(const char* data, const PlyProperty& prop) {
-    if (prop.type == "float" || prop.type == "float32") {
-        float v;
-        std::memcpy(&v, data + prop.offset, 4);
-        return v;
-    }
-    if (prop.type == "double" || prop.type == "float64") {
-        double v;
-        std::memcpy(&v, data + prop.offset, 8);
-        return static_cast<float>(v);
-    }
-    if (prop.type == "uchar" || prop.type == "uint8") {
-        // uchar is conventionally normalized [0,255] → [0,1] (color channels).
-        uint8_t v;
-        std::memcpy(&v, data + prop.offset, 1);
-        return static_cast<float>(v) / 255.0f;
-    }
-    // Integer scalar types are returned as raw values (no normalization).
-    // bone_index is the only known int-typed column today; if future PLY
-    // columns need different semantics, decode them at the call site.
-    if (prop.type == "int" || prop.type == "int32") {
-        int32_t v;
-        std::memcpy(&v, data + prop.offset, 4);
-        return static_cast<float>(v);
-    }
-    if (prop.type == "uint" || prop.type == "uint32") {
-        uint32_t v;
-        std::memcpy(&v, data + prop.offset, 4);
-        return static_cast<float>(v);
-    }
-    if (prop.type == "short" || prop.type == "int16") {
-        int16_t v;
-        std::memcpy(&v, data + prop.offset, 2);
-        return static_cast<float>(v);
-    }
-    if (prop.type == "ushort" || prop.type == "uint16") {
-        uint16_t v;
-        std::memcpy(&v, data + prop.offset, 2);
-        return static_cast<float>(v);
-    }
-    if (prop.type == "char" || prop.type == "int8") {
-        int8_t v;
-        std::memcpy(&v, data + prop.offset, 1);
-        return static_cast<float>(v);
-    }
-    throw std::runtime_error("Unsupported PLY property type: " + prop.type);
-}
-
-}  // namespace
-
-GaussianCloud GaussianCloud::load_ply(const std::string& path,
-                                      CoordinateSystem coords) {
-    auto resolved = resolve_asset_path(path);
-    std::ifstream file(resolved, std::ios::binary);
-    if (!file.is_open()) {
-        throw std::runtime_error("Failed to open PLY file: " + resolved.string());
-    }
-
-    // Parse header
-    std::string line;
-    std::getline(file, line);
-    if (line.find("ply") == std::string::npos) {
-        throw std::runtime_error("Not a PLY file: " + path);
-    }
-
-    bool binary_little_endian = false;
-    uint32_t vertex_count = 0;
-    std::vector<PlyProperty> properties;
-    size_t vertex_stride = 0;
-    // Track the element currently being declared so non-vertex elements
-    // (e.g. `face`, `edge`) don't leak their `property` lines into the
-    // vertex layout. Without this, vertex_stride and per-property offsets
-    // are corrupted whenever the PLY contains anything beyond `vertex`.
-    std::string current_element;
-
-    while (std::getline(file, line)) {
-        // Strip trailing \r for Windows line endings
-        if (!line.empty() && line.back() == '\r') line.pop_back();
-
-        std::istringstream iss(line);
-        std::string token;
-        iss >> token;
-
-        if (token == "format") {
-            std::string fmt;
-            iss >> fmt;
-            binary_little_endian = (fmt == "binary_little_endian");
-        } else if (token == "element") {
-            uint32_t count;
-            iss >> current_element >> count;
-            if (current_element == "vertex") {
-                vertex_count = count;
-            }
-        } else if (token == "property" && current_element == "vertex") {
-            std::string type, name;
-            iss >> type >> name;
-            // List properties are variable-length per row, which would
-            // invalidate the fixed vertex_stride model. 3DGS PLYs don't
-            // use list-typed vertex columns; refuse the file rather than
-            // produce silently-misaligned output.
-            if (type == "list") {
-                throw std::runtime_error(
-                    "Vertex list properties are unsupported (column: " + name + ")");
-            }
-
-            PlyProperty prop;
-            prop.name = name;
-            prop.type = type;
-            prop.offset = vertex_stride;
-            prop.size = type_size(type);
-            // type_size returns 0 for any unknown PLY scalar type. Recording
-            // a zero-stride property would leave subsequent column offsets
-            // pointing into the wrong byte ranges, silently corrupting reads.
-            // Fail fast instead.
-            if (prop.size == 0) {
-                throw std::runtime_error(
-                    "Unsupported PLY property type '" + type + "' (column: " + name + ")");
-            }
-            vertex_stride += prop.size;
-            properties.push_back(std::move(prop));
-        } else if (token == "end_header") {
-            break;
-        }
-    }
-
-    if (vertex_count == 0) {
-        return {};
-    }
-
-    if (!binary_little_endian) {
-        throw std::runtime_error("Only binary_little_endian PLY files are supported");
-    }
-
-    // Build property lookup
-    std::unordered_map<std::string, const PlyProperty*> prop_map;
-    for (const auto& p : properties) {
-        prop_map[p.name] = &p;
-    }
-
-    // Common PLY column name variants
-    auto find_prop = [&](const std::initializer_list<const char*>& names) -> const PlyProperty* {
-        for (const char* n : names) {
-            auto it = prop_map.find(n);
-            if (it != prop_map.end()) return it->second;
-        }
-        return nullptr;
-    };
-
-    // Position
-    auto* px = find_prop({"x"});
-    auto* py = find_prop({"y"});
-    auto* pz = find_prop({"z"});
-
-    // Scale (gsplat: scale_0/1/2, nerfstudio: scaling_0/1/2, original: scale_0/1/2)
-    auto* sx = find_prop({"scale_0", "scaling_0"});
-    auto* sy = find_prop({"scale_1", "scaling_1"});
-    auto* sz = find_prop({"scale_2", "scaling_2"});
-
-    // Rotation quaternion (w, x, y, z ordering in PLY)
-    auto* rw = find_prop({"rot_0", "rotation_0"});
-    auto* rx = find_prop({"rot_1", "rotation_1"});
-    auto* ry = find_prop({"rot_2", "rotation_2"});
-    auto* rz = find_prop({"rot_3", "rotation_3"});
-
-    // Color: SH DC coefficients (f_dc_0/1/2) or direct RGB (red/green/blue)
-    auto* cr = find_prop({"f_dc_0", "red"});
-    auto* cg = find_prop({"f_dc_1", "green"});
-    auto* cb = find_prop({"f_dc_2", "blue"});
-    bool use_sh = (prop_map.count("f_dc_0") > 0);
-
-    // Opacity
-    auto* op = find_prop({"opacity"});
-
-    // Bone index (character skeletal posing)
-    auto* bi = find_prop({"bone_index"});
-
-    // Emissive intensity
-    auto* em = find_prop({"emission"});
-
-    if (!px || !py || !pz) {
-        throw std::runtime_error("PLY file missing position properties (x, y, z)");
-    }
-
-    // Read binary vertex data
-    std::vector<char> vertex_data(static_cast<size_t>(vertex_count) * vertex_stride);
-    file.read(vertex_data.data(), static_cast<std::streamsize>(vertex_data.size()));
-    if (!file) {
-        throw std::runtime_error("Failed to read vertex data from PLY file");
-    }
-
-    GaussianCloud cloud;
-    cloud.gaussians_.resize(vertex_count);
-
-    for (uint32_t i = 0; i < vertex_count; ++i) {
-        const char* row = vertex_data.data() + static_cast<size_t>(i) * vertex_stride;
-        Gaussian& g = cloud.gaussians_[i];
-
-        // Position
-        g.position.x = read_float(row, *px);
-        g.position.y = read_float(row, *py);
-        g.position.z = read_float(row, *pz);
-
-        if (coords == CoordinateSystem::kVulkanYDown) {
-            g.position.y = -g.position.y;
-        }
-
-        // Scale: stored as log(scale) in standard 3DGS → apply exp()
-        if (sx && sy && sz) {
-            g.scale.x = std::exp(read_float(row, *sx));
-            g.scale.y = std::exp(read_float(row, *sy));
-            g.scale.z = std::exp(read_float(row, *sz));
-        } else {
-            g.scale = glm::vec3(0.01f);
-        }
-
-        // Rotation quaternion (normalized)
-        if (rw && rx && ry && rz) {
-            g.rotation = glm::normalize(glm::quat(
-                read_float(row, *rw),
-                read_float(row, *rx),
-                read_float(row, *ry),
-                read_float(row, *rz)
-            ));
-        } else {
-            g.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
-        }
-
-        // Y-flip: mirror the rotation around the XZ plane by negating qx and qz
-        if (coords == CoordinateSystem::kVulkanYDown) {
-            g.rotation.x = -g.rotation.x;
-            g.rotation.z = -g.rotation.z;
-        }
-
-        // Color
-        if (cr && cg && cb) {
-            if (use_sh) {
-                // SH DC → linear RGB: color = SH_C0 * f_dc + 0.5
-                g.color.r = kSH_C0 * read_float(row, *cr) + 0.5f;
-                g.color.g = kSH_C0 * read_float(row, *cg) + 0.5f;
-                g.color.b = kSH_C0 * read_float(row, *cb) + 0.5f;
-            } else {
-                g.color.r = read_float(row, *cr);
-                g.color.g = read_float(row, *cg);
-                g.color.b = read_float(row, *cb);
-            }
-            g.color = glm::clamp(g.color, glm::vec3(0.0f), glm::vec3(1.0f));
-        } else {
-            g.color = glm::vec3(1.0f);
-        }
-
-        // Opacity: stored as logit(opacity) → apply sigmoid()
-        if (op) {
-            float raw = read_float(row, *op);
-            g.opacity = 1.0f / (1.0f + std::exp(-raw));
-        } else {
-            g.opacity = 1.0f;
-        }
-
-        // Importance for LOD: large, opaque Gaussians are most important
-        g.importance = g.opacity * std::max({g.scale.x, g.scale.y, g.scale.z});
-
-        // Bone index
-        if (bi) {
-            if (bi->type == "uchar" || bi->type == "uint8") {
-                uint8_t v;
-                std::memcpy(&v, row + bi->offset, 1);
-                g.bone_index = static_cast<uint32_t>(v);
-            } else {
-                g.bone_index = static_cast<uint32_t>(read_float(row, *bi));
-            }
-        } else {
-            g.bone_index = 0;
-        }
-
-        // Emission
-        g.emission = em ? read_float(row, *em) : 0.0f;
-
-        cloud.bounds_.expand(g.position);
-    }
-
-    return cloud;
-}
+// PLY I/O (load_ply / write_ply) lives in gaussian_cloud_ply.cpp. That file is
+// NOT compiled into gseurat_core — only into offline tools (ply2heightmap)
+// and tests. The runtime path goes through load_with_gsvx_first, which
+// requires a sibling .gsvx baked by the build-time bake_gsvx target.
 
 GaussianCloud GaussianCloud::from_gaussians(std::vector<Gaussian> gaussians) {
     GaussianCloud cloud;
@@ -330,87 +24,6 @@ GaussianCloud GaussianCloud::from_gaussians(std::vector<Gaussian> gaussians) {
         cloud.bounds_.expand(g.position);
     }
     return cloud;
-}
-
-void GaussianCloud::write_ply(const std::string& path,
-                              const std::vector<Gaussian>& gaussians,
-                              CoordinateSystem coords) {
-    std::ofstream file(path, std::ios::binary);
-    if (!file.is_open()) {
-        throw std::runtime_error("Failed to open PLY file for writing: " + path);
-    }
-
-    // Write header
-    file << "ply\n";
-    file << "format binary_little_endian 1.0\n";
-    file << "element vertex " << gaussians.size() << "\n";
-    file << "property float x\n";
-    file << "property float y\n";
-    file << "property float z\n";
-    file << "property float scale_0\n";
-    file << "property float scale_1\n";
-    file << "property float scale_2\n";
-    file << "property float rot_0\n";
-    file << "property float rot_1\n";
-    file << "property float rot_2\n";
-    file << "property float rot_3\n";
-    file << "property float f_dc_0\n";
-    file << "property float f_dc_1\n";
-    file << "property float f_dc_2\n";
-    file << "property float opacity\n";
-    file << "property float emission\n";
-    file << "end_header\n";
-
-    // Write binary vertex data
-    // load_ply applies: exp(scale), sigmoid(opacity), SH_C0*f_dc+0.5 for color
-    // So we write the inverse: log(scale), logit(opacity), (color-0.5)/SH_C0
-    constexpr float kSH_C0 = 0.28209479177387814f;
-
-    for (const auto& g : gaussians) {
-        // Position (negate Y when writing for Y-down consumers)
-        float x = g.position.x;
-        float y = (coords == CoordinateSystem::kVulkanYDown) ? -g.position.y : g.position.y;
-        float z = g.position.z;
-        file.write(reinterpret_cast<const char*>(&x), 4);
-        file.write(reinterpret_cast<const char*>(&y), 4);
-        file.write(reinterpret_cast<const char*>(&z), 4);
-
-        // Scale: write log(scale) since load_ply applies exp()
-        float s0 = std::log(std::max(g.scale.x, 1e-10f));
-        float s1 = std::log(std::max(g.scale.y, 1e-10f));
-        float s2 = std::log(std::max(g.scale.z, 1e-10f));
-        file.write(reinterpret_cast<const char*>(&s0), 4);
-        file.write(reinterpret_cast<const char*>(&s1), 4);
-        file.write(reinterpret_cast<const char*>(&s2), 4);
-
-        // Rotation quaternion (stored directly, w first)
-        // Mirror around XZ plane for Y-down: negate qx and qz
-        float rw = g.rotation.w;
-        float rx = (coords == CoordinateSystem::kVulkanYDown) ? -g.rotation.x : g.rotation.x;
-        float ry = g.rotation.y;
-        float rz = (coords == CoordinateSystem::kVulkanYDown) ? -g.rotation.z : g.rotation.z;
-        file.write(reinterpret_cast<const char*>(&rw), 4);
-        file.write(reinterpret_cast<const char*>(&rx), 4);
-        file.write(reinterpret_cast<const char*>(&ry), 4);
-        file.write(reinterpret_cast<const char*>(&rz), 4);
-
-        // Color: write (color - 0.5) / SH_C0 since load_ply applies SH_C0*f_dc+0.5
-        float dc0 = (g.color.r - 0.5f) / kSH_C0;
-        float dc1 = (g.color.g - 0.5f) / kSH_C0;
-        float dc2 = (g.color.b - 0.5f) / kSH_C0;
-        file.write(reinterpret_cast<const char*>(&dc0), 4);
-        file.write(reinterpret_cast<const char*>(&dc1), 4);
-        file.write(reinterpret_cast<const char*>(&dc2), 4);
-
-        // Opacity: write logit(opacity) since load_ply applies sigmoid()
-        float op_clamped = std::clamp(g.opacity, 1e-6f, 1.0f - 1e-6f);
-        float logit = std::log(op_clamped / (1.0f - op_clamped));
-        file.write(reinterpret_cast<const char*>(&logit), 4);
-
-        // Emission (stored directly)
-        float em = g.emission;
-        file.write(reinterpret_cast<const char*>(&em), 4);
-    }
 }
 
 GsvxPayload GaussianCloud::load_gsvx(const std::string& path) {
@@ -524,8 +137,8 @@ GsvxPayload GaussianCloud::load_gsvx(const std::string& path) {
 
 namespace {
 
-// Convert a baked GpuGaussian buffer back into the CPU Gaussian form that
-// load_ply produces. `coords` is applied symmetrically with load_ply
+// Convert a baked GpuGaussian buffer back into the CPU Gaussian form.
+// `coords` is applied symmetrically with the PLY parser
 // (negate position.y, flip rotation.x and rotation.z when kVulkanYDown).
 // `importance` is left default — `from_gaussians` recomputes it.
 std::vector<Gaussian> unpack_gpu_gaussians(const std::vector<GpuGaussian>& gpu,
@@ -569,28 +182,23 @@ GaussianCloud GaussianCloud::load_with_gsvx_first(const std::string& ply_path,
     gsvx_candidate.replace_extension(".gsvx");
     const std::string gsvx_path_str = gsvx_candidate.string();
 
-    // Probe for the sibling. We resolve through the same asset-root logic
-    // load_gsvx will use so the existence check matches what the load
-    // attempt would see.
+    // The runtime engine does not link the PLY parser. Every bundled .ply
+    // must have a sibling .gsvx produced by the build-time bake_gsvx target;
+    // a missing or invalid .gsvx is a build/asset-pipeline error, not a
+    // runtime fallback case.
     auto resolved = resolve_asset_path(gsvx_path_str);
     std::error_code ec;
-    if (std::filesystem::is_regular_file(resolved, ec)) {
-        try {
-            GsvxPayload payload = load_gsvx(gsvx_path_str);
-            return GaussianCloud::from_gaussians(
-                unpack_gpu_gaussians(payload.gpu_gaussians, coords));
-        } catch (const std::exception& e) {
-            // Sibling exists but won't parse — log once per failure (worker
-            // threads share stderr; expected to be rare and is useful PR-B
-            // signal) and fall through to PLY.
-            std::fprintf(stderr,
-                "[gaussian_cloud] sibling .gsvx failed to load (%s); "
-                "falling back to PLY: %s\n",
-                e.what(), ply_path.c_str());
-        }
+    if (!std::filesystem::is_regular_file(resolved, ec)) {
+        throw std::runtime_error(
+            "GaussianCloud: missing sibling .gsvx for '" + ply_path +
+            "' (expected at '" + resolved.string() + "'). The build-time " +
+            "bake_gsvx target produces .gsvx siblings for every bundled .ply; " +
+            "rebuild or invoke ply_importer manually if you added a PLY " +
+            "outside the build system.");
     }
-
-    return load_ply(ply_path, coords);
+    GsvxPayload payload = load_gsvx(gsvx_path_str);
+    return GaussianCloud::from_gaussians(
+        unpack_gpu_gaussians(payload.gpu_gaussians, coords));
 }
 
 }  // namespace gseurat

--- a/src/engine/gaussian_cloud_ply.cpp
+++ b/src/engine/gaussian_cloud_ply.cpp
@@ -7,10 +7,11 @@
 // GaussianCloud::load_with_gsvx_first throws on missing .gsvx rather
 // than falling back here.
 //
-// Splitting load_ply / write_ply off keeps the runtime binary free of
-// the text-PLY parser; that's the M1 closure of #396.
+// load / write live in `gseurat::ply::` (not on the GaussianCloud class)
+// so the public engine header surface matches the engine link surface
+// — addresses Codex P2 on PR #425.
 
-#include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/gaussian_cloud_ply.hpp"
 
 #include "gseurat/engine/project_root.hpp"
 
@@ -22,7 +23,7 @@
 #include <stdexcept>
 #include <unordered_map>
 
-namespace gseurat {
+namespace gseurat::ply {
 
 namespace {
 
@@ -94,8 +95,7 @@ float read_float(const char* data, const PlyProperty& prop) {
 
 }  // namespace
 
-GaussianCloud GaussianCloud::load_ply(const std::string& path,
-                                      CoordinateSystem coords) {
+GaussianCloud load(const std::string& path, CoordinateSystem coords) {
     auto resolved = resolve_asset_path(path);
     std::ifstream file(resolved, std::ios::binary);
     if (!file.is_open()) {
@@ -304,9 +304,9 @@ GaussianCloud GaussianCloud::load_ply(const std::string& path,
     return GaussianCloud::from_gaussians(std::move(gaussians));
 }
 
-void GaussianCloud::write_ply(const std::string& path,
-                              const std::vector<Gaussian>& gaussians,
-                              CoordinateSystem coords) {
+void write(const std::string& path,
+           const std::vector<Gaussian>& gaussians,
+           CoordinateSystem coords) {
     std::ofstream file(path, std::ios::binary);
     if (!file.is_open()) {
         throw std::runtime_error("Failed to open PLY file for writing: " + path);
@@ -375,4 +375,4 @@ void GaussianCloud::write_ply(const std::string& path,
     }
 }
 
-}  // namespace gseurat
+}  // namespace gseurat::ply

--- a/src/engine/gaussian_cloud_ply.cpp
+++ b/src/engine/gaussian_cloud_ply.cpp
@@ -1,0 +1,378 @@
+// PLY-format I/O for GaussianCloud.
+//
+// Compiled INTO offline tooling (ply2heightmap, tests) but NOT into
+// gseurat_core. The runtime engine consumes pre-baked .gsvx files via
+// GaussianCloud::load_gsvx — every bundled .ply has a sibling .gsvx
+// produced by the build-time bake_gsvx target (CMakeLists.txt), and
+// GaussianCloud::load_with_gsvx_first throws on missing .gsvx rather
+// than falling back here.
+//
+// Splitting load_ply / write_ply off keeps the runtime binary free of
+// the text-PLY parser; that's the M1 closure of #396.
+
+#include "gseurat/engine/gaussian_cloud.hpp"
+
+#include "gseurat/engine/project_root.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace gseurat {
+
+namespace {
+
+// SH coefficient C0 for converting DC spherical harmonic to RGB
+constexpr float kSH_C0 = 0.28209479177387814f;  // 1 / (2 * sqrt(pi))
+
+struct PlyProperty {
+    std::string name;
+    std::string type;
+    size_t offset = 0;
+    size_t size = 0;
+};
+
+size_t type_size(const std::string& type) {
+    if (type == "float" || type == "float32") return 4;
+    if (type == "double" || type == "float64") return 8;
+    if (type == "uchar" || type == "uint8") return 1;
+    if (type == "char" || type == "int8") return 1;
+    if (type == "int" || type == "int32") return 4;
+    if (type == "uint" || type == "uint32") return 4;
+    if (type == "short" || type == "int16") return 2;
+    if (type == "ushort" || type == "uint16") return 2;
+    return 0;
+}
+
+float read_float(const char* data, const PlyProperty& prop) {
+    if (prop.type == "float" || prop.type == "float32") {
+        float v;
+        std::memcpy(&v, data + prop.offset, 4);
+        return v;
+    }
+    if (prop.type == "double" || prop.type == "float64") {
+        double v;
+        std::memcpy(&v, data + prop.offset, 8);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "uchar" || prop.type == "uint8") {
+        uint8_t v;
+        std::memcpy(&v, data + prop.offset, 1);
+        return static_cast<float>(v) / 255.0f;
+    }
+    if (prop.type == "int" || prop.type == "int32") {
+        int32_t v;
+        std::memcpy(&v, data + prop.offset, 4);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "uint" || prop.type == "uint32") {
+        uint32_t v;
+        std::memcpy(&v, data + prop.offset, 4);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "short" || prop.type == "int16") {
+        int16_t v;
+        std::memcpy(&v, data + prop.offset, 2);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "ushort" || prop.type == "uint16") {
+        uint16_t v;
+        std::memcpy(&v, data + prop.offset, 2);
+        return static_cast<float>(v);
+    }
+    if (prop.type == "char" || prop.type == "int8") {
+        int8_t v;
+        std::memcpy(&v, data + prop.offset, 1);
+        return static_cast<float>(v);
+    }
+    throw std::runtime_error("Unsupported PLY property type: " + prop.type);
+}
+
+}  // namespace
+
+GaussianCloud GaussianCloud::load_ply(const std::string& path,
+                                      CoordinateSystem coords) {
+    auto resolved = resolve_asset_path(path);
+    std::ifstream file(resolved, std::ios::binary);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open PLY file: " + resolved.string());
+    }
+
+    std::string line;
+    std::getline(file, line);
+    if (line.find("ply") == std::string::npos) {
+        throw std::runtime_error("Not a PLY file: " + path);
+    }
+
+    bool binary_little_endian = false;
+    uint32_t vertex_count = 0;
+    std::vector<PlyProperty> properties;
+    size_t vertex_stride = 0;
+    // Track the element currently being declared so non-vertex elements
+    // (e.g. `face`, `edge`) don't leak their `property` lines into the
+    // vertex layout. Without this, vertex_stride and per-property offsets
+    // are corrupted whenever the PLY contains anything beyond `vertex`.
+    std::string current_element;
+
+    while (std::getline(file, line)) {
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+
+        std::istringstream iss(line);
+        std::string token;
+        iss >> token;
+
+        if (token == "format") {
+            std::string fmt;
+            iss >> fmt;
+            binary_little_endian = (fmt == "binary_little_endian");
+        } else if (token == "element") {
+            uint32_t count;
+            iss >> current_element >> count;
+            if (current_element == "vertex") {
+                vertex_count = count;
+            }
+        } else if (token == "property" && current_element == "vertex") {
+            std::string type, name;
+            iss >> type >> name;
+            // List properties are variable-length per row, which would
+            // invalidate the fixed vertex_stride model. 3DGS PLYs don't
+            // use list-typed vertex columns; refuse the file rather than
+            // produce silently-misaligned output.
+            if (type == "list") {
+                throw std::runtime_error(
+                    "Vertex list properties are unsupported (column: " + name + ")");
+            }
+
+            PlyProperty prop;
+            prop.name = name;
+            prop.type = type;
+            prop.offset = vertex_stride;
+            prop.size = type_size(type);
+            // type_size returns 0 for any unknown PLY scalar type. Recording
+            // a zero-stride property would leave subsequent column offsets
+            // pointing into the wrong byte ranges, silently corrupting reads.
+            // Fail fast instead.
+            if (prop.size == 0) {
+                throw std::runtime_error(
+                    "Unsupported PLY property type '" + type + "' (column: " + name + ")");
+            }
+            vertex_stride += prop.size;
+            properties.push_back(std::move(prop));
+        } else if (token == "end_header") {
+            break;
+        }
+    }
+
+    if (vertex_count == 0) {
+        return {};
+    }
+
+    if (!binary_little_endian) {
+        throw std::runtime_error("Only binary_little_endian PLY files are supported");
+    }
+
+    std::unordered_map<std::string, const PlyProperty*> prop_map;
+    for (const auto& p : properties) {
+        prop_map[p.name] = &p;
+    }
+
+    auto find_prop = [&](const std::initializer_list<const char*>& names) -> const PlyProperty* {
+        for (const char* n : names) {
+            auto it = prop_map.find(n);
+            if (it != prop_map.end()) return it->second;
+        }
+        return nullptr;
+    };
+
+    auto* px = find_prop({"x"});
+    auto* py = find_prop({"y"});
+    auto* pz = find_prop({"z"});
+
+    auto* sx = find_prop({"scale_0", "scaling_0"});
+    auto* sy = find_prop({"scale_1", "scaling_1"});
+    auto* sz = find_prop({"scale_2", "scaling_2"});
+
+    auto* rw = find_prop({"rot_0", "rotation_0"});
+    auto* rx = find_prop({"rot_1", "rotation_1"});
+    auto* ry = find_prop({"rot_2", "rotation_2"});
+    auto* rz = find_prop({"rot_3", "rotation_3"});
+
+    auto* cr = find_prop({"f_dc_0", "red"});
+    auto* cg = find_prop({"f_dc_1", "green"});
+    auto* cb = find_prop({"f_dc_2", "blue"});
+    bool use_sh = (prop_map.count("f_dc_0") > 0);
+
+    auto* op = find_prop({"opacity"});
+    auto* bi = find_prop({"bone_index"});
+    auto* em = find_prop({"emission"});
+
+    if (!px || !py || !pz) {
+        throw std::runtime_error("PLY file missing position properties (x, y, z)");
+    }
+
+    std::vector<char> vertex_data(static_cast<size_t>(vertex_count) * vertex_stride);
+    file.read(vertex_data.data(), static_cast<std::streamsize>(vertex_data.size()));
+    if (!file) {
+        throw std::runtime_error("Failed to read vertex data from PLY file");
+    }
+
+    GaussianCloud cloud;
+    std::vector<Gaussian> gaussians(vertex_count);
+
+    for (uint32_t i = 0; i < vertex_count; ++i) {
+        const char* row = vertex_data.data() + static_cast<size_t>(i) * vertex_stride;
+        Gaussian& g = gaussians[i];
+
+        g.position.x = read_float(row, *px);
+        g.position.y = read_float(row, *py);
+        g.position.z = read_float(row, *pz);
+
+        if (coords == CoordinateSystem::kVulkanYDown) {
+            g.position.y = -g.position.y;
+        }
+
+        if (sx && sy && sz) {
+            g.scale.x = std::exp(read_float(row, *sx));
+            g.scale.y = std::exp(read_float(row, *sy));
+            g.scale.z = std::exp(read_float(row, *sz));
+        } else {
+            g.scale = glm::vec3(0.01f);
+        }
+
+        if (rw && rx && ry && rz) {
+            g.rotation = glm::normalize(glm::quat(
+                read_float(row, *rw),
+                read_float(row, *rx),
+                read_float(row, *ry),
+                read_float(row, *rz)
+            ));
+        } else {
+            g.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+        }
+
+        // Y-flip: mirror the rotation around the XZ plane by negating qx and qz
+        if (coords == CoordinateSystem::kVulkanYDown) {
+            g.rotation.x = -g.rotation.x;
+            g.rotation.z = -g.rotation.z;
+        }
+
+        if (cr && cg && cb) {
+            if (use_sh) {
+                // SH DC → linear RGB: color = SH_C0 * f_dc + 0.5
+                g.color.r = kSH_C0 * read_float(row, *cr) + 0.5f;
+                g.color.g = kSH_C0 * read_float(row, *cg) + 0.5f;
+                g.color.b = kSH_C0 * read_float(row, *cb) + 0.5f;
+            } else {
+                g.color.r = read_float(row, *cr);
+                g.color.g = read_float(row, *cg);
+                g.color.b = read_float(row, *cb);
+            }
+            g.color = glm::clamp(g.color, glm::vec3(0.0f), glm::vec3(1.0f));
+        } else {
+            g.color = glm::vec3(1.0f);
+        }
+
+        // Opacity: stored as logit(opacity) → apply sigmoid()
+        if (op) {
+            float raw = read_float(row, *op);
+            g.opacity = 1.0f / (1.0f + std::exp(-raw));
+        } else {
+            g.opacity = 1.0f;
+        }
+
+        g.importance = g.opacity * std::max({g.scale.x, g.scale.y, g.scale.z});
+
+        if (bi) {
+            if (bi->type == "uchar" || bi->type == "uint8") {
+                uint8_t v;
+                std::memcpy(&v, row + bi->offset, 1);
+                g.bone_index = static_cast<uint32_t>(v);
+            } else {
+                g.bone_index = static_cast<uint32_t>(read_float(row, *bi));
+            }
+        } else {
+            g.bone_index = 0;
+        }
+
+        g.emission = em ? read_float(row, *em) : 0.0f;
+    }
+
+    return GaussianCloud::from_gaussians(std::move(gaussians));
+}
+
+void GaussianCloud::write_ply(const std::string& path,
+                              const std::vector<Gaussian>& gaussians,
+                              CoordinateSystem coords) {
+    std::ofstream file(path, std::ios::binary);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open PLY file for writing: " + path);
+    }
+
+    file << "ply\n";
+    file << "format binary_little_endian 1.0\n";
+    file << "element vertex " << gaussians.size() << "\n";
+    file << "property float x\n";
+    file << "property float y\n";
+    file << "property float z\n";
+    file << "property float scale_0\n";
+    file << "property float scale_1\n";
+    file << "property float scale_2\n";
+    file << "property float rot_0\n";
+    file << "property float rot_1\n";
+    file << "property float rot_2\n";
+    file << "property float rot_3\n";
+    file << "property float f_dc_0\n";
+    file << "property float f_dc_1\n";
+    file << "property float f_dc_2\n";
+    file << "property float opacity\n";
+    file << "property float emission\n";
+    file << "end_header\n";
+
+    // load_ply applies: exp(scale), sigmoid(opacity), SH_C0*f_dc+0.5 for color
+    // So we write the inverse: log(scale), logit(opacity), (color-0.5)/SH_C0
+
+    for (const auto& g : gaussians) {
+        float x = g.position.x;
+        float y = (coords == CoordinateSystem::kVulkanYDown) ? -g.position.y : g.position.y;
+        float z = g.position.z;
+        file.write(reinterpret_cast<const char*>(&x), 4);
+        file.write(reinterpret_cast<const char*>(&y), 4);
+        file.write(reinterpret_cast<const char*>(&z), 4);
+
+        float s0 = std::log(std::max(g.scale.x, 1e-10f));
+        float s1 = std::log(std::max(g.scale.y, 1e-10f));
+        float s2 = std::log(std::max(g.scale.z, 1e-10f));
+        file.write(reinterpret_cast<const char*>(&s0), 4);
+        file.write(reinterpret_cast<const char*>(&s1), 4);
+        file.write(reinterpret_cast<const char*>(&s2), 4);
+
+        float rw = g.rotation.w;
+        float rx = (coords == CoordinateSystem::kVulkanYDown) ? -g.rotation.x : g.rotation.x;
+        float ry = g.rotation.y;
+        float rz = (coords == CoordinateSystem::kVulkanYDown) ? -g.rotation.z : g.rotation.z;
+        file.write(reinterpret_cast<const char*>(&rw), 4);
+        file.write(reinterpret_cast<const char*>(&rx), 4);
+        file.write(reinterpret_cast<const char*>(&ry), 4);
+        file.write(reinterpret_cast<const char*>(&rz), 4);
+
+        float dc0 = (g.color.r - 0.5f) / kSH_C0;
+        float dc1 = (g.color.g - 0.5f) / kSH_C0;
+        float dc2 = (g.color.b - 0.5f) / kSH_C0;
+        file.write(reinterpret_cast<const char*>(&dc0), 4);
+        file.write(reinterpret_cast<const char*>(&dc1), 4);
+        file.write(reinterpret_cast<const char*>(&dc2), 4);
+
+        float op_clamped = std::clamp(g.opacity, 1e-6f, 1.0f - 1e-6f);
+        float logit = std::log(op_clamped / (1.0f - op_clamped));
+        file.write(reinterpret_cast<const char*>(&logit), 4);
+
+        float em = g.emission;
+        file.write(reinterpret_cast<const char*>(&em), 4);
+    }
+}
+
+}  // namespace gseurat

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -281,7 +281,7 @@ void Renderer::init_gs(const GaussianCloud& cloud, uint32_t width, uint32_t heig
     // Snapshot constant-size cloud metadata for demo-layer setup queries
     // (camera framing, ground-plane derivation). The Gaussians themselves
     // are NOT cached on the renderer — Option B per #396 §A: demos that
-    // need the splats re-parse from disk via `GaussianCloud::load_ply`.
+    // need the splats re-parse from disk via `GaussianCloud::load_with_gsvx_first`.
     gs_cloud_metadata_.bounds = cloud.bounds();
     gs_cloud_metadata_.gaussian_count = cloud.count();
 

--- a/src/tools/ply2heightmap.cpp
+++ b/src/tools/ply2heightmap.cpp
@@ -5,6 +5,7 @@
 //                      [--min-opacity N] [--z-up]
 
 #include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/gaussian_cloud_ply.hpp"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
@@ -359,7 +360,7 @@ int main(int argc, char* argv[]) {
     // Load PLY
     GaussianCloud cloud;
     try {
-        cloud = GaussianCloud::load_ply(input_path);
+        cloud = gseurat::ply::load(input_path);
     } catch (const std::exception& e) {
         fprintf(stderr, "Error loading PLY: %s\n", e.what());
         return 1;

--- a/tests/test_bridge_reconnect_root.cpp
+++ b/tests/test_bridge_reconnect_root.cpp
@@ -11,6 +11,7 @@
 
 #include "gseurat/engine/project_root.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/gaussian_cloud_ply.hpp"
 
 #include <cassert>
 #include <cstdio>
@@ -64,7 +65,7 @@ int main() {
     {
         set_project_root("");
         bool threw = false;
-        try { GaussianCloud::load_ply("assets/maps/tunnel.ply"); }
+        try { ply::load("assets/maps/tunnel.ply"); }
         catch (const std::runtime_error&) { threw = true; }
         check(threw, "relative path fails without project_root");
     }
@@ -73,7 +74,7 @@ int main() {
     std::printf("Scenario 2: project_root set, relative path succeeds\n");
     {
         set_project_root(project.string());
-        auto cloud = GaussianCloud::load_ply("assets/maps/tunnel.ply");
+        auto cloud = ply::load("assets/maps/tunnel.ply");
         check(cloud.count() == 10, "loaded 10 Gaussians with project_root");
     }
 
@@ -82,7 +83,7 @@ int main() {
     {
         set_project_root("");
         auto abs_path = (project / "assets" / "maps" / "tunnel.ply").string();
-        auto cloud = GaussianCloud::load_ply(abs_path);
+        auto cloud = ply::load(abs_path);
         check(cloud.count() == 10, "absolute path works without project_root");
     }
 
@@ -94,7 +95,7 @@ int main() {
         std::string bridge_path = project.string();
         std::string relative = "assets/maps/tunnel.ply";
         std::string resolved = bridge_path + "/" + relative;
-        auto cloud = GaussianCloud::load_ply(resolved);
+        auto cloud = ply::load(resolved);
         check(cloud.count() == 10, "pre-resolved path loads without project_root");
     }
 

--- a/tests/test_gaussian_cloud.cpp
+++ b/tests/test_gaussian_cloud.cpp
@@ -821,24 +821,22 @@ int main() {
         write_test_gsvx_v2(gsvx_path, data, aabb);
     };
 
-    // ====== Test 24: fallback to PLY when no .gsvx sibling exists ======
+    // ====== Test 24: throws when no .gsvx sibling exists ======
+    // Post-#396 M1: there is no PLY fallback in the runtime path. The
+    // bake_gsvx CMake target guarantees a sibling .gsvx for every bundled
+    // .ply; a missing one is a build/asset-pipeline error.
     {
-        const std::string ply_path = tmp_dir + "/test_dual_fallback.ply";
+        const std::string ply_path = tmp_dir + "/test_dual_no_sibling.ply";
         write_test_ply(ply_path, 5);
 
-        auto via_ply  = GaussianCloud::load_ply(ply_path);
-        auto via_dual = GaussianCloud::load_with_gsvx_first(ply_path);
-
-        assert(via_dual.count() == via_ply.count() && "fallback count matches");
-        for (uint32_t i = 0; i < via_ply.count(); ++i) {
-            const auto& a = via_ply.gaussians()[i];
-            const auto& b = via_dual.gaussians()[i];
-            assert(approx(a.position.x, b.position.x, 1e-6f) && "fallback position.x");
-            assert(approx(a.opacity,    b.opacity,    1e-6f) && "fallback opacity");
-            assert(approx(a.scale.x,    b.scale.x,    1e-6f) && "fallback scale.x");
-            assert(approx(a.importance, b.importance, 1e-6f) && "fallback importance");
+        bool threw = false;
+        try {
+            (void)GaussianCloud::load_with_gsvx_first(ply_path);
+        } catch (const std::runtime_error&) {
+            threw = true;
         }
-        printf("PASS: Test 24 - load_with_gsvx_first falls back to PLY when no sibling\n");
+        assert(threw && "load_with_gsvx_first throws when no sibling .gsvx");
+        printf("PASS: Test 24 - load_with_gsvx_first throws when no sibling .gsvx\n");
     }
 
     // ====== Test 25: prefers .gsvx sibling when present (parity with load_ply) ======
@@ -882,12 +880,12 @@ int main() {
         printf("PASS: Test 25 - load_with_gsvx_first prefers sibling .gsvx (parity)\n");
     }
 
-    // ====== Test 26: graceful fallback to PLY when .gsvx is corrupt ======
+    // ====== Test 26: throws when sibling .gsvx is corrupt ======
     {
         const std::string ply_path  = tmp_dir + "/test_dual_corrupt.ply";
         const std::string gsvx_path = tmp_dir + "/test_dual_corrupt.gsvx";
         write_test_ply(ply_path, 4);
-        // Write a bad-magic GSVX next to the PLY
+        // Write a bad-magic GSVX next to the PLY.
         {
             std::ofstream out(gsvx_path, std::ios::binary);
             GsvxHeader header{};
@@ -896,25 +894,23 @@ int main() {
             out.write(reinterpret_cast<const char*>(&header), sizeof(header));
         }
 
-        auto via_ply  = GaussianCloud::load_ply(ply_path);
-        auto via_dual = GaussianCloud::load_with_gsvx_first(ply_path);
-
-        assert(via_dual.count() == via_ply.count() && "corrupt fallback count");
-        for (uint32_t i = 0; i < via_ply.count(); ++i) {
-            assert(approx(via_ply.gaussians()[i].position.x,
-                          via_dual.gaussians()[i].position.x, 1e-6f) &&
-                   "corrupt fallback position.x");
+        bool threw = false;
+        try {
+            (void)GaussianCloud::load_with_gsvx_first(ply_path);
+        } catch (const std::runtime_error&) {
+            threw = true;
         }
-        printf("PASS: Test 26 - load_with_gsvx_first falls back on corrupt sibling\n");
+        assert(threw && "load_with_gsvx_first throws on corrupt sibling .gsvx");
+        printf("PASS: Test 26 - load_with_gsvx_first throws on corrupt sibling\n");
     }
 
-    // ====== Test 27: graceful fallback when sibling .gsvx is truncated ======
+    // ====== Test 27: throws when sibling .gsvx is truncated ======
     {
         const std::string ply_path  = tmp_dir + "/test_dual_short.ply";
         const std::string gsvx_path = tmp_dir + "/test_dual_short.gsvx";
         write_test_ply(ply_path, 3);
-        // Write a header that claims count=999 but contains no payload — load_gsvx
-        // throws on size mismatch; wrapper must catch and fall through.
+        // Header claims count=999 but contains no payload — load_gsvx
+        // throws on size mismatch and the wrapper now propagates it.
         {
             std::ofstream out(gsvx_path, std::ios::binary);
             GsvxHeader header{};
@@ -925,11 +921,14 @@ int main() {
             out.write(reinterpret_cast<const char*>(&header), sizeof(header));
         }
 
-        auto via_ply  = GaussianCloud::load_ply(ply_path);
-        auto via_dual = GaussianCloud::load_with_gsvx_first(ply_path);
-
-        assert(via_dual.count() == via_ply.count() && "truncated fallback count");
-        printf("PASS: Test 27 - load_with_gsvx_first falls back on truncated sibling\n");
+        bool threw = false;
+        try {
+            (void)GaussianCloud::load_with_gsvx_first(ply_path);
+        } catch (const std::runtime_error&) {
+            threw = true;
+        }
+        assert(threw && "load_with_gsvx_first throws on truncated sibling .gsvx");
+        printf("PASS: Test 27 - load_with_gsvx_first throws on truncated sibling\n");
     }
 
     // ====== Test 28: kVulkanYDown applied symmetrically on GSVX path ======

--- a/tests/test_gaussian_cloud.cpp
+++ b/tests/test_gaussian_cloud.cpp
@@ -16,6 +16,7 @@
 // Run: ./build/test_gaussian_cloud
 
 #include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/gaussian_cloud_ply.hpp"
 #include "gseurat/engine/collision_gen.hpp"
 #include "gseurat/engine/scene_loader.hpp"
 
@@ -239,7 +240,7 @@ int main() {
         const std::string ply_path = tmp_dir + "/test_standard.ply";
         write_test_ply(ply_path, 10);
 
-        auto cloud = GaussianCloud::load_ply(ply_path);
+        auto cloud = ply::load(ply_path);
         assert(cloud.count() == 10 && "Should load 10 Gaussians");
         assert(!cloud.empty() && "Cloud should not be empty");
 
@@ -282,7 +283,7 @@ int main() {
         const std::string ply_path = tmp_dir + "/test_nerfstudio.ply";
         write_test_ply_nerfstudio(ply_path);
 
-        auto cloud = GaussianCloud::load_ply(ply_path);
+        auto cloud = ply::load(ply_path);
         assert(cloud.count() == 1 && "Should load 1 Gaussian");
 
         const auto& g = cloud.gaussians()[0];
@@ -302,7 +303,7 @@ int main() {
     {
         bool threw = false;
         try {
-            GaussianCloud::load_ply(tmp_dir + "/nonexistent.ply");
+            ply::load(tmp_dir + "/nonexistent.ply");
         } catch (const std::runtime_error&) {
             threw = true;
         }
@@ -315,7 +316,7 @@ int main() {
         const std::string ply_path = tmp_dir + "/test_empty.ply";
         write_test_ply(ply_path, 0);
 
-        auto cloud = GaussianCloud::load_ply(ply_path);
+        auto cloud = ply::load(ply_path);
         assert(cloud.count() == 0 && "Should have 0 Gaussians");
         assert(cloud.empty() && "Cloud should be empty");
         printf("PASS: Test 4 - Empty PLY (0 vertices)\n");
@@ -428,7 +429,7 @@ int main() {
     {
         const std::string ply_path = tmp_dir + "/test_standard.ply";
         write_test_ply(ply_path, 5);
-        auto cloud = GaussianCloud::load_ply(ply_path);
+        auto cloud = ply::load(ply_path);
 
         std::vector<GpuGaussian> expected(cloud.count());
         for (uint32_t i = 0; i < cloud.count(); ++i) {
@@ -638,8 +639,8 @@ int main() {
         const std::string ply_path = tmp_dir + "/test_standard.ply";
         write_test_ply(ply_path, 10);
 
-        auto cloud_yup = GaussianCloud::load_ply(ply_path);
-        auto cloud_ydn = GaussianCloud::load_ply(ply_path, CoordinateSystem::kVulkanYDown);
+        auto cloud_yup = ply::load(ply_path);
+        auto cloud_ydn = ply::load(ply_path, CoordinateSystem::kVulkanYDown);
 
         assert(cloud_ydn.count() == 10 && "Y-down should load same count");
 
@@ -673,8 +674,8 @@ int main() {
 
         // Write with Y-down, then read back with default (Y-up) — Y should be negated
         const std::string ply_path = tmp_dir + "/test_ydown_roundtrip.ply";
-        GaussianCloud::write_ply(ply_path, src, CoordinateSystem::kVulkanYDown);
-        auto cloud = GaussianCloud::load_ply(ply_path);  // default Y-up load
+        ply::write(ply_path, src, CoordinateSystem::kVulkanYDown);
+        auto cloud = ply::load(ply_path);  // default Y-up load
 
         const auto& g = cloud.gaussians()[0];
         assert(approx(g.position.x, 1.0f) && "Written X unchanged");
@@ -703,8 +704,8 @@ int main() {
         src[0].emission = 0.0f;
 
         const std::string ply_path = tmp_dir + "/test_ydown_identity.ply";
-        GaussianCloud::write_ply(ply_path, src, CoordinateSystem::kVulkanYDown);
-        auto cloud = GaussianCloud::load_ply(ply_path, CoordinateSystem::kVulkanYDown);
+        ply::write(ply_path, src, CoordinateSystem::kVulkanYDown);
+        auto cloud = ply::load(ply_path, CoordinateSystem::kVulkanYDown);
 
         const auto& g = cloud.gaussians()[0];
         // Double-negation should recover original position
@@ -725,7 +726,7 @@ int main() {
     {
         const std::string ply_path = tmp_dir + "/test_standard.ply";
         write_test_ply(ply_path, 5);
-        auto cloud = GaussianCloud::load_ply(ply_path);
+        auto cloud = ply::load(ply_path);
 
         std::vector<GpuGaussian> data(cloud.count());
         AABB expected_aabb;
@@ -766,7 +767,7 @@ int main() {
     {
         const std::string ply_path = tmp_dir + "/test_standard.ply";
         write_test_ply(ply_path, 5);
-        auto cloud = GaussianCloud::load_ply(ply_path);
+        auto cloud = ply::load(ply_path);
 
         std::vector<GpuGaussian> data(cloud.count());
         for (uint32_t i = 0; i < cloud.count(); ++i) {
@@ -803,7 +804,7 @@ int main() {
 
     auto bake_sibling_gsvx_v2 = [](const std::string& ply_path,
                                     const std::string& gsvx_path) {
-        auto cloud = GaussianCloud::load_ply(ply_path);
+        auto cloud = ply::load(ply_path);
         std::vector<GpuGaussian> data(cloud.count());
         AABB aabb;
         for (uint32_t i = 0; i < cloud.count(); ++i) {
@@ -846,7 +847,7 @@ int main() {
         write_test_ply(ply_path, 7);
         bake_sibling_gsvx_v2(ply_path, gsvx_path);
 
-        auto via_ply  = GaussianCloud::load_ply(ply_path);
+        auto via_ply  = ply::load(ply_path);
         auto via_dual = GaussianCloud::load_with_gsvx_first(ply_path);
 
         assert(via_dual.count() == via_ply.count() && "prefer count matches");
@@ -938,7 +939,7 @@ int main() {
         write_test_ply(ply_path, 5);
         bake_sibling_gsvx_v2(ply_path, gsvx_path);
 
-        auto via_ply  = GaussianCloud::load_ply(ply_path, CoordinateSystem::kVulkanYDown);
+        auto via_ply  = ply::load(ply_path, CoordinateSystem::kVulkanYDown);
         auto via_dual = GaussianCloud::load_with_gsvx_first(ply_path,
                                                              CoordinateSystem::kVulkanYDown);
 

--- a/tests/test_gs_emission.cpp
+++ b/tests/test_gs_emission.cpp
@@ -4,6 +4,7 @@
 // and packed into the GPU struct.
 
 #include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/gaussian_cloud_ply.hpp"
 
 #include <cassert>
 #include <cstdio>
@@ -47,10 +48,10 @@ int main() {
 
         // Write PLY
         const char* path = "/tmp/test_emission.ply";
-        GaussianCloud::write_ply(path, input);
+        ply::write(path, input);
 
         // Read back
-        GaussianCloud cloud = GaussianCloud::load_ply(path);
+        GaussianCloud cloud = ply::load(path);
         const auto& output = cloud.gaussians();
         assert(output.size() == 3);
         assert(output[0].emission == 0.0f);
@@ -95,7 +96,7 @@ int main() {
             f.write(reinterpret_cast<const char*>(data), sizeof(data));
         }
 
-        GaussianCloud cloud = GaussianCloud::load_ply(path);
+        GaussianCloud cloud = ply::load(path);
         assert(cloud.gaussians().size() == 1);
         assert(cloud.gaussians()[0].emission == 0.0f);
 

--- a/tests/test_ply_path_resolution.cpp
+++ b/tests/test_ply_path_resolution.cpp
@@ -8,6 +8,7 @@
 
 #include "gseurat/engine/project_root.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/gaussian_cloud_ply.hpp"
 
 #include <cassert>
 #include <cstdio>
@@ -84,7 +85,7 @@ int main() {
     {
         set_project_root(project_dir.string());
         try {
-            auto cloud = GaussianCloud::load_ply("assets/maps/tunnel_present.ply");
+            auto cloud = ply::load("assets/maps/tunnel_present.ply");
             check(cloud.count() == 4, "loaded 4 Gaussians via project_root");
         } catch (const std::exception& e) {
             check(false, e.what());
@@ -98,7 +99,7 @@ int main() {
         set_project_root("");
         bool threw = false;
         try {
-            auto cloud = GaussianCloud::load_ply("assets/maps/tunnel_present.ply");
+            auto cloud = ply::load("assets/maps/tunnel_present.ply");
         } catch (const std::runtime_error&) {
             threw = true;
         }
@@ -117,7 +118,7 @@ int main() {
 
         // Simulate: command 2 loads scene (which calls load_ply internally)
         try {
-            auto cloud = GaussianCloud::load_ply("assets/maps/tunnel_present.ply");
+            auto cloud = ply::load("assets/maps/tunnel_present.ply");
             check(cloud.count() == 4, "load succeeds when root set in same frame before load");
         } catch (const std::exception& e) {
             check(false, e.what());
@@ -143,7 +144,7 @@ int main() {
 
         set_project_root(project_dir.string());
         try {
-            auto cloud = GaussianCloud::load_ply("assets/characters/knight/knight.ply");
+            auto cloud = ply::load("assets/characters/knight/knight.ply");
             check(cloud.count() == 8, "character PLY loaded via project_root (8 gaussians)");
         } catch (const std::exception& e) {
             check(false, e.what());


### PR DESCRIPTION
## Summary

PR-2 of two for closing **M1 (Phase 1 end / #396)** — *severing the runtime PLY parser*. Builds on #424 (the GSVX bake step).

After this PR, the engine binary **cannot** parse text PLY. Every runtime cloud load must hit a sibling `.gsvx` baked by `bake_gsvx`; a missing or corrupt one is now a hard `std::runtime_error`, not a silent fallback.

## What moved

- `GaussianCloud::load_ply`, `GaussianCloud::write_ply`, and their helpers (`PlyProperty`, `type_size`, `read_float`, `kSH_C0`) extracted from `src/engine/gaussian_cloud.cpp` into a new `src/engine/gaussian_cloud_ply.cpp`.
- The new file is compiled **only** into `ply2heightmap` (offline tool) and the test targets that need PLY fixtures — **not** into `gseurat_core`.
- `gaussian_cloud.cpp` is now ~175 LOC (was 597). Net diff: –463/+451.

## Contract change

`load_with_gsvx_first`:
- **Before:** preferred sibling `.gsvx`, fell back silently to `load_ply` on any failure (missing file, bad magic, truncated payload, etc.).
- **After:** throws `std::runtime_error` if the sibling is missing or fails to parse. Hard contract — caller can trust the GSVX path or fail loudly.

Header doc-comment updated to spell this out.

## CMake

10 targets that listed `src/engine/gaussian_cloud.cpp` outside `gseurat_core` now also list `src/engine/gaussian_cloud_ply.cpp`:
- `ply2heightmap`
- 9 `add_gseurat_test` entries (`test_gaussian_cloud`, `test_gs_chunk_streamer`, `test_gs_emission`, `test_gs_particle`, `test_scene_loading`, `test_incremental_sync`, `test_vfx_lights_rotation`, `test_ply_path_resolution`, `test_bridge_reconnect_root`, `test_ply2heightmap`)

The `gseurat_core` source list is untouched — that's the whole point.

## Test updates

Three tests in `test_gaussian_cloud.cpp` previously asserted **fallback** behavior (no sibling / corrupt sibling / truncated sibling). They now assert that `load_with_gsvx_first` **throws**:
- Test 24 — throws when no sibling .gsvx
- Test 26 — throws on corrupt sibling
- Test 27 — throws on truncated sibling

Tests 25, 28, 29 (GSVX-first happy path) are unchanged.

## Validation

- `cmake --build --preset macos-debug --target gseurat_demo gseurat_staging ply2heightmap` → clean.
- `test_gaussian_cloud` — all 29 tests pass, including the 3 inverted ones.
- 10-second runtime smoke against the demo: loads `seurat_island.ply` scene + 7 `BoneAnimated` characters + dozens of PBD trees. **Zero** thrown errors, **zero** missing-sibling warnings, every cloud served from GSVX.

## What this closes

**M1 (Phase 1 end) of #396** — engine binary no longer links a text-PLY parser. Phase 2 (instrumentation: `GS_LABEL` per dispatch, `GS_DBG_INVARIANT` migration) is the next milestone per `docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md` §6.

## Test plan

- [ ] CI green
- [ ] `cmake --build --preset macos-debug --target gseurat_demo` succeeds
- [ ] `./build/macos-debug/test_gaussian_cloud` prints all 29 PASS lines
- [ ] Launch demo, walk to a portal target, verify no `missing sibling .gsvx` throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)
