### PR TITLE
refactor(engine): route PBD elements upload through event bus (Phase 4d-1)

### DIFF
--- a/include/gseurat/engine/pbd_events.hpp
+++ b/include/gseurat/engine/pbd_events.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+// Phase 4d-1: PBD elements loaded event.
+//
+// Emitted by scene-load paths (gs_scene_loader during initial finalize,
+// IslandDemoState during chunk-load) when a batch of PBD-tagged elements
+// is ready for the GPU PBD solver. Consumed by `gseurat::systems::PbdSystem`
+// which forwards the upload to `GsRenderer::upload_pbd_elements`.
+//
+// Carries the prepared GPU state directly (rather than the
+// PbdConfig+anchor pairs) since producers already compose these on
+// their side. Future iterations may shift composition into the system,
+// but that's not required for the 4d-1 wiring refactor.
+
+#include "gseurat/engine/pbd_types.hpp"
+
+#include <vector>
+
+namespace gseurat {
+
+struct PbdElementsLoadedEvent {
+    std::vector<PbdPhysicsState> states;
+    std::vector<PbdElementParams> params;
+};
+
+}  // namespace gseurat

--- a/include/gseurat/engine/systems/pbd_system.hpp
+++ b/include/gseurat/engine/systems/pbd_system.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 // Phase 4c-pbd: PBD splat system.
+// Phase 4d-1:  + PbdElementsLoadedEvent consumer.
 //
 // Mirrors VfxSystem's per-frame compose pattern, but lighter — PBD has
 // no per-instance lifecycle, no animator, no distance culling. Callers
@@ -11,11 +12,19 @@
 // copies the resulting slots into dynamic_gaussian_ssbo at offset
 // `persistent + vfx_count`.
 //
+// 4d-1: additionally consumes `PbdElementsLoadedEvent`s from the world's
+// event bus (drained once per frame from main_loop), forwarding the
+// physics-state + params upload to `GsRenderer::upload_pbd_elements`.
+// This decouples scene-load and chunk-load producers from the renderer.
+//
 // Held by AppBase as a unique_ptr alongside VfxSystem. Constructed in
 // init_game_object_system before RenderState exists; late-binds via
 // set_render_state() from init_render_state().
 
+#include "gseurat/engine/ecs/events.hpp"
+#include "gseurat/engine/ecs/world.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/pbd_events.hpp"
 #include "gseurat/engine/render_state.hpp"
 
 #include <cstddef>
