### PR TITLE
refactor(engine): migrate PBD splats out of Renderer to PbdSystem (Phase 4c-pbd)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,7 @@ target_sources(gseurat_core PRIVATE src/engine/random.cpp)
 target_sources(gseurat_core PRIVATE src/engine/ecs/events.cpp)
 target_sources(gseurat_core PRIVATE src/engine/render_state.cpp)
 target_sources(gseurat_core PRIVATE src/engine/systems/vfx_system.cpp)
+target_sources(gseurat_core PRIVATE src/engine/systems/pbd_system.cpp)
 
 if(GSEURAT_SHARED_LIBS)
     target_compile_definitions(gseurat_core PUBLIC GSEURAT_ENGINE_BUILD_SHARED)

--- a/include/gseurat/demo/island_demo_state.hpp
+++ b/include/gseurat/demo/island_demo_state.hpp
@@ -22,6 +22,7 @@
 
 namespace gseurat {
 
+class AppBase;
 class Renderer;
 
 class IslandDemoState : public GameState {
@@ -54,7 +55,7 @@ private:
     void update_walk_animation(AppBase& app, float dt);
     void update_environment_animation(AppBase& app, float dt);
     void step_pbd_chain(float dt);
-    void gather_pbd_chain(Renderer& renderer);
+    void gather_pbd_chain(AppBase& app);
     void draw_gizmos(AppBase& app);
 
     // Scene

--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -41,6 +41,7 @@
 #include "gseurat/engine/staging_uploader.hpp"
 #include "gseurat/engine/scene.hpp"
 #include "gseurat/engine/screen_effects.hpp"
+#include "gseurat/engine/systems/pbd_system.hpp"
 #include "gseurat/engine/systems/transition_system.hpp"
 #include "gseurat/engine/systems/vfx_system.hpp"
 #include "gseurat/engine/weather_system.hpp"
@@ -94,6 +95,10 @@ public:
     // it later than this accessor's first plausible use site.
     systems::VfxSystem* vfx_system() { return vfx_system_.get(); }
     const systems::VfxSystem* vfx_system() const { return vfx_system_.get(); }
+    // Phase 4c-pbd: PBD splat state ownership lives here too. Same
+    // late-construction caveat — null until init_game_object_system runs.
+    systems::PbdSystem* pbd_system() { return pbd_system_.get(); }
+    const systems::PbdSystem* pbd_system() const { return pbd_system_.get(); }
     ResourceManager& resources() { return resources_; }
     Scene& scene() { return scene_; }
     ecs::World& world() { return world_; }
@@ -321,6 +326,11 @@ protected:
     // re-process events across frames. Registered with system_scheduler_
     // in init_game_object_system().
     std::unique_ptr<systems::VfxSystem> vfx_system_;
+
+    // Phase 4c-pbd: PBD splat owner. Constructed alongside vfx_system_
+    // in init_game_object_system; render_state binding late-binds the
+    // same way as VfxSystem.
+    std::unique_ptr<systems::PbdSystem> pbd_system_;
 
     // Bone pre-upload hook (Phase 4b: writer API). Game-specific code
     // installs this to fill specific bone slots (e.g. the player's bones)

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -138,24 +138,32 @@ public:
     void update_gaussian_data(const Gaussian* data, uint32_t count);
 
     // Per-frame dynamic upload API (CPU-sourced transient: particles,
-    // scene anims, pending dynamics). Writes at offset
-    // `persistent_dyn_count_ + vfx_prefix`; sets dynamic_count_ to
-    // `persistent_dyn_count_ + vfx_prefix + count`. Static geometry
-    // (terrain) arrives via load_cloud_async + publish_pending_chunks.
+    // scene anims). Writes at offset `persistent_dyn_count_ + gpu_prefix`
+    // and sets dynamic_count_ to `persistent_dyn_count_ + gpu_prefix +
+    // count`. Static geometry (terrain) arrives via load_cloud_async +
+    // publish_pending_chunks.
     //
-    // `vfx_prefix` is the number of slots already filled at offset
-    // `persistent_dyn_count_` by the GPU compose pass (4c-vfx). Callers
-    // that don't run the compose pass pass 0 (default) and behave as
-    // before.
+    // `gpu_prefix` is the number of slots already filled at offset
+    // `persistent_dyn_count_` by GPU compose passes (4c-vfx + 4c-pbd =
+    // vfx_count + pbd_count). Callers that don't run any compose pass
+    // pass 0 (default) and behave as before.
     void update_dynamic_gaussians(const Gaussian* data, uint32_t count,
-                                  uint32_t vfx_prefix = 0);
+                                  uint32_t gpu_prefix = 0);
 
-    // Phase 4c-vfx: GPU compose pass. Copies `vfx_count` slots from
-    // RenderState's vfx_buffer (bound via set_render_state) into
-    // dynamic_gaussian_ssbo at offset `persistent_dyn_count_`. Must be
-    // called BEFORE update_dynamic_gaussians on the same frame.
+    // Phase 4c-vfx: GPU compose pass for VFX splats. Copies `vfx_count`
+    // slots from RenderState's vfx_buffer (bound via set_render_state)
+    // into dynamic_gaussian_ssbo at offset `persistent_dyn_count_`.
+    // Must be called BEFORE update_dynamic_gaussians on the same frame.
     void dispatch_compose_vfx(VkCommandBuffer cmd, FrameIndex frame_idx,
                               uint32_t vfx_count);
+
+    // Phase 4c-pbd: GPU compose pass for PBD splats. Copies `pbd_count`
+    // slots from RenderState's pbd_buffer into dynamic_gaussian_ssbo at
+    // offset `persistent_dyn_count_ + vfx_count`. Must be called AFTER
+    // dispatch_compose_vfx (so the offset is correct) and BEFORE
+    // update_dynamic_gaussians on the same frame.
+    void dispatch_compose_pbd(VkCommandBuffer cmd, FrameIndex frame_idx,
+                              uint32_t vfx_count, uint32_t pbd_count);
 
     // Once-per-scene (or per-chunk-event) upload API for the "persistent prefix"
     // of the dynamic buffer: characters, NPCs, PBD-tagged trees. Replaces all
@@ -669,16 +677,20 @@ private:
     VkPipeline pbd_pipeline_ = VK_NULL_HANDLE;
     VkDescriptorSet pbd_set_ = VK_NULL_HANDLE;
 
-    // Phase 4c-vfx: GPU compose pass. Dedicated descriptor pool so the
-    // central kSetCount=58 allocation in dispatch_descriptor_sets doesn't
-    // get reshuffled. Two sets total (one per frame in flight).
+    // Phase 4c-vfx / 4c-pbd: GPU compose pass. Dedicated descriptor pool
+    // so the central kSetCount=58 allocation in dispatch_descriptor_sets
+    // doesn't get reshuffled. One set per (frame, source) pair: VFX +
+    // PBD share the same pipeline + push-constant layout (splat_count,
+    // dst_offset) but distinct src descriptors, so we allocate
+    // 2 × kMaxFramesInFlight sets total.
     VkDescriptorSetLayout compose_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout compose_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline compose_pipeline_ = VK_NULL_HANDLE;
     VkDescriptorPool compose_pool_ = VK_NULL_HANDLE;
-    std::array<VkDescriptorSet, kMaxFramesInFlight> compose_sets_{};
-    // Cached dst-info so the compose set update can be (re)issued from
-    // set_render_state without holding a Buffer reference.
+    std::array<VkDescriptorSet, kMaxFramesInFlight> compose_sets_vfx_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> compose_sets_pbd_{};
+    // Both sets are written together by update_compose_descriptors when
+    // render_state_ and dynamic_gaussian_ssbo_ are both live.
     bool compose_descriptors_initialised_ = false;
     void create_compose_pipeline();
     void update_compose_descriptors();  // called from set_render_state

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -36,7 +36,7 @@ struct GLFWwindow;
 namespace gseurat {
 
 class ResourceManager;
-namespace systems { class VfxSystem; }
+namespace systems { class VfxSystem; class PbdSystem; }
 
 // Small constant-size summary of the loaded GS cloud. Replaces the demo-side
 // reads of `cloud_bounds()` / `chunk_count()` / `all_gaussians()` with a
@@ -157,13 +157,18 @@ public:
     void add_gs_particle_emitter(const GsEmitterConfig& config);
     void clear_gs_particle_emitters();
     std::vector<GaussianParticleEmitter>& gs_particle_emitters() { return gs_particle_emitters_; }
-    void append_dynamic_gaussians(const Gaussian* data, uint32_t count);
 
     // Phase 4c-vfx-2: GaussianAnimator + vfx_instances_ moved to
     // systems::VfxSystem. The renderer now holds a non-owning pointer
     // to dispatch its per-frame VFX update and dispatch_compose_vfx
     // from record_gs_prepass.
     void set_vfx_system(systems::VfxSystem* vs) noexcept { vfx_system_ = vs; }
+
+    // Phase 4c-pbd: PBD splats migrated out of gs_pending_dynamics_ into
+    // systems::PbdSystem. The renderer holds a non-owning pointer to
+    // dispatch its per-frame PBD update + dispatch_compose_pbd from
+    // record_gs_prepass.
+    void set_pbd_system(systems::PbdSystem* ps) noexcept { pbd_system_ = ps; }
 
     // Scene-placed animations (with loop support)
     struct ReformConfig {
@@ -345,14 +350,15 @@ private:
     // pure GPU consumer once init_gs returns.
     GsCloudMetadata gs_cloud_metadata_;
     std::vector<Gaussian> gs_dynamic_buffer_;
-    std::vector<Gaussian> gs_pending_dynamics_;
     glm::mat4 gs_prev_view_{0.0f};  // for camera dirty detection
     bool gs_static_force_dirty_ = false;
     std::vector<GaussianParticleEmitter> gs_particle_emitters_;
     std::vector<SceneAnimation> gs_scene_animations_;
-    // Phase 4c-vfx-2: VFX instances + animator moved to systems::VfxSystem;
-    // we only keep a non-owning pointer so record_gs_prepass can tick it.
+    // Phase 4c-vfx-2 / 4c-pbd: VFX instances + animator (4c-vfx-2) and
+    // PBD pending splats (4c-pbd) moved to their respective systems;
+    // we only keep non-owning pointers so record_gs_prepass can tick them.
     systems::VfxSystem* vfx_system_ = nullptr;
+    systems::PbdSystem* pbd_system_ = nullptr;
 
     // ── Frame-determinism harness internal state ──
     struct DeterminismTestState {

--- a/include/gseurat/engine/systems/pbd_system.hpp
+++ b/include/gseurat/engine/systems/pbd_system.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+// Phase 4c-pbd: PBD splat system.
+//
+// Mirrors VfxSystem's per-frame compose pattern, but lighter — PBD has
+// no per-instance lifecycle, no animator, no distance culling. Callers
+// (currently only IslandDemoState's PBD chain demo) buffer their CPU
+// splats via push_splats() during state update, and the renderer drains
+// them once per frame in update_per_frame(): each Gaussian is encoded
+// into RenderState's pbd_writer, and GsRenderer::dispatch_compose_pbd
+// copies the resulting slots into dynamic_gaussian_ssbo at offset
+// `persistent + vfx_count`.
+//
+// Held by AppBase as a unique_ptr alongside VfxSystem. Constructed in
+// init_game_object_system before RenderState exists; late-binds via
+// set_render_state() from init_render_state().
+
+#include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/render_state.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace gseurat {
+namespace systems {
+
+class PbdSystem {
+public:
+    // `render_state` may be null at construction time. Per-frame splat
+    // writes become a no-op until set_render_state() binds it.
+    PbdSystem() noexcept = default;
+    explicit PbdSystem(RenderState* render_state) noexcept
+        : render_state_(render_state) {}
+
+    void set_render_state(RenderState* rs) noexcept { render_state_ = rs; }
+
+    // Buffer CPU splats for this frame. The renderer drains pending_
+    // once per frame via update_per_frame(); callers may push multiple
+    // batches per frame and they all coalesce into the same write.
+    void push_splats(const Gaussian* data, std::size_t count);
+
+    // Discard any buffered splats without writing them. Used by tests
+    // and scene-swap cleanup. update_per_frame() always clears pending_
+    // as part of its normal flow, so explicit clear is rarely needed.
+    void clear_splats() noexcept { pending_.clear(); }
+
+    // Encode pending_ into pbd_writer(frame_idx) starting at slot 0.
+    // Returns the number of slots written (clamped to writer capacity).
+    // Always clears pending_, even if render_state_ is null.
+    uint32_t update_per_frame(FrameIndex frame_idx);
+
+    // Test seam — size of the per-frame buffer before update_per_frame
+    // drains it. Used by unit tests; production callers shouldn't need it.
+    std::size_t pending_count() const noexcept { return pending_.size(); }
+
+private:
+    RenderState* render_state_ = nullptr;
+    std::vector<Gaussian> pending_;
+};
+
+}  // namespace systems
+}  // namespace gseurat

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1052,7 +1052,7 @@ void IslandDemoState::update(AppBase& app, float dt) {
     // PBD chain physics step + visual gather
     if (pbd_chain_active_) {
         step_pbd_chain(dt);
-        gather_pbd_chain(app.renderer());
+        gather_pbd_chain(app);
     }
 
     // Set player position as LOD focus for foveated culling
@@ -1660,7 +1660,7 @@ void IslandDemoState::step_pbd_chain(float dt) {
 
 // ── PBD visual gather ──
 
-void IslandDemoState::gather_pbd_chain(Renderer& renderer) {
+void IslandDemoState::gather_pbd_chain(AppBase& app) {
     std::vector<Gaussian> buf;
     buf.reserve(120);
 
@@ -1729,7 +1729,9 @@ void IslandDemoState::gather_pbd_chain(Renderer& renderer) {
         }
     }
 
-    renderer.append_dynamic_gaussians(buf.data(), static_cast<uint32_t>(buf.size()));
+    if (auto* pbd = app.pbd_system()) {
+        pbd->push_splats(buf.data(), buf.size());
+    }
 }
 
 // ── build_draw_lists (debug HUD) ──

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -600,11 +600,21 @@ void AppBase::init_render_state() {
     if (render_state_) return;
     render_state_ = std::make_unique<RenderState>(renderer_.context());
     renderer_.gs_renderer().set_render_state(render_state_.get());
-    // Late-bind RenderState into VfxSystem if it was constructed first
-    // (init_game_object_system runs before init_render_state).
+    // Late-bind RenderState into VfxSystem + PbdSystem if they were
+    // constructed first (init_game_object_system runs before
+    // init_render_state in the canonical AppBase init order).
     if (vfx_system_) {
         vfx_system_->set_render_state(render_state_.get());
     }
+    if (pbd_system_) {
+        pbd_system_->set_render_state(render_state_.get());
+    }
+    // Renderer needs back-pointers to both systems so record_gs_prepass
+    // can drive their per-frame update + dispatch_compose calls.
+    // (4c-pbd: also fixes a latent wire-up gap from 4c-vfx-2 where
+    // set_vfx_system was declared but never invoked.)
+    renderer_.set_vfx_system(vfx_system_.get());
+    renderer_.set_pbd_system(pbd_system_.get());
 }
 
 void AppBase::upload_bone_transforms() {
@@ -873,6 +883,12 @@ void AppBase::init_game_object_system() {
     // before init_render_state in some flows) — VfxSystem tolerates the
     // null and treats per-frame splat-write as a no-op until rs binds.
     vfx_system_ = std::make_unique<systems::VfxSystem>(&renderer_, render_state_.get());
+
+    // Phase 4c-pbd: PbdSystem owns the pending CPU-side PBD splats
+    // (currently fed by IslandDemoState's PBD chain demo) and packs
+    // them into RenderState's pbd_buffer per frame. Same late-bind
+    // pattern as VfxSystem; init_render_state wires render_state_.
+    pbd_system_ = std::make_unique<systems::PbdSystem>(render_state_.get());
 
     // Register engine-level systems
     system_scheduler_.add_system({"bone_animation",

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -764,13 +764,16 @@ void GsRenderer::create_compose_pipeline() {
     }
     vkDestroyShaderModule(device_, module, nullptr);
 
-    // Dedicated descriptor pool — kMaxFramesInFlight sets × 2 SSBO bindings each.
+    // Dedicated descriptor pool — 2 × kMaxFramesInFlight sets (vfx + pbd),
+    // each with 2 SSBO bindings (src + dst).
+    constexpr uint32_t kSetsPerSource = kMaxFramesInFlight;
+    constexpr uint32_t kSources = 2;  // vfx + pbd
     VkDescriptorPoolSize pool_sizes[1] = {
-        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, kMaxFramesInFlight * 2},
+        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, kSetsPerSource * kSources * 2},
     };
     VkDescriptorPoolCreateInfo pool_ci{};
     pool_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    pool_ci.maxSets = kMaxFramesInFlight;
+    pool_ci.maxSets = kSetsPerSource * kSources;
     pool_ci.poolSizeCount = 1;
     pool_ci.pPoolSizes = pool_sizes;
     if (vkCreateDescriptorPool(device_, &pool_ci, nullptr, &compose_pool_) != VK_SUCCESS) {
@@ -784,33 +787,51 @@ void GsRenderer::create_compose_pipeline() {
     alloc_info.descriptorPool = compose_pool_;
     alloc_info.descriptorSetCount = kMaxFramesInFlight;
     alloc_info.pSetLayouts = layouts.data();
-    if (vkAllocateDescriptorSets(device_, &alloc_info, compose_sets_.data()) != VK_SUCCESS) {
-        throw std::runtime_error("Failed to allocate compose descriptor sets");
+    if (vkAllocateDescriptorSets(device_, &alloc_info, compose_sets_vfx_.data()) != VK_SUCCESS) {
+        throw std::runtime_error("Failed to allocate compose (vfx) descriptor sets");
+    }
+    if (vkAllocateDescriptorSets(device_, &alloc_info, compose_sets_pbd_.data()) != VK_SUCCESS) {
+        throw std::runtime_error("Failed to allocate compose (pbd) descriptor sets");
     }
 }
 
 void GsRenderer::update_compose_descriptors() {
     if (!render_state_) return;
     for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-        VkDescriptorBufferInfo src_info{render_state_->vfx_buffer(FrameIndex{f}), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo vfx_src_info{render_state_->vfx_buffer(FrameIndex{f}), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo pbd_src_info{render_state_->pbd_buffer(FrameIndex{f}), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo dst_info{dynamic_gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
-        VkWriteDescriptorSet writes[2]{};
+        VkWriteDescriptorSet writes[4]{};
         writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        writes[0].dstSet = compose_sets_[f];
+        writes[0].dstSet = compose_sets_vfx_[f];
         writes[0].dstBinding = 0;
         writes[0].descriptorCount = 1;
         writes[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        writes[0].pBufferInfo = &src_info;
+        writes[0].pBufferInfo = &vfx_src_info;
 
         writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        writes[1].dstSet = compose_sets_[f];
+        writes[1].dstSet = compose_sets_vfx_[f];
         writes[1].dstBinding = 1;
         writes[1].descriptorCount = 1;
         writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
         writes[1].pBufferInfo = &dst_info;
 
-        vkUpdateDescriptorSets(device_, 2, writes, 0, nullptr);
+        writes[2].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[2].dstSet = compose_sets_pbd_[f];
+        writes[2].dstBinding = 0;
+        writes[2].descriptorCount = 1;
+        writes[2].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[2].pBufferInfo = &pbd_src_info;
+
+        writes[3].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[3].dstSet = compose_sets_pbd_[f];
+        writes[3].dstBinding = 1;
+        writes[3].descriptorCount = 1;
+        writes[3].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[3].pBufferInfo = &dst_info;
+
+        vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
     }
     compose_descriptors_initialised_ = true;
 }
@@ -822,7 +843,7 @@ void GsRenderer::dispatch_compose_vfx(VkCommandBuffer cmd, FrameIndex frame_idx,
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, compose_pipeline_);
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
                             compose_pipeline_layout_, 0, 1,
-                            &compose_sets_[to_u32(frame_idx)], 0, nullptr);
+                            &compose_sets_vfx_[to_u32(frame_idx)], 0, nullptr);
     struct PushConstants {
         uint32_t splat_count;
         uint32_t dst_offset;
@@ -835,6 +856,37 @@ void GsRenderer::dispatch_compose_vfx(VkCommandBuffer cmd, FrameIndex frame_idx,
 
     // Compute→compute SSBO write→read barrier so the downstream preprocess
     // pipeline (which reads dynamic_gaussian_ssbo) sees our writes.
+    // dispatch_compose_pbd, if it runs next, only writes disjoint slots, but
+    // we keep this barrier here so a vfx-only frame remains correct on its
+    // own; pbd's barrier handles the second-source case.
+    VkMemoryBarrier mb{};
+    mb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    mb.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    mb.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+    vkCmdPipelineBarrier(cmd,
+                         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         0, 1, &mb, 0, nullptr, 0, nullptr);
+}
+
+void GsRenderer::dispatch_compose_pbd(VkCommandBuffer cmd, FrameIndex frame_idx,
+                                       uint32_t vfx_count, uint32_t pbd_count) {
+    if (pbd_count == 0 || !compose_descriptors_initialised_) return;
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, compose_pipeline_);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                            compose_pipeline_layout_, 0, 1,
+                            &compose_sets_pbd_[to_u32(frame_idx)], 0, nullptr);
+    struct PushConstants {
+        uint32_t splat_count;
+        uint32_t dst_offset;
+    } pc{pbd_count, persistent_dyn_count_ + vfx_count};
+    vkCmdPushConstants(cmd, compose_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                       0, sizeof(pc), &pc);
+    constexpr uint32_t kLocalSize = 64;
+    const uint32_t groups = (pbd_count + kLocalSize - 1) / kLocalSize;
+    vkCmdDispatch(cmd, groups, 1, 1);
+
     VkMemoryBarrier mb{};
     mb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
     mb.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
@@ -2529,15 +2581,16 @@ void GsRenderer::set_persistent_dynamics(const Gaussian* data, uint32_t count) {
 }
 
 void GsRenderer::update_dynamic_gaussians(const Gaussian* data, uint32_t count,
-                                            uint32_t vfx_prefix) {
-    // `count` is the CPU-sourced transient portion (particles, scene anims,
-    // pending dynamics). `vfx_prefix` is the slot count already filled by
-    // the GPU compose pass at offset persistent_dyn_count_ (4c-vfx).
-    // Persistent prefix lives in indices [0, persistent_dyn_count_).
-    const uint32_t fixed_prefix = persistent_dyn_count_ + vfx_prefix;
+                                            uint32_t gpu_prefix) {
+    // `count` is the CPU-sourced transient portion (particles, scene anims).
+    // `gpu_prefix` is the slot count already filled by the GPU compose
+    // passes at offset persistent_dyn_count_ — currently vfx_count +
+    // pbd_count (4c-vfx + 4c-pbd). Persistent prefix lives in indices
+    // [0, persistent_dyn_count_).
+    const uint32_t fixed_prefix = persistent_dyn_count_ + gpu_prefix;
     const uint32_t total = fixed_prefix + count;
     if (total > max_dynamic_count_) {
-        // Cap the CPU portion so total fits; vfx_prefix is GPU-controlled
+        // Cap the CPU portion so total fits; gpu_prefix is GPU-controlled
         // and can't be truncated here.
         count = (max_dynamic_count_ > fixed_prefix)
             ? max_dynamic_count_ - fixed_prefix : 0;
@@ -2549,7 +2602,7 @@ void GsRenderer::update_dynamic_gaussians(const Gaussian* data, uint32_t count,
         for (uint32_t i = 0; i < count; ++i) {
             encode_gaussian(data[i], staging[i]);
         }
-        // Write at offset (persistent_dyn_count_ + vfx_prefix) * sizeof(GpuGaussian)
+        // Write at offset (persistent_dyn_count_ + gpu_prefix) * sizeof(GpuGaussian)
         auto* dst = static_cast<uint8_t*>(dynamic_gaussian_ssbo_.mapped())
                     + fixed_prefix * sizeof(GpuGaussian);
         std::memcpy(dst, staging.data(), count * sizeof(GpuGaussian));

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -1337,6 +1337,23 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
         if (pbd_system_ && !determinism_test_state_.active) {
             pbd_count = pbd_system_->update_per_frame(FrameIndex{current_frame_});
         }
+        // Clamp the GPU-composed prefix so persistent + vfx + pbd fits
+        // inside max_dynamic_count_. Without this the compose shaders
+        // would write past `dynamic_gaussian_ssbo`'s end when a scene's
+        // persistent prefix is large enough to leave less headroom than
+        // the system writer caps (RenderStateConfig max_vfx_splats +
+        // max_pbd_splats currently 250k vs. kDynamicHeadroom 1M minus
+        // persistent). The old pending-dynamics path was implicitly
+        // clipped by update_dynamic_gaussians, which can only truncate
+        // the CPU portion (after the GPU prefix) — Codex P2 on #437.
+        {
+            const uint32_t max_dyn = gs_renderer_.max_dynamic_count();
+            const uint32_t persistent = gs_renderer_.persistent_dynamic_count();
+            uint32_t gpu_budget = (max_dyn > persistent) ? (max_dyn - persistent) : 0;
+            if (vfx_count > gpu_budget) vfx_count = gpu_budget;
+            gpu_budget -= vfx_count;
+            if (pbd_count > gpu_budget) pbd_count = gpu_budget;
+        }
 
         if (!determinism_test_state_.active) {
             gs_dynamic_buffer_.clear();

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -9,6 +9,7 @@
 #include "gseurat/engine/sort_entry.hpp"
 #include "gseurat/engine/sort_hash.hpp"
 #include "gseurat/engine/streaming_config.hpp"
+#include "gseurat/engine/systems/pbd_system.hpp"
 #include "gseurat/engine/systems/vfx_system.hpp"
 
 #include <cstdio>
@@ -1317,10 +1318,12 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
         // (particle re-emission ordering, std::erase_if removal of dead
         // entries reshuffling indices), and the std::vector clear+fill
         // pattern would change capacity allocations across frames.
-        // Phase 4c-vfx-2: VFX splats now go through VfxSystem → vfx_buffer
-        // (RenderState) → GPU compose pass → dynamic_gaussian_ssbo. We
-        // need vfx_count BEFORE update_dynamic_gaussians so its vfx_prefix
-        // is right. Distance-cull origin computed once and reused below.
+        // Phase 4c-vfx-2 / 4c-pbd: VFX + PBD splats now go through their
+        // respective systems → vfx_buffer / pbd_buffer (RenderState) →
+        // GPU compose passes → dynamic_gaussian_ssbo. We need both
+        // counts BEFORE update_dynamic_gaussians so its gpu_prefix is
+        // right. Distance-cull origin computed once and reused below
+        // (PBD doesn't distance-cull — its CPU producers can if they care).
         const glm::vec3 cull_origin_v = glm::vec3(glm::inverse(gs_view_)[3]);
         const float cull_dist_sq_v = gs_max_render_distance_ > 0.0f
             ? gs_max_render_distance_ * gs_max_render_distance_ : 0.0f;
@@ -1329,6 +1332,10 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             vfx_count = vfx_system_->update_per_frame(
                 dt, FrameIndex{current_frame_}, cull_origin_v, cull_dist_sq_v,
                 flags.animation, flags.particles);
+        }
+        uint32_t pbd_count = 0;
+        if (pbd_system_ && !determinism_test_state_.active) {
+            pbd_count = pbd_system_->update_per_frame(FrameIndex{current_frame_});
         }
 
         if (!determinism_test_state_.active) {
@@ -1384,40 +1391,38 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 }
             }
 
-            // Append pending dynamics from game states (e.g., PBD chain demo)
-            if (!gs_pending_dynamics_.empty()) {
-                gs_dynamic_buffer_.insert(gs_dynamic_buffer_.end(),
-                                          gs_pending_dynamics_.begin(),
-                                          gs_pending_dynamics_.end());
-                gs_pending_dynamics_.clear();
-            }
-
             // Upload dynamic Gaussians. The dynamic_gaussian_ssbo layout
-            // is now [persistent | vfx | cpu], where `vfx_count` slots
-            // are filled by the GPU compose pass below, and `count`
-            // CPU-sourced slots come after.
+            // is now [persistent | vfx | pbd | cpu]: `vfx_count` and
+            // `pbd_count` slots are filled by the GPU compose passes
+            // below, and `count` CPU-sourced slots come after.
             {
                 auto count = static_cast<uint32_t>(gs_dynamic_buffer_.size());
-                const uint32_t max_cpu = (gs_renderer_.max_dynamic_count() > vfx_count)
-                    ? gs_renderer_.max_dynamic_count() - vfx_count : 0;
+                const uint32_t gpu_prefix = vfx_count + pbd_count;
+                const uint32_t max_cpu = (gs_renderer_.max_dynamic_count() > gpu_prefix)
+                    ? gs_renderer_.max_dynamic_count() - gpu_prefix : 0;
                 if (count > max_cpu) {
                     gs_dynamic_buffer_.resize(max_cpu);
                     count = max_cpu;
                 }
                 gs_renderer_.update_dynamic_gaussians(gs_dynamic_buffer_.data(), count,
-                                                       /*vfx_prefix=*/vfx_count);
+                                                       /*gpu_prefix=*/gpu_prefix);
 #if GSEURAT_DEBUG_BUILD
-                dbg_dyn_count = count + vfx_count;
+                dbg_dyn_count = count + gpu_prefix;
 #endif
             }
         }
 
-        // Phase 4c-vfx-2: GPU compose pass — copy VfxSystem's per-frame
-        // vfx_buffer into dynamic_gaussian_ssbo at offset
-        // persistent_dyn_count_ for `vfx_count` slots. Must run on the
-        // same cmd buffer BEFORE gs_renderer_.render() so downstream
-        // preprocess/sort/raster see the composed splats.
+        // Phase 4c-vfx-2 / 4c-pbd: GPU compose passes — copy VfxSystem's
+        // per-frame vfx_buffer into dynamic_gaussian_ssbo at offset
+        // persistent_dyn_count_ for `vfx_count` slots, then PbdSystem's
+        // pbd_buffer at offset persistent_dyn_count_ + vfx_count. Both
+        // must run on the same cmd buffer BEFORE gs_renderer_.render()
+        // so downstream preprocess/sort/raster see the composed splats.
+        // Order matters because dispatch_compose_pbd uses vfx_count as
+        // an offset.
         gs_renderer_.dispatch_compose_vfx(cmd, FrameIndex{current_frame_}, vfx_count);
+        gs_renderer_.dispatch_compose_pbd(cmd, FrameIndex{current_frame_},
+                                          vfx_count, pbd_count);
 
 #if GSEURAT_DEBUG_BUILD
         const auto t_prepass_pre_render = std::chrono::steady_clock::now();
@@ -1688,10 +1693,6 @@ void Renderer::add_gs_particle_emitter(const GsEmitterConfig& config) {
 
 void Renderer::clear_gs_particle_emitters() {
     gs_particle_emitters_.clear();
-}
-
-void Renderer::append_dynamic_gaussians(const Gaussian* data, uint32_t count) {
-    gs_pending_dynamics_.insert(gs_pending_dynamics_.end(), data, data + count);
 }
 
 void Renderer::add_gs_animation(const std::string& effect, const GsAnimRegion& region,

--- a/src/engine/systems/pbd_system.cpp
+++ b/src/engine/systems/pbd_system.cpp
@@ -1,0 +1,30 @@
+#include "gseurat/engine/systems/pbd_system.hpp"
+
+#include <algorithm>
+
+namespace gseurat::systems {
+
+void PbdSystem::push_splats(const Gaussian* data, std::size_t count) {
+    if (data == nullptr || count == 0) return;
+    pending_.insert(pending_.end(), data, data + count);
+}
+
+uint32_t PbdSystem::update_per_frame(FrameIndex frame_idx) {
+    if (render_state_ == nullptr) {
+        pending_.clear();
+        return 0;
+    }
+    auto writer = render_state_->pbd_writer(frame_idx);
+    const uint32_t cap = writer.capacity();
+    const uint32_t count = static_cast<uint32_t>(pending_.size());
+    const uint32_t live = std::min(count, cap);
+    for (uint32_t i = 0; i < live; ++i) {
+        GpuGaussian packed{};
+        encode_gaussian(pending_[i], packed);
+        writer.write_at(i, &packed, sizeof(GpuGaussian));
+    }
+    pending_.clear();
+    return live;
+}
+
+}  // namespace gseurat::systems


### PR DESCRIPTION
## Summary

Third PR in the Phase 4c trilogy. Completes the GPU-composed transient splat migration started by 4c-vfx (#435 + #436). The CPU `gs_pending_dynamics_` back-channel the IslandDemo PBD chain demo used to push splats into the renderer is replaced by a typed writer + per-frame compose dispatch, mirroring the VFX pattern.

### Migration map

| Before | After |
|---|---|
| `Renderer::gs_pending_dynamics_` | `systems::PbdSystem::pending_` |
| `Renderer::append_dynamic_gaussians()` | `PbdSystem::push_splats()` |
| CPU `gs_pending_dynamics_` insert/clear block in `record_gs_prepass` | deleted (data goes straight to `pbd_buffer`) |
| `IslandDemoState::gather_pbd_chain(Renderer&)` | `gather_pbd_chain(AppBase&)` via `app.pbd_system()` |

### New per-frame data flow

1. `record_gs_prepass` ticks `pbd_system_->update_per_frame(frame_idx)` alongside the existing `vfx_system_->update_per_frame(...)`. Each pending `Gaussian` is encoded via `encode_gaussian` into RenderState's per-frame `pbd_buffer` via `pbd_writer`. Returns `pbd_count`.
2. `update_dynamic_gaussians(data, count, gpu_prefix=vfx_count + pbd_count)` uploads CPU splats AFTER both GPU-composed regions.
3. `dispatch_compose_vfx(cmd, frame, vfx_count)` copies VFX splats into `dynamic_gaussian_ssbo` at offset `persistent_dyn_count_`.
4. `dispatch_compose_pbd(cmd, frame, vfx_count, pbd_count)` copies PBD splats at offset `persistent_dyn_count_ + vfx_count`. Each compose dispatch issues its own COMPUTE→COMPUTE SHADER_WRITE→SHADER_READ barrier.
5. `gs_renderer_.render(...)` — unchanged.

`dynamic_gaussian_ssbo` layout is now `[persistent | vfx | pbd | cpu]`. The renderer's `update_dynamic_gaussians` parameter is renamed `vfx_prefix` → `gpu_prefix` since it now covers both GPU-composed regions.

### Compose-pipeline extension (Path A.1)

Existing `shaders/gs_compose.comp` is reused for both sources. The descriptor pool grows from `kMaxFramesInFlight` sets (vfx-only) to `kMaxFramesInFlight × 2` (vfx + pbd). `update_compose_descriptors` writes both `compose_sets_vfx_[f]` and `compose_sets_pbd_[f]` together when RenderState and `dynamic_gaussian_ssbo` are both live.

### Bonus fix — set_vfx_system / set_pbd_system wire-up

Audit uncovered that `Renderer::set_vfx_system` was declared in 4c-vfx-2 (#436) but never invoked from AppBase, leaving `Renderer::vfx_system_` permanently null. Every VFX hook in `record_gs_prepass` has been silently no-op'd in main since 90d51484: `vfx_system_->update_per_frame` never ran, `dispatch_compose_vfx` saw `vfx_count=0`, and VFX-emitted lights weren't gathered. This PR adds both `renderer_.set_vfx_system(vfx_system_.get())` and `renderer_.set_pbd_system(pbd_system_.get())` in `AppBase::init_render_state`. The smoke test below confirms VFX spawns now actually fire.

### Out of scope (deferred to 4d / 4e)

- No `PbdElementsLoadedEvent` (PBD ownership stays demo-pushed for now).
- No particles writer, no point-lights writer.
- No `CommandContext` / `SceneLoadContext` field additions — no command or scene-load callers touch PBD yet.

## Test plan

- [x] macos-debug build clean
- [x] macos-release build clean
- [x] macos-release-with-diag build clean
- [x] `test_render_state` — 10/10 PASS
- [x] `test_vfx_system` — 6/6 PASS
- [x] `test_pbd_solver` — 127/127 PASS
- [x] `test_async_loader` — PASS
- [x] 8s `gseurat_demo` smoke: PBD trees configured + GPU upload (`[GS] PBD upload: 12 elements`), VFX spawn fires (`[VfxTrigger] SPAWN 'chimney_smoke.vfx.json'` — proves the latent wire-up fix), ControlServer listening, ShutdownAuditor reports no leaks, no Vulkan validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)