### PR TITLE
feat(engine): RenderState contract (Phase 3b)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,7 @@ target_sources(gseurat_core PRIVATE src/engine/debug.cpp)
 target_sources(gseurat_core PRIVATE src/engine/sim_clock.cpp)
 target_sources(gseurat_core PRIVATE src/engine/random.cpp)
 target_sources(gseurat_core PRIVATE src/engine/ecs/events.cpp)
+target_sources(gseurat_core PRIVATE src/engine/render_state.cpp)
 
 if(GSEURAT_SHARED_LIBS)
     target_compile_definitions(gseurat_core PUBLIC GSEURAT_ENGINE_BUILD_SHARED)
@@ -497,6 +498,7 @@ add_gseurat_test(test_pbd_solver)
 add_gseurat_test(test_component_registry src/engine/component_registry.cpp)
 add_gseurat_test(test_system_scheduler  src/engine/system_scheduler.cpp src/engine/ecs/events.cpp)
 add_gseurat_test(test_event_queue       src/engine/system_scheduler.cpp src/engine/ecs/events.cpp)
+add_gseurat_test(test_render_state)
 add_gseurat_test(test_island_systems    src/engine/trigger_systems.cpp
     src/engine/random.cpp
     src/character/character_manifest.cpp

--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -31,6 +31,7 @@
 #include "gseurat/engine/locale_manager.hpp"
 #include "gseurat/engine/minimap.hpp"
 #include "gseurat/engine/particle.hpp"
+#include "gseurat/engine/render_state.hpp"
 #include "gseurat/engine/renderer.hpp"
 #include "gseurat/engine/resource_manager.hpp"
 #include "gseurat/engine/save_system.hpp"
@@ -237,6 +238,14 @@ public:
     // Pending character load (set by load_character command, consumed by StagingState)
     std::string pending_character_path;  // non-empty = load request pending
 
+    // === RenderState contract (Phase 3b) ===
+    // Constructed during main_loop() once VkContext is initialized; reset
+    // in cleanup() before renderer_.shutdown() tears the context down.
+    // Phase 4 PRs migrate producers/consumers onto this contract.
+    RenderState& render_state() { return *render_state_; }
+    const RenderState& render_state() const { return *render_state_; }
+    bool has_render_state() const noexcept { return render_state_ != nullptr; }
+
 protected:
     void init_window();
     virtual void init_game_content();
@@ -290,6 +299,12 @@ protected:
 
     // Debug metrics
     DebugMetrics debug_metrics_;
+
+    // RenderState — constructed lazily in AppBase::main_loop() after the
+    // renderer (and thus VkContext) has been initialised by the subclass.
+    // Held by unique_ptr so its destructor runs deterministically before
+    // VkContext tear-down inside cleanup().
+    std::unique_ptr<RenderState> render_state_;
 
     // Bone pre-upload hook
     std::function<void(glm::mat4*, uint32_t)> bone_pre_upload_hook_;

--- a/include/gseurat/engine/render_state.hpp
+++ b/include/gseurat/engine/render_state.hpp
@@ -1,0 +1,193 @@
+#pragma once
+
+// Phase 3b: RenderState contract.
+//
+// `RenderState` is the typed, persistent-mapped, per-frame-in-flight data
+// contract between ECS systems (which produce data via small typed Writer
+// APIs) and `GsRenderer::render()` (which consumes raw VkBuffer handles).
+//
+// Scope of this PR: infrastructure only — owned by AppBase, but no caller
+// migrates yet. begin_frame/end_frame exist for future use and are not
+// invoked from main_loop in this PR. Phase 4 PRs that wire actual
+// producers will hook them up.
+//
+// Design reference: docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md §5.2
+
+#include "gseurat/engine/buffer.hpp"
+#include "gseurat/engine/types.hpp"
+
+#include <glm/glm.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <span>
+
+namespace gseurat {
+
+class VkContext;
+
+// Strongly-typed frame index. Constructed from a raw uint32_t and
+// implicitly convertible to uint32_t for indexing/comparison.
+enum class FrameIndex : uint32_t {};
+
+constexpr uint32_t to_u32(FrameIndex f) noexcept {
+    return static_cast<uint32_t>(f);
+}
+
+// Inclusive [first, last] tracking — empty when first > last. Touch
+// individual slots via mark(); end_frame() consumes and resets.
+struct DirtyRange {
+    std::size_t first = std::numeric_limits<std::size_t>::max();
+    std::size_t last = 0;
+
+    bool empty() const noexcept { return first > last; }
+
+    void mark(std::size_t slot) noexcept {
+        if (slot < first) first = slot;
+        if (slot > last) last = slot;
+    }
+
+    void clear() noexcept {
+        first = std::numeric_limits<std::size_t>::max();
+        last = 0;
+    }
+};
+
+// Typed slot-indexed writer. Non-owning view over mapped storage and a
+// dirty range. Created on demand by RenderState's *_writer() methods.
+template <typename T>
+class TypedSlotWriter {
+public:
+    TypedSlotWriter() = default;
+    TypedSlotWriter(T* mapped, uint32_t capacity, DirtyRange* dirty) noexcept
+        : mapped_(mapped), capacity_(capacity), dirty_(dirty) {}
+
+    // Out-of-range slots are silently ignored in Release. Phase 4 PRs that
+    // migrate callers will add GS_DBG_INVARIANT here for stricter debug
+    // diagnostics once concrete capacities are settled.
+    void write(uint32_t slot, const T& value) noexcept {
+        if (slot >= capacity_ || mapped_ == nullptr) return;
+        mapped_[slot] = value;
+        if (dirty_) dirty_->mark(slot);
+    }
+
+    uint32_t capacity() const noexcept { return capacity_; }
+    bool valid() const noexcept { return mapped_ != nullptr; }
+
+private:
+    T* mapped_ = nullptr;
+    uint32_t capacity_ = 0;
+    DirtyRange* dirty_ = nullptr;
+};
+
+// Byte-granular writer for fixed-stride splat-style payloads whose
+// concrete C++ type is still in flux (will be unified by Phase 4 once
+// caller migration finalises the GSVX/Gaussian POD layout).
+class BytesSlotWriter {
+public:
+    BytesSlotWriter() = default;
+    BytesSlotWriter(std::byte* mapped, uint32_t capacity, std::size_t stride,
+                    DirtyRange* dirty) noexcept
+        : mapped_(mapped), capacity_(capacity), stride_(stride), dirty_(dirty) {}
+
+    void write_bytes(uint32_t slot, std::span<const std::byte> payload) noexcept {
+        if (slot >= capacity_ || mapped_ == nullptr) return;
+        if (payload.size() != stride_) return;
+        std::memcpy(mapped_ + static_cast<std::size_t>(slot) * stride_,
+                    payload.data(), stride_);
+        if (dirty_) dirty_->mark(slot);
+    }
+
+    // Convenience for callers holding a raw pointer + size pair.
+    void write_at(uint32_t slot, const void* src, std::size_t bytes) noexcept {
+        if (slot >= capacity_ || mapped_ == nullptr) return;
+        if (bytes != stride_) return;
+        std::memcpy(mapped_ + static_cast<std::size_t>(slot) * stride_, src, stride_);
+        if (dirty_) dirty_->mark(slot);
+    }
+
+    uint32_t capacity() const noexcept { return capacity_; }
+    std::size_t stride() const noexcept { return stride_; }
+    bool valid() const noexcept { return mapped_ != nullptr; }
+
+private:
+    std::byte* mapped_ = nullptr;
+    uint32_t capacity_ = 0;
+    std::size_t stride_ = 0;
+    DirtyRange* dirty_ = nullptr;
+};
+
+using BonesWriter = TypedSlotWriter<glm::mat4>;
+using PointLightsWriter = TypedSlotWriter<PointLight>;
+using VfxWriter = BytesSlotWriter;
+using PbdWriter = BytesSlotWriter;
+using ParticlesWriter = BytesSlotWriter;
+
+// Defaults match the spec's working-set estimate (~12 MB for VFX splats,
+// per frame in flight, doubled). Phase 4 may tune per-app needs.
+struct RenderStateConfig {
+    uint32_t max_bone_transforms = 1024;
+    uint32_t max_vfx_splats = 200'000;
+    uint32_t max_pbd_splats = 50'000;
+    uint32_t max_particles = 8'192;
+    uint32_t max_point_lights = kMaxLights;
+    std::size_t splat_stride = 64;  // matches current Gaussian/GSVX layout
+};
+
+class RenderState {
+public:
+    explicit RenderState(VkContext& ctx, const RenderStateConfig& cfg = {});
+    ~RenderState();
+
+    RenderState(const RenderState&) = delete;
+    RenderState& operator=(const RenderState&) = delete;
+    RenderState(RenderState&&) = delete;
+    RenderState& operator=(RenderState&&) = delete;
+
+    // === Writers — called from ECS systems during update() ===
+    BonesWriter bones_writer(FrameIndex) noexcept;
+    VfxWriter vfx_writer(FrameIndex) noexcept;
+    PbdWriter pbd_writer(FrameIndex) noexcept;
+    ParticlesWriter particles_writer(FrameIndex) noexcept;
+    PointLightsWriter point_lights_writer(FrameIndex) noexcept;
+
+    // === Renderer-side read access — const, called from GsRenderer::render() ===
+    VkBuffer bones_buffer(FrameIndex) const noexcept;
+    VkBuffer vfx_buffer(FrameIndex) const noexcept;
+    VkBuffer pbd_buffer(FrameIndex) const noexcept;
+    VkBuffer particles_buffer(FrameIndex) const noexcept;
+    VkBuffer point_lights_buffer(FrameIndex) const noexcept;
+
+    // === Lifecycle ===
+    // begin_frame: resets dirty ranges for the given frame slot.
+    // end_frame:   on non-coherent memory, would issue
+    //              vkFlushMappedMemoryRanges over the dirty regions. On
+    //              Apple Silicon's unified memory it's a no-op.
+    void begin_frame(FrameIndex) noexcept;
+    void end_frame(FrameIndex) noexcept;
+
+    const RenderStateConfig& config() const noexcept { return cfg_; }
+
+private:
+    struct PerFrame {
+        Buffer bones;
+        Buffer vfx;
+        Buffer pbd;
+        Buffer particles;
+        Buffer point_lights;
+        DirtyRange bones_dirty;
+        DirtyRange vfx_dirty;
+        DirtyRange pbd_dirty;
+        DirtyRange particles_dirty;
+        DirtyRange lights_dirty;
+    };
+
+    VkContext& ctx_;
+    RenderStateConfig cfg_;
+    std::array<PerFrame, kMaxFramesInFlight> per_frame_{};
+};
+
+}  // namespace gseurat

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -120,6 +120,12 @@ void AppBase::main_loop() {
             resources_.texture_cache().insert(cache_key, std::move(sp));
         });
 