@@ -23,17 +32,27 @@
 #include <vector>
 
 namespace gseurat {
+
+class Renderer;
+
 namespace systems {
 
 class PbdSystem {
 public:
-    // `render_state` may be null at construction time. Per-frame splat
-    // writes become a no-op until set_render_state() binds it.
+    // `renderer` / `render_state` may be null at construction time. The
+    // event consumer becomes a no-op without a renderer; the per-frame
+    // splat write becomes a no-op without a render_state.
     PbdSystem() noexcept = default;
-    explicit PbdSystem(RenderState* render_state) noexcept
-        : render_state_(render_state) {}
+    PbdSystem(Renderer* renderer, RenderState* render_state) noexcept
+        : renderer_(renderer), render_state_(render_state) {}
 
+    void set_renderer(Renderer* r) noexcept { renderer_ = r; }
     void set_render_state(RenderState* rs) noexcept { render_state_ = rs; }
+
+    // Phase 4d-1: drain PbdElementsLoadedEvents from the world's event
+    // bus and forward each batch to GsRenderer::upload_pbd_elements.
+    // Called once per frame from main_loop.
+    void run(ecs::World& world, float dt);
 
     // Buffer CPU splats for this frame. The renderer drains pending_
     // once per frame via update_per_frame(); callers may push multiple
@@ -54,8 +73,23 @@ public:
     // drains it. Used by unit tests; production callers shouldn't need it.
     std::size_t pending_count() const noexcept { return pending_.size(); }
 
+    // Test seam — drain events without forwarding to the renderer, so
+    // tests can assert on event content without a live Vulkan context.
+    std::vector<PbdElementsLoadedEvent> drain_events(ecs::World& world) {
+        auto& queue = world.events<PbdElementsLoadedEvent>();
+        std::vector<PbdElementsLoadedEvent> out;
+        queue.read(load_cursor_).for_each(
+            [&](const PbdElementsLoadedEvent& evt) { out.push_back(evt); });
+        return out;
+    }
+
+    ecs::EventCursor& cursor() noexcept { return load_cursor_; }
+    const ecs::EventCursor& cursor() const noexcept { return load_cursor_; }
+
 private:
+    Renderer* renderer_ = nullptr;
     RenderState* render_state_ = nullptr;
+    ecs::EventCursor load_cursor_{};
     std::vector<Gaussian> pending_;
 };
 

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -21,6 +21,7 @@
 #include "gseurat/engine/gs_particle.hpp"
 #include "gseurat/engine/gs_animator.hpp"
 #include "gseurat/engine/gs_vfx.hpp"
+#include "gseurat/engine/pbd_events.hpp"
 #include "gseurat/engine/pbd_types.hpp"
 #include "gseurat/engine/bone_animation_registry.hpp"
 #include "gseurat/engine/bone_animation_system.hpp"
@@ -686,7 +687,10 @@ void IslandDemoState::on_enter(AppBase& app) {
                 params[i].wind = glm::vec4(cfg.wind_direction, cfg.wind_strength);
                 params[i].dynamics = glm::vec4(cfg.wind_frequency, cfg.ground_y, cfg.bounce, 0.0f);
             }
-            app.renderer().gs_renderer().upload_pbd_elements(states.data(), params.data(), count);
+            // Phase 4d-1: route through PbdElementsLoadedEvent;
+            // PbdSystem::run picks this up on the next main_loop tick.
+            app.world().events<PbdElementsLoadedEvent>().send(
+                PbdElementsLoadedEvent{std::move(states), std::move(params)});
         }
     }
 

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -364,6 +364,9 @@ void AppBase::main_loop() {
         if (vfx_system_) {
             vfx_system_->run(world_, dt);
         }
+        if (pbd_system_) {
+            pbd_system_->run(world_, dt);
+        }
         world_.rotate_events();
 #if GSEURAT_DEBUG_BUILD
         const auto t_after_update = std::chrono::steady_clock::now();
@@ -888,7 +891,10 @@ void AppBase::init_game_object_system() {
     // (currently fed by IslandDemoState's PBD chain demo) and packs
     // them into RenderState's pbd_buffer per frame. Same late-bind
     // pattern as VfxSystem; init_render_state wires render_state_.
-    pbd_system_ = std::make_unique<systems::PbdSystem>(render_state_.get());
+    // Phase 4d-1: also consumes PbdElementsLoadedEvent and forwards
+    // the GPU upload to GsRenderer, so it needs a back-pointer to
+    // the Renderer (constructed before this in init_window).
+    pbd_system_ = std::make_unique<systems::PbdSystem>(&renderer_, render_state_.get());
 
     // Register engine-level systems
     system_scheduler_.add_system({"bone_animation",

--- a/src/engine/gs_scene_loader.cpp
+++ b/src/engine/gs_scene_loader.cpp
@@ -7,6 +7,7 @@
 #include "gseurat/engine/coordinate.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/gs_vfx.hpp"
+#include "gseurat/engine/pbd_events.hpp"
 #include "gseurat/engine/pbd_types.hpp"
 #include "gseurat/engine/renderer.hpp"
 #include "gseurat/engine/resource_manager.hpp"
@@ -290,10 +291,14 @@ void GsSceneLoader::finalize_on_main(SceneLoadContext& ctx, const SceneData& sce
                     params[i].wind = glm::vec4(cfg.wind_direction, cfg.wind_strength);
                     params[i].dynamics = glm::vec4(cfg.wind_frequency, cfg.ground_y, cfg.bounce, 0.0f);
                 }
-                ctx.renderer.gs_renderer().upload_pbd_elements(states.data(), params.data(), count);
-                std::fprintf(stderr, "[GS] PBD upload: %u elements, wind=(%.2f,%.2f,%.2f) str=%.2f freq=%.2f\n",
+                std::fprintf(stderr, "[GS] PBD load event queued: %u elements, wind=(%.2f,%.2f,%.2f) str=%.2f freq=%.2f\n",
                              count, params[0].wind.x, params[0].wind.y, params[0].wind.z,
                              params[0].wind.w, params[0].dynamics.x);
+                // Phase 4d-1: emit instead of calling upload_pbd_elements
+                // directly — `systems::PbdSystem::run` drains this on the
+                // next main_loop tick and forwards to GsRenderer.
+                ctx.world.events<PbdElementsLoadedEvent>().send(
+                    PbdElementsLoadedEvent{std::move(states), std::move(params)});
             }
 
             // Store cloud bounds for camera centering

--- a/src/engine/systems/pbd_system.cpp
+++ b/src/engine/systems/pbd_system.cpp
@@ -1,8 +1,24 @@
 #include "gseurat/engine/systems/pbd_system.hpp"
 
+#include "gseurat/engine/gs_renderer.hpp"
+#include "gseurat/engine/renderer.hpp"
+
 #include <algorithm>
+#include <cstdio>
 
 namespace gseurat::systems {
+
+void PbdSystem::run(ecs::World& world, float /*dt*/) {
+    if (renderer_ == nullptr) return;
+    auto& queue = world.events<PbdElementsLoadedEvent>();
+    queue.read(load_cursor_).for_each([this](const PbdElementsLoadedEvent& evt) {
+        const auto count = static_cast<uint32_t>(evt.states.size());
+        if (count == 0 || evt.params.size() != evt.states.size()) return;
+        renderer_->gs_renderer().upload_pbd_elements(
+            evt.states.data(), evt.params.data(), count);
+        std::fprintf(stderr, "[PbdSystem] uploaded %u PBD elements\n", count);
+    });
+}
 
 void PbdSystem::push_splats(const Gaussian* data, std::size_t count) {
     if (data == nullptr || count == 0) return;

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -4,6 +4,7 @@
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/gs_parallax_camera.hpp"
 #include "gseurat/engine/project_root.hpp"
+#include "gseurat/engine/pbd_events.hpp"
 #include "gseurat/engine/scene_loader.hpp"
 #include "gseurat/engine/gs_vfx.hpp"
 #include "gseurat/engine/vfx_events.hpp"
@@ -105,6 +106,10 @@ void StagingApp::clear_scene() {
     // bigger world_.clear() hammer; Staging's lighter teardown
     // surgically drops just this queue.
     world_.events<VfxSpawnEvent>().clear();
+    // Phase 4d-1: same hazard for PbdElementsLoadedEvents queued by an
+    // in-progress scene load before this clear runs. Drop them so the
+    // next scene's PBD config doesn't get clobbered by stale state.
+    world_.events<PbdElementsLoadedEvent>().clear();
     scene_.clear_lights();
     gs_terrain_.terrain_aabb = AABB{};
     gs_terrain_.terrain_aabb.min = glm::vec3(0.0f);


### PR DESCRIPTION
## Summary

First half of Phase 4d. Migrates the two `upload_pbd_elements` call sites from direct renderer mutation to typed event emission, mirroring the 4a `VfxSpawnEvent` pattern.

### Migration map

| Before | After |
|---|---|
| `gs_scene_loader.cpp:293` calls `gs_renderer.upload_pbd_elements(...)` | emits `PbdElementsLoadedEvent` |
| `island_demo_state.cpp:689` (chunk-load re-upload) calls `gs_renderer.upload_pbd_elements(...)` | emits `PbdElementsLoadedEvent` |
| (no consumer existed) | `systems::PbdSystem::run(world, dt)` drains and forwards each batch via `GsRenderer::upload_pbd_elements` |

### New types

```cpp
struct PbdElementsLoadedEvent {
    std::vector<PbdPhysicsState> states;
    std::vector<PbdElementParams> params;
};
```

### PbdSystem extensions

- Constructor now takes `Renderer*` alongside `RenderState*` (mirrors VfxSystem); both `nullptr`-tolerant for tests.
- New `EventCursor load_cursor_`, `drain_events(world)` test seam, `set_renderer(Renderer*)` late-bind setter.
- `run()` called once per main_loop tick from `AppBase::main_loop`.

### Scene-clear handling

- `AppBase::clear_scene` already calls `world_.clear()` — covers the new queue automatically.
- `StagingApp::clear_scene` uses the surgical drain pattern; added explicit `world_.events<PbdElementsLoadedEvent>().clear()` to prevent a stale event from surviving a scene swap (parallel to the `VfxSpawnEvent` fix in PR #431).

## Test plan

- [x] macos-debug build clean
- [x] macos-release build clean
- [x] macos-release-with-diag build clean
- [x] `test_render_state` — 10/10 PASS
- [x] `test_vfx_system` — 6/6 PASS
- [x] `test_pbd_solver` — 127/127 PASS
- [x] 8s `gseurat_demo` smoke test confirms full producer→consumer→renderer flow:

```
[GS] PBD load event queued: 12 elements, wind=(1.00,0.00,0.30) str=0.06 freq=0.80
[PbdSystem] uploaded 12 PBD elements
[PbdSystem] uploaded 12 PBD elements   # gs_scene_loader + on_enter re-upload — both routed
[VfxTrigger] SPAWN 'chimney_smoke.vfx.json'
[ShutdownAuditor] No tracked objects alive.
```

Two consumer uploads is the expected steady state: `gs_scene_loader.cpp` emits during `finalize_on_main`, and `IslandDemoState::on_enter` re-emits because `init_gs` resets `pbd_count_` (existing behavior, unchanged). Same data; second upload is idempotent.

## Out of scope (4d-2 follow-up)

- `PointLightsLoadedEvent` + new `systems::LightingSystem`.
- Migration of the per-frame static+VFX point-light merge out of `Renderer::record_gs_prepass`.
- The 4 `set_point_lights` call sites (scene loader, command dispatcher, dev panel, per-frame renderer merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)