### PR TITLE
refactor(engine): wire GS_DIAG_STREAMING through gs::dbg::Diag registry (Phase 2c — closes M2)

### DIFF
--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1943,17 +1943,16 @@ void GsRenderer::poll_transfers(VkCommandBuffer frame_cmd, uint32_t frame_in_fli
     publish_pending_chunks(frame_cmd, frame_in_flight);
 
     // ── DIAG: streaming-state dump (PR #387 ghost investigation) ──
-    // Opt-in via env var GS_DIAG_STREAMING=1. Cached once. Prints to
-    // stderr each frame for the first 5 frames (initial state — what the
-    // user reported as the "initial spawn state ghost") then every 60
-    // frames (~1s @ 60fps) thereafter. Reads HOST_VISIBLE+MAPPED buffers
-    // directly without vkDeviceWaitIdle: this is sampling, torn reads
-    // are acceptable for diagnostic output.
+    // Opt-in via env var GS_DIAG_STREAMING=1 (read once by
+    // gs::dbg::init_diag_registry() at VkInstance creation; cached in
+    // the Diag flag array thereafter). Prints to stderr each frame for
+    // the first 5 frames (initial state — what the user reported as the
+    // "initial spawn state ghost") then every 60 frames (~1s @ 60fps)
+    // thereafter. Reads HOST_VISIBLE+MAPPED buffers directly without
+    // vkDeviceWaitIdle: this is sampling, torn reads are acceptable for
+    // diagnostic output.
     {
-        static const bool diag_enabled = []() {
-            const char* env = std::getenv("GS_DIAG_STREAMING");
-            return env != nullptr && env[0] == '1';
-        }();
+        static const bool diag_enabled = ::gs::dbg::enabled(::gs::dbg::Diag::StreamingState);
         if (diag_enabled && streaming_initialized_) {
             static uint64_t diag_frame = 0;
             ++diag_frame;


### PR DESCRIPTION
## Summary

**Phase 2 PR-3** — final piece of Phase 2. Migrates the streaming-state diagnostic gate from a local `getenv("GS_DIAG_STREAMING")` cache to `gs::dbg::enabled(gs::dbg::Diag::StreamingState)`, routing through the central env-var registry initialized by `gs::dbg::init_diag_registry()` at VkInstance creation.

After this PR, **M2 (end of Phase 2)** is closed.

## What changed

Single callsite in `gs_renderer.cpp::poll_transfers`:

**Before:**
```cpp
static const bool diag_enabled = []() {
    const char* env = std::getenv("GS_DIAG_STREAMING");
    return env != nullptr && env[0] == '1';
}();
```

**After:**
```cpp
static const bool diag_enabled = ::gs::dbg::enabled(::gs::dbg::Diag::StreamingState);
```

User-facing surface unchanged — same env var name, same `"1"`-to-enable semantics. The registry was already wired up in `vk_context.cpp:29,42` at instance creation time (`gs::dbg::init_diag_registry()` landed with Phase 0a #390), so this PR is purely the consumer-side switch.

**Diff:** `+9 / -10` lines, single file.

## Why centralize

- Single point of truth for every `Diag::*` flag (`StreamingState`, `GpuTiming`, `ChunkInventory`, `RenderStateSlots`, `EventQueueSizes`). Future diag callsites read from the same array instead of scattering `getenv` parsing logic across the codebase.
- `gs::dbg::enabled()` is a single array index in debug builds — zero syscall overhead vs. one `getenv` syscall per process at the original callsite.
- Plan-doc-mandated (`docs/superpowers/plans/2026-05-02-engine-refactor-phase1-plan.md:1477`): "replace `getenv("GS_DIAG_STREAMING")` with `gs::dbg::enabled(gs::dbg::Diag::StreamingState)`".

## Validation

End-to-end test of the registry round-trip:

| Scenario | Expected | Actual |
|---|---|---|
| 6s run, `GS_DIAG_STREAMING` unset | 0 `[gs_diag]` lines | **0** ✓ |
| 6s run, `GS_DIAG_STREAMING=1` | many `[gs_diag]` lines | **179** ✓ |

Sample diag output from `GS_DIAG_STREAMING=1` run:
```
[gs_diag] f=1 static=0 dynamic=742573 total_active=0 max_static=10000000
[gs_diag]   active_chunks=0
[gs_diag]   projected_ssbo_ tail scan [0..2048):
[gs_diag]     summary: non_zero=0 real_looking=0 (in 2048 slots)
[gs_diag]   static_sort_as_[0] tail [0..1024): non_sentinel=0 first_offender=none
```

Confirms the full chain works:
1. `init_diag_registry()` reads `GS_DIAG_STREAMING` from env at vk-instance creation
2. Sets `g_diag_flags[Diag::StreamingState] = true`
3. Migrated `enabled(...)` call returns `true` on first frame
4. Dump function fires on frames 1–5 + every 60th thereafter

## Note on the other `Diag::*` enum values

`GpuTiming`, `ChunkInventory`, `RenderStateSlots`, `EventQueueSizes` have **no existing consumer callsites** yet — they're scaffolding for Phase 3+ instrumentation and remain valid lookup keys in the registry, ready when their callsites land in future PRs (likely Phase 3/4 alongside the `RenderState` writers and `EventQueue<T>` bus).

## What this closes

**M2 (end of Phase 2)** — all three Phase 2 actionables from `docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md` §6 / plan §Phase2/PR2 are now in:

| Actionable | PR | Status |
|---|---|---|
| `GS_LABEL` on every dispatch in `gs_renderer.cpp` | #426 | ✅ Merged |
| `GS_DBG_INVARIANT` migration + PR #387 invariant | #427 | ✅ Merged |
| `gs::dbg::Diag` registry wired through consumer | **this PR** | 🟡 In review |

Next: **Phase 3** — infrastructure scaffolding (`EventQueue<T>` bus + `RenderState` passive struct). No callers migrate in Phase 3; the bus and writers compile but stay uninstalled until Phase 4.

## Test plan

- [ ] CI green (build all platforms, tests pass, golden-frame harness pixel-identical — migration is debug-output-only)
- [ ] Local: `cmake --build --preset macos-debug --target gseurat_demo` succeeds
- [ ] Local: `./gseurat_demo` with `GS_DIAG_STREAMING=1` shows `[gs_diag]` lines every ~60 frames; without the env var, none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
