### PR TITLE
feat(ecs): typed event queue infrastructure (Phase 3a)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,7 @@ target_compile_definitions(gseurat_core PUBLIC
 target_sources(gseurat_core PRIVATE src/engine/debug.cpp)
 target_sources(gseurat_core PRIVATE src/engine/sim_clock.cpp)
 target_sources(gseurat_core PRIVATE src/engine/random.cpp)
+target_sources(gseurat_core PRIVATE src/engine/ecs/events.cpp)
 
 if(GSEURAT_SHARED_LIBS)
     target_compile_definitions(gseurat_core PUBLIC GSEURAT_ENGINE_BUILD_SHARED)
@@ -494,7 +495,8 @@ add_gseurat_test(test_gs_spline src/engine/gs_spline.cpp)
 add_gseurat_test(test_gs_post_process)
 add_gseurat_test(test_pbd_solver)
 add_gseurat_test(test_component_registry src/engine/component_registry.cpp)
-add_gseurat_test(test_system_scheduler  src/engine/system_scheduler.cpp)
+add_gseurat_test(test_system_scheduler  src/engine/system_scheduler.cpp src/engine/ecs/events.cpp)
+add_gseurat_test(test_event_queue       src/engine/system_scheduler.cpp src/engine/ecs/events.cpp)
 add_gseurat_test(test_island_systems    src/engine/trigger_systems.cpp
     src/engine/random.cpp
     src/character/character_manifest.cpp

--- a/include/gseurat/engine/ecs/events.hpp
+++ b/include/gseurat/engine/ecs/events.hpp
@@ -121,8 +121,16 @@ public:
             curr_start = 0;
         }
 
-        std::span<const T> prev_span{prev_buf.data() + prev_start, prev_buf.size() - prev_start};
-        std::span<const T> curr_span{curr_buf.data() + curr_start, curr_buf.size() - curr_start};
+        // Guard against `data() + offset` UB on empty vectors: libc++'s
+        // empty std::vector returns nullptr from data(), and `nullptr + 0`
+        // is undefined per the C++ standard (UBSan flags it). Construct an
+        // empty span explicitly when there's nothing to read from a buffer.
+        std::span<const T> prev_span = (prev_start < prev_buf.size())
+            ? std::span<const T>{prev_buf.data() + prev_start, prev_buf.size() - prev_start}
+            : std::span<const T>{};
+        std::span<const T> curr_span = (curr_start < curr_buf.size())
+            ? std::span<const T>{curr_buf.data() + curr_start, curr_buf.size() - curr_start}
+            : std::span<const T>{};
 
         cursor.last_seen_generation = generation_;
         cursor.last_read_per_buffer[prev_idx] = prev_buf.size();

--- a/include/gseurat/engine/ecs/events.hpp
+++ b/include/gseurat/engine/ecs/events.hpp
@@ -68,11 +68,22 @@ public:
     virtual ~EventQueueBase();
     virtual void rotate() noexcept = 0;
     virtual std::size_t pending_count() const noexcept = 0;
+    // Exposed so EventRegistry::clear() can advance its epoch floor past
+    // any live queue's current generation, preventing cursor collisions
+    // with freshly recreated queues.
+    virtual uint32_t current_generation() const noexcept = 0;
 };
 
 template <typename T>
 class EventQueue final : public EventQueueBase {
 public:
+    EventQueue() = default;
+    // Seed `generation_` past any prior generation a stale cursor might
+    // be carrying. Used by EventRegistry to make post-clear queues immune
+    // to cursors that survived World::clear() — see EventRegistry::clear.
+    explicit EventQueue(uint32_t initial_generation) noexcept
+        : generation_(initial_generation) {}
+
     void send(T evt) {
         buffers_[write_idx_].push_back(std::move(evt));
     }
@@ -130,6 +141,7 @@ public:
         return buffers_[0].size() + buffers_[1].size();
     }
 
+    uint32_t current_generation() const noexcept override { return generation_; }
     uint32_t generation() const noexcept { return generation_; }
 
 private:
@@ -149,7 +161,10 @@ public:
         if (it != queues_.end()) {
             return *static_cast<EventQueue<T>*>(it->second.get());
         }
-        auto owned = std::make_unique<EventQueue<T>>();
+        // Seed the new queue's generation past the epoch floor so any
+        // cursor surviving a prior clear() cannot collide with this
+        // queue's starting generation.
+        auto owned = std::make_unique<EventQueue<T>>(epoch_floor_);
         EventQueue<T>* raw = owned.get();
         queues_.emplace(key, std::move(owned));
         return *raw;
