### PR TITLE
refactor(engine): migrate particles to ParticleSystem + compose pass (Phase 4e)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,7 @@ target_sources(gseurat_core PRIVATE src/engine/render_state.cpp)
 target_sources(gseurat_core PRIVATE src/engine/systems/vfx_system.cpp)
 target_sources(gseurat_core PRIVATE src/engine/systems/pbd_system.cpp)
 target_sources(gseurat_core PRIVATE src/engine/systems/lighting_system.cpp)
+target_sources(gseurat_core PRIVATE src/engine/systems/particle_system.cpp)
 
 if(GSEURAT_SHARED_LIBS)
     target_compile_definitions(gseurat_core PUBLIC GSEURAT_ENGINE_BUILD_SHARED)

--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -42,6 +42,7 @@
 #include "gseurat/engine/scene.hpp"
 #include "gseurat/engine/screen_effects.hpp"
 #include "gseurat/engine/systems/lighting_system.hpp"
+#include "gseurat/engine/systems/particle_system.hpp"
 #include "gseurat/engine/systems/pbd_system.hpp"
 #include "gseurat/engine/systems/transition_system.hpp"
 #include "gseurat/engine/systems/vfx_system.hpp"
@@ -103,6 +104,9 @@ public:
     // Phase 4d-2: static lights + static+VFX merge ownership.
     systems::LightingSystem* lighting_system() { return lighting_system_.get(); }
     const systems::LightingSystem* lighting_system() const { return lighting_system_.get(); }
+    // Phase 4e: particle emitter ownership + per-frame compose.
+    systems::ParticleSystem* particle_system() { return particle_system_.get(); }
+    const systems::ParticleSystem* particle_system() const { return particle_system_.get(); }
     ResourceManager& resources() { return resources_; }
     Scene& scene() { return scene_; }
     ecs::World& world() { return world_; }
@@ -339,6 +343,11 @@ protected:
     // Phase 4d-2: Static lights + static+VFX merge owner. Same
     // late-construction shape as VFX/PBD.
     std::unique_ptr<systems::LightingSystem> lighting_system_;
+
+    // Phase 4e: Particle emitters owner. Writes encoded GpuGaussians
+    // into RenderState::particles_buffer per frame, consumed by
+    // GsRenderer::dispatch_compose_particles.
+    std::unique_ptr<systems::ParticleSystem> particle_system_;
 
     // Bone pre-upload hook (Phase 4b: writer API). Game-specific code
     // installs this to fill specific bone slots (e.g. the player's bones)

--- a/include/gseurat/engine/command_context.hpp
+++ b/include/gseurat/engine/command_context.hpp
@@ -25,7 +25,7 @@ class ControlServer;
 struct FeatureFlags;
 class CameraZoneSystem;
 class CollisionSystem;
