### PR TITLE
refactor(engine): unified gs::log API retiring Diag::Watchdog fprintf pattern

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,7 @@ target_compile_definitions(gseurat_core PUBLIC
 )
 
 target_sources(gseurat_core PRIVATE src/engine/debug.cpp)
+target_sources(gseurat_core PRIVATE src/engine/log.cpp)
 target_sources(gseurat_core PRIVATE src/engine/sim_clock.cpp)
 target_sources(gseurat_core PRIVATE src/engine/random.cpp)
 target_sources(gseurat_core PRIVATE src/engine/ecs/events.cpp)
@@ -629,6 +630,7 @@ function(add_gseurat_gpu_test NAME)
         tests/onesweep_test_runner.cpp
         src/engine/vk_context.cpp
         src/engine/debug.cpp
+        src/engine/log.cpp
         src/engine/sim_clock.cpp
         src/engine/random.cpp
         src/engine/buffer.cpp

--- a/include/gseurat/engine/debug.hpp
+++ b/include/gseurat/engine/debug.hpp
@@ -40,7 +40,8 @@ enum class Diag : std::uint16_t {
   ChunkInventory,    // GS_DIAG_CHUNKS
   RenderStateSlots,  // GS_DIAG_RENDERSTATE
   EventQueueSizes,   // GS_DIAG_EVENTS
-  Watchdog,          // GS_DIAG_WATCHDOG — per-frame [loop/wd] / [draw_scene/wd] traces
+  // Watchdog was retired — per-frame traces moved to gs::log::Category::Frame
+  // (env GS_LOG_FRAME=1). See include/gseurat/engine/log.hpp.
   COUNT_
 };
 

--- a/include/gseurat/engine/log.hpp
+++ b/include/gseurat/engine/log.hpp
@@ -1,0 +1,61 @@
+// include/gseurat/engine/log.hpp
+//
+// Structured engine logging — replaces the ad-hoc
+// `#if GSEURAT_DEBUG_BUILD + if (Diag::Watchdog) + fprintf(stderr,...)` pattern
+// that scattered through the frame-hot paths and caused pipe-fill deadlocks
+// when the regression harness captured stderr via subprocess.PIPE.
+//
+// Pattern:
+//   GS_LOG_FRAME("[loop/wd] iter_start tick={}", tick_);   // std::format-style
+//
+// Compile-time: the macro expands to ((void)0) outside GSEURAT_DEBUG_BUILD.
+// Runtime:      env GS_LOG_FRAME=1 enables Category::Frame at startup.
+// Sink:         default stderr; env GS_LOG_SINK=/path redirects to a file.
+#pragma once
+
+#include <cstdint>
+#include <format>
+#include <string_view>
+#include <utility>
+
+#ifndef GSEURAT_DEBUG_BUILD
+#  define GSEURAT_DEBUG_BUILD 0
+#endif
+
+namespace gs::log {
+
+enum class Category : std::uint8_t {
+  Frame,   // per-frame watchdog traces (env: GS_LOG_FRAME=1)
+  COUNT_
+};
+
+enum class Level : std::uint8_t { Trace, Info, Warn, Error };
+
+bool enabled(Category) noexcept;
+
+// Non-template impl lives in log.cpp so callers don't drag <format>'s
+// instantiations through every TU more than necessary.
+void logf_impl(Level, Category, std::string_view fmt,
+               std::format_args args) noexcept;
+
+template <typename... Args>
+inline void logf(Level lvl, Category cat,
+                 std::format_string<Args...> fmt, Args&&... args) noexcept {
+  if (!enabled(cat)) return;
+  logf_impl(lvl, cat, fmt.get(),
+            std::make_format_args(args...));
+}
+
+// Lifecycle — call once at startup (alongside gs::dbg::init_diag_registry)
+// and once at shutdown. Both are idempotent.
+void init_log() noexcept;
+void shutdown_log() noexcept;
+
+}  // namespace gs::log
+
+#if GSEURAT_DEBUG_BUILD
+  #define GS_LOG_FRAME(...) \
+    ::gs::log::logf(::gs::log::Level::Trace, ::gs::log::Category::Frame, __VA_ARGS__)
+#else
+  #define GS_LOG_FRAME(...) ((void)0)
+#endif

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -1,5 +1,6 @@
 #include "gseurat/engine/app_base.hpp"
 #include "gseurat/engine/debug.hpp"