@@ -168,12 +183,26 @@ public:
     // Drop every registered queue. Used when the host clears the World (e.g.
     // scene transition) so stale events from the prior scene cannot leak
     // into consumers on the new scene.
-    void clear() noexcept { queues_.clear(); }
+    //
+    // Also advances `epoch_floor_` past the highest live queue generation
+    // so a long-lived EventCursor that survived the clear cannot match the
+    // generation of any freshly recreated queue (which would otherwise
+    // cause its stale per-buffer offsets to silently skip new events).
+    void clear() noexcept {
+        for (auto& [type_idx, queue] : queues_) {
+            if (queue->current_generation() >= epoch_floor_) {
+                epoch_floor_ = queue->current_generation() + 1;
+            }
+        }
+        queues_.clear();
+    }
 
     std::size_t queue_count() const noexcept { return queues_.size(); }
+    uint32_t epoch_floor() const noexcept { return epoch_floor_; }
 
 private:
     std::unordered_map<std::type_index, std::unique_ptr<EventQueueBase>> queues_;
+    uint32_t epoch_floor_ = 0;
 };
 
 }  // namespace gseurat::ecs

--- a/include/gseurat/engine/ecs/events.hpp
+++ b/include/gseurat/engine/ecs/events.hpp
@@ -1,0 +1,174 @@
+#pragma once
+
+// Phase 3a: Typed event bus (Bevy `Events<T>` model).
+//
+// Per-event-type queues with 2-frame retention. Producers call `send(T)`;
+// consumers poll via `read(EventCursor&)`. `EventCleanupStage` (driven by
+// SystemScheduler::run_all) rotates buffers at end-of-frame so events sent
+// in frame N stay visible through frame N+1, then expire.
+//
+// Scope of this PR: infrastructure only. No callers migrate yet (Phase 4).
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <typeindex>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace gseurat::ecs {
+
+inline constexpr uint32_t kEventRetentionFrames = 2;
+
+// Per-consumer cursor. Tracks the last event seen across rotates.
+//
+// `last_seen_generation` advances each time the queue rotates; the cursor
+// uses it to know whether `last_read_per_buffer` is still valid for the
+// queue's current buffer pairing.
+struct EventCursor {
+    uint32_t last_seen_generation = 0;
+    std::size_t last_read_per_buffer[kEventRetentionFrames] = {0, 0};
+};
+
+// Span-pair view returned by EventQueue<T>::read. Iterating yields events
+// in chronological order: previous frame first, then current frame.
+template <typename T>
+class EventReader {
+public:
+    EventReader() = default;
+    EventReader(std::span<const T> prev, std::span<const T> curr) noexcept
+        : prev_(prev), curr_(curr) {}
+
+    std::span<const T> prev_frame() const noexcept { return prev_; }
+    std::span<const T> curr_frame() const noexcept { return curr_; }
+
+    std::size_t size() const noexcept { return prev_.size() + curr_.size(); }
+    bool empty() const noexcept { return prev_.empty() && curr_.empty(); }
+
+    // Iterate prev then curr via callback. Returns count visited.
+    template <typename F>
+    std::size_t for_each(F&& fn) const {
+        std::size_t n = 0;
+        for (const auto& e : prev_) { fn(e); ++n; }
+        for (const auto& e : curr_) { fn(e); ++n; }
+        return n;
+    }
+
+private:
+    std::span<const T> prev_;
+    std::span<const T> curr_;
+};
+
+// Type-erased base so the registry can hold heterogeneous queues.
+class EventQueueBase {
+public:
+    virtual ~EventQueueBase();
+    virtual void rotate() noexcept = 0;
+    virtual std::size_t pending_count() const noexcept = 0;
+};
+
+template <typename T>
+class EventQueue final : public EventQueueBase {
+public:
+    void send(T evt) {
+        buffers_[write_idx_].push_back(std::move(evt));
+    }
+
+    template <typename... Args>
+    void emplace(Args&&... args) {
+        buffers_[write_idx_].emplace_back(std::forward<Args>(args)...);
+    }
+
+    // Returns unread events as a (prev_frame, curr_frame) span pair and
+    // advances the cursor in place. Safe across rotates.
+    EventReader<T> read(EventCursor& cursor) const noexcept {
+        const uint8_t prev_idx = static_cast<uint8_t>(1u - write_idx_);
+        const std::vector<T>& prev_buf = buffers_[prev_idx];
+        const std::vector<T>& curr_buf = buffers_[write_idx_];
+
+        // If cursor is from an older generation, prior per-buffer offsets
+        // are stale. The previous buffer is what was "current" at cursor
+        // capture time (now demoted to prev), so its offset still applies;
+        // the current buffer is new and should be read from the start.
+        std::size_t prev_start = 0;
+        std::size_t curr_start = 0;
+        if (cursor.last_seen_generation == generation_) {
+            prev_start = std::min(cursor.last_read_per_buffer[prev_idx], prev_buf.size());
+            curr_start = std::min(cursor.last_read_per_buffer[write_idx_], curr_buf.size());
+        } else if (cursor.last_seen_generation + 1 == generation_) {
+            // Single rotate behind: what was the cursor's "curr" is now "prev"
+            // (its events are still retained); the new curr buffer is fresh.
+            prev_start = std::min(cursor.last_read_per_buffer[prev_idx], prev_buf.size());
+            curr_start = 0;
+        } else {
+            // Two or more rotates behind: all previously seen events have
+            // expired. Read everything currently retained.
+            prev_start = 0;
+            curr_start = 0;
+        }
+
+        std::span<const T> prev_span{prev_buf.data() + prev_start, prev_buf.size() - prev_start};
+        std::span<const T> curr_span{curr_buf.data() + curr_start, curr_buf.size() - curr_start};
+
+        cursor.last_seen_generation = generation_;
+        cursor.last_read_per_buffer[prev_idx] = prev_buf.size();
+        cursor.last_read_per_buffer[write_idx_] = curr_buf.size();
+
+        return EventReader<T>(prev_span, curr_span);
+    }
+
+    void rotate() noexcept override {
+        write_idx_ = static_cast<uint8_t>(1u - write_idx_);
+        buffers_[write_idx_].clear();
+        ++generation_;
+    }
+
+    std::size_t pending_count() const noexcept override {
+        return buffers_[0].size() + buffers_[1].size();
+    }
+
+    uint32_t generation() const noexcept { return generation_; }
+
+private:
+    std::array<std::vector<T>, kEventRetentionFrames> buffers_{};
+    uint8_t write_idx_ = 0;
+    uint32_t generation_ = 0;
+};
+
+// Type-erased registry of EventQueue<T> instances, keyed by std::type_index.
+// One queue per distinct T; lazily created on first `get_or_create<T>()`.
+class EventRegistry {
+public:
+    template <typename T>
+    EventQueue<T>& get_or_create() {
+        const std::type_index key = std::type_index(typeid(T));
+        auto it = queues_.find(key);
+        if (it != queues_.end()) {
+            return *static_cast<EventQueue<T>*>(it->second.get());
+        }
+        auto owned = std::make_unique<EventQueue<T>>();
+        EventQueue<T>* raw = owned.get();
+        queues_.emplace(key, std::move(owned));
+        return *raw;
+    }
+
+    template <typename T>
+    EventQueue<T>* try_get() {
+        const std::type_index key = std::type_index(typeid(T));
+        auto it = queues_.find(key);
+        if (it == queues_.end()) return nullptr;
+        return static_cast<EventQueue<T>*>(it->second.get());
+    }
+
+    void rotate_all() noexcept;
+
+    std::size_t queue_count() const noexcept { return queues_.size(); }
+
+private:
+    std::unordered_map<std::type_index, std::unique_ptr<EventQueueBase>> queues_;
+};
+
+}  // namespace gseurat::ecs