+    // Phase 3b: RenderState contract. Allocates persistent-mapped storage
+    // buffers per frame-in-flight. No callers consume it yet — Phase 4
+    // PRs will wire producers (BoneAnimationSystem, VfxSystem, ...) and
+    // the renderer through it.
+    render_state_ = std::make_unique<RenderState>(renderer_.context());
+
     // Start control server for bridge integration
     control_server_.start();
 
@@ -548,6 +554,9 @@ void AppBase::cleanup() {
     async_loader_.shutdown();
     staging_uploader_.shutdown();
     audio_engine_.reset();
+    // RenderState owns VMA buffers; must die before renderer_ tears down
+    // the VkContext that owns the allocator.
+    render_state_.reset();
     resources_.shutdown();
     renderer_.shutdown();
     glfwDestroyWindow(window_);

--- a/src/engine/render_state.cpp
+++ b/src/engine/render_state.cpp
@@ -1,0 +1,108 @@
+#include "gseurat/engine/render_state.hpp"
+
+#include "gseurat/engine/vk_context.hpp"
+
+namespace gseurat {
+
+RenderState::RenderState(VkContext& ctx, const RenderStateConfig& cfg)
+    : ctx_(ctx), cfg_(cfg) {
+    VmaAllocator alloc = ctx_.allocator();
+    const VkDeviceSize bones_bytes =
+        static_cast<VkDeviceSize>(cfg_.max_bone_transforms) * sizeof(glm::mat4);
+    const VkDeviceSize vfx_bytes =
+        static_cast<VkDeviceSize>(cfg_.max_vfx_splats) * cfg_.splat_stride;
+    const VkDeviceSize pbd_bytes =
+        static_cast<VkDeviceSize>(cfg_.max_pbd_splats) * cfg_.splat_stride;
+    const VkDeviceSize part_bytes =
+        static_cast<VkDeviceSize>(cfg_.max_particles) * cfg_.splat_stride;
+    const VkDeviceSize light_bytes =
+        static_cast<VkDeviceSize>(cfg_.max_point_lights) * sizeof(PointLight);
+
+    for (auto& f : per_frame_) {
+        f.bones = Buffer::create_storage(alloc, bones_bytes);
+        f.vfx = Buffer::create_storage(alloc, vfx_bytes);
+        f.pbd = Buffer::create_storage(alloc, pbd_bytes);
+        f.particles = Buffer::create_storage(alloc, part_bytes);
+        f.point_lights = Buffer::create_storage(alloc, light_bytes);
+    }
+}
+
+RenderState::~RenderState() {
+    VmaAllocator alloc = ctx_.allocator();
+    if (alloc == VK_NULL_HANDLE) return;  // VkContext already torn down
+    for (auto& f : per_frame_) {
+        f.bones.destroy(alloc);
+        f.vfx.destroy(alloc);
+        f.pbd.destroy(alloc);
+        f.particles.destroy(alloc);
+        f.point_lights.destroy(alloc);
+    }
+}
+
+BonesWriter RenderState::bones_writer(FrameIndex f) noexcept {
+    auto& pf = per_frame_[to_u32(f) % kMaxFramesInFlight];
+    return BonesWriter{static_cast<glm::mat4*>(pf.bones.mapped()),
+                       cfg_.max_bone_transforms, &pf.bones_dirty};
+}
+
+VfxWriter RenderState::vfx_writer(FrameIndex f) noexcept {
+    auto& pf = per_frame_[to_u32(f) % kMaxFramesInFlight];
+    return VfxWriter{static_cast<std::byte*>(pf.vfx.mapped()),
+                     cfg_.max_vfx_splats, cfg_.splat_stride, &pf.vfx_dirty};
+}
+
+PbdWriter RenderState::pbd_writer(FrameIndex f) noexcept {
+    auto& pf = per_frame_[to_u32(f) % kMaxFramesInFlight];
+    return PbdWriter{static_cast<std::byte*>(pf.pbd.mapped()),
+                     cfg_.max_pbd_splats, cfg_.splat_stride, &pf.pbd_dirty};
+}
+
+ParticlesWriter RenderState::particles_writer(FrameIndex f) noexcept {
+    auto& pf = per_frame_[to_u32(f) % kMaxFramesInFlight];
+    return ParticlesWriter{static_cast<std::byte*>(pf.particles.mapped()),
+                           cfg_.max_particles, cfg_.splat_stride,
+                           &pf.particles_dirty};
+}
+
+PointLightsWriter RenderState::point_lights_writer(FrameIndex f) noexcept {
+    auto& pf = per_frame_[to_u32(f) % kMaxFramesInFlight];
+    return PointLightsWriter{static_cast<PointLight*>(pf.point_lights.mapped()),
+                             cfg_.max_point_lights, &pf.lights_dirty};
+}
+
+VkBuffer RenderState::bones_buffer(FrameIndex f) const noexcept {
+    return per_frame_[to_u32(f) % kMaxFramesInFlight].bones.buffer();
+}
+VkBuffer RenderState::vfx_buffer(FrameIndex f) const noexcept {
+    return per_frame_[to_u32(f) % kMaxFramesInFlight].vfx.buffer();
+}
+VkBuffer RenderState::pbd_buffer(FrameIndex f) const noexcept {
+    return per_frame_[to_u32(f) % kMaxFramesInFlight].pbd.buffer();
+}
+VkBuffer RenderState::particles_buffer(FrameIndex f) const noexcept {
+    return per_frame_[to_u32(f) % kMaxFramesInFlight].particles.buffer();
+}
+VkBuffer RenderState::point_lights_buffer(FrameIndex f) const noexcept {
+    return per_frame_[to_u32(f) % kMaxFramesInFlight].point_lights.buffer();
+}
+
+void RenderState::begin_frame(FrameIndex f) noexcept {
+    auto& pf = per_frame_[to_u32(f) % kMaxFramesInFlight];
+    pf.bones_dirty.clear();
+    pf.vfx_dirty.clear();
+    pf.pbd_dirty.clear();
+    pf.particles_dirty.clear();
+    pf.lights_dirty.clear();
+}
+
+void RenderState::end_frame(FrameIndex /*f*/) noexcept {
+    // Buffers are HOST_ACCESS_SEQUENTIAL_WRITE + MAPPED via VMA's
+    // create_storage. On coherent memory (Apple Silicon's unified
+    // memory, most discrete GPUs' HOST_VISIBLE | HOST_COHERENT) writes
+    // are visible to the GPU without an explicit flush — no work to do.
+    //
+    // If a future target exposes non-coherent host memory, this is
+    // where vkFlushMappedMemoryRanges over the dirty ranges would go.
+}
+
+}  // namespace gseurat

--- a/src/engine/render_state.cpp
+++ b/src/engine/render_state.cpp
@@ -4,6 +4,26 @@
 
 namespace gseurat {
 
+namespace {
+
+// Flush the byte range covered by `dr` for a HOST_VISIBLE allocation.
+// vmaFlushAllocation is a no-op when the allocation's memory type is
+// HOST_COHERENT, so this is safe to call unconditionally and correct
+// on platforms where VMA selects non-coherent host memory.
+void flush_dirty(VmaAllocator alloc, VmaAllocation a,
+                 const DirtyRange& dr, std::size_t stride) noexcept {
+    if (dr.empty() || a == VK_NULL_HANDLE || alloc == VK_NULL_HANDLE) return;
+    const VkDeviceSize offset = static_cast<VkDeviceSize>(dr.first) * stride;
+    const VkDeviceSize size =
+        static_cast<VkDeviceSize>(dr.last - dr.first + 1) * stride;
+    // Return value ignored: failure is a device-lost-class event and will
+    // surface through other code paths; we don't have a return channel here.
+    (void)vmaFlushAllocation(alloc, a, offset, size);
+}
+
+}  // namespace
+
+
 RenderState::RenderState(VkContext& ctx, const RenderStateConfig& cfg)
     : ctx_(ctx), cfg_(cfg) {
     VmaAllocator alloc = ctx_.allocator();
@@ -95,14 +115,24 @@ void RenderState::begin_frame(FrameIndex f) noexcept {
     pf.lights_dirty.clear();
 }
 
-void RenderState::end_frame(FrameIndex /*f*/) noexcept {
+void RenderState::end_frame(FrameIndex f) noexcept {
     // Buffers are HOST_ACCESS_SEQUENTIAL_WRITE + MAPPED via VMA's
-    // create_storage. On coherent memory (Apple Silicon's unified
-    // memory, most discrete GPUs' HOST_VISIBLE | HOST_COHERENT) writes
-    // are visible to the GPU without an explicit flush — no work to do.
+    // create_storage. VMA may select either HOST_COHERENT or
+    // non-coherent memory depending on the platform; vmaFlushAllocation
+    // is a no-op in the coherent case (Apple Silicon's unified memory,
+    // typical discrete-GPU HOST_VISIBLE | HOST_COHERENT) and issues the
+    // required vkFlushMappedMemoryRanges otherwise. Calling it
+    // unconditionally is correct everywhere.
     //
-    // If a future target exposes non-coherent host memory, this is
-    // where vkFlushMappedMemoryRanges over the dirty ranges would go.
+    // DirtyRange state is preserved here; begin_frame() clears it when
+    // this slot is reused in a future frame.
+    auto& pf = per_frame_[to_u32(f) % kMaxFramesInFlight];
+    VmaAllocator alloc = ctx_.allocator();
+    flush_dirty(alloc, pf.bones.allocation(),        pf.bones_dirty,     sizeof(glm::mat4));
+    flush_dirty(alloc, pf.vfx.allocation(),          pf.vfx_dirty,       cfg_.splat_stride);
+    flush_dirty(alloc, pf.pbd.allocation(),          pf.pbd_dirty,       cfg_.splat_stride);
+    flush_dirty(alloc, pf.particles.allocation(),    pf.particles_dirty, cfg_.splat_stride);
+    flush_dirty(alloc, pf.point_lights.allocation(), pf.lights_dirty,    sizeof(PointLight));
 }
 
 }  // namespace gseurat

--- a/tests/test_render_state.cpp
+++ b/tests/test_render_state.cpp
@@ -1,0 +1,238 @@
+// Phase 3b: Unit tests for RenderState's writer + DirtyRange + frame
+// isolation logic. Writers are constructed against heap-backed storage
+// so the entire test runs without a VkContext or VMA. RenderState's
+// Vulkan-backed paths are exercised separately by the demo smoke test.
+
+#include "gseurat/engine/render_state.hpp"
+#include "gseurat/engine/types.hpp"
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+using namespace gseurat;
+
+namespace {
+
+// Probe a typed writer against a heap-backed vector. Returns the dirty
+// range produced by writes.
+template <typename T>
+DirtyRange write_through(std::vector<T>& storage, std::span<const std::pair<uint32_t, T>> ops) {
+    DirtyRange dirty;
+    TypedSlotWriter<T> w{storage.data(), static_cast<uint32_t>(storage.size()), &dirty};
+    for (const auto& [slot, value] : ops) {
+        w.write(slot, value);
+    }
+    return dirty;
+}
+
+}  // namespace
+
+int main() {
+    // 1. TypedSlotWriter writes to mapped storage at the correct slot
+    {
+        std::vector<glm::mat4> storage(4, glm::mat4{0.0f});
+        DirtyRange dirty;
+        BonesWriter w{storage.data(), 4, &dirty};
+
+        glm::mat4 m = glm::translate(glm::mat4(1.0f), glm::vec3(1, 2, 3));
+        w.write(2, m);
+
+        assert(storage[0] == glm::mat4{0.0f});
+        assert(storage[1] == glm::mat4{0.0f});
+        assert(storage[2] == m);
+        assert(storage[3] == glm::mat4{0.0f});
+        std::printf("PASS: TypedSlotWriter writes to correct slot\n");
+    }
+
+    // 2. TypedSlotWriter rejects out-of-range slots without writing
+    {
+        std::vector<glm::mat4> storage(4, glm::mat4{0.0f});
+        DirtyRange dirty;
+        BonesWriter w{storage.data(), 4, &dirty};
+
+        glm::mat4 m = glm::translate(glm::mat4(1.0f), glm::vec3(5, 5, 5));
+        w.write(4, m);   // exactly at capacity → reject
+        w.write(99, m);  // far past → reject
+
+        for (const auto& slot : storage) {
+            assert(slot == glm::mat4{0.0f});
+        }
+        assert(dirty.empty());
+        std::printf("PASS: TypedSlotWriter rejects out-of-range slots\n");
+    }
+
+    // 3. DirtyRange spans cover the [min, max] of touched slots
+    {
+        std::vector<glm::mat4> storage(16, glm::mat4{0.0f});
+        DirtyRange dirty;
+        BonesWriter w{storage.data(), 16, &dirty};
+
+        assert(dirty.empty());
+
+        w.write(7, glm::mat4(1.0f));
+        assert(!dirty.empty());
+        assert(dirty.first == 7 && dirty.last == 7);
+
+        w.write(3, glm::mat4(1.0f));
+        assert(dirty.first == 3 && dirty.last == 7);
+
+        w.write(12, glm::mat4(1.0f));
+        assert(dirty.first == 3 && dirty.last == 12);
+
+        dirty.clear();
+        assert(dirty.empty());
+        std::printf("PASS: DirtyRange tracks min/max across writes\n");
+    }
+
+    // 4. Out-of-range writes don't mutate the dirty range
+    {
+        std::vector<glm::mat4> storage(8, glm::mat4{0.0f});
+        DirtyRange dirty;
+        BonesWriter w{storage.data(), 8, &dirty};
+
+        w.write(3, glm::mat4(1.0f));
+        assert(dirty.first == 3 && dirty.last == 3);
+
+        w.write(100, glm::mat4(1.0f));
+        assert(dirty.first == 3 && dirty.last == 3);
+        std::printf("PASS: rejected writes leave DirtyRange intact\n");
+    }
+
+    // 5. BytesSlotWriter writes the right stride at the right offset
+    {
+        constexpr std::size_t kStride = 64;
+        std::vector<std::byte> storage(kStride * 4, std::byte{0});
+        DirtyRange dirty;
+        VfxWriter w{storage.data(), 4, kStride, &dirty};
+
+        std::array<std::byte, kStride> payload;
+        for (std::size_t i = 0; i < kStride; ++i) {
+            payload[i] = static_cast<std::byte>(i + 1);
+        }
+
+        w.write_bytes(2, std::span<const std::byte>{payload.data(), kStride});
+
+        // Slot 0 + 1 + 3 untouched
+        for (std::size_t s : {0u, 1u, 3u}) {
+            for (std::size_t i = 0; i < kStride; ++i) {
+                assert(storage[s * kStride + i] == std::byte{0});
+            }
+        }
+        // Slot 2 contains payload
+        for (std::size_t i = 0; i < kStride; ++i) {
+            assert(storage[2 * kStride + i] == payload[i]);
+        }
+        assert(dirty.first == 2 && dirty.last == 2);
+        std::printf("PASS: BytesSlotWriter writes correct stride/offset\n");
+    }
+
+    // 6. BytesSlotWriter rejects mismatched payload sizes (silent in release)
+    {
+        constexpr std::size_t kStride = 64;
+        std::vector<std::byte> storage(kStride * 2, std::byte{0xAA});
+        DirtyRange dirty;
+        VfxWriter w{storage.data(), 2, kStride, &dirty};
+
+        std::array<std::byte, 32> too_small{};  // half the expected stride
+        w.write_bytes(0, std::span<const std::byte>{too_small.data(), too_small.size()});
+
+        // Storage and dirty range untouched
+        for (auto b : storage) assert(b == std::byte{0xAA});
+        assert(dirty.empty());
+        std::printf("PASS: BytesSlotWriter rejects mismatched payload size\n");
+    }
+
+    // 7. BytesSlotWriter::write_at convenience overload
+    {
+        constexpr std::size_t kStride = 16;
+        std::vector<std::byte> storage(kStride * 2, std::byte{0});
+        DirtyRange dirty;
+        VfxWriter w{storage.data(), 2, kStride, &dirty};
+
+        std::array<uint32_t, 4> data = {0xDEADBEEF, 0xCAFEBABE, 0x12345678, 0x9ABCDEF0};
+        w.write_at(1, data.data(), sizeof(data));
+
+        // Slot 0 untouched
+        for (std::size_t i = 0; i < kStride; ++i) {
+            assert(storage[i] == std::byte{0});
+        }
+        // Slot 1 has the words
+        std::array<uint32_t, 4> readback{};
+        std::memcpy(readback.data(), storage.data() + kStride, kStride);
+        assert(readback[0] == 0xDEADBEEF);
+        assert(readback[3] == 0x9ABCDEF0);
+        assert(dirty.first == 1 && dirty.last == 1);
+        std::printf("PASS: BytesSlotWriter::write_at copies raw bytes\n");
+    }
+
+    // 8. Null-mapped writer is a no-op (defensive — exercises the early return)
+    {
+        DirtyRange dirty;
+        BonesWriter w{nullptr, 4, &dirty};
+        assert(!w.valid());
+        w.write(0, glm::mat4(1.0f));  // must not crash
+        assert(dirty.empty());
+
+        VfxWriter bw{nullptr, 4, 64, &dirty};
+        std::array<std::byte, 64> payload{};
+        bw.write_bytes(0, std::span<const std::byte>{payload.data(), payload.size()});
+        assert(dirty.empty());
+        std::printf("PASS: null-mapped writer is no-op\n");
+    }
+
+    // 9. Frame-in-flight isolation: writes to one frame's dirty range don't
+    //    affect the other. Simulates the per-frame ownership inside
+    //    RenderState by spawning two independent writer + dirty range pairs.
+    {
+        std::array<std::vector<glm::mat4>, kMaxFramesInFlight> storages;
+        std::array<DirtyRange, kMaxFramesInFlight> dirties;
+        for (auto& s : storages) s.assign(8, glm::mat4{0.0f});
+
+        BonesWriter w0{storages[0].data(), 8, &dirties[0]};
+        BonesWriter w1{storages[1].data(), 8, &dirties[1]};
+
+        glm::mat4 m0 = glm::translate(glm::mat4(1.0f), glm::vec3(1));
+        glm::mat4 m1 = glm::translate(glm::mat4(1.0f), glm::vec3(2));
+
+        w0.write(2, m0);
+        w1.write(5, m1);
+
+        // Frame 0 sees its own write only
+        assert(storages[0][2] == m0);
+        assert(storages[0][5] == glm::mat4{0.0f});
+        assert(dirties[0].first == 2 && dirties[0].last == 2);
+
+        // Frame 1 sees its own write only
+        assert(storages[1][5] == m1);
+        assert(storages[1][2] == glm::mat4{0.0f});
+        assert(dirties[1].first == 5 && dirties[1].last == 5);
+        std::printf("PASS: per-frame writers and dirty ranges are isolated\n");
+    }
+
+    // 10. PointLightsWriter (typed for the existing PointLight POD)
+    {
+        std::vector<PointLight> lights(kMaxLights);
+        DirtyRange dirty;
+        PointLightsWriter w{lights.data(), kMaxLights, &dirty};
+
+        PointLight pl;
+        pl.position_and_radius = {10.0f, 5.0f, 3.0f, 7.5f};
+        pl.color = {1.0f, 0.5f, 0.25f, 2.0f};
+        w.write(3, pl);
+
+        assert(lights[3].position_and_radius.w == 7.5f);
+        assert(lights[3].color.r == 1.0f);
+        assert(dirty.first == 3 && dirty.last == 3);
+        std::printf("PASS: PointLightsWriter handles PointLight POD\n");
+    }
+
+    std::printf("\nALL RENDER STATE TESTS PASSED\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

**Phase 3 PR-2 (final Phase 3 PR)** of the engine rebuild (canonical: `docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md` §5.2 + `docs/superpowers/plans/2026-05-02-engine-refactor-phase1-plan.md` PR 3b).

Adds `gseurat::RenderState` — the typed, persistent-mapped, per-frame-in-flight data contract between ECS systems (producers) and `GsRenderer::render()` (consumer). `AppBase` owns it via `unique_ptr` and constructs it once the renderer's `VkContext` is alive. **No callers migrate in this PR** — Phase 4 PRs (4a–4e) will wire actual producers and consumers.

After this PR, **M3 (end of Phase 3) closes.**

## API surface

### Header sketch — `include/gseurat/engine/render_state.hpp`

```cpp
namespace gseurat {

enum class FrameIndex : uint32_t {};

struct DirtyRange {                // inclusive [first, last]
    void mark(std::size_t slot);
    void clear();
    bool empty() const;
};

template <typename T>
class TypedSlotWriter {            // BonesWriter, PointLightsWriter
    void write(uint32_t slot, const T& value);
    uint32_t capacity() const;
};

class BytesSlotWriter {            // VfxWriter, PbdWriter, ParticlesWriter
    void write_bytes(uint32_t slot, std::span<const std::byte>);
    void write_at(uint32_t slot, const void* src, std::size_t bytes);
};

using BonesWriter        = TypedSlotWriter<glm::mat4>;
using PointLightsWriter  = TypedSlotWriter<PointLight>;
using VfxWriter          = BytesSlotWriter;
using PbdWriter          = BytesSlotWriter;
using ParticlesWriter    = BytesSlotWriter;

struct RenderStateConfig { /* per-buffer capacities + splat_stride */ };

class RenderState {
public:
    RenderState(VkContext&, const RenderStateConfig& = {});

    BonesWriter        bones_writer(FrameIndex);
    VfxWriter          vfx_writer(FrameIndex);
    PbdWriter          pbd_writer(FrameIndex);
    ParticlesWriter    particles_writer(FrameIndex);
    PointLightsWriter  point_lights_writer(FrameIndex);

    VkBuffer bones_buffer(FrameIndex) const noexcept;
    /* ... and the others ... */

    void begin_frame(FrameIndex);  // resets dirty ranges
    void end_frame(FrameIndex);    // flushes mapped writes if non-coherent
};

}  // namespace gseurat
```

### Why two writer flavours?

- **Concrete types** (`BonesWriter`, `PointLightsWriter`) — payload is a known POD (`glm::mat4`, existing `PointLight`). Typed `write(slot, value)`.
- **Byte-granular** (`VfxWriter`, `PbdWriter`, `ParticlesWriter`) — splat layout is still in flux (Gaussian/GSVX evolution per Phase 1/2 work). Untyped `write_bytes(slot, span<byte>)` keeps the infra agnostic; Phase 4 PRs can either type these aliases or keep the byte interface, without breaking the public contract here.

## AppBase wiring (minimal)

- New `std::unique_ptr<RenderState> render_state_` member (header).
- Constructed in `AppBase::main_loop()` right after `staging_uploader_.init(...)` — `renderer_.context()` is guaranteed alive at that point (subclass `run()` calls `renderer_.init()` before invoking `main_loop`).
- Reset in `AppBase::cleanup()` **before** `renderer_.shutdown()`, so the VMA destructor runs while the allocator handle is still valid.
- Public accessors: `RenderState& render_state()`, `bool has_render_state()`.
- **`begin_frame` / `end_frame` are intentionally not invoked from `main_loop` in this PR.** They exist on the API and are correct. Phase 4 PRs that wire real producers will add the frame calls at the right moment (after fence wait, before/after system schedule).

## Memory growth

Per spec §3b ("~12 MB for double-buffered dynamic data" — that was the VFX-only estimate; total is larger because we also reserve bones / PBD / particles / lights).

| Buffer | Per-frame size | Note |
|---|---|---|
| Bones (1024 × mat4) | 64 KB | mat4 = 64 B |
| VFX (200K × 64B) | 12.8 MB | matches spec's working set |
| PBD (50K × 64B) | 3.2 MB | trees + cloth |
| Particles (8192 × 64B) | 512 KB | |
| PointLights (8 × 64B) | ~0.5 KB | |
| **Total per frame** | **~16.6 MB** | |
| **Across kMaxFramesInFlight = 2** | **~33 MB** | persistent-mapped storage |

Configurable via `RenderStateConfig` — Phase 4 / per-app tuning can adjust without touching the header.

## Validation

### test_render_state (10/10 pass — Vulkan-free)

Writers are constructed against heap-backed storage so the entire test suite runs without a `VkContext`. The Vulkan-backed buffer creation/destruction path is exercised by the demo smoke (below).

```
PASS: TypedSlotWriter writes to correct slot
PASS: TypedSlotWriter rejects out-of-range slots
PASS: DirtyRange tracks min/max across writes
PASS: rejected writes leave DirtyRange intact
PASS: BytesSlotWriter writes correct stride/offset
PASS: BytesSlotWriter rejects mismatched payload size
PASS: BytesSlotWriter::write_at copies raw bytes
PASS: null-mapped writer is no-op
PASS: per-frame writers and dirty ranges are isolated
PASS: PointLightsWriter handles PointLight POD
```

### Demo smoke

`gseurat_demo` build clean, 10s runtime with full scene load + steady-state render. Zero invariant failures, zero Vulkan validation warnings, zero OOM. RenderState's VMA buffers were allocated through the existing `Buffer::create_storage` path and lived for the whole run.

## Namespace note

Spec §5.2 sketches `namespace gs`. The codebase uses `gseurat::` throughout (matches PR #429's `gseurat::ecs::EventQueue`). Aligned with the existing convention rather than introducing a parallel namespace.

## What this closes

Closes Phase 3 PR-2 / `refactor/3b-render-state`. **M3 (end of Phase 3)** is now closed:

| Actionable | PR | Status |
|---|---|---|
| `EventQueue<T>` + `World::events<T>()` + scheduler rotation | #429 | ✅ Merged |
| `RenderState` + writers + AppBase ownership | **this PR** | 🟡 In review |

Next: **Phase 4 — caller migration.** PR 4a (`refactor/4a-cmd-events`) wires `CommandDispatcher::handle_vfx_spawn` through `world.events<VfxSpawnEvent>()` and introduces `VfxSystem` as the consumer.

## Test plan

- [ ] CI green (all platforms build, tests pass)
- [ ] Local: `cmake --build --preset macos-debug --target test_render_state && ./build/macos-debug/test_render_state` — all 10 pass
- [ ] Local: `cmake --build --preset macos-debug --target gseurat_demo && ./build/macos-debug/gseurat_demo` — runs ≥10s clean
- Harness regression deferred: RenderState's runtime path is unused by any caller, so compute/render output is pixel-identical by construction. Harness will exercise this in Phase 4 caller-migration PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