-namespace systems { class VfxSystem; }
+namespace systems { class VfxSystem; class ParticleSystem; }
 struct CommandContext {
     const GsTerrainState& terrain;
     SceneObjectState& scene_objects;
@@ -63,6 +63,9 @@ struct CommandContext {
     // Phase 4c-vfx-2: VFX commands talk to VfxSystem, not Renderer.
     // Null only in test harnesses without an AppBase.
     systems::VfxSystem* vfx_system = nullptr;
+    // Phase 4e: emitter add/clear and emitter-count reads go through
+    // ParticleSystem. Same nullable contract.
+    systems::ParticleSystem* particle_system = nullptr;
 
     // Step-mode: set by the "step" command; main loop consumes one per frame.
     // Non-null only when AppBase wires it up (demo/gameplay path). Atomic so

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -165,6 +165,16 @@ public:
     void dispatch_compose_pbd(VkCommandBuffer cmd, FrameIndex frame_idx,
                               uint32_t vfx_count, uint32_t pbd_count);
 
+    // Phase 4e: GPU compose pass for particle splats. Copies
+    // `particles_count` slots from RenderState's particles_buffer
+    // into dynamic_gaussian_ssbo at offset
+    // `persistent_dyn_count_ + vfx_count + pbd_count`. Must be called
+    // AFTER both other compose dispatches and BEFORE
+    // update_dynamic_gaussians on the same frame.
+    void dispatch_compose_particles(VkCommandBuffer cmd, FrameIndex frame_idx,
+                                    uint32_t prior_offset,
+                                    uint32_t particles_count);
+
     // Once-per-scene (or per-chunk-event) upload API for the "persistent prefix"
     // of the dynamic buffer: characters, NPCs, PBD-tagged trees. Replaces all
     // existing persistent-dynamic content. Caller assembles the full vector;
@@ -677,18 +687,19 @@ private:
     VkPipeline pbd_pipeline_ = VK_NULL_HANDLE;
     VkDescriptorSet pbd_set_ = VK_NULL_HANDLE;
 
-    // Phase 4c-vfx / 4c-pbd: GPU compose pass. Dedicated descriptor pool
-    // so the central kSetCount=58 allocation in dispatch_descriptor_sets
-    // doesn't get reshuffled. One set per (frame, source) pair: VFX +
-    // PBD share the same pipeline + push-constant layout (splat_count,
-    // dst_offset) but distinct src descriptors, so we allocate
-    // 2 × kMaxFramesInFlight sets total.
+    // Phase 4c-vfx / 4c-pbd / 4e: GPU compose pass. Dedicated descriptor
+    // pool so the central kSetCount=58 allocation in dispatch_descriptor_sets
+    // doesn't get reshuffled. One set per (frame, source) tuple: VFX +
+    // PBD + Particles share the same pipeline + push-constant layout
+    // (splat_count, dst_offset) but distinct src descriptors, so we
+    // allocate 3 × kMaxFramesInFlight sets total.
     VkDescriptorSetLayout compose_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout compose_pipeline_layout_ = VK_NULL_HANDLE;
     VkPipeline compose_pipeline_ = VK_NULL_HANDLE;
     VkDescriptorPool compose_pool_ = VK_NULL_HANDLE;
     std::array<VkDescriptorSet, kMaxFramesInFlight> compose_sets_vfx_{};
     std::array<VkDescriptorSet, kMaxFramesInFlight> compose_sets_pbd_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> compose_sets_particles_{};
     // Both sets are written together by update_compose_descriptors when
     // render_state_ and dynamic_gaussian_ssbo_ are both live.
     bool compose_descriptors_initialised_ = false;

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -36,7 +36,7 @@ struct GLFWwindow;
 namespace gseurat {
 
 class ResourceManager;
-namespace systems { class VfxSystem; class PbdSystem; class LightingSystem; }
+namespace systems { class VfxSystem; class PbdSystem; class LightingSystem; class ParticleSystem; }
 
 // Small constant-size summary of the loaded GS cloud. Replaces the demo-side
 // reads of `cloud_bounds()` / `chunk_count()` / `all_gaussians()` with a
@@ -153,10 +153,11 @@ public:
     PostProcessParams& post_process_params() { return pp_params_; }
     const PostProcessParams& post_process_params() const { return pp_params_; }
 
-    // Gaussian particle emitters
-    void add_gs_particle_emitter(const GsEmitterConfig& config);
-    void clear_gs_particle_emitters();
-    std::vector<GaussianParticleEmitter>& gs_particle_emitters() { return gs_particle_emitters_; }
+    // Phase 4e: Gaussian particle emitters moved to systems::ParticleSystem.
+    // Callers use `app.particle_system()->add_emitter(...)`,
+    // `clear_emitters()`, and `emitters()`. The renderer holds a non-
+    // owning pointer to dispatch per-frame update + compose from
+    // record_gs_prepass.
 
     // Phase 4c-vfx-2: GaussianAnimator + vfx_instances_ moved to
     // systems::VfxSystem. The renderer now holds a non-owning pointer
@@ -175,6 +176,13 @@ public:
     // calls lighting_system_->update_per_frame() from record_gs_prepass.
     void set_lighting_system(systems::LightingSystem* ls) noexcept {
         lighting_system_ = ls;
+    }
+
+    // Phase 4e: particle emitters moved to systems::ParticleSystem.
+    // Renderer drives per-frame update + dispatch_compose_particles
+    // from record_gs_prepass.
+    void set_particle_system(systems::ParticleSystem* ps) noexcept {
+        particle_system_ = ps;
     }
 
     // Scene-placed animations (with loop support)
@@ -357,18 +365,17 @@ private:
     // `GsSceneLoader::parse` (Option B per #396 §A); the renderer is a
     // pure GPU consumer once init_gs returns.
     GsCloudMetadata gs_cloud_metadata_;
-    std::vector<Gaussian> gs_dynamic_buffer_;
     glm::mat4 gs_prev_view_{0.0f};  // for camera dirty detection
     bool gs_static_force_dirty_ = false;
-    std::vector<GaussianParticleEmitter> gs_particle_emitters_;
     std::vector<SceneAnimation> gs_scene_animations_;
-    // Phase 4c-vfx-2 / 4c-pbd / 4d-2: VFX instances + animator (4c-vfx-2),
-    // PBD pending splats (4c-pbd), and static lights + per-frame merge
-    // (4d-2) all moved to their respective systems; we only keep
-    // non-owning pointers so record_gs_prepass can tick them.
+    // Phase 4c-vfx-2 / 4c-pbd / 4d-2 / 4e: VFX instances + animator,
+    // PBD pending splats, static lights + per-frame merge, and particle
+    // emitters have all moved to their respective systems; we only
+    // keep non-owning pointers so record_gs_prepass can tick them.
     systems::VfxSystem* vfx_system_ = nullptr;
     systems::PbdSystem* pbd_system_ = nullptr;
     systems::LightingSystem* lighting_system_ = nullptr;
+    systems::ParticleSystem* particle_system_ = nullptr;
 
     // ── Frame-determinism harness internal state ──
     struct DeterminismTestState {

--- a/include/gseurat/engine/scene_load_context.hpp
+++ b/include/gseurat/engine/scene_load_context.hpp
@@ -10,7 +10,7 @@ namespace ecs { class World; }
 class ComponentRegistry;
 class ResourceManager;
 struct FeatureFlags;
-namespace systems { class VfxSystem; }
+namespace systems { class VfxSystem; class ParticleSystem; }
 
 struct SceneLoadContext {
     GsTerrainState& terrain;
@@ -24,6 +24,9 @@ struct SceneLoadContext {
     // Phase 4c-vfx-2: VFX spawn target. Null is tolerated (scene load
     // without VfxSystem skips VFX instances rather than crashing).
     systems::VfxSystem* vfx_system = nullptr;
+    // Phase 4e: Particle emitter sink. Null tolerated; scene loads
+    // without a system skip emitter setup.
+    systems::ParticleSystem* particle_system = nullptr;
 };
 
 }  // namespace gseurat

--- a/include/gseurat/engine/systems/particle_system.hpp
+++ b/include/gseurat/engine/systems/particle_system.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+// Phase 4e: Gaussian particle system.
+//
+// Owns the per-scene set of Gaussian particle emitters that used to
+// live as `Renderer::gs_particle_emitters_`. Per-frame, ticks each
+// emitter, distance-culls, gathers emitted Gaussians, encodes them
+// into RenderState's `particles_buffer` via `particles_writer`, and
+// returns the slot count for `GsRenderer::dispatch_compose_particles`
+// to copy into `dynamic_gaussian_ssbo` after the VFX + PBD prefixes.
+//
+// Same back-pointer / late-bind pattern as VFX / PBD / Lighting:
+// constructed in `AppBase::init_game_object_system` with a possibly-
+// null `RenderState*`; `init_render_state` late-binds the writer.
+
+#include "gseurat/engine/gaussian_cloud.hpp"
+#include "gseurat/engine/gs_particle.hpp"
+#include "gseurat/engine/render_state.hpp"
+
+#include <glm/glm.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace gseurat::systems {
+
+class ParticleSystem {
+public:
+    ParticleSystem() noexcept = default;
+    explicit ParticleSystem(RenderState* render_state) noexcept
+        : render_state_(render_state) {}
+
+    void set_render_state(RenderState* rs) noexcept { render_state_ = rs; }
+
+    // Producer API (replaces Renderer::add_gs_particle_emitter /
+    // clear_gs_particle_emitters). The system constructs the emitter
+    // in-place to preserve the existing emplace_back pattern.
+    void add_emitter(const GsEmitterConfig& config);
+    void clear_emitters() noexcept { emitters_.clear(); }
+
+    // Read access (replaces Renderer::gs_particle_emitters() for the
+    // 7+ caller sites in demo / staging / dispatcher). Mutating
+    // returned vector is permitted but rare — most callers iterate.
+    std::vector<GaussianParticleEmitter>& emitters() noexcept { return emitters_; }
+    const std::vector<GaussianParticleEmitter>& emitters() const noexcept {
+        return emitters_;
+    }
+
+    // Per-frame tick. Updates each emitter, gathers Gaussians via
+    // emitter.gather, encodes them into RenderState::particles_buffer,
+    // erases dead emitters. Returns the slot count actually written
+    // (clamped to writer capacity). Returns 0 if render_state_ is null
+    // or no emitters are active.
+    //
+    // `cull_dist_sq <= 0` disables distance culling. `cull_origin` is
+    // the camera world position. Distance-culled emitters still tick
+    // (so their simulation doesn't freeze when off-screen) but their
+    // gathered Gaussians are dropped for this frame.
+    uint32_t update_per_frame(float dt, FrameIndex frame_idx,
+                              const glm::vec3& cull_origin,
+                              float cull_dist_sq);
+
+private:
+    RenderState* render_state_ = nullptr;
+    std::vector<GaussianParticleEmitter> emitters_;
+    // Scratch CPU buffer reused frame-to-frame for emitter.gather.
+    std::vector<Gaussian> scratch_;
+};
+
+}  // namespace gseurat::systems

--- a/src/demo/gs_demo_state.cpp
+++ b/src/demo/gs_demo_state.cpp
@@ -430,7 +430,7 @@ void GsDemoState::update(AppBase& app, float dt) {
     if (app.input().was_key_pressed(GLFW_KEY_J)) {
         auto preset = gs_preset_spark_shower();
         preset.position = target_;
-        app.renderer().add_gs_particle_emitter(preset);
+        app.particle_system()->add_emitter(preset);
         std::fprintf(stderr, "GS Particles: spark shower at (%.1f, %.1f, %.1f)\n",
                      target_.x, target_.y, target_.z);
     }
@@ -563,7 +563,7 @@ void GsDemoState::build_draw_lists(AppBase& app) {
         // Show marker info
         std::snprintf(buf, sizeof(buf), "Markers: %zu  Path: %zu  Emitters: %zu  Anims: %zu  VFX: %zu",
                       demo_markers_.size(), demo_path_.size(),
-                      app.renderer().gs_particle_emitters().size(),
+                      app.particle_system()->emitters().size(),
                       app.renderer().gs_scene_animations().size(),
                       app.vfx_system() ? app.vfx_system()->instances().size() : 0);
         ui.label(buf, lx, y, scale, layer_color);
@@ -647,7 +647,7 @@ void GsDemoState::build_draw_lists(AppBase& app) {
             }
 
             // Draw particle emitter markers (P0, P1, ...) — magenta diamond
-            auto& emitters = app.renderer().gs_particle_emitters();
+            auto& emitters = app.particle_system()->emitters();
             for (size_t i = 0; i < emitters.size(); ++i) {
                 auto [sx, sy] = project(emitters[i].config().position);
                 if (sx > 0 && sx < screen_w && sy > 0 && sy < screen_h) {

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1332,7 +1332,7 @@ void IslandDemoState::update_effects(AppBase& app, float dt) {
         world.view<EmitterToggle, ProximityTrigger>().each(
             [&](ecs::Entity, EmitterToggle& et, ProximityTrigger& pt) {
                 count++;
-                auto& emitters = app.renderer().gs_particle_emitters();
+                auto& emitters = app.particle_system()->emitters();
                 if (et.emitter_index >= emitters.size()) return;
                 auto& emitter = emitters[et.emitter_index];
                 if (pt.triggered && !et.active) {
@@ -1409,7 +1409,7 @@ void IslandDemoState::update_effects(AppBase& app, float dt) {
                     cfg.opacity_end = 0.0f;
                     cfg.emission = et.emission * 1.5f;  // extra glow for bloom
                     cfg.burst_duration = 0.0f;  // continuous
-                    app.renderer().add_gs_particle_emitter(cfg);
+                    app.particle_system()->add_emitter(cfg);
                 }
                 if (!pt.triggered && et.applied) {
                     et.applied = false;
@@ -1430,7 +1430,7 @@ void IslandDemoState::update_effects(AppBase& app, float dt) {
                     be.fired = true;
                     std::fprintf(stderr, "[BurstEffect] FIRED at (%.1f, %.1f, %.1f) emitter_index=%u\n",
                         t.position.x(), t.position.y(), t.position.z(), be.emitter_index);
-                    auto& emitters = app.renderer().gs_particle_emitters();
+                    auto& emitters = app.particle_system()->emitters();
                     if (be.emitter_index < emitters.size()) {
                         auto& emitter = emitters[be.emitter_index];
                         auto cfg = emitter.config();
@@ -1526,7 +1526,7 @@ void IslandDemoState::update_effects(AppBase& app, float dt) {
                     cfg.opacity_end = 0.0f;
                     cfg.emission = 8.0f;  // bright glow for bloom
                     cfg.burst_duration = 0.8f;  // short burst, not continuous
-                    app.renderer().add_gs_particle_emitter(cfg);
+                    app.particle_system()->add_emitter(cfg);
 
                     // Add a bright celebration light
                     PointLight pl{};
@@ -1818,7 +1818,7 @@ void IslandDemoState::build_draw_lists(AppBase& app) {
     auto& ff = app.feature_flags();
     uint32_t gs_total = gs.gaussian_count();
     uint32_t gs_visible = gs.visible_count();
-    size_t emitter_count = app.renderer().gs_particle_emitters().size();
+    size_t emitter_count = app.particle_system()->emitters().size();
 
     // Count triggered proximity triggers
     int triggered_count = 0;
@@ -2076,7 +2076,7 @@ void IslandDemoState::draw_gizmos(AppBase& app) {
     // ── Emitter gizmos ──
     if (ov.show_gizmo_emitters) {
         ImU32 col = IM_COL32(236, 72, 153, 200);
-        auto& emitters = app.renderer().gs_particle_emitters();
+        auto& emitters = app.particle_system()->emitters();
         for (size_t i = 0; i < emitters.size(); i++) {
             auto& cfg = emitters[i].config();
             float sx, sy;

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -921,6 +921,20 @@ void AppBase::init_game_object_system() {
     // Render_state binding is late.
     particle_system_ = std::make_unique<systems::ParticleSystem>(render_state_.get());
 
+    // CommandDispatcher captured a CommandContext snapshot during AppBase
+    // member-init (see hpp: `command_dispatcher_{build_command_context()}`),
+    // BEFORE any of the systems above existed. That snapshot saw null
+    // pointers for vfx_system / particle_system, so commands routed
+    // through ctx_.* would silently fail on the system-driven paths
+    // (update_scene_data emitter rebuild, update_vfx_positions, etc.).
+    // CommandContext has reference members so it can't be reassigned —
+    // patch the pointer fields in place via the existing context()
+    // accessor. (Codex P2 on PR #440; also retroactively fixes the same
+    // hazard for vfx_system introduced in PR #436.)
+    auto& ctx = command_dispatcher_.context();
+    ctx.vfx_system = vfx_system_.get();
+    ctx.particle_system = particle_system_.get();
+
     // Register engine-level systems
     system_scheduler_.add_system({"bone_animation",
         [this](ecs::World& w, float dt) {

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -618,6 +618,9 @@ void AppBase::init_render_state() {
     if (lighting_system_) {
         lighting_system_->set_render_state(render_state_.get());
     }
+    if (particle_system_) {
+        particle_system_->set_render_state(render_state_.get());
+    }
     // Renderer needs back-pointers to these systems so record_gs_prepass
     // can drive their per-frame work. (4c-pbd: also fixes a latent
     // wire-up gap from 4c-vfx-2 where set_vfx_system was declared
@@ -625,6 +628,7 @@ void AppBase::init_render_state() {
     renderer_.set_vfx_system(vfx_system_.get());
     renderer_.set_pbd_system(pbd_system_.get());
     renderer_.set_lighting_system(lighting_system_.get());
+    renderer_.set_particle_system(particle_system_.get());
 }
 
 void AppBase::upload_bone_transforms() {
@@ -912,6 +916,11 @@ void AppBase::init_game_object_system() {
     lighting_system_ = std::make_unique<systems::LightingSystem>(
         &renderer_, vfx_system_.get(), render_state_.get());
 
+    // Phase 4e: ParticleSystem owns gs_particle_emitters_ and packs
+    // per-frame Gaussians into RenderState::particles_buffer.
+    // Render_state binding is late.
+    particle_system_ = std::make_unique<systems::ParticleSystem>(render_state_.get());
+
     // Register engine-level systems
     system_scheduler_.add_system({"bone_animation",
         [this](ecs::World& w, float dt) {
@@ -991,6 +1000,7 @@ CommandContext AppBase::build_command_context() {
         },
         .control_server = &control_server_,
         .vfx_system = vfx_system_.get(),
+        .particle_system = particle_system_.get(),
         .pending_steps = &pending_steps_,
         .deferred_step_response = &deferred_step_response_,
     };
@@ -1003,6 +1013,7 @@ void AppBase::load_gs_scene(const SceneData& scene_data, const GsSceneOptions& o
         gs_terrain_, scene_objects_, renderer_, scene_,
         world_, component_registry_, resources_, feature_flags_,
         vfx_system_.get(),
+        particle_system_.get(),
     };
     GsSceneLoader loader;
     loader.load(ctx, scene_data, opts);
@@ -1018,6 +1029,7 @@ void AppBase::load_pre_parsed_gs_scene(const SceneData& scene_data,
         gs_terrain_, scene_objects_, renderer_, scene_,
         world_, component_registry_, resources_, feature_flags_,
         vfx_system_.get(),
+        particle_system_.get(),
     };
     GsSceneLoader loader;
     loader.finalize_on_main(ctx, scene_data, std::move(parsed), opts);
@@ -1075,6 +1087,7 @@ void AppBase::tick_async_load_gs_scene() {
         gs_terrain_, scene_objects_, renderer_, scene_,
         world_, component_registry_, resources_, feature_flags_,
         vfx_system_.get(),
+        particle_system_.get(),
     };
     GsSceneLoader loader;
     loader.finalize_on_main(ctx, pending.scene_data, std::move(parsed), pending.opts);

--- a/src/engine/command_dispatcher.cpp
+++ b/src/engine/command_dispatcher.cpp
@@ -14,6 +14,7 @@
 #include "gseurat/engine/gs_vfx.hpp"
 #include "gseurat/engine/input_manager.hpp"
 #include "gseurat/engine/light_events.hpp"
+#include "gseurat/engine/systems/particle_system.hpp"
 #include "gseurat/engine/project_root.hpp"
 #include "gseurat/engine/renderer.hpp"
 #include "gseurat/engine/scene.hpp"
@@ -349,12 +350,14 @@ void CommandDispatcher::register_default_commands() {
             ctx_.scene.set_fog_color(scene_data.weather.fog_color);
 
             // Rebuild emitters
-            ctx_.renderer.clear_gs_particle_emitters();
-            for (const auto& em : scene_data.gs_particle_emitters) {
-                auto config = em.config;
-                auto world_pos = coord::to_world(coord::GridPos(config.position), aabb);
-                config.position = world_pos.vec();
-                ctx_.renderer.add_gs_particle_emitter(config);
+            if (ctx_.particle_system) {
+                ctx_.particle_system->clear_emitters();
+                for (const auto& em : scene_data.gs_particle_emitters) {
+                    auto config = em.config;
+                    auto world_pos = coord::to_world(coord::GridPos(config.position), aabb);
+                    config.position = world_pos.vec();
+                    ctx_.particle_system->add_emitter(config);
+                }
             }
 
             // Rebuild animations
@@ -536,7 +539,9 @@ void CommandDispatcher::register_default_commands() {
                 });
             });
         response["triggers"] = triggers;
-        response["emitter_count"] = ctx_.renderer.gs_particle_emitters().size();
+        response["emitter_count"] = ctx_.particle_system
+            ? ctx_.particle_system->emitters().size()
+            : std::size_t{0};
         return response;
     });
 

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -764,10 +764,10 @@ void GsRenderer::create_compose_pipeline() {
     }
     vkDestroyShaderModule(device_, module, nullptr);
 
-    // Dedicated descriptor pool — 2 × kMaxFramesInFlight sets (vfx + pbd),
-    // each with 2 SSBO bindings (src + dst).
+    // Dedicated descriptor pool — 3 × kMaxFramesInFlight sets
+    // (vfx + pbd + particles), each with 2 SSBO bindings (src + dst).
     constexpr uint32_t kSetsPerSource = kMaxFramesInFlight;
-    constexpr uint32_t kSources = 2;  // vfx + pbd
+    constexpr uint32_t kSources = 3;  // vfx + pbd + particles
     VkDescriptorPoolSize pool_sizes[1] = {
         {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, kSetsPerSource * kSources * 2},
     };
@@ -793,6 +793,9 @@ void GsRenderer::create_compose_pipeline() {
     if (vkAllocateDescriptorSets(device_, &alloc_info, compose_sets_pbd_.data()) != VK_SUCCESS) {
         throw std::runtime_error("Failed to allocate compose (pbd) descriptor sets");
     }
+    if (vkAllocateDescriptorSets(device_, &alloc_info, compose_sets_particles_.data()) != VK_SUCCESS) {
+        throw std::runtime_error("Failed to allocate compose (particles) descriptor sets");
+    }
 }
 
 void GsRenderer::update_compose_descriptors() {
@@ -800,9 +803,10 @@ void GsRenderer::update_compose_descriptors() {
     for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
         VkDescriptorBufferInfo vfx_src_info{render_state_->vfx_buffer(FrameIndex{f}), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo pbd_src_info{render_state_->pbd_buffer(FrameIndex{f}), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo part_src_info{render_state_->particles_buffer(FrameIndex{f}), 0, VK_WHOLE_SIZE};
         VkDescriptorBufferInfo dst_info{dynamic_gaussian_ssbo_.buffer(), 0, VK_WHOLE_SIZE};
 
-        VkWriteDescriptorSet writes[4]{};
+        VkWriteDescriptorSet writes[6]{};
         writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
         writes[0].dstSet = compose_sets_vfx_[f];
         writes[0].dstBinding = 0;
@@ -831,7 +835,21 @@ void GsRenderer::update_compose_descriptors() {
         writes[3].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
         writes[3].pBufferInfo = &dst_info;
 
-        vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
+        writes[4].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[4].dstSet = compose_sets_particles_[f];
+        writes[4].dstBinding = 0;
+        writes[4].descriptorCount = 1;
+        writes[4].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[4].pBufferInfo = &part_src_info;
+
+        writes[5].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[5].dstSet = compose_sets_particles_[f];
+        writes[5].dstBinding = 1;
+        writes[5].descriptorCount = 1;
+        writes[5].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[5].pBufferInfo = &dst_info;
+
+        vkUpdateDescriptorSets(device_, 6, writes, 0, nullptr);
     }
     compose_descriptors_initialised_ = true;
 }
@@ -885,6 +903,35 @@ void GsRenderer::dispatch_compose_pbd(VkCommandBuffer cmd, FrameIndex frame_idx,
                        0, sizeof(pc), &pc);
     constexpr uint32_t kLocalSize = 64;
     const uint32_t groups = (pbd_count + kLocalSize - 1) / kLocalSize;
+    vkCmdDispatch(cmd, groups, 1, 1);
+
+    VkMemoryBarrier mb{};
+    mb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    mb.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    mb.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+    vkCmdPipelineBarrier(cmd,
+                         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         0, 1, &mb, 0, nullptr, 0, nullptr);
+}
+
+void GsRenderer::dispatch_compose_particles(VkCommandBuffer cmd, FrameIndex frame_idx,
+                                             uint32_t prior_offset,
+                                             uint32_t particles_count) {
+    if (particles_count == 0 || !compose_descriptors_initialised_) return;
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, compose_pipeline_);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                            compose_pipeline_layout_, 0, 1,
+                            &compose_sets_particles_[to_u32(frame_idx)], 0, nullptr);
+    struct PushConstants {
+        uint32_t splat_count;
+        uint32_t dst_offset;
+    } pc{particles_count, persistent_dyn_count_ + prior_offset};
+    vkCmdPushConstants(cmd, compose_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                       0, sizeof(pc), &pc);
+    constexpr uint32_t kLocalSize = 64;
+    const uint32_t groups = (particles_count + kLocalSize - 1) / kLocalSize;
     vkCmdDispatch(cmd, groups, 1, 1);
 
     VkMemoryBarrier mb{};

--- a/src/engine/gs_scene_loader.cpp
+++ b/src/engine/gs_scene_loader.cpp
@@ -1,5 +1,6 @@
 #include "gseurat/engine/gs_scene_loader.hpp"
 
+#include "gseurat/engine/systems/particle_system.hpp"
 #include "gseurat/engine/systems/vfx_system.hpp"
 #include "gseurat/engine/scene_load_context.hpp"
 #include "gseurat/engine/gs_terrain_state.hpp"
@@ -212,7 +213,7 @@ ParsedScene GsSceneLoader::parse(const SceneData& scene_data) {
 void GsSceneLoader::finalize_on_main(SceneLoadContext& ctx, const SceneData& scene_data,
                                      ParsedScene&& parsed, const GsSceneOptions& opts) {
 
-    ctx.renderer.clear_gs_particle_emitters();
+    if (ctx.particle_system) ctx.particle_system->clear_emitters();
     ctx.renderer.clear_gs_animations();
     if (ctx.vfx_system) {
         ctx.vfx_system->clear_instances();
@@ -368,11 +369,13 @@ void GsSceneLoader::finalize_on_main(SceneLoadContext& ctx, const SceneData& sce
                 PointLightsLoadedEvent{gs_lights});
 
             // Emitters (grid->world)
-            for (const auto& em : scene_data.gs_particle_emitters) {
-                auto config = em.config;
-                auto world_pos = coord::to_world(coord::GridPos(config.position), ctx.terrain.terrain_aabb);
-                config.position = world_pos.vec();
-                ctx.renderer.add_gs_particle_emitter(config);
+            if (ctx.particle_system) {
+                for (const auto& em : scene_data.gs_particle_emitters) {
+                    auto config = em.config;
+                    auto world_pos = coord::to_world(coord::GridPos(config.position), ctx.terrain.terrain_aabb);
+                    config.position = world_pos.vec();
+                    ctx.particle_system->add_emitter(config);
+                }
             }
 
             // Animations (grid->world)

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -10,6 +10,7 @@
 #include "gseurat/engine/sort_hash.hpp"
 #include "gseurat/engine/streaming_config.hpp"
 #include "gseurat/engine/systems/lighting_system.hpp"
+#include "gseurat/engine/systems/particle_system.hpp"
 #include "gseurat/engine/systems/pbd_system.hpp"
 #include "gseurat/engine/systems/vfx_system.hpp"
 
@@ -1338,15 +1339,23 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
         if (pbd_system_ && !determinism_test_state_.active) {
             pbd_count = pbd_system_->update_per_frame(FrameIndex{current_frame_});
         }
-        // Clamp the GPU-composed prefix so persistent + vfx + pbd fits
-        // inside max_dynamic_count_. Without this the compose shaders
+        // Phase 4e: particle emitters now own their per-frame tick + cull
+        // + erase, writing encoded GpuGaussians directly into
+        // particles_buffer. flags.particles gates BOTH the tick and the
+        // dispatch (matching pre-refactor behavior).
+        uint32_t particles_count = 0;
+        if (particle_system_ && flags.particles && !determinism_test_state_.active) {
+            particles_count = particle_system_->update_per_frame(
+                dt, FrameIndex{current_frame_}, cull_origin_v, cull_dist_sq_v);
+        }
+        // Clamp the GPU-composed prefix so persistent + vfx + pbd + particles
+        // fits inside max_dynamic_count_. Without this the compose shaders
         // would write past `dynamic_gaussian_ssbo`'s end when a scene's
         // persistent prefix is large enough to leave less headroom than
-        // the system writer caps (RenderStateConfig max_vfx_splats +
-        // max_pbd_splats currently 250k vs. kDynamicHeadroom 1M minus
-        // persistent). The old pending-dynamics path was implicitly
-        // clipped by update_dynamic_gaussians, which can only truncate
-        // the CPU portion (after the GPU prefix) — Codex P2 on #437.
+        // the system writer caps. The old pending-dynamics path was
+        // implicitly clipped by update_dynamic_gaussians, which can only
+        // truncate a CPU portion (which no longer exists post-4e) —
+        // Codex P2 on #437.
         {
             const uint32_t max_dyn = gs_renderer_.max_dynamic_count();
             const uint32_t persistent = gs_renderer_.persistent_dynamic_count();
@@ -1354,11 +1363,11 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
             if (vfx_count > gpu_budget) vfx_count = gpu_budget;
             gpu_budget -= vfx_count;
             if (pbd_count > gpu_budget) pbd_count = gpu_budget;
+            gpu_budget -= pbd_count;
+            if (particles_count > gpu_budget) particles_count = gpu_budget;
         }
 
         if (!determinism_test_state_.active) {
-            gs_dynamic_buffer_.clear();
-
             if (!gs_scene_animations_.empty()) {
                 // Phase 2 deferred: scene animations on streamed terrain
                 // need GPU-side region tagging (compute shader) since the
@@ -1375,24 +1384,6 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 gs_scene_animations_.clear();
             }
 
-            // Update and gather Gaussian particles from emitters
-            // (VFX iteration above wrote to vfx_buffer; emitters still
-            // write to gs_dynamic_buffer_ → slots after the VFX prefix.)
-            if (flags.particles) {
-                for (auto& emitter : gs_particle_emitters_) {
-                    emitter.update(dt);
-                    if (cull_dist_sq_v > 0.0f) {
-                        glm::vec3 d = emitter.position() - cull_origin_v;
-                        if (glm::dot(d, d) > cull_dist_sq_v) continue;
-                    }
-                    emitter.gather(gs_dynamic_buffer_);
-                }
-                gs_particle_emitters_.erase(
-                    std::remove_if(gs_particle_emitters_.begin(), gs_particle_emitters_.end(),
-                        [](const GaussianParticleEmitter& e) { return !e.active() && e.alive_count() == 0; }),
-                    gs_particle_emitters_.end());
-            }
-
             // Phase 4d-2: static + VFX-emitted light merge moved into
             // systems::LightingSystem. Falls through harmlessly if the
             // system isn't bound (tests / standalone harness).
@@ -1400,38 +1391,33 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 lighting_system_->update_per_frame();
             }
 
-            // Upload dynamic Gaussians. The dynamic_gaussian_ssbo layout
-            // is now [persistent | vfx | pbd | cpu]: `vfx_count` and
-            // `pbd_count` slots are filled by the GPU compose passes
-            // below, and `count` CPU-sourced slots come after.
-            {
-                auto count = static_cast<uint32_t>(gs_dynamic_buffer_.size());
-                const uint32_t gpu_prefix = vfx_count + pbd_count;
-                const uint32_t max_cpu = (gs_renderer_.max_dynamic_count() > gpu_prefix)
-                    ? gs_renderer_.max_dynamic_count() - gpu_prefix : 0;
-                if (count > max_cpu) {
-                    gs_dynamic_buffer_.resize(max_cpu);
-                    count = max_cpu;
-                }
-                gs_renderer_.update_dynamic_gaussians(gs_dynamic_buffer_.data(), count,
-                                                       /*gpu_prefix=*/gpu_prefix);
+            // Phase 4e: no more CPU dynamic upload. Every transient
+            // splat now lives in a per-frame RenderState buffer and
+            // arrives via a compose dispatch below. Calling
+            // update_dynamic_gaussians with count=0 still updates
+            // dynamic_count_ so downstream raster knows the active
+            // range.
+            const uint32_t gpu_prefix = vfx_count + pbd_count + particles_count;
+            gs_renderer_.update_dynamic_gaussians(nullptr, 0, /*gpu_prefix=*/gpu_prefix);
 #if GSEURAT_DEBUG_BUILD
-                dbg_dyn_count = count + gpu_prefix;
+            dbg_dyn_count = gpu_prefix;
 #endif
-            }
         }
 
-        // Phase 4c-vfx-2 / 4c-pbd: GPU compose passes — copy VfxSystem's
-        // per-frame vfx_buffer into dynamic_gaussian_ssbo at offset
-        // persistent_dyn_count_ for `vfx_count` slots, then PbdSystem's
-        // pbd_buffer at offset persistent_dyn_count_ + vfx_count. Both
-        // must run on the same cmd buffer BEFORE gs_renderer_.render()
-        // so downstream preprocess/sort/raster see the composed splats.
-        // Order matters because dispatch_compose_pbd uses vfx_count as
-        // an offset.
+        // Phase 4c-vfx-2 / 4c-pbd / 4e: GPU compose passes — copy each
+        // per-frame source buffer (vfx_buffer / pbd_buffer /
+        // particles_buffer) into dynamic_gaussian_ssbo at successive
+        // offsets after persistent_dyn_count_. All three must run on
+        // the same cmd buffer BEFORE gs_renderer_.render() so the
+        // downstream preprocess/sort/raster see the composed splats.
+        // Order matters because each dispatch uses the cumulative
+        // prior offset.
         gs_renderer_.dispatch_compose_vfx(cmd, FrameIndex{current_frame_}, vfx_count);
         gs_renderer_.dispatch_compose_pbd(cmd, FrameIndex{current_frame_},
                                           vfx_count, pbd_count);
+        gs_renderer_.dispatch_compose_particles(cmd, FrameIndex{current_frame_},
+                                                /*prior_offset=*/vfx_count + pbd_count,
+                                                particles_count);
 
 #if GSEURAT_DEBUG_BUILD
         const auto t_prepass_pre_render = std::chrono::steady_clock::now();
@@ -1447,7 +1433,7 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                 t_prepass_pre_render - t_prepass_start).count();
             const double gs_render_ms = std::chrono::duration<double, std::milli>(
                 t_prepass_end - t_prepass_pre_render).count();
-            const size_t emitter_count = gs_particle_emitters_.size();
+            const size_t emitter_count = particle_system_ ? particle_system_->emitters().size() : 0;
             const size_t vfx_inst_count = vfx_system_ ? vfx_system_->instances().size() : 0;
             GS_LOG_FRAME("[gs_prepass/wd/SLOW] total={:.1f}ms cpu_gather={:.1f} gs_render={:.1f} "
                          "dyn_count={} emitters={} vfx_inst={} static_dirty={}",
@@ -1692,16 +1678,6 @@ void Renderer::draw_debug_colliders(VkCommandBuffer cmd,
     // Re-bind sprite pipeline for any subsequent passes
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, sprite_pipeline_);
     sprite_batch_.bind(cmd, current_frame_);
-}
-
-void Renderer::add_gs_particle_emitter(const GsEmitterConfig& config) {
-    auto& emitter = gs_particle_emitters_.emplace_back();
-    emitter.configure(config);
-    emitter.set_active(true);
-}
-
-void Renderer::clear_gs_particle_emitters() {
-    gs_particle_emitters_.clear();
 }
 
 void Renderer::add_gs_animation(const std::string& effect, const GsAnimRegion& region,

--- a/src/engine/systems/particle_system.cpp
+++ b/src/engine/systems/particle_system.cpp
@@ -1,0 +1,50 @@
+#include "gseurat/engine/systems/particle_system.hpp"
+
+#include <algorithm>
+
+namespace gseurat::systems {
+
+void ParticleSystem::add_emitter(const GsEmitterConfig& config) {
+    auto& emitter = emitters_.emplace_back();
+    emitter.configure(config);
+    emitter.set_active(true);
+}
+
+uint32_t ParticleSystem::update_per_frame(float dt, FrameIndex frame_idx,
+                                           const glm::vec3& cull_origin,
+                                           float cull_dist_sq) {
+    if (render_state_ == nullptr || emitters_.empty()) {
+        // Still tick simulations so off-screen state doesn't freeze
+        // — but only if there's no render_state we have nowhere to
+        // write anyway. Mirrors pre-refactor "gated on flags.particles"
+        // semantics: callers gate by skipping update_per_frame entirely.
+        return 0;
+    }
+
+    scratch_.clear();
+    for (auto& emitter : emitters_) {
+        emitter.update(dt);
+        if (cull_dist_sq > 0.0f) {
+            glm::vec3 d = emitter.position() - cull_origin;
+            if (glm::dot(d, d) > cull_dist_sq) continue;
+        }
+        emitter.gather(scratch_);
+    }
+    std::erase_if(emitters_,
+        [](const GaussianParticleEmitter& e) {
+            return !e.active() && e.alive_count() == 0;
+        });
+
+    auto writer = render_state_->particles_writer(frame_idx);
+    const uint32_t cap = writer.capacity();
+    const uint32_t count = static_cast<uint32_t>(scratch_.size());
+    const uint32_t live = (count > cap) ? cap : count;
+    for (uint32_t i = 0; i < live; ++i) {
+        GpuGaussian packed{};
+        encode_gaussian(scratch_[i], packed);
+        writer.write_at(i, &packed, sizeof(GpuGaussian));
+    }
+    return live;
+}
+
+}  // namespace gseurat::systems

--- a/src/staging/staging_app.cpp
+++ b/src/staging/staging_app.cpp
@@ -94,7 +94,9 @@ void StagingApp::init_scene(const std::string& scene_path) {
 
 void StagingApp::clear_scene() {
     vkDeviceWaitIdle(renderer_.context().device());
-    renderer_.clear_gs_particle_emitters();
+    if (particle_system_) {
+        particle_system_->clear_emitters();
+    }
     renderer_.clear_gs_animations();
     if (vfx_system_) {
         vfx_system_->clear_instances();

--- a/src/staging/staging_state.cpp
+++ b/src/staging/staging_state.cpp
@@ -1019,7 +1019,7 @@ void StagingState::draw_gizmos(AppBase& app) {
     // ── Standalone emitter gizmos (with spawn region) ──
     if (ov.show_gizmo_emitters) {
         ImU32 emitter_col = IM_COL32(236, 72, 153, 200);  // pink
-        auto& emitters = app.renderer().gs_particle_emitters();
+        auto& emitters = app.particle_system()->emitters();
         for (size_t i = 0; i < emitters.size(); i++) {
             auto& cfg = emitters[i].config();
             float sx, sy;


### PR DESCRIPTION
## Summary

Final caller-migration PR of Phase 4. Moves the last residual transient state (`gs_particle_emitters_`) and its per-frame CPU update out of Renderer into a new `systems::ParticleSystem`, and extends the compose pipeline with a third source. `gs_dynamic_buffer_` is fully retired: every transient splat now flows through a typed RenderState writer.

### Migration map

| Before | After |
|---|---|
| `Renderer::gs_particle_emitters_` field | `systems::ParticleSystem::emitters_` |
| `Renderer::add_gs_particle_emitter()` | `ParticleSystem::add_emitter()` |
| `Renderer::clear_gs_particle_emitters()` | `ParticleSystem::clear_emitters()` |
| `Renderer::gs_particle_emitters()` accessor | `ParticleSystem::emitters()` |
| Per-frame emitter loop in `renderer.cpp:1378-1394` | `ParticleSystem::update_per_frame()` writes encoded GpuGaussians to `RenderState::particles_buffer` via `particles_writer` |
| `Renderer::gs_dynamic_buffer_` | **deleted** — no callers left after particles moves to GPU compose; scene_animations was already a no-op |

### New per-frame data flow

1. `vfx_system_->update_per_frame()` → `vfx_count`
2. `pbd_system_->update_per_frame()` → `pbd_count`
3. `particle_system_->update_per_frame()` → `particles_count`
4. Clamp all three counts against `max_dynamic_count_ - persistent_dyn_count_` (extends the 4c-pbd Codex P2 fix to cover all sources)
5. `update_dynamic_gaussians(nullptr, 0, vfx + pbd + particles)` — updates `dynamic_count_` only; no CPU upload remains
6. `dispatch_compose_{vfx,pbd,particles}` copy each src buffer at successive offsets
7. `gs_renderer_.render()` consumes the composed layout `[persistent | vfx | pbd | particles]`

### Compose-pipeline extension (Path A.1, third application)

- `compose_pool_` grows from `2 × kMaxFramesInFlight` to `3 × kMaxFramesInFlight` sets
- Parallel `compose_sets_particles_` alongside vfx/pbd
- `update_compose_descriptors` now writes 6 descriptors per frame (vfx src+dst, pbd src+dst, particles src+dst)
- New `dispatch_compose_particles(cmd, frame, prior_offset, count)` mirrors the vfx/pbd shape (same shader, same push constants)

### DI plumbing

- `CommandContext::particle_system` for dispatcher's emitter add/clear/count
- `SceneLoadContext::particle_system` for scene loader's emitter setup
- `AppBase::particle_system()` accessor + late-bind
- 10 caller sites (demo / staging / dispatcher / scene loader) updated

### Validation gate (per engine-refactor plan)

```
$ git grep "gs_animator_|vfx_instances_|gs_pending_dynamics_|gs_particle_emitters_" src/engine/renderer.cpp
(empty)
```

All four legacy transient fields are now gone from `renderer.cpp`. ✅

## Test plan

- [x] macos-debug build clean
- [x] macos-release build clean
- [x] macos-release-with-diag build clean
- [x] Validation gate (above) passes
- [x] `test_render_state` — 10/10 PASS
- [x] `test_vfx_system` — 6/6 PASS
- [x] `test_pbd_solver` — 127/127 PASS
- [x] 8s `gseurat_demo` smoke: chimney_smoke VFX (which contains a particle emitter sub-component) spawns + renders, PBD upload flow intact, clean ShutdownAuditor, no Vulkan validation errors

## Phase 4 complete after this lands

Next: **Phase 5** (renderer system extraction — 5a-resource-mgr, 5b-post-process, 5c-sort-system, 5d-tile-bin-system, 5e-streaming-system).

🤖 Generated with [Claude Code](https://claude.com/claude-code)