--- a/include/gseurat/engine/ecs/events.hpp
+++ b/include/gseurat/engine/ecs/events.hpp
@@ -165,6 +165,11 @@ public:
 
     void rotate_all() noexcept;
 
+    // Drop every registered queue. Used when the host clears the World (e.g.
+    // scene transition) so stale events from the prior scene cannot leak
+    // into consumers on the new scene.
+    void clear() noexcept { queues_.clear(); }
+
     std::size_t queue_count() const noexcept { return queues_.size(); }
 
 private:

--- a/include/gseurat/engine/ecs/world.hpp
+++ b/include/gseurat/engine/ecs/world.hpp
@@ -2,6 +2,7 @@
 
 #include "gseurat/engine/ecs/archetype.hpp"
 #include "gseurat/engine/ecs/component.hpp"
+#include "gseurat/engine/ecs/events.hpp"
 #include "gseurat/engine/ecs/types.hpp"
 #include "gseurat/engine/ecs/view.hpp"
 
@@ -149,6 +150,22 @@ public:
         return e;
     }
 
+    // --- Event bus (Phase 3a) ---
+    // Per-event-type queue lazily created on first access. See
+    // gseurat/engine/ecs/events.hpp for semantics. No callers migrate
+    // in Phase 3; consumers will be wired in Phase 4.
+    template <typename T>
+    EventQueue<T>& events() {
+        return events_.get_or_create<T>();
+    }
+
+    EventRegistry& event_registry() noexcept { return events_; }
+    const EventRegistry& event_registry() const noexcept { return events_; }
+
+    // Called once per frame by SystemScheduler (end of update) to advance
+    // every event queue's retention window.
+    void rotate_events() noexcept { events_.rotate_all(); }
+
 private:
     Archetype* find_or_create_archetype(const TypeSet& type_set) {
         for (auto& arch : archetypes_) {
@@ -195,6 +212,7 @@ private:
     uint32_t next_id_ = 1;
     std::vector<std::unique_ptr<Archetype>> archetypes_;
     std::unordered_map<uint32_t, Archetype*> entity_archetype_;
+    EventRegistry events_;
 };
 
 }  // namespace gseurat::ecs

