### PR TITLE
refactor(engine): extract LightingSystem + route lights via event bus (Phase 4d-2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,7 @@ target_sources(gseurat_core PRIVATE src/engine/ecs/events.cpp)
 target_sources(gseurat_core PRIVATE src/engine/render_state.cpp)
 target_sources(gseurat_core PRIVATE src/engine/systems/vfx_system.cpp)
 target_sources(gseurat_core PRIVATE src/engine/systems/pbd_system.cpp)
+target_sources(gseurat_core PRIVATE src/engine/systems/lighting_system.cpp)
 
 if(GSEURAT_SHARED_LIBS)
     target_compile_definitions(gseurat_core PUBLIC GSEURAT_ENGINE_BUILD_SHARED)

--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -41,6 +41,7 @@
 #include "gseurat/engine/staging_uploader.hpp"
 #include "gseurat/engine/scene.hpp"
 #include "gseurat/engine/screen_effects.hpp"
+#include "gseurat/engine/systems/lighting_system.hpp"
 #include "gseurat/engine/systems/pbd_system.hpp"
 #include "gseurat/engine/systems/transition_system.hpp"
 #include "gseurat/engine/systems/vfx_system.hpp"
@@ -99,6 +100,9 @@ public:
     // late-construction caveat — null until init_game_object_system runs.
     systems::PbdSystem* pbd_system() { return pbd_system_.get(); }
     const systems::PbdSystem* pbd_system() const { return pbd_system_.get(); }
+    // Phase 4d-2: static lights + static+VFX merge ownership.
+    systems::LightingSystem* lighting_system() { return lighting_system_.get(); }
+    const systems::LightingSystem* lighting_system() const { return lighting_system_.get(); }
     ResourceManager& resources() { return resources_; }
     Scene& scene() { return scene_; }
     ecs::World& world() { return world_; }
@@ -331,6 +335,10 @@ protected:
     // in init_game_object_system; render_state binding late-binds the
     // same way as VfxSystem.
     std::unique_ptr<systems::PbdSystem> pbd_system_;
+
+    // Phase 4d-2: Static lights + static+VFX merge owner. Same
+    // late-construction shape as VFX/PBD.
+    std::unique_ptr<systems::LightingSystem> lighting_system_;
 
     // Bone pre-upload hook (Phase 4b: writer API). Game-specific code
     // installs this to fill specific bone slots (e.g. the player's bones)

--- a/include/gseurat/engine/light_events.hpp
+++ b/include/gseurat/engine/light_events.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+// Phase 4d-2: Point-lights loaded event.
+//
+// Emitted by scene-load paths (gs_scene_loader at finalize, command
+// dispatcher on update_scene_data, dev panels on user edit) when the
+// set of static scene lights changes. Consumed by
+// `gseurat::systems::LightingSystem` which stores the static set and
+// merges it with VFX-emitted lights once per frame.
+//
+// An empty payload means "clear the static set" — the consumer also
+// resets `light_mode` to 0 to mirror the prior command_dispatcher
+// behavior.
+
+#include "gseurat/engine/types.hpp"
+
+#include <vector>
+
+namespace gseurat {
+
+struct PointLightsLoadedEvent {
+    std::vector<PointLight> lights;
+};
+
+}  // namespace gseurat

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -36,7 +36,7 @@ struct GLFWwindow;
 namespace gseurat {
 
 class ResourceManager;
-namespace systems { class VfxSystem; class PbdSystem; }
+namespace systems { class VfxSystem; class PbdSystem; class LightingSystem; }
 
 // Small constant-size summary of the loaded GS cloud. Replaces the demo-side
 // reads of `cloud_bounds()` / `chunk_count()` / `all_gaussians()` with a
@@ -170,6 +170,13 @@ public:
     // record_gs_prepass.
     void set_pbd_system(systems::PbdSystem* ps) noexcept { pbd_system_ = ps; }
 
+    // Phase 4d-2: static lights + per-frame static+VFX merge moved to
+    // systems::LightingSystem. Same back-pointer pattern; the renderer
+    // calls lighting_system_->update_per_frame() from record_gs_prepass.
+    void set_lighting_system(systems::LightingSystem* ls) noexcept {
+        lighting_system_ = ls;
+    }
+
     // Scene-placed animations (with loop support)
     struct ReformConfig {
         float lifetime = 2.0f;
@@ -195,7 +202,8 @@ public:
     // Phase 4c-vfx-2: add/clear/list VFX instances moved to
     // systems::VfxSystem. Callers should use `vfx_system->add_instance(...)`
     // / `vfx_system->clear_instances()` / `vfx_system->instances()`.
-    void set_gs_static_lights(const std::vector<PointLight>& lights) { gs_static_lights_ = lights; }
+    // Phase 4d-2: set_gs_static_lights moved to systems::LightingSystem
+    // (callers emit PointLightsLoadedEvent instead).
 
     // Current frame-in-flight slot. Stable for the duration of a frame's
     // CPU-side work; advances at the end of draw_scene. Producers that
@@ -354,11 +362,13 @@ private:
     bool gs_static_force_dirty_ = false;
     std::vector<GaussianParticleEmitter> gs_particle_emitters_;
     std::vector<SceneAnimation> gs_scene_animations_;
-    // Phase 4c-vfx-2 / 4c-pbd: VFX instances + animator (4c-vfx-2) and
-    // PBD pending splats (4c-pbd) moved to their respective systems;
-    // we only keep non-owning pointers so record_gs_prepass can tick them.
+    // Phase 4c-vfx-2 / 4c-pbd / 4d-2: VFX instances + animator (4c-vfx-2),
+    // PBD pending splats (4c-pbd), and static lights + per-frame merge
+    // (4d-2) all moved to their respective systems; we only keep
+    // non-owning pointers so record_gs_prepass can tick them.
     systems::VfxSystem* vfx_system_ = nullptr;
     systems::PbdSystem* pbd_system_ = nullptr;
+    systems::LightingSystem* lighting_system_ = nullptr;
 
     // ── Frame-determinism harness internal state ──
     struct DeterminismTestState {
@@ -385,7 +395,6 @@ private:
     uint32_t gs_prev_budget_ = 0;
     glm::vec3 gs_lod_focus_pos_{0.0f};  // Player position for foveated LOD
     bool gs_has_lod_focus_ = false;
-    std::vector<PointLight> gs_static_lights_;  // Scene-defined lights (for VFX light merging)
 
     // Persistent post-process params (modified by Staging panels)
     PostProcessParams pp_params_;

--- a/include/gseurat/engine/systems/lighting_system.hpp
+++ b/include/gseurat/engine/systems/lighting_system.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+// Phase 4d-2: Lighting system.
+//
+// Owns the static point-light set that used to live as
+// `Renderer::gs_static_lights_`. Subscribes to `PointLightsLoadedEvent`
+// (emitted by scene loader, command dispatcher, and dev panels) and
+// performs the per-frame merge with VFX-emitted lights that previously
+// sat inline in `Renderer::record_gs_prepass`.
+//
+// Flow per frame:
+//   1. main_loop calls `run(world, dt)` — drains events; an empty
+//      payload resets `light_mode` to 0 (preserves command_dispatcher
+//      behavior on update_scene_data with no lights).
+//   2. `update_per_frame()` (called from `record_gs_prepass`) merges
+//      `static_lights_` with VFX-active lights up to 8 entries and
+//      pushes the result via `GsRenderer::set_point_lights` if
+//      non-empty. Empty result leaves the prior GPU state intact —
+//      matches the historical per-frame merge that gated on
+//      `!all_lights.empty()`.
+//
+// Held by AppBase as a unique_ptr alongside VfxSystem / PbdSystem.
+// Constructed in init_game_object_system; render_state late-binds in
+// init_render_state.
+
+#include "gseurat/engine/ecs/events.hpp"
+#include "gseurat/engine/ecs/world.hpp"
+#include "gseurat/engine/light_events.hpp"
+#include "gseurat/engine/render_state.hpp"
+#include "gseurat/engine/types.hpp"
+
+#include <cstddef>
+#include <vector>
+
+namespace gseurat {
+
+class Renderer;
+namespace systems {
+
+class VfxSystem;
+
+class LightingSystem {
+public:
+    LightingSystem() noexcept = default;
+    LightingSystem(Renderer* renderer, VfxSystem* vfx_system,
+                   RenderState* render_state) noexcept
+        : renderer_(renderer), vfx_system_(vfx_system),
+          render_state_(render_state) {}
+
+    void set_renderer(Renderer* r) noexcept { renderer_ = r; }
+    void set_vfx_system(VfxSystem* vs) noexcept { vfx_system_ = vs; }
+    void set_render_state(RenderState* rs) noexcept { render_state_ = rs; }
+
+    // Drain PointLightsLoadedEvents — each event REPLACES static_lights_.
+    // Empty payload also resets renderer's light_mode to 0 (preserves
+    // pre-refactor command_dispatcher::update_scene_data behavior).
+    void run(ecs::World& world, float dt);
+
+    // Per-frame merge: static_lights_ ∪ vfx_system_->collect_active_lights
+    // (cap 8). If non-empty, push to renderer.gs_renderer().set_point_lights
+    // and set light_mode=2 if it was lower. Called from Renderer's
+    // record_gs_prepass once per frame.
+    void update_per_frame();
+
+    // Direct setter for tests / future bypasses. Production paths emit
+    // events; this skips the bus.
+    void set_static_lights(std::vector<PointLight> lights) noexcept {
+        static_lights_ = std::move(lights);
+    }
+    const std::vector<PointLight>& static_lights() const noexcept {
+        return static_lights_;
+    }
+
+    // Test seam — drains and returns events without forwarding.
+    std::vector<PointLightsLoadedEvent> drain_events(ecs::World& world) {
+        auto& queue = world.events<PointLightsLoadedEvent>();
+        std::vector<PointLightsLoadedEvent> out;
+        queue.read(load_cursor_).for_each(
+            [&](const PointLightsLoadedEvent& evt) { out.push_back(evt); });
+        return out;
+    }
+
+    ecs::EventCursor& cursor() noexcept { return load_cursor_; }
+    const ecs::EventCursor& cursor() const noexcept { return load_cursor_; }
+
+private:
+    Renderer* renderer_ = nullptr;
+    VfxSystem* vfx_system_ = nullptr;
+    RenderState* render_state_ = nullptr;
+    ecs::EventCursor load_cursor_{};
+    std::vector<PointLight> static_lights_;
+};
+
+}  // namespace systems
+}  // namespace gseurat

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -367,6 +367,9 @@ void AppBase::main_loop() {
         if (pbd_system_) {
             pbd_system_->run(world_, dt);
         }
+        if (lighting_system_) {
+            lighting_system_->run(world_, dt);
+        }
         world_.rotate_events();
 #if GSEURAT_DEBUG_BUILD
         const auto t_after_update = std::chrono::steady_clock::now();
@@ -612,12 +615,16 @@ void AppBase::init_render_state() {
     if (pbd_system_) {
         pbd_system_->set_render_state(render_state_.get());
     }
-    // Renderer needs back-pointers to both systems so record_gs_prepass
-    // can drive their per-frame update + dispatch_compose calls.
-    // (4c-pbd: also fixes a latent wire-up gap from 4c-vfx-2 where
-    // set_vfx_system was declared but never invoked.)
+    if (lighting_system_) {
+        lighting_system_->set_render_state(render_state_.get());
+    }
+    // Renderer needs back-pointers to these systems so record_gs_prepass
+    // can drive their per-frame work. (4c-pbd: also fixes a latent
+    // wire-up gap from 4c-vfx-2 where set_vfx_system was declared
+    // but never invoked.)
     renderer_.set_vfx_system(vfx_system_.get());
     renderer_.set_pbd_system(pbd_system_.get());
+    renderer_.set_lighting_system(lighting_system_.get());
 }
 
 void AppBase::upload_bone_transforms() {
@@ -895,6 +902,15 @@ void AppBase::init_game_object_system() {
     // the GPU upload to GsRenderer, so it needs a back-pointer to
     // the Renderer (constructed before this in init_window).
     pbd_system_ = std::make_unique<systems::PbdSystem>(&renderer_, render_state_.get());
+
+    // Phase 4d-2: LightingSystem owns the static light set and runs
+    // the per-frame static+VFX merge. Needs both Renderer (for GPU
+    // upload via set_point_lights / light_mode) and VfxSystem (for
+    // per-frame collect_active_lights). vfx_system_ is non-null by
+    // now (constructed a few lines above); render_state_ may be null
+    // until init_render_state runs.
+    lighting_system_ = std::make_unique<systems::LightingSystem>(
+        &renderer_, vfx_system_.get(), render_state_.get());
 
     // Register engine-level systems
     system_scheduler_.add_system({"bone_animation",

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -13,6 +13,7 @@
 #include "gseurat/engine/gs_terrain_state.hpp"
 #include "gseurat/engine/gs_vfx.hpp"
 #include "gseurat/engine/input_manager.hpp"
+#include "gseurat/engine/light_events.hpp"
 #include "gseurat/engine/project_root.hpp"
 #include "gseurat/engine/renderer.hpp"
 #include "gseurat/engine/scene.hpp"
@@ -337,13 +338,11 @@ void CommandDispatcher::register_default_commands() {
                 t.position_and_radius.z = world.vec().y;  // internal slot 2 = world Y (height)
                 gs_lights.push_back(t);
             }
-            if (!gs_lights.empty()) {
-                ctx_.renderer.gs_renderer().set_light_mode(2);
-                ctx_.renderer.gs_renderer().set_point_lights(gs_lights);
-                ctx_.renderer.set_gs_static_lights(gs_lights);
-            } else {
-                ctx_.renderer.gs_renderer().set_light_mode(0);
-            }
+            // Phase 4d-2: route through PointLightsLoadedEvent. Empty
+            // payload tells LightingSystem to reset light_mode to 0,
+            // preserving prior update_scene_data semantics.
+            ctx_.world.events<PointLightsLoadedEvent>().send(
+                PointLightsLoadedEvent{gs_lights});
 
             // Apply weather fog directly to scene (no WeatherSystem in Staging)
             ctx_.scene.set_fog_density(scene_data.weather.fog_density);

--- a/src/engine/dev_panels.cpp
+++ b/src/engine/dev_panels.cpp
@@ -2,8 +2,10 @@
 
 #include "gseurat/engine/dev_panels.hpp"
 #include "gseurat/engine/app_base.hpp"
+#include "gseurat/engine/light_events.hpp"
 #include "gseurat/engine/renderer.hpp"
 #include "gseurat/engine/gs_renderer.hpp"
+#include "gseurat/engine/systems/lighting_system.hpp"
 
 #include <imgui.h>
 #include <filesystem>
@@ -182,7 +184,13 @@ void draw_lighting_panel(AppBase& app) {
 
     ImGui::Separator();
 
-    auto lights = gs.point_lights();
+    // Phase 4d-2: read from LightingSystem's static set (the renderer-side
+    // point_lights_ now also includes VFX-merged entries, which we don't
+    // want to expose here). Falls back to the renderer's list if the
+    // system isn't yet bound (e.g. early init in test harnesses).
+    auto lights = app.lighting_system()
+        ? app.lighting_system()->static_lights()
+        : gs.point_lights();
     bool lights_changed = false;
     ImGui::Text("Point Lights: %zu / 8", lights.size());
 
@@ -233,7 +241,11 @@ void draw_lighting_panel(AppBase& app) {
     }
 
     if (lights_changed) {
-        gs.set_point_lights(lights);
+        // Phase 4d-2: emit the new static set; LightingSystem's run()
+        // will pick it up on the next tick and the per-frame merge
+        // will re-upload to the GPU.
+        app.world().events<PointLightsLoadedEvent>().send(
+            PointLightsLoadedEvent{lights});
     }
 
     ImGui::End();

--- a/src/engine/gs_scene_loader.cpp
+++ b/src/engine/gs_scene_loader.cpp
@@ -7,6 +7,7 @@
 #include "gseurat/engine/coordinate.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/gs_vfx.hpp"
+#include "gseurat/engine/light_events.hpp"
 #include "gseurat/engine/pbd_events.hpp"
 #include "gseurat/engine/pbd_types.hpp"
 #include "gseurat/engine/renderer.hpp"
@@ -357,12 +358,14 @@ void GsSceneLoader::finalize_on_main(SceneLoadContext& ctx, const SceneData& sce
                 gs_lights.push_back(test_light);
             }
 
-            if (!gs_lights.empty()) {
-                ctx.renderer.gs_renderer().set_light_mode(2);
-                ctx.renderer.gs_renderer().set_point_lights(gs_lights);
-                ctx.renderer.set_gs_static_lights(gs_lights);
-                if (opts.set_god_rays) ctx.renderer.set_god_rays_intensity(1.0f);
+            if (!gs_lights.empty() && opts.set_god_rays) {
+                ctx.renderer.set_god_rays_intensity(1.0f);
             }
+            // Phase 4d-2: route through PointLightsLoadedEvent. LightingSystem::run
+            // updates its static_lights_; the next update_per_frame produces the
+            // merged static+VFX upload and sets light_mode.
+            ctx.world.events<PointLightsLoadedEvent>().send(
+                PointLightsLoadedEvent{gs_lights});
 
             // Emitters (grid->world)
             for (const auto& em : scene_data.gs_particle_emitters) {

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -9,6 +9,7 @@
 #include "gseurat/engine/sort_entry.hpp"
 #include "gseurat/engine/sort_hash.hpp"
 #include "gseurat/engine/streaming_config.hpp"
+#include "gseurat/engine/systems/lighting_system.hpp"
 #include "gseurat/engine/systems/pbd_system.hpp"
 #include "gseurat/engine/systems/vfx_system.hpp"
 
@@ -1392,20 +1393,11 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                     gs_particle_emitters_.end());
             }
 
-            // Phase 4c-vfx-2: VFX per-frame timeline + erase has moved
-            // into VfxSystem::update_per_frame above. Lights still merge
-            // here so the renderer remains the owner of the lights upload.
-            {
-                auto all_lights = gs_static_lights_;
-                if (vfx_system_) {
-                    vfx_system_->collect_active_lights(all_lights, 8);
-                }
-                if (!all_lights.empty()) {
-                    if (gs_renderer_.light_mode() < 2) {
-                        gs_renderer_.set_light_mode(2);
-                    }
-                    gs_renderer_.set_point_lights(all_lights);
-                }
+            // Phase 4d-2: static + VFX-emitted light merge moved into
+            // systems::LightingSystem. Falls through harmlessly if the
+            // system isn't bound (tests / standalone harness).
+            if (lighting_system_) {
+                lighting_system_->update_per_frame();
             }
 
             // Upload dynamic Gaussians. The dynamic_gaussian_ssbo layout

--- a/src/engine/systems/lighting_system.cpp
+++ b/src/engine/systems/lighting_system.cpp
@@ -15,7 +15,16 @@ void LightingSystem::run(ecs::World& world, float /*dt*/) {
             // a scene declares no lights, the prior implementation
             // explicitly turned off light_mode rather than leaving
             // stale lights bound.
-            renderer_->gs_renderer().set_light_mode(0);
+            auto& gs = renderer_->gs_renderer();
+            gs.set_light_mode(0);
+            // Also flush GsRenderer's cached point_lights_ vector so
+            // later reads (e.g. dev_panels' point_lights() / gizmos)
+            // and any re-enable of light_mode don't surface stale
+            // entries from the previous scene (Codex P2 on PR #439).
+            // The per-frame merge can't do this on its own because it
+            // gates uploads on `!all.empty()` to preserve historical
+            // behavior; the explicit-clear case lives here.
+            gs.set_point_lights({});
         }
     });
 }

--- a/src/engine/systems/lighting_system.cpp
+++ b/src/engine/systems/lighting_system.cpp
@@ -1,0 +1,42 @@
+#include "gseurat/engine/systems/lighting_system.hpp"
+
+#include "gseurat/engine/gs_renderer.hpp"
+#include "gseurat/engine/renderer.hpp"
+#include "gseurat/engine/systems/vfx_system.hpp"
+
+namespace gseurat::systems {
+
+void LightingSystem::run(ecs::World& world, float /*dt*/) {
+    auto& queue = world.events<PointLightsLoadedEvent>();
+    queue.read(load_cursor_).for_each([this](const PointLightsLoadedEvent& evt) {
+        static_lights_ = evt.lights;
+        if (evt.lights.empty() && renderer_) {
+            // Mirror command_dispatcher's update_scene_data path: when
+            // a scene declares no lights, the prior implementation
+            // explicitly turned off light_mode rather than leaving
+            // stale lights bound.
+            renderer_->gs_renderer().set_light_mode(0);
+        }
+    });
+}
+
+void LightingSystem::update_per_frame() {
+    if (renderer_ == nullptr) return;
+    auto all = static_lights_;
+    if (vfx_system_ != nullptr) {
+        vfx_system_->collect_active_lights(all, 8);
+    }
+    if (all.empty()) {
+        // Preserve historical behavior: when the merge yields no
+        // lights this frame, don't touch the renderer's GPU light
+        // state. The mode-reset case is handled in run() on event.
+        return;
+    }
+    auto& gs = renderer_->gs_renderer();
+    if (gs.light_mode() < 2) {
+        gs.set_light_mode(2);
+    }
+    gs.set_point_lights(all);
+}
+
+}  // namespace gseurat::systems

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -4,6 +4,7 @@
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/gs_parallax_camera.hpp"
 #include "gseurat/engine/project_root.hpp"
+#include "gseurat/engine/light_events.hpp"
 #include "gseurat/engine/pbd_events.hpp"
 #include "gseurat/engine/scene_loader.hpp"
 #include "gseurat/engine/gs_vfx.hpp"
@@ -110,6 +111,8 @@ void StagingApp::clear_scene() {
     // in-progress scene load before this clear runs. Drop them so the
     // next scene's PBD config doesn't get clobbered by stale state.
     world_.events<PbdElementsLoadedEvent>().clear();
+    // Phase 4d-2: same for PointLightsLoadedEvents.
+    world_.events<PointLightsLoadedEvent>().clear();
     scene_.clear_lights();
     gs_terrain_.terrain_aabb = AABB{};
     gs_terrain_.terrain_aabb.min = glm::vec3(0.0f);


### PR DESCRIPTION
## Summary

Second half of Phase 4d. Completes the scene-load event migration by moving the static point-light set out of Renderer into a new `systems::LightingSystem` and routing all 4 `set_point_lights` call sites through `PointLightsLoadedEvent`.

### Migration map

| Before | After |
|---|---|
| `Renderer::gs_static_lights_` field | `LightingSystem::static_lights_` |
| `Renderer::set_gs_static_lights(...)` | callers emit `PointLightsLoadedEvent` |
| Per-frame `static ∪ vfx_lights → set_point_lights` in `record_gs_prepass:1399-1408` | `LightingSystem::update_per_frame()` |
| `gs_scene_loader.cpp:362` direct call | emit event |
| `command_dispatcher.cpp:340` direct call (with empty-set mode reset) | emit event (empty payload triggers mode reset in `LightingSystem::run`) |
| `dev_panels.cpp:236` direct call | emit event, reads from `app.lighting_system()->static_lights()` |

### New types

```cpp
// light_events.hpp
struct PointLightsLoadedEvent {
    std::vector<PointLight> lights;  // empty = clear static set + reset light_mode
};

// systems/lighting_system.hpp
class LightingSystem {
    LightingSystem(Renderer*, VfxSystem*, RenderState*);
    void run(ecs::World&, float);   // drain events
    void update_per_frame();         // merge + push to renderer
    ...
};
```

### Empty-payload semantics

The pre-refactor `command_dispatcher::update_scene_data` path had a quirk: when the new scene had no lights, it explicitly reset `light_mode=0`. This behavior is preserved by `LightingSystem::run` — an empty event payload resets light_mode while clearing the static set. The per-frame merge then does nothing.

### Note on the SSBO path

`RenderState::point_lights_buffer` exists from Phase 3b but the renderer doesn't yet read from it — `GsRenderer` packs lights into its per-frame UBO via the `point_lights_` vector each draw. This PR keeps the CPU ownership move clean. The GPU descriptor migration (renderer reads from `RenderState::point_lights_buffer(FrameIndex)`) is a separate later PR.

## Test plan

- [x] macos-debug build clean
- [x] macos-release build clean
- [x] macos-release-with-diag build clean
- [x] `test_render_state` — 10/10 PASS
- [x] `test_vfx_system` — 6/6 PASS
- [x] `test_pbd_solver` — 127/127 PASS
- [x] 8s `gseurat_demo` smoke: VFX `chimney_smoke` spawns (exercises the per-frame merge path since the chimney emits VFX lights), `ShutdownAuditor` clean, no Vulkan validation errors

## Out of scope (4e follow-up)

- Particle emitter writer (`gs_particle_emitters_`).
- Final cleanup of any remaining Renderer state fields.
- Renderer-side descriptor migration to read lights from `RenderState::point_lights_buffer` instead of GsRenderer's internal `point_lights_` vector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)