+#include "gseurat/engine/log.hpp"
 #include "gseurat/engine/sim_clock.hpp"
 #include "gseurat/engine/debug_dump_eyes.hpp"
 #include "gseurat/engine/debug_dump_ears.hpp"
@@ -258,10 +259,8 @@ void AppBase::main_loop() {
            !g_shutdown_requested.load(std::memory_order_relaxed)) {
 #if GSEURAT_DEBUG_BUILD
         const auto t_iter_start = std::chrono::steady_clock::now();
-        if (gs::dbg::enabled(gs::dbg::Diag::Watchdog)) {
-            std::fprintf(stderr, "[loop/wd] iter_start tick=%u\n", tick_);
-        }
 #endif
+        GS_LOG_FRAME("[loop/wd] iter_start tick={}", tick_);
         glfwPollEvents();
 
         // Poll control server for bridge commands
@@ -368,10 +367,8 @@ void AppBase::main_loop() {
         world_.rotate_events();
 #if GSEURAT_DEBUG_BUILD
         const auto t_after_update = std::chrono::steady_clock::now();
-        if (gs::dbg::enabled(gs::dbg::Diag::Watchdog)) {
-            std::fprintf(stderr, "[loop/wd] post_update tick=%u\n", tick_);
-        }
 #endif
+        GS_LOG_FRAME("[loop/wd] post_update tick={}", tick_);
 
         // Broadcast camera state to subscribed clients (throttled to 30 Hz)
         camera_broadcast_timer_ += dt;
@@ -424,19 +421,13 @@ void AppBase::main_loop() {
             ui_ctx_.begin_frame(ui_input);
         }
 
-#if GSEURAT_DEBUG_BUILD
-        if (gs::dbg::enabled(gs::dbg::Diag::Watchdog)) {
-            std::fprintf(stderr, "[loop/wd] before_build_draw_lists tick=%u\n", tick_);
-        }
-#endif
+        GS_LOG_FRAME("[loop/wd] before_build_draw_lists tick={}", tick_);
         // Let states build their draw lists
         state_stack_.build_draw_lists(*this);
 #if GSEURAT_DEBUG_BUILD
         const auto t_after_build_draw_lists = std::chrono::steady_clock::now();
-        if (gs::dbg::enabled(gs::dbg::Diag::Watchdog)) {
-            std::fprintf(stderr, "[loop/wd] after_build_draw_lists tick=%u\n", tick_);
-        }
 #endif
+        GS_LOG_FRAME("[loop/wd] after_build_draw_lists tick={}", tick_);
 
         // Loading/Warming overlay (after the active state's draw lists are
         // built so the overlay paints over them). Default AppBase impl is a
@@ -503,34 +494,29 @@ void AppBase::main_loop() {
         // skips them entirely; Warming dispatches them to flush driver state
         // against freshly-uploaded buffers; Playing is the steady state.
         const bool dispatch_gpu_compute = loading_monitor_.should_dispatch_gpu_work();
-#if GSEURAT_DEBUG_BUILD
-        if (gs::dbg::enabled(gs::dbg::Diag::Watchdog)) {
-            std::fprintf(stderr, "[loop/wd] before_draw_scene tick=%u dispatch=%d\n",
-                         tick_, dispatch_gpu_compute ? 1 : 0);
-        }
-#endif
+        GS_LOG_FRAME("[loop/wd] before_draw_scene tick={} dispatch={}",
+                     tick_, dispatch_gpu_compute ? 1 : 0);
         renderer_.draw_scene(scene_, draw_lists_.entity, draw_lists_.outline, draw_lists_.reflection,
                              draw_lists_.shadow, particle_sprites, draw_lists_.overlay, ui_batches,
                              draw_lists_.debug_colliders, feature_flags_, dispatch_gpu_compute);
 #if GSEURAT_DEBUG_BUILD
         const auto t_after_draw_scene = std::chrono::steady_clock::now();
-        if (gs::dbg::enabled(gs::dbg::Diag::Watchdog)) {
-            std::fprintf(stderr, "[loop/wd] after_draw_scene tick=%u\n", tick_);
-        }
+#endif
+        GS_LOG_FRAME("[loop/wd] after_draw_scene tick={}", tick_);
 
+#if GSEURAT_DEBUG_BUILD
         const double iter_total_ms = std::chrono::duration<double, std::milli>(
             t_after_draw_scene - t_iter_start).count();
-        if (iter_total_ms > 100.0 && gs::dbg::enabled(gs::dbg::Diag::Watchdog)) {
+        if (iter_total_ms > 100.0) {
             const double pre_update_ms = std::chrono::duration<double, std::milli>(
                 t_after_update - t_iter_start).count();
             const double draw_lists_ms = std::chrono::duration<double, std::milli>(
                 t_after_build_draw_lists - t_after_update).count();
             const double draw_scene_ms = std::chrono::duration<double, std::milli>(
                 t_after_draw_scene - t_after_build_draw_lists).count();
-            std::fprintf(stderr,
-                "[loop/wd/SLOW] tick=%u total=%.1fms "
-                "phases pre_update=%.1f draw_lists=%.1f draw_scene=%.1f\n",
-                tick_, iter_total_ms, pre_update_ms, draw_lists_ms, draw_scene_ms);
+            GS_LOG_FRAME("[loop/wd/SLOW] tick={} total={:.1f}ms "
+                         "phases pre_update={:.1f} draw_lists={:.1f} draw_scene={:.1f}",
+                         tick_, iter_total_ms, pre_update_ms, draw_lists_ms, draw_scene_ms);
         }
 #endif
 

--- a/src/engine/debug.cpp
+++ b/src/engine/debug.cpp
@@ -23,7 +23,6 @@ constexpr const char* env_var_for(Diag d) noexcept {
     case Diag::ChunkInventory:   return "GS_DIAG_CHUNKS";
     case Diag::RenderStateSlots: return "GS_DIAG_RENDERSTATE";
     case Diag::EventQueueSizes:  return "GS_DIAG_EVENTS";
-    case Diag::Watchdog:         return "GS_DIAG_WATCHDOG";
     case Diag::COUNT_:           break;
   }
   return "";

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1,5 +1,6 @@
 #include "gseurat/engine/gs_renderer.hpp"
 #include "gseurat/engine/debug.hpp"
+#include "gseurat/engine/log.hpp"
 #include "gseurat/engine/pipeline.hpp"
 #include "gseurat/engine/render_state.hpp"
 #include "gseurat/engine/scoped_timer.hpp"
@@ -3669,18 +3670,17 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
 #if GSEURAT_DEBUG_BUILD
         const auto t_wait_end = std::chrono::steady_clock::now();
         const double wait_ms = std::chrono::duration<double, std::milli>(t_wait_end - t_wait_start).count();
-        if (wait_ms > 100.0 && ::gs::dbg::enabled(::gs::dbg::Diag::Watchdog)) {
+        if (wait_ms > 100.0) {
             float prev_depth_ms = (ts_result == VK_SUCCESS && ts[1] > ts[0])
                 ? static_cast<float>(ts[1] - ts[0]) * timestamp_period_ns_ / 1e6f : -1.0f;
             float prev_tile_ms = (ts_result == VK_SUCCESS && ts[3] > ts[2])
                 ? static_cast<float>(ts[3] - ts[2]) * timestamp_period_ns_ / 1e6f : -1.0f;
             float prev_raster_ms = (ts_result == VK_SUCCESS && ts[5] > ts[4])
                 ? static_cast<float>(ts[5] - ts[4]) * timestamp_period_ns_ / 1e6f : -1.0f;
-            std::fprintf(stderr,
-                "[gs_render/wd/WAIT_SLOW] wait_ms=%.1f prev_depth=%.1fms prev_tile=%.1fms prev_raster=%.1fms "
-                "static=%u dyn=%u total=%u\n",
-                wait_ms, prev_depth_ms, prev_tile_ms, prev_raster_ms,
-                static_count_, dynamic_count_, gaussian_count_);
+            GS_LOG_FRAME("[gs_render/wd/WAIT_SLOW] wait_ms={:.1f} prev_depth={:.1f}ms prev_tile={:.1f}ms prev_raster={:.1f}ms "
+                         "static={} dyn={} total={}",
+                         wait_ms, prev_depth_ms, prev_tile_ms, prev_raster_ms,
+                         static_count_, dynamic_count_, gaussian_count_);
         }
 #endif
         if (ts_result == VK_SUCCESS && ts[5] > ts[4] && ts[3] > ts[2] && ts[1] > ts[0]) {
@@ -3698,10 +3698,8 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
                 float d_avg = depth_sort_ms_accum_ / static_cast<float>(kTimestampAvgFrames);
                 float t_avg = tile_sort_ms_accum_ / static_cast<float>(kTimestampAvgFrames);
                 float r_avg = rasterize_ms_accum_ / static_cast<float>(kTimestampAvgFrames);
-                if (::gs::dbg::enabled(::gs::dbg::Diag::Watchdog)) {
-                    std::fprintf(stderr, "[gs_renderer] DepthSort: %.3f ms  TileSort: %.3f ms  Rasterize: %.3f ms  Total: %.3f ms (avg %u frames)\n",
-                                 d_avg, t_avg, r_avg, d_avg + t_avg + r_avg, kTimestampAvgFrames);
-                }
+                GS_LOG_FRAME("[gs_renderer] DepthSort: {:.3f} ms  TileSort: {:.3f} ms  Rasterize: {:.3f} ms  Total: {:.3f} ms (avg {} frames)",
+                             d_avg, t_avg, r_avg, d_avg + t_avg + r_avg, kTimestampAvgFrames);
                 depth_sort_ms_avg_ = d_avg;
                 tile_sort_ms_avg_ = t_avg;
                 rasterize_ms_avg_ = r_avg;

--- a/src/engine/log.cpp
+++ b/src/engine/log.cpp
@@ -1,0 +1,82 @@
+// src/engine/log.cpp
+#include "gseurat/engine/log.hpp"
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+
+namespace gs::log {
+
+namespace {
+
+std::array<bool, static_cast<std::size_t>(Category::COUNT_)> g_enabled{};
+std::FILE* g_sink = nullptr;
+bool g_sink_owned = false;
+std::mutex g_mutex;
+
+constexpr const char* env_var_for(Category c) noexcept {
+  switch (c) {
+    case Category::Frame:  return "GS_LOG_FRAME";
+    case Category::COUNT_: break;
+  }
+  return "";
+}
+
+}  // namespace
+
+bool enabled(Category c) noexcept {
+  const auto idx = static_cast<std::size_t>(c);
+  return idx < g_enabled.size() && g_enabled[idx];
+}
+
+void logf_impl(Level /*lvl*/, Category /*cat*/, std::string_view fmt,
+               std::format_args args) noexcept {
+  try {
+    std::string line = std::vformat(fmt, args);
+    std::lock_guard<std::mutex> lk(g_mutex);
+    std::FILE* sink = g_sink ? g_sink : stderr;
+    std::fwrite(line.data(), 1, line.size(), sink);
+    std::fputc('\n', sink);
+  } catch (...) {
+    // Logging must never throw out of a callee. Swallow formatting errors.
+  }
+}
+
+void init_log() noexcept {
+  for (std::size_t i = 0; i < g_enabled.size(); ++i) {
+    const char* var = env_var_for(static_cast<Category>(i));
+    if (var[0] == '\0') continue;
+    const char* val = std::getenv(var);
+    g_enabled[i] = (val && val[0] == '1');
+  }
+
+  // Sink selection — env var redirects to a file (append mode). On open
+  // failure we silently fall back to stderr; logging must not fail loudly.
+  const char* sink_path = std::getenv("GS_LOG_SINK");
+  if (sink_path && sink_path[0] != '\0') {
+    std::FILE* f = std::fopen(sink_path, "ab");
+    if (f) {
+      std::lock_guard<std::mutex> lk(g_mutex);
+      g_sink = f;
+      g_sink_owned = true;
+      return;
+    }
+  }
+  std::lock_guard<std::mutex> lk(g_mutex);
+  g_sink = stderr;
+  g_sink_owned = false;
+}
+
+void shutdown_log() noexcept {
+  std::lock_guard<std::mutex> lk(g_mutex);
+  if (g_sink_owned && g_sink) {
+    std::fclose(g_sink);
+  }
+  g_sink = nullptr;
+  g_sink_owned = false;
+}
+
+}  // namespace gs::log

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -1,5 +1,6 @@
 #include "gseurat/engine/renderer.hpp"
 #include "gseurat/engine/debug.hpp"
+#include "gseurat/engine/log.hpp"
 #include "gseurat/engine/pipeline.hpp"
 #include "gseurat/engine/procedural_textures.hpp"
 #include "gseurat/engine/project_root.hpp"
@@ -404,10 +405,8 @@ void Renderer::draw_scene(Scene& scene,
                            const std::vector<DebugColliderDrawInfo>& debug_colliders_list,
                            const FeatureFlags& flags,
                            bool dispatch_gpu_compute) {
+    GS_LOG_FRAME("[draw_scene/wd] entry current_frame={}", current_frame_);
 #if GSEURAT_DEBUG_BUILD
-    if (gs::dbg::enabled(gs::dbg::Diag::Watchdog)) {
-        std::fprintf(stderr, "[draw_scene/wd] entry current_frame=%u\n", current_frame_);
-    }
     const auto t_ds_entry = std::chrono::steady_clock::now();
 #endif
     auto device = context_.device();
@@ -459,10 +458,9 @@ void Renderer::draw_scene(Scene& scene,
             "main-thread blocked on prior frame's GPU work; retrying with infinite timeout\n",
             fence_ms, current_frame_);
         vkWaitForFences(device, 1, &frame_sync.in_flight, VK_TRUE, UINT64_MAX);
-    } else if (fence_ms > 50.0 && gs::dbg::enabled(gs::dbg::Diag::Watchdog)) {
-        std::fprintf(stderr,
-            "[renderer/watchdog] vkWaitForFences slow: %.2f ms (current_frame=%u)\n",
-            fence_ms, current_frame_);
+    } else if (fence_ms > 50.0) {
+        GS_LOG_FRAME("[renderer/watchdog] vkWaitForFences slow: {:.2f} ms (current_frame={})",
+                     fence_ms, current_frame_);
     }
 
     uint32_t image_index;
@@ -480,9 +478,8 @@ void Renderer::draw_scene(Scene& scene,
             acquire_ms);
         vkAcquireNextImageKHR(device, swapchain_.swapchain(), UINT64_MAX, acquire_sem,
                               VK_NULL_HANDLE, &image_index);
-    } else if (acquire_ms > 50.0 && gs::dbg::enabled(gs::dbg::Diag::Watchdog)) {
-        std::fprintf(stderr,
-            "[renderer/watchdog] vkAcquireNextImageKHR slow: %.2f ms\n", acquire_ms);
+    } else if (acquire_ms > 50.0) {
+        GS_LOG_FRAME("[renderer/watchdog] vkAcquireNextImageKHR slow: {:.2f} ms", acquire_ms);
     }
 #else
     vkWaitForFences(device, 1, &frame_sync.in_flight, VK_TRUE, UINT64_MAX);
@@ -953,7 +950,7 @@ void Renderer::draw_scene(Scene& scene,
 
     const double draw_total_ms = std::chrono::duration<double, std::milli>(
         t_ds_post_present - t_ds_entry).count();
-    if (draw_total_ms > 100.0 && gs::dbg::enabled(gs::dbg::Diag::Watchdog)) {
+    if (draw_total_ms > 100.0) {
         const double setup_ms = std::chrono::duration<double, std::milli>(
             t_ds_pre_poll - t_ds_entry).count();
         const double poll_ms = std::chrono::duration<double, std::milli>(
@@ -974,13 +971,12 @@ void Renderer::draw_scene(Scene& scene,
             t_ds_pre_end - t_ds_post_pp).count();
         const double end_cmdbuf_ms = std::chrono::duration<double, std::milli>(
             t_ds_post_end - t_ds_pre_end).count();
-        std::fprintf(stderr,
-            "[draw_scene/wd/SLOW] frame=%u total=%.1fms "
-            "setup=%.1f poll_xfers=%.1f gs_prepass=%.1f scene_pass=%.1f post_process=%.1f composite=%.1f end_cmdbuf=%.1f "
-            "submit=%.1f post_submit=%.1f present=%.1f\n",
-            current_frame_, draw_total_ms,
-            setup_ms, poll_ms, prepass_ms, prepass_to_pp_ms, post_process_ms, pp_to_end_ms, end_cmdbuf_ms,
-            submit_ms, post_submit_to_present_ms, present_ms);
+        GS_LOG_FRAME("[draw_scene/wd/SLOW] frame={} total={:.1f}ms "
+                     "setup={:.1f} poll_xfers={:.1f} gs_prepass={:.1f} scene_pass={:.1f} post_process={:.1f} composite={:.1f} end_cmdbuf={:.1f} "
+                     "submit={:.1f} post_submit={:.1f} present={:.1f}",
+                     current_frame_, draw_total_ms,
+                     setup_ms, poll_ms, prepass_ms, prepass_to_pp_ms, post_process_ms, pp_to_end_ms, end_cmdbuf_ms,
+                     submit_ms, post_submit_to_present_ms, present_ms);
     }
 #endif
 
@@ -1439,18 +1435,17 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
 
         const double total_ms = std::chrono::duration<double, std::milli>(
             t_prepass_end - t_prepass_start).count();
-        if (total_ms > 100.0 && gs::dbg::enabled(gs::dbg::Diag::Watchdog)) {
+        if (total_ms > 100.0) {
             const double cpu_gather_ms = std::chrono::duration<double, std::milli>(
                 t_prepass_pre_render - t_prepass_start).count();
             const double gs_render_ms = std::chrono::duration<double, std::milli>(
                 t_prepass_end - t_prepass_pre_render).count();
             const size_t emitter_count = gs_particle_emitters_.size();
             const size_t vfx_count = vfx_instances_.size();
-            std::fprintf(stderr,
-                "[gs_prepass/wd/SLOW] total=%.1fms cpu_gather=%.1f gs_render=%.1f "
-                "dyn_count=%u emitters=%zu vfx_inst=%zu static_dirty=%d\n",
-                total_ms, cpu_gather_ms, gs_render_ms, dbg_dyn_count,
-                emitter_count, vfx_count, gs_static_force_dirty_ ? 1 : 0);
+            GS_LOG_FRAME("[gs_prepass/wd/SLOW] total={:.1f}ms cpu_gather={:.1f} gs_render={:.1f} "
+                         "dyn_count={} emitters={} vfx_inst={} static_dirty={}",
+                         total_ms, cpu_gather_ms, gs_render_ms, dbg_dyn_count,
+                         emitter_count, vfx_count, gs_static_force_dirty_ ? 1 : 0);
         }
 #endif
     }

--- a/src/engine/vk_context.cpp
+++ b/src/engine/vk_context.cpp
@@ -2,6 +2,7 @@
 #include "gseurat/engine/vk_context.hpp"
 
 #include "gseurat/engine/debug.hpp"
+#include "gseurat/engine/log.hpp"
 #include "gseurat/engine/project_root.hpp"
 
 #include <cstdio>
@@ -27,6 +28,7 @@ void VkContext::init(GLFWwindow* window) {
     setup_debug_messenger();
     gs::dbg::init_function_pointers(instance_);
     gs::dbg::init_diag_registry();
+    gs::log::init_log();
     create_surface(window);
     pick_physical_device();
     create_logical_device();
@@ -40,6 +42,7 @@ void VkContext::init_headless() {
     setup_debug_messenger();
     gs::dbg::init_function_pointers(instance_);
     gs::dbg::init_diag_registry();
+    gs::log::init_log();
     pick_physical_device_headless();
     create_logical_device_headless();
     create_allocator();
@@ -86,6 +89,8 @@ void VkContext::shutdown() {
 #endif
 
     vkDestroyInstance(instance_, nullptr);
+
+    gs::log::shutdown_log();
 }
 
 void VkContext::create_instance() {


### PR DESCRIPTION
## Summary

Structural follow-up to Phase 4b (PR #432, `project_logging_refactor_followup.md` in memory). Retires the `#if GSEURAT_DEBUG_BUILD + if (gs::dbg::Diag::Watchdog) + fprintf(stderr,...)` pattern that caused the harness pipe-fill deadlock during Phase 4b validation.

- **New API** `include/gseurat/engine/log.hpp`: `gs::log::Category::Frame` (env: `GS_LOG_FRAME=1`), `GS_LOG_FRAME(...)` macro using `std::format`, hard-elided to `((void)0)` outside `GSEURAT_DEBUG_BUILD`.
- **Sink redirect**: `GS_LOG_SINK=/path/to/file` routes logs to disk — the long-term cure for harness pipe-fill (no buffering risk regardless of log volume).
- **14 sites migrated**: app_base.cpp (7), renderer.cpp (5), gs_renderer.cpp (2).
- **`Diag::Watchdog` retired** — `GS_DIAG_WATCHDOG=1` stops working; use `GS_LOG_FRAME=1`.
- **Harness drain workaround kept** as defense in depth.

Out of scope: the ~195 init/error-path `fprintf` calls. Those don't fire per frame and aren't a deadlock risk; bulk cleanup can come later if anyone wants it.

## Test plan

- [x] `cmake --build --preset macos-debug` clean
- [x] `cmake --build --preset macos-release` clean
- [x] `cmake --build --preset macos-release-with-diag` clean
- [x] Default 3s demo smoke — no Vulkan errors, 0 watchdog lines on stderr (gate works)
- [x] `GS_LOG_FRAME=1` 3s smoke — 1274 watchdog lines emitted, format renders correctly
- [x] `GS_LOG_FRAME=1 GS_LOG_SINK=/tmp/x` 3s smoke — 1309 lines to file, **0 on stderr** (harness deadlock cure)
- [ ] No harness `--self-check`. Engine output is mechanically equivalent (same data, different sink); harness adds no signal here and the Apple Silicon SSIM methodology is task #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)