--- a/include/gseurat/engine/ecs/world.hpp
+++ b/include/gseurat/engine/ecs/world.hpp
@@ -141,6 +141,9 @@ public:
         entity_archetype_.clear();
         archetypes_.clear();
         next_id_ = 1;
+        // Drop pending events too — otherwise queued events from the prior
+        // scene leak into consumers on the new scene for up to two rotations.
+        events_.clear();
     }
 
     template <typename... Ts>

--- a/src/engine/ecs/events.cpp
+++ b/src/engine/ecs/events.cpp
@@ -1,0 +1,13 @@
+#include "gseurat/engine/ecs/events.hpp"
+
+namespace gseurat::ecs {
+
+EventQueueBase::~EventQueueBase() = default;
+
+void EventRegistry::rotate_all() noexcept {
+    for (auto& [type_idx, queue] : queues_) {
+        queue->rotate();
+    }
+}
+
+}  // namespace gseurat::ecs

--- a/src/engine/system_scheduler.cpp
+++ b/src/engine/system_scheduler.cpp
@@ -10,6 +10,9 @@ void SystemScheduler::run_all(ecs::World& world, float dt) {
     for (auto& sys : systems_) {
         sys.fn(world, dt);
     }
+    // End-of-frame event cleanup: rotates every registered EventQueue<T>
+    // so frame N's events remain visible through frame N+1 then expire.
+    world.rotate_events();
 }
 
 }  // namespace gseurat

--- a/tests/test_event_queue.cpp
+++ b/tests/test_event_queue.cpp
@@ -297,6 +297,74 @@ int main() {
         std::printf("PASS: World::clear drops pending events\n");
     }
 
+    // 14. Cursor surviving World::clear() does NOT drop events from the
+    //     freshly recreated queue (regression for Codex P2 on commit bb014684).
+    //
+    // Old behavior bug: queue gen reset to 0 → if cursor's last_seen_generation
+    // was also 0 with nonzero per-buffer offsets, the `==` branch in read()
+    // applied stale offsets and silently skipped new-scene events.
+    {
+        World world;
+
+        // Pre-clear: consumer reads some events at gen 0.
+        world.events<ClickEvent>().send({1, 1});
+        world.events<ClickEvent>().send({2, 2});
+        world.events<ClickEvent>().send({3, 3});
+
+        EventCursor persistent_cursor;
+        auto pre = drain(world.events<ClickEvent>(), persistent_cursor);
+        assert(pre.size() == 3);
+        // Cursor now has last_seen_generation=0, last_read_per_buffer[0]=3.
+
+        // Scene transition.
+        world.clear();
+        assert(world.event_registry().epoch_floor() >= 1);
+
+        // New-scene producer sends 2 events. Fresh queue's generation_
+        // should be >= 1 (seeded from epoch_floor_), so the persistent
+        // cursor's last_seen_generation=0 cannot match it.
+        world.events<ClickEvent>().send({10, 10});
+        world.events<ClickEvent>().send({20, 20});
+
+        // Without the epoch fix, this would return 0 events (cursor's
+        // stale offset 3 clamped to buffer size 2 → curr_start=2 → empty).
+        auto post = drain(world.events<ClickEvent>(), persistent_cursor);
+        assert(post.size() == 2);
+        assert(post[0].x == 10);
+        assert(post[1].x == 20);
+        std::printf("PASS: surviving cursor reads all new events after clear\n");
+    }
+
+    // 15. Multiple clears continue to advance epoch_floor monotonically;
+    //     a stale cursor across N clears still cannot collide with new queues.
+    {
+        EventRegistry reg;
+
+        // Cycle 1
+        reg.get_or_create<ClickEvent>().send({1, 1});
+        EventCursor cursor;
+        drain(reg.get_or_create<ClickEvent>(), cursor);
+        reg.clear();
+        const uint32_t floor1 = reg.epoch_floor();
+        assert(floor1 >= 1);
+
+        // Cycle 2 — different mix of rotates
+        reg.get_or_create<ClickEvent>().send({2, 2});
+        reg.get_or_create<ClickEvent>().rotate();
+        reg.get_or_create<ClickEvent>().rotate();
+        reg.clear();
+        const uint32_t floor2 = reg.epoch_floor();
+        assert(floor2 > floor1);
+
+        // Cycle 3 — fresh queue, cursor from cycle 1 still around
+        reg.get_or_create<ClickEvent>().send({3, 3});
+        auto seen = drain(reg.get_or_create<ClickEvent>(), cursor);
+        // Persistent cursor from cycle 1 sees the new event without skip.
+        assert(seen.size() == 1);
+        assert(seen[0].x == 3);
+        std::printf("PASS: epoch_floor advances across multiple clears\n");
+    }
+
     std::printf("\nALL EVENT QUEUE TESTS PASSED\n");
     return 0;
 }

--- a/tests/test_event_queue.cpp
+++ b/tests/test_event_queue.cpp
@@ -276,6 +276,27 @@ int main() {
         std::printf("PASS: producer+consumer systems in same frame\n");
     }
 
+    // 13. World::clear() drops pending events (no leak across scene transitions)
+    {
+        World world;
+        world.events<ClickEvent>().send({77, 88});
+        world.events<KeyEvent>().send({'x'});
+        assert(world.event_registry().queue_count() == 2);
+        assert(world.events<ClickEvent>().pending_count() == 1);
+
+        world.clear();
+
+        // After clear: registry is empty; lazily recreated queue starts fresh.
+        assert(world.event_registry().queue_count() == 0);
+        auto& fresh = world.events<ClickEvent>();
+        assert(fresh.pending_count() == 0);
+
+        EventCursor cursor;
+        auto seen = drain(fresh, cursor);
+        assert(seen.empty());
+        std::printf("PASS: World::clear drops pending events\n");
+    }
+
     std::printf("\nALL EVENT QUEUE TESTS PASSED\n");
     return 0;
 }

--- a/tests/test_event_queue.cpp
+++ b/tests/test_event_queue.cpp
@@ -1,0 +1,281 @@
+// Phase 3a: Unit tests for gseurat::ecs::EventQueue<T> + EventRegistry +
+// World::events<T>() + SystemScheduler end-of-frame rotation.
+//
+// Covers: same-frame read, retention across one rotate, expiry after two
+// rotates, cursor non-repeat, multi-type registry isolation, World access,
+// SystemScheduler-driven rotation.
+
+#include "gseurat/engine/ecs/events.hpp"
+#include "gseurat/engine/ecs/world.hpp"
+#include "gseurat/engine/system_scheduler.hpp"
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace gseurat;
+using namespace gseurat::ecs;
+
+namespace {
+
+struct ClickEvent {
+    int x = 0;
+    int y = 0;
+};
+
+struct KeyEvent {
+    char key = 0;
+};
+
+template <typename T>
+std::vector<T> drain(EventQueue<T>& q, EventCursor& cursor) {
+    std::vector<T> out;
+    q.read(cursor).for_each([&](const T& e) { out.push_back(e); });
+    return out;
+}
+
+}  // namespace
+
+int main() {
+    // 1. send + same-frame read returns all events in order
+    {
+        EventQueue<ClickEvent> q;
+        q.send({1, 2});
+        q.send({3, 4});
+        q.send({5, 6});
+
+        EventCursor cursor;
+        auto seen = drain(q, cursor);
+        assert(seen.size() == 3);
+        assert(seen[0].x == 1 && seen[0].y == 2);
+        assert(seen[1].x == 3 && seen[1].y == 4);
+        assert(seen[2].x == 5 && seen[2].y == 6);
+        std::printf("PASS: same-frame send+read in order\n");
+    }
+
+    // 2. Cursor does not repeat events on second read in same frame
+    {
+        EventQueue<ClickEvent> q;
+        q.send({1, 1});
+        q.send({2, 2});
+
+        EventCursor cursor;
+        auto first = drain(q, cursor);
+        assert(first.size() == 2);
+
+        auto second = drain(q, cursor);
+        assert(second.empty());
+
+        q.send({3, 3});
+        auto third = drain(q, cursor);
+        assert(third.size() == 1);
+        assert(third[0].x == 3);
+        std::printf("PASS: cursor advances without repeats\n");
+    }
+
+    // 3. Events sent in frame N are visible in frame N+1 (single rotate)
+    {
+        EventQueue<ClickEvent> q;
+        q.send({7, 8});
+        q.send({9, 10});
+
+        // Cursor created mid-frame N before reading anything.
+        EventCursor cursor;
+
+        q.rotate();  // end of frame N
+
+        // Consumer reads on frame N+1: still sees both events.
+        auto seen = drain(q, cursor);
+        assert(seen.size() == 2);
+        assert(seen[0].x == 7);
+        assert(seen[1].x == 9);
+        std::printf("PASS: events retained across one rotate\n");
+    }
+
+    // 4. Events expire after two rotates (consumer skipped frame N+1)
+    {
+        EventQueue<ClickEvent> q;
+        q.send({100, 200});
+
+        EventCursor cursor;
+        q.rotate();   // end of frame N (events now in "prev")
+        q.rotate();   // end of frame N+1 (events expired, prev cleared)
+
+        auto seen = drain(q, cursor);
+        assert(seen.empty());
+        std::printf("PASS: events expire after two rotates\n");
+    }
+
+    // 5. Consumer that reads on frame N then again on frame N+1 sees each event exactly once
+    {
+        EventQueue<ClickEvent> q;
+        q.send({1, 1});
+        q.send({2, 2});
+
+        EventCursor cursor;
+        auto a = drain(q, cursor);
+        assert(a.size() == 2);
+
+        q.rotate();
+        q.send({3, 3});  // new event in frame N+1
+
+        auto b = drain(q, cursor);
+        // Should see only the new event — the prior two were already consumed.
+        assert(b.size() == 1);
+        assert(b[0].x == 3);
+        std::printf("PASS: cursor survives rotate without re-reading consumed events\n");
+    }
+
+    // 6. Mixed send/rotate/send sequence: prev+curr both contain unseen events
+    {
+        EventQueue<ClickEvent> q;
+        q.send({10, 10});  // frame N
+        EventCursor cursor;
+        q.rotate();        // end of N: {10,10} moves to prev
+        q.send({20, 20});  // frame N+1: live in curr
+
+        auto seen = drain(q, cursor);
+        assert(seen.size() == 2);
+        assert(seen[0].x == 10);  // prev first
+        assert(seen[1].x == 20);  // curr second
+        std::printf("PASS: read combines prev and curr in chronological order\n");
+    }
+
+    // 7. pending_count reflects total live events across both buffers
+    {
+        EventQueue<ClickEvent> q;
+        assert(q.pending_count() == 0);
+        q.send({1, 1});
+        q.send({2, 2});
+        assert(q.pending_count() == 2);
+        q.rotate();
+        q.send({3, 3});
+        assert(q.pending_count() == 3);  // 2 in prev + 1 in curr
+        q.rotate();
+        assert(q.pending_count() == 1);  // prev cleared, 1 in (now-)prev
+        std::printf("PASS: pending_count tracks both buffers\n");
+    }
+
+    // 8. EventRegistry: queues for distinct types are isolated
+    {
+        EventRegistry reg;
+        auto& clicks = reg.get_or_create<ClickEvent>();
+        auto& keys = reg.get_or_create<KeyEvent>();
+
+        clicks.send({1, 2});
+        keys.send({'a'});
+        keys.send({'b'});
+
+        assert(clicks.pending_count() == 1);
+        assert(keys.pending_count() == 2);
+        assert(reg.queue_count() == 2);
+
+        // get_or_create<T> returns the same instance for the same T.
+        auto& clicks_again = reg.get_or_create<ClickEvent>();
+        assert(&clicks_again == &clicks);
+
+        // try_get<T> returns the same instance, or null for unregistered T.
+        assert(reg.try_get<ClickEvent>() == &clicks);
+        struct Unrelated {};
+        assert(reg.try_get<Unrelated>() == nullptr);
+        std::printf("PASS: EventRegistry isolates per-type queues\n");
+    }
+
+    // 9. EventRegistry::rotate_all rotates every registered queue
+    {
+        EventRegistry reg;
+        auto& clicks = reg.get_or_create<ClickEvent>();
+        auto& keys = reg.get_or_create<KeyEvent>();
+
+        clicks.send({99, 99});
+        keys.send({'z'});
+
+        reg.rotate_all();
+        // Both queues' events should still be visible (one rotate behind).
+        assert(clicks.pending_count() == 1);
+        assert(keys.pending_count() == 1);
+
+        reg.rotate_all();
+        // Two rotates: all events expired.
+        assert(clicks.pending_count() == 0);
+        assert(keys.pending_count() == 0);
+        std::printf("PASS: EventRegistry::rotate_all rotates every queue\n");
+    }
+
+    // 10. World::events<T>() returns the same queue across calls
+    {
+        World world;
+        auto& q1 = world.events<ClickEvent>();
+        auto& q2 = world.events<ClickEvent>();
+        assert(&q1 == &q2);
+
+        q1.send({42, 42});
+        EventCursor cursor;
+        auto seen = drain(q2, cursor);
+        assert(seen.size() == 1);
+        assert(seen[0].x == 42);
+        std::printf("PASS: World::events<T> returns stable instance\n");
+    }
+
+    // 11. SystemScheduler::run_all rotates event queues at end of frame
+    {
+        World world;
+        world.events<ClickEvent>().send({1, 1});
+        world.events<ClickEvent>().send({2, 2});
+
+        SystemScheduler sched;
+        // Trivial system that does nothing — we only care about the
+        // implicit end-of-frame rotation in run_all.
+        sched.add_system({"noop", [](ecs::World&, float) {}, {}, {}});
+
+        EventCursor cursor;
+
+        // Read before first run: see both events.
+        auto pre = drain(world.events<ClickEvent>(), cursor);
+        assert(pre.size() == 2);
+
+        sched.run_all(world, 0.016f);  // rotate #1: events still retained
+
+        world.events<ClickEvent>().send({3, 3});  // new event in frame N+1
+        auto mid = drain(world.events<ClickEvent>(), cursor);
+        assert(mid.size() == 1);
+        assert(mid[0].x == 3);
+
+        sched.run_all(world, 0.016f);  // rotate #2: prior events expire
+        sched.run_all(world, 0.016f);  // rotate #3: {3,3} also expires
+
+        EventCursor fresh_cursor;
+        auto post = drain(world.events<ClickEvent>(), fresh_cursor);
+        assert(post.empty());
+        std::printf("PASS: SystemScheduler::run_all drives event rotation\n");
+    }
+
+    // 12. Producer system sends, consumer system reads — same frame
+    {
+        World world;
+        SystemScheduler sched;
+        std::vector<ClickEvent> consumed;
+        EventCursor cursor;
+
+        sched.add_system({"producer",
+                          [](ecs::World& w, float) {
+                              w.events<ClickEvent>().send({11, 22});
+                          },
+                          {}, {}});
+        sched.add_system({"consumer",
+                          [&](ecs::World& w, float) {
+                              w.events<ClickEvent>().read(cursor).for_each(
+                                  [&](const ClickEvent& e) { consumed.push_back(e); });
+                          },
+                          {}, {}});
+
+        sched.run_all(world, 0.016f);
+        assert(consumed.size() == 1);
+        assert(consumed[0].x == 11 && consumed[0].y == 22);
+        std::printf("PASS: producer+consumer systems in same frame\n");
+    }
+
+    std::printf("\nALL EVENT QUEUE TESTS PASSED\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

**Phase 3 PR-1** of the engine rebuild (canonical: `docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md` §5.3 + `docs/superpowers/plans/2026-05-02-engine-refactor-phase1-plan.md` PR 3a).

Builds the typed event-bus infrastructure that Phase 4 callers will migrate to (Bevy `Events<T>` model). **No production callers migrate in this PR** — the bus exists, compiles, is owned by `World`, and rotates at end-of-frame, but nothing produces or consumes events yet.

## What changed

**New files:**
- `include/gseurat/engine/ecs/events.hpp`
  - `EventQueueBase` (abstract base for type-erased storage)
  - `EventQueue<T>` (template; 2-buffer double-buffered, generation-counted)
  - `EventCursor { last_seen_generation, last_read_per_buffer[2] }`
  - `EventReader<T>` (zero-copy span-pair view over `prev_frame + curr_frame`)
  - `EventRegistry` (`std::unordered_map<std::type_index, std::unique_ptr<EventQueueBase>>`)
- `src/engine/ecs/events.cpp` — vtable anchor + `EventRegistry::rotate_all`.
- `tests/test_event_queue.cpp` — 12 unit tests.

**Modified:**
- `include/gseurat/engine/ecs/world.hpp` — adds `events<T>()` accessor, `rotate_events()`, and an `EventRegistry events_` member.
- `src/engine/system_scheduler.cpp` — `run_all` calls `world.rotate_events()` after every system (the `EventCleanupStage` from the spec).
- `CMakeLists.txt` — links `events.cpp` into `gseurat_core`; registers `test_event_queue`.

## Design notes

### Cursor semantics

The cursor encodes per-buffer read offsets plus a generation counter. `read()` returns events from both the previous-frame buffer and the current-frame buffer in chronological order:

| Cursor generation vs queue | Behavior |
|---|---|
| Equal (no rotate since last read) | Read from cursor offsets in both buffers |
| One behind (single rotate) | Cursor's old "curr" is now "prev"; its offset still applies. New "curr" buffer reads from 0 |
| Two+ behind | All prior events have expired; read everything currently retained |

This survives rotates without ever returning duplicate events to a consumer that polls at least every other frame. Consumers that poll only once every 3+ frames may miss expired events — by design (Bevy's Events<T> contract).

### Returning span-pair instead of single span

Spec §5.3 sketches `std::span<const T> read(EventCursor&)`, but a single span can't cover events that straddle two physical buffers. `EventReader<T>` exposes both spans with an iteration helper (`for_each(callable)`); future Phase 4 consumers can iterate without copying. Spec explicitly flags the implementation as TBD in §9.

### Namespace deviation from spec

Spec §5.3 writes `namespace gs::ecs`. The existing ECS code lives in `namespace gseurat::ecs` (`include/gseurat/engine/ecs/world.hpp:13`). Aligned with the existing convention rather than creating a parallel namespace; this is a stale spec detail, not a design change.

## Validation

### test_event_queue (12/12 pass)

```
PASS: same-frame send+read in order
PASS: cursor advances without repeats
PASS: events retained across one rotate
PASS: events expire after two rotates
PASS: cursor survives rotate without re-reading consumed events
PASS: read combines prev and curr in chronological order
PASS: pending_count tracks both buffers
PASS: EventRegistry isolates per-type queues
PASS: EventRegistry::rotate_all rotates every queue
PASS: World::events<T> returns stable instance
PASS: SystemScheduler::run_all drives event rotation
PASS: producer+consumer systems in same frame
```

### Regression

- `test_system_scheduler` passes (existing tests unchanged by the new `world.rotate_events()` call at end of `run_all` — no event queues registered means no work).
- `gseurat_demo` builds clean and runs 10s smoke without invariant failures, Vulkan errors, or abort signals. No production code paths touch `events_` yet, so behavior is identical by construction.

## What this enables (Phase 4 preview)

Per spec §5.3 / plan §Phase4:

| Phase | Producer | Event | Consumer |
|---|---|---|---|
| 4a | `CommandDispatcher::handle_vfx_spawn` | `VfxSpawnEvent` | `VfxSystem` |
| 4d | `gs_scene_loader.cpp:289` | `PbdElementsLoadedEvent` | `PbdSystem` |
| 4d | scene loader (lights) | `PointLightsLoadedEvent` | `LightingSystem` |
| 4e | particle emitter trigger | `ParticleEmitterEvent` | `ParticleSystem` |

## What this closes

Closes Phase 3 PR-1 / `refactor/3a-event-bus`. Next: **Phase 3 PR-2** — `refactor/3b-render-state` (`gs::RenderState` class with persistent-mapped buffers + typed writers, also infrastructure-only).

Once 3b lands, **M3 (end of Phase 3)** closes.

## Test plan

- [ ] CI green (all platforms build, tests pass)
- [ ] Local: `cmake --build --preset macos-debug --target test_event_queue && ./build/macos-debug/test_event_queue` — all 12 pass
- [ ] Local: `cmake --build --preset macos-debug --target gseurat_demo && ./build/macos-debug/gseurat_demo` — runs ≥10s clean

Golden-frame regression harness is deferred — this PR's runtime path is unused by any caller, so the renderer's output is pixel-identical by construction. Harness will be exercised in Phase 4 PRs that actually wire callers through `EventQueue<T>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
