### PR TITLE
refactor(engine): extract GsPostProcessSystem (Phase 5b)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,7 @@ target_sources(gseurat_core PRIVATE src/engine/systems/pbd_system.cpp)
 target_sources(gseurat_core PRIVATE src/engine/systems/lighting_system.cpp)
 target_sources(gseurat_core PRIVATE src/engine/systems/particle_system.cpp)
 target_sources(gseurat_core PRIVATE src/engine/gs_renderer/gs_resources.cpp)
+target_sources(gseurat_core PRIVATE src/engine/gs_renderer/post/gs_post_process_system.cpp)
 
 if(GSEURAT_SHARED_LIBS)
     target_compile_definitions(gseurat_core PUBLIC GSEURAT_ENGINE_BUILD_SHARED)

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -3,6 +3,8 @@
 #include "gseurat/engine/buffer.hpp"
 #include "gseurat/engine/gaussian_cloud.hpp"
 #include "gseurat/engine/gs_renderer/gs_resources.hpp"
+#include "gseurat/engine/gs_renderer/post/gs_post_process_system.hpp"
+#include "gseurat/engine/gs_renderer/post/post_process_params.hpp"
 #include "gseurat/engine/pbd_types.hpp"
 #include "gseurat/engine/render_state.hpp"  // FrameIndex
 #include "gseurat/engine/slab_allocator.hpp"
@@ -29,58 +31,9 @@ namespace gseurat {
 
 class RenderState;
 
-// Post-process parameters forwarded from the composite pipeline to GS compute.
-// Mirrors relevant fields from PostProcessParams for consistent visual treatment.
-struct GsPostProcessParams {
-    float fog_density = 0.0f;
-    float fog_color_r = 0.3f;
-    float fog_color_g = 0.35f;
-    float fog_color_b = 0.45f;
-    float exposure = 1.2f;
-    float vignette_radius = 0.75f;
-    float vignette_softness = 0.45f;
-    float bloom_intensity = 0.35f;
-    float bloom_threshold = 1.0f;
-    float fade_amount = 0.0f;
-    float flash_r = 0.0f;
-    float flash_g = 0.0f;
-    float flash_b = 0.0f;
-    float ca_intensity = 0.0f;
-    float dof_focus_distance = 12.0f;
-    float dof_focus_range = 3.0f;
-    float dof_max_blur = 0.5f;
-    float far_plane = 1000.0f;  // GS camera far plane for depth normalization
-
-    // Hybrid background (ground plane + sky gradient)
-    glm::vec3 ground_color{0.0f};  // RGB ground color (0 = disabled)
-    glm::vec3 sky_color{0.0f};     // RGB sky color (0 = disabled)
-    float horizon_y = 0.5f;        // Normalized screen Y of horizon (0=top, 1=bottom)
-    bool background_enabled = false;
-
-    // Scene-transition overlay (final mix() applied at end of compositing).
-    // overlay_alpha == 0 produces a shader no-op.
-    float overlay_r = 1.0f;
-    float overlay_g = 1.0f;
-    float overlay_b = 1.0f;
-    float overlay_alpha = 0.0f;
-    uint32_t overlay_effect_type = 0;  // 0 = solid fade, 1 = left-to-right wipe
-};
-
-// GPU UBO layout for gs_post_process.comp (std140, 8 × vec4 + 16 = 144 bytes)
-struct GsPostProcessUbo {
-    glm::vec4 fog_params;         // density, r, g, b
-    glm::vec4 exposure_vignette;  // exposure, radius, softness, bloom_intensity
-    glm::vec4 bloom_fade;         // bloom_threshold, fade_amount, flash_r, flash_g
-    glm::vec4 effects;            // flash_b, ca_intensity, dof_focus_dist, dof_focus_range
-    glm::vec4 dimensions;         // dof_max_blur, width, height, far_plane
-    glm::vec4 ground_sky;         // ground_r, ground_g, ground_b, horizon_y
-    glm::vec4 sky_enable;         // sky_r, sky_g, sky_b, enable (> 0.5 = on)
-    glm::vec4 overlay;            // r, g, b, alpha (scene transition overlay)
-    uint32_t  overlay_effect_type; // 0 = solid fade, 1 = left-to-right wipe
-    uint32_t  _pad0;
-    uint32_t  _pad1;
-    uint32_t  _pad2;
-};
+// Phase 5b: GsPostProcessParams and GsPostProcessUbo definitions moved to
+// gseurat/engine/gs_renderer/post/post_process_params.hpp (included above).
+// The include keeps external callers source-compatible.
 
 // Push constants for preprocess shader (static/dynamic offset)
 struct GsPreprocessPush {
@@ -343,8 +296,9 @@ public:
     uint32_t pbd_constraint_count() const { return pbd_constraint_count_; }
 
     // Post-process parameters (fog, tone mapping, vignette, etc.)
-    void set_post_process_params(const GsPostProcessParams& p) { gs_pp_params_ = p; }
-    const GsPostProcessParams& post_process_params() const { return gs_pp_params_; }
+    // Phase 5b: forwards to the by-value GsPostProcessSystem member.
+    void set_post_process_params(const GsPostProcessParams& p) { post_.params() = p; }
+    const GsPostProcessParams& post_process_params() const { return post_.params(); }
 
     // Frame-determinism test harness (Mode 1): when active, copy the
     // post-Onesweep tile_sort_a_ buffer into a host-mapped readback so the
@@ -506,6 +460,12 @@ private:
     // Phase 5a: GPU resource ownership. Non-owning; bound via set_resources()
     // before init(). AppBase owns the GsResourceManager lifetime.
     GsResourceManager* resources_ = nullptr;
+
+    // Phase 5b: first system extraction. Owns the gs_post_process.comp
+    // pipeline + descriptors + runtime params. Lifetime tied to the
+    // renderer; init() in GsRenderer::init(), shutdown() inside our
+    // explicit shutdown(allocator).
+    GsPostProcessSystem post_;
 
     // Phase 4b: bone transform storage moved to gseurat::RenderState
     // (per-frame-in-flight, persistent-mapped). Set via set_render_state
@@ -685,14 +645,9 @@ private:
     void create_compose_pipeline();
     void update_compose_descriptors();  // called from set_render_state
 
-    // Post-process pipeline
-    VkDescriptorSetLayout post_process_layout_ = VK_NULL_HANDLE;
-    VkPipelineLayout post_process_pipeline_layout_ = VK_NULL_HANDLE;
-    VkPipeline post_process_pipeline_ = VK_NULL_HANDLE;
-    // post_process binds input output_image + depth_image AND output processed_image
-    // — three per-frame images, so the set is per-frame.
-    std::array<VkDescriptorSet, kMaxFramesInFlight> post_process_sets_{};
-    GsPostProcessParams gs_pp_params_;
+    // Phase 5b: post-process pipeline / layout / sets / params live in
+    // GsPostProcessSystem (by-value member below). Renderer dispatches via
+    // post_.dispatch(); set_post_process_params() forwards to post_.params().
 
     // Legacy sort (kept for fallback, not dispatched)
     VkDescriptorSetLayout sort_layout_ = VK_NULL_HANDLE;

--- a/include/gseurat/engine/gs_renderer/post/gs_post_process_system.hpp
+++ b/include/gseurat/engine/gs_renderer/post/gs_post_process_system.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "gseurat/engine/gs_renderer/post/post_process_params.hpp"
+#include "gseurat/engine/types.hpp"  // kMaxFramesInFlight
+
+#include <vulkan/vulkan.h>
+
+#include <array>
+#include <cstdint>
+
+namespace gseurat {
+
+struct GsResourceManager;
+
+// Phase 5b: first system extraction. Owns the post-process compute pipeline
+// (gs_post_process.comp): descriptor set layout, pipeline layout, pipeline,
+// and the per-frame descriptor sets that bind frame f's
+// {output_view, depth_view, processed_view, pp_ubo_buffer}.
+//
+// Lifetime: by-value member of GsRenderer. Same lifetime as the renderer;
+// no heap allocation overhead. Lifecycle: init() at GsRenderer::init() time
+// (after the renderer's gs_pool_ and GsResourceManager are live); shutdown()
+// from GsRenderer::shutdown(). The dispatch path is invoked from
+// GsRenderer::render() once per frame; the system owns the
+// processed_image UNDEFINED→GENERAL barrier but the downstream
+// SHADER_READ_ONLY transition stays with the renderer's orchestration.
+class GsPostProcessSystem {
+public:
+    GsPostProcessSystem() = default;
+    ~GsPostProcessSystem();
+
+    GsPostProcessSystem(const GsPostProcessSystem&) = delete;
+    GsPostProcessSystem& operator=(const GsPostProcessSystem&) = delete;
+    GsPostProcessSystem(GsPostProcessSystem&&) = delete;
+    GsPostProcessSystem& operator=(GsPostProcessSystem&&) = delete;
+
+    // Create the set layout, pipeline layout, pipeline, and allocate two
+    // descriptor sets (one per frame in flight). `pool` is GsRenderer's
+    // shared gs_pool_ — moving pool ownership is out of scope for 5b.
+    void init(VkDevice device, VkPipelineCache pipeline_cache,
+              VkDescriptorPool pool, GsResourceManager* resources);
+
+    // Per-frame descriptor binding refresh. Called from
+    // GsRenderer::update_descriptors after the per-frame image views are
+    // (re)created on resize.
+    void write_descriptors();
+
+    // Issue the gs_post_process.comp dispatch. Owns the processed_image
+    // UNDEFINED→GENERAL pre-barrier. Caller owns the inter-pass barriers
+    // around this (input layout transition before, SHADER_READ_ONLY after).
+    // `frame_in_flight` selects the descriptor set + processed image slot.
+    void dispatch(VkCommandBuffer cmd, uint32_t frame_in_flight,
+                  uint32_t width, uint32_t height);
+
+    // Runtime params (formerly GsRenderer::gs_pp_params_). The renderer's
+    // public setter/getter forwards to this.
+    GsPostProcessParams&       params()       { return params_; }
+    const GsPostProcessParams& params() const { return params_; }
+
+    // Prewarm hook — GsRenderer::prewarm_pipelines aggregates this into its
+    // full prewarm list so the on-disk pipeline cache covers our pipeline.
+    struct PrewarmInfo {
+        VkPipeline               pipeline;
+        VkPipelineLayout         pipeline_layout;
+        VkDescriptorSetLayout    set_layout;
+    };
+    PrewarmInfo prewarm_info() const {
+        return {pipeline_, pipeline_layout_, set_layout_};
+    }
+
+    // Tear down everything. Idempotent against null handles.
+    void shutdown();
+
+private:
+    VkDevice                                          device_     = VK_NULL_HANDLE;
+    GsResourceManager*                                resources_  = nullptr;
+
+    VkDescriptorSetLayout                             set_layout_         = VK_NULL_HANDLE;
+    VkPipelineLayout                                  pipeline_layout_    = VK_NULL_HANDLE;
+    VkPipeline                                        pipeline_           = VK_NULL_HANDLE;
+    std::array<VkDescriptorSet, kMaxFramesInFlight>   sets_{};
+
+    GsPostProcessParams                               params_{};
+};
+
+}  // namespace gseurat

--- a/include/gseurat/engine/gs_renderer/post/post_process_params.hpp
+++ b/include/gseurat/engine/gs_renderer/post/post_process_params.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include <cstdint>
+
+namespace gseurat {
+
+// Post-process parameters forwarded from the composite pipeline to GS compute.
+// Mirrors relevant fields from PostProcessParams for consistent visual treatment.
+// Phase 5b: extracted into its own header so GsPostProcessSystem can include
+// it without dragging gs_renderer.hpp (which would create a cycle). The
+// struct is still re-exported by gs_renderer.hpp for external API stability.
+struct GsPostProcessParams {
+    float fog_density = 0.0f;
+    float fog_color_r = 0.3f;
+    float fog_color_g = 0.35f;
+    float fog_color_b = 0.45f;
+    float exposure = 1.2f;
+    float vignette_radius = 0.75f;
+    float vignette_softness = 0.45f;
+    float bloom_intensity = 0.35f;
+    float bloom_threshold = 1.0f;
+    float fade_amount = 0.0f;
+    float flash_r = 0.0f;
+    float flash_g = 0.0f;
+    float flash_b = 0.0f;
+    float ca_intensity = 0.0f;
+    float dof_focus_distance = 12.0f;
+    float dof_focus_range = 3.0f;
+    float dof_max_blur = 0.5f;
+    float far_plane = 1000.0f;  // GS camera far plane for depth normalization
+
+    // Hybrid background (ground plane + sky gradient)
+    glm::vec3 ground_color{0.0f};  // RGB ground color (0 = disabled)
+    glm::vec3 sky_color{0.0f};     // RGB sky color (0 = disabled)
+    float horizon_y = 0.5f;        // Normalized screen Y of horizon (0=top, 1=bottom)
+    bool background_enabled = false;
+
+    // Scene-transition overlay (final mix() applied at end of compositing).
+    // overlay_alpha == 0 produces a shader no-op.
+    float overlay_r = 1.0f;
+    float overlay_g = 1.0f;
+    float overlay_b = 1.0f;
+    float overlay_alpha = 0.0f;
+    uint32_t overlay_effect_type = 0;  // 0 = solid fade, 1 = left-to-right wipe
+};
+
+// GPU UBO layout for gs_post_process.comp (std140, 8 × vec4 + 16 = 144 bytes)
+struct GsPostProcessUbo {
+    glm::vec4 fog_params;         // density, r, g, b
+    glm::vec4 exposure_vignette;  // exposure, radius, softness, bloom_intensity
+    glm::vec4 bloom_fade;         // bloom_threshold, fade_amount, flash_r, flash_g
+    glm::vec4 effects;            // flash_b, ca_intensity, dof_focus_dist, dof_focus_range
+    glm::vec4 dimensions;         // dof_max_blur, width, height, far_plane
+    glm::vec4 ground_sky;         // ground_r, ground_g, ground_b, horizon_y
+    glm::vec4 sky_enable;         // sky_r, sky_g, sky_b, enable (> 0.5 = on)
+    glm::vec4 overlay;            // r, g, b, alpha (scene transition overlay)
+    uint32_t  overlay_effect_type; // 0 = solid fade, 1 = left-to-right wipe
+    uint32_t  _pad0;
+    uint32_t  _pad1;
+    uint32_t  _pad2;
+};
+
+}  // namespace gseurat

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -112,6 +112,13 @@ void GsRenderer::init(VkDevice device, VkPhysicalDevice physical_device,
     create_descriptor_resources();
     create_compute_pipelines();
 
+    // Phase 5b: init the post-process system. Must run after
+    // create_descriptor_resources() (gs_pool_ live) and before
+    // prewarm_pipelines() / update_descriptors() (both read post_'s
+    // pipeline / descriptor sets).
+    assert(resources_ != nullptr && "set_resources() must run before init()");
+    post_.init(device_, pipeline_cache_, gs_pool_, resources_);
+
     // Create timestamp query pool for GPU profiling (2 queries: before/after rasterize)
     {
         VkQueryPoolCreateInfo qp_info{};
@@ -285,20 +292,7 @@ void GsRenderer::create_descriptor_resources() {
         vkCreateDescriptorSetLayout(device_, &ci, nullptr, &render_layout_);
     }
 
-    // Post-process layout: { input_image(readonly), depth_image(readonly), output_image(writeonly), ubo }
-    {
-        VkDescriptorSetLayoutBinding bindings[] = {
-            {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},   // input
-            {1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},   // depth
-            {2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},   // output
-            {3, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},  // UBO
-        };
-        VkDescriptorSetLayoutCreateInfo ci{};
-        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        ci.bindingCount = 4;
-        ci.pBindings = bindings;
-        vkCreateDescriptorSetLayout(device_, &ci, nullptr, &post_process_layout_);
-    }
+    // Phase 5b: post-process descriptor set layout moved to GsPostProcessSystem.
 
     // Merge layout: { static_sort(0), dynamic_sort(1), merged_sort(2), counts(3) }
     {
@@ -458,67 +452,69 @@ void GsRenderer::create_descriptor_resources() {
                   "dynamic_preprocess/merge/depth_hist/depth_scatter/dynamic_depth_hist/"
                   "dynamic_depth_scatter) at the end of `layouts`.");
 
+    // Phase 5b: post_process_layout_ entries removed (indices 3 and 31 in
+    // the pre-5b layout). GsPostProcessSystem allocates its own 2 sets from
+    // the same gs_pool_. All subsequent indices shifted down accordingly;
+    // kSetCount decreased from 58 to 56.
     VkDescriptorSetLayout layouts[] = {
         preprocess_layout_, sort_layout_, render_layout_,   // 0-2: legacy preprocess_sets_[0], sort_sets_[0], render_sets_[0]
-        post_process_layout_,                               // 3: post-process (post_process_sets_[0])
-        preprocess_layout_, preprocess_layout_,             // 4-5: static_preprocess_sets_[0], dynamic_preprocess_sets_[0]
-        merge_layout_,                                      // 6: merge_sets_[0]
-        render_layout_,                                     // 7: merged render
-        pbd_layout_,                                        // 8: PBD solver
+        preprocess_layout_, preprocess_layout_,             // 3-4: static_preprocess_sets_[0], dynamic_preprocess_sets_[0]
+        merge_layout_,                                      // 5: merge_sets_[0]
+        render_layout_,                                     // 6: merged render
+        pbd_layout_,                                        // 7: PBD solver
         // Tile binning sets
-        tile_bin_layout_,                                   // 9: tile bin (count + scatter)
-        tile_ranges_layout_,                                // 10: tile range detection (slot [0])
-        tile_indirect_layout_,                              // 11: indirect dispatch prep (slot [0])
-        tile_render_layout_,                                // 12: tile render (tile_render_sets_[0])
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 13-14: tile onesweep histogram A, B (slot [0])
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 15-16: tile onesweep scatter A→B, B→A (slot [0])
+        tile_bin_layout_,                                   // 8: tile bin (count + scatter)
+        tile_ranges_layout_,                                // 9: tile range detection (slot [0])
+        tile_indirect_layout_,                              // 10: indirect dispatch prep (slot [0])
+        tile_render_layout_,                                // 11: tile render (tile_render_sets_[0])
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 12-13: tile onesweep histogram A, B (slot [0])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 14-15: tile onesweep scatter A→B, B→A (slot [0])
         // Depth sort Onesweep sets (reusing onesweep layouts)
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 17-18: legacy depth hist A, B (slot [0])
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 19-20: legacy depth scatter AB, BA (slot [0])
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 21-22: static depth hist A, B (single-instance)
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 23-24: static depth scatter AB, BA (single-instance)
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 25-26: dynamic depth hist A, B (slot [0])
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 27-28: dynamic depth scatter AB, BA (slot [0])
-        tile_scan_layout_,                                  // 29: deterministic tile-bin scan (slot [0])
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 16-17: legacy depth hist A, B (slot [0])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 18-19: legacy depth scatter AB, BA (slot [0])
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 20-21: static depth hist A, B (single-instance)
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 22-23: static depth scatter AB, BA (single-instance)
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 24-25: dynamic depth hist A, B (slot [0])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 26-27: dynamic depth scatter AB, BA (slot [0])
+        tile_scan_layout_,                                  // 28: deterministic tile-bin scan (slot [0])
         // Per-frame [1] copies for sets that bind per-frame images:
-        render_layout_,                                     // 30: render_sets_[1]
-        post_process_layout_,                               // 31: post_process_sets_[1]
-        tile_render_layout_,                                // 32: tile_render_sets_[1]
+        render_layout_,                                     // 29: render_sets_[1]
+        tile_render_layout_,                                // 30: tile_render_sets_[1]
         // Phase 2 per-frame [1] copies for compute sets that bind per-frame
         // racing SSBOs (projected, sort_keys, visible_count, counts, dynamic_sort_a).
-        preprocess_layout_,                                 // 33: preprocess_sets_[1]
-        sort_layout_,                                       // 34: sort_sets_[1]
-        preprocess_layout_,                                 // 35: static_preprocess_sets_[1]
-        preprocess_layout_,                                 // 36: dynamic_preprocess_sets_[1]
+        preprocess_layout_,                                 // 31: preprocess_sets_[1]
+        sort_layout_,                                       // 32: sort_sets_[1]
+        preprocess_layout_,                                 // 33: static_preprocess_sets_[1]
+        preprocess_layout_,                                 // 34: dynamic_preprocess_sets_[1]
         // Phase 3 per-frame [1] copies for the racing onesweep/merge sets.
         // Dispatch binds [frame_in_flight] for these — frame N+1's preprocess
         // writes its own slot's projected/sort_keys/visible_count without
         // clobbering frame N's still-active reads.
-        merge_layout_,                                      // 37: merge_sets_[1]
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 38-39: legacy depth hist A, B (slot [1])
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 40-41: legacy depth scatter AB, BA (slot [1])
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 42-43: dynamic depth hist A, B (slot [1])
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 44-45: dynamic depth scatter AB, BA (slot [1])
+        merge_layout_,                                      // 35: merge_sets_[1]
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 36-37: legacy depth hist A, B (slot [1])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 38-39: legacy depth scatter AB, BA (slot [1])
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 40-41: dynamic depth hist A, B (slot [1])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 42-43: dynamic depth scatter AB, BA (slot [1])
         // tile_bin_set_ reads racing projected/merged/counts — must be per-frame
         // so tile_bin in frame f reads the slot frame f's preprocess wrote.
-        // (slot [0] is sets[9]; this is the slot [1] copy.)
-        tile_bin_layout_,                                   // 46: tile_bin_sets_[1]
+        // (slot [0] is sets[8]; this is the slot [1] copy.)
+        tile_bin_layout_,                                   // 44: tile_bin_sets_[1]
         // Phase 3.5 per-frame [1] copies for the racing tile-pipeline sets:
         // tile_scan/tile_indirect/tile_ranges + tile onesweep hist/scatter.
         // Each binds at least one of the newly per-frame tile buffers
         // (tile_sort_a/b, tile_sort_count, tile_ranges, tile_indirect_args,
         // per_splat_tile_count/offset, scan_block_sums).
-        tile_scan_layout_,                                  // 47: tile_scan_sets_[1]
-        tile_indirect_layout_,                              // 48: tile_indirect_sets_[1]
-        tile_ranges_layout_,                                // 49: tile_ranges_sets_[1]
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 50-51: tile onesweep hist A, B (slot [1])
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 52-53: tile onesweep scatter AB, BA (slot [1])
+        tile_scan_layout_,                                  // 45: tile_scan_sets_[1]
+        tile_indirect_layout_,                              // 46: tile_indirect_sets_[1]
+        tile_ranges_layout_,                                // 47: tile_ranges_sets_[1]
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 48-49: tile onesweep hist A, B (slot [1])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 50-51: tile onesweep scatter AB, BA (slot [1])
         // Per-frame onesweep status fix — static depth onesweep sets become
         // per-frame so they can bind resources_->depth_onesweep_statuses[f].
-        onesweep_hist_layout_, onesweep_hist_layout_,       // 54-55: static depth hist A, B (slot [1])
-        onesweep_scatter_layout_, onesweep_scatter_layout_, // 56-57: static depth scatter AB, BA (slot [1])
+        onesweep_hist_layout_, onesweep_hist_layout_,       // 52-53: static depth hist A, B (slot [1])
+        onesweep_scatter_layout_, onesweep_scatter_layout_, // 54-55: static depth scatter AB, BA (slot [1])
     };
-    constexpr uint32_t kSetCount = 58;
+    constexpr uint32_t kSetCount = 56;
     VkDescriptorSet sets[kSetCount];
     VkDescriptorSetAllocateInfo alloc_info{};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -535,72 +531,71 @@ void GsRenderer::create_descriptor_resources() {
 
     // Legacy sets (per-frame Phase 2)
     preprocess_sets_[0] = sets[0];
-    preprocess_sets_[1] = sets[33];
+    preprocess_sets_[1] = sets[31];
     sort_sets_[0] = sets[1];
-    sort_sets_[1] = sets[34];
+    sort_sets_[1] = sets[32];
     render_sets_[0] = sets[2];
-    render_sets_[1] = sets[30];
-    post_process_sets_[0] = sets[3];
-    post_process_sets_[1] = sets[31];
+    render_sets_[1] = sets[29];
+    // Phase 5b: post_process_sets_ now lives in GsPostProcessSystem.
     // Static/dynamic preprocess (per-frame Phase 2)
-    static_preprocess_sets_[0] = sets[4];
-    static_preprocess_sets_[1] = sets[35];
-    dynamic_preprocess_sets_[0] = sets[5];
-    dynamic_preprocess_sets_[1] = sets[36];
-    merge_sets_[0] = sets[6];
-    merge_sets_[1] = sets[37];
-    // sets[7] is the merged render set (render_layout_)
-    pbd_set_ = sets[8];
+    static_preprocess_sets_[0] = sets[3];
+    static_preprocess_sets_[1] = sets[33];
+    dynamic_preprocess_sets_[0] = sets[4];
+    dynamic_preprocess_sets_[1] = sets[34];
+    merge_sets_[0] = sets[5];
+    merge_sets_[1] = sets[35];
+    // sets[6] is the merged render set (render_layout_)
+    pbd_set_ = sets[7];
     // Tile binning
-    tile_bin_sets_[0] = sets[9];
-    tile_bin_sets_[1] = sets[46];
+    tile_bin_sets_[0] = sets[8];
+    tile_bin_sets_[1] = sets[44];
     // Phase 3.5: per-frame tile_ranges / tile_indirect / tile_scan + tile onesweep
-    tile_ranges_sets_[0] = sets[10];
-    tile_ranges_sets_[1] = sets[49];
-    tile_indirect_sets_[0] = sets[11];
-    tile_indirect_sets_[1] = sets[48];
-    tile_render_sets_[0] = sets[12];
-    tile_render_sets_[1] = sets[32];
-    onesweep_hist_sets_a_[0] = sets[13];
-    onesweep_hist_sets_b_[0] = sets[14];
-    onesweep_scatter_sets_ab_[0] = sets[15];
-    onesweep_scatter_sets_ba_[0] = sets[16];
-    onesweep_hist_sets_a_[1] = sets[50];
-    onesweep_hist_sets_b_[1] = sets[51];
-    onesweep_scatter_sets_ab_[1] = sets[52];
-    onesweep_scatter_sets_ba_[1] = sets[53];
+    tile_ranges_sets_[0] = sets[9];
+    tile_ranges_sets_[1] = sets[47];
+    tile_indirect_sets_[0] = sets[10];
+    tile_indirect_sets_[1] = sets[46];
+    tile_render_sets_[0] = sets[11];
+    tile_render_sets_[1] = sets[30];
+    onesweep_hist_sets_a_[0] = sets[12];
+    onesweep_hist_sets_b_[0] = sets[13];
+    onesweep_scatter_sets_ab_[0] = sets[14];
+    onesweep_scatter_sets_ba_[0] = sets[15];
+    onesweep_hist_sets_a_[1] = sets[48];
+    onesweep_hist_sets_b_[1] = sets[49];
+    onesweep_scatter_sets_ab_[1] = sets[50];
+    onesweep_scatter_sets_ba_[1] = sets[51];
     // Depth sort Onesweep (legacy) — per-frame (racing sort_keys/sort_b SSBOs)
-    depth_hist_sets_a_[0] = sets[17];
-    depth_hist_sets_b_[0] = sets[18];
-    depth_scatter_sets_ab_[0] = sets[19];
-    depth_scatter_sets_ba_[0] = sets[20];
-    depth_hist_sets_a_[1] = sets[38];
-    depth_hist_sets_b_[1] = sets[39];
-    depth_scatter_sets_ab_[1] = sets[40];
-    depth_scatter_sets_ba_[1] = sets[41];
+    depth_hist_sets_a_[0] = sets[16];
+    depth_hist_sets_b_[0] = sets[17];
+    depth_scatter_sets_ab_[0] = sets[18];
+    depth_scatter_sets_ba_[0] = sets[19];
+    depth_hist_sets_a_[1] = sets[36];
+    depth_hist_sets_b_[1] = sets[37];
+    depth_scatter_sets_ab_[1] = sets[38];
+    depth_scatter_sets_ba_[1] = sets[39];
     // Depth sort Onesweep (static) — per-frame so each slot can bind frame
     // f's resources_->depth_onesweep_statuses[f] AND its own resources_->static_sort_as[f]/
     // resources_->static_sort_bs[f] ping-pong buffers.
-    static_depth_hist_sets_a_[0] = sets[21];
-    static_depth_hist_sets_b_[0] = sets[22];
-    static_depth_scatter_sets_ab_[0] = sets[23];
-    static_depth_scatter_sets_ba_[0] = sets[24];
-    static_depth_hist_sets_a_[1] = sets[54];
-    static_depth_hist_sets_b_[1] = sets[55];
-    static_depth_scatter_sets_ab_[1] = sets[56];
-    static_depth_scatter_sets_ba_[1] = sets[57];
+    static_depth_hist_sets_a_[0] = sets[20];
+    static_depth_hist_sets_b_[0] = sets[21];
+    static_depth_scatter_sets_ab_[0] = sets[22];
+    static_depth_scatter_sets_ba_[0] = sets[23];
+    static_depth_hist_sets_a_[1] = sets[52];
+    static_depth_hist_sets_b_[1] = sets[53];
+    static_depth_scatter_sets_ab_[1] = sets[54];
+    static_depth_scatter_sets_ba_[1] = sets[55];
     // Depth sort Onesweep (dynamic) — per-frame (racing resources_->dynamic_sort_as/bs_)
-    dynamic_depth_hist_sets_a_[0] = sets[25];
-    dynamic_depth_hist_sets_b_[0] = sets[26];
-    dynamic_depth_scatter_sets_ab_[0] = sets[27];
-    dynamic_depth_scatter_sets_ba_[0] = sets[28];
-    dynamic_depth_hist_sets_a_[1] = sets[42];
-    dynamic_depth_hist_sets_b_[1] = sets[43];
-    dynamic_depth_scatter_sets_ab_[1] = sets[44];
-    dynamic_depth_scatter_sets_ba_[1] = sets[45];
+    dynamic_depth_hist_sets_a_[0] = sets[24];
+    dynamic_depth_hist_sets_b_[0] = sets[25];
+    dynamic_depth_scatter_sets_ab_[0] = sets[26];
+    dynamic_depth_scatter_sets_ba_[0] = sets[27];
+    dynamic_depth_hist_sets_a_[1] = sets[40];
+    dynamic_depth_hist_sets_b_[1] = sets[41];
+    dynamic_depth_scatter_sets_ab_[1] = sets[42];
+    dynamic_depth_scatter_sets_ba_[1] = sets[43];
     // Deterministic tile-bin scan — per-frame (Phase 3.5)
-    tile_scan_sets_[0] = sets[29];
-    tile_scan_sets_[1] = sets[47];
+    tile_scan_sets_[0] = sets[28];
+    tile_scan_sets_[1] = sets[45];
 }
 
 void GsRenderer::create_compute_pipelines() {
@@ -648,9 +643,7 @@ void GsRenderer::create_compute_pipelines() {
     create_pipeline("shaders/gs_sort.comp.spv", sort_layout_, 8,
                     sort_pipeline_layout_, sort_pipeline_);
 
-    // Post-process pipeline (no push constants — dimensions in UBO)
-    create_pipeline("shaders/gs_post_process.comp.spv", post_process_layout_, 0,
-                    post_process_pipeline_layout_, post_process_pipeline_);
+    // Phase 5b: post-process pipeline lives in GsPostProcessSystem.
 
     // PBD solver pipeline (push constant = pbd_count)
     create_pipeline("shaders/pbd_solver.comp.spv", pbd_layout_,
@@ -1172,10 +1165,14 @@ void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool,
                   {0,1,2,4,5,6,8}, {3}, {});
         add_entry("gs_sort", sort_pipeline_, sort_pipeline_layout_, sort_layout_, 8,
                   {0}, {1}, {});
-        add_entry("gs_post_process", post_process_pipeline_, post_process_pipeline_layout_,
-                  post_process_layout_, 0,
-                  {}, {3},
-                  {{0u, color_view}, {1u, depth_view}, {2u, color_view}});
+        // Phase 5b: post-process pipeline owned by GsPostProcessSystem.
+        {
+            auto info = post_.prewarm_info();
+            add_entry("gs_post_process", info.pipeline, info.pipeline_layout,
+                      info.set_layout, 0,
+                      {}, {3},
+                      {{0u, color_view}, {1u, depth_view}, {2u, color_view}});
+        }
         add_entry("pbd_solver", pbd_pipeline_, pbd_pipeline_layout_, pbd_layout_,
                   sizeof(uint32_t),
                   {0,1,2}, {3}, {});
@@ -2820,27 +2817,8 @@ void GsRenderer::update_descriptors() {
         vkUpdateDescriptorSets(device_, 6, writes, 0, nullptr);
     }
 
-    // Post-process set: input_image(0), depth_image(1), processed_image(2), pp_ubo(3)
-    // Per-frame: each post_process_sets_[i] binds frame i's output, depth, processed views.
-    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-        VkDescriptorImageInfo input_info{VK_NULL_HANDLE, resources_->output_views[f], VK_IMAGE_LAYOUT_GENERAL};
-        VkDescriptorImageInfo depth_info{VK_NULL_HANDLE, resources_->depth_views[f], VK_IMAGE_LAYOUT_GENERAL};
-        VkDescriptorImageInfo proc_info{VK_NULL_HANDLE, resources_->processed_views[f], VK_IMAGE_LAYOUT_GENERAL};
-        VkDescriptorBufferInfo ubo_info{resources_->pp_ubo_buffer.buffer(), 0, sizeof(GsPostProcessUbo)};
-
-        VkDescriptorSet set = post_process_sets_[f];
-        VkWriteDescriptorSet writes[] = {
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
-             VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &input_info, nullptr, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
-             VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &depth_info, nullptr, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
-             VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &proc_info, nullptr, nullptr},
-            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
-             VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &ubo_info, nullptr},
-        };
-        vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
-    }
+    // Phase 5b: post-process descriptor writes moved to GsPostProcessSystem.
+    post_.write_descriptors();
 
     // Depth Onesweep descriptor sets (legacy path) — same layout as tile Onesweep
     if (resources_->depth_onesweep_statuses[0].buffer() && resources_->depth_sort_params.buffer()) {
@@ -3795,7 +3773,8 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
     const VkImage out_img       = resources_->output_images[frame_in_flight];
     const VkImage depth_img     = resources_->depth_images[frame_in_flight];
     const VkImage processed_img = resources_->processed_images[frame_in_flight];
-    VkDescriptorSet post_process_set = post_process_sets_[frame_in_flight];
+    // Phase 5b: post-process descriptor set now lives in GsPostProcessSystem;
+    // post_.dispatch() resolves the per-frame set internally.
     VkDescriptorSet tile_render_set  = tile_render_sets_[frame_in_flight];
 
     uint32_t width = resources_->output_width;
@@ -4236,69 +4215,12 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
 
     }
 
-    // Pass 4: Post-process (always runs — params like fade_amount change every frame)
+    // Pass 4: Post-process (always runs — params like fade_amount change every frame).
+    // Phase 5b: dispatch + UBO upload + processed_image UNDEFINED→GENERAL barrier
+    // all live inside GsPostProcessSystem now.
     {
         GS_LABEL(cmd, "PostProcess");
-        // Update post-process UBO
-        GsPostProcessUbo pp_ubo{};
-        pp_ubo.fog_params = glm::vec4(gs_pp_params_.fog_density,
-                                       gs_pp_params_.fog_color_r,
-                                       gs_pp_params_.fog_color_g,
-                                       gs_pp_params_.fog_color_b);
-        pp_ubo.exposure_vignette = glm::vec4(gs_pp_params_.exposure,
-                                              gs_pp_params_.vignette_radius,
-                                              gs_pp_params_.vignette_softness,
-                                              gs_pp_params_.bloom_intensity);
-        pp_ubo.bloom_fade = glm::vec4(gs_pp_params_.bloom_threshold,
-                                       gs_pp_params_.fade_amount,
-                                       gs_pp_params_.flash_r,
-                                       gs_pp_params_.flash_g);
-        pp_ubo.effects = glm::vec4(gs_pp_params_.flash_b,
-                                    gs_pp_params_.ca_intensity,
-                                    gs_pp_params_.dof_focus_distance,
-                                    gs_pp_params_.dof_focus_range);
-        pp_ubo.dimensions = glm::vec4(gs_pp_params_.dof_max_blur,
-                                       static_cast<float>(width),
-                                       static_cast<float>(height),
-                                       gs_pp_params_.far_plane);
-        pp_ubo.ground_sky = glm::vec4(gs_pp_params_.ground_color,
-                                       gs_pp_params_.horizon_y);
-        pp_ubo.sky_enable = glm::vec4(gs_pp_params_.sky_color,
-                                       gs_pp_params_.background_enabled ? 1.0f : 0.0f);
-        pp_ubo.overlay = glm::vec4(gs_pp_params_.overlay_r,
-                                    gs_pp_params_.overlay_g,
-                                    gs_pp_params_.overlay_b,
-                                    gs_pp_params_.overlay_alpha);
-        pp_ubo.overlay_effect_type = gs_pp_params_.overlay_effect_type;
-        pp_ubo._pad0 = pp_ubo._pad1 = pp_ubo._pad2 = 0;
-        std::memcpy(resources_->pp_ubo_buffer.mapped(), &pp_ubo, sizeof(pp_ubo));
-
-        // Transition this frame's processed image to GENERAL for compute write
-        {
-            VkImageMemoryBarrier barrier{};
-            barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-            barrier.srcAccessMask = 0;
-            barrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-            barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-            barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-            barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            barrier.image = processed_img;
-            barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-
-            vkCmdPipelineBarrier(cmd,
-                VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                0, 0, nullptr, 0, nullptr, 1, &barrier);
-        }
-
-        // Dispatch post-process (same tile grid as render)
-        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, post_process_pipeline_);
-        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                post_process_pipeline_layout_, 0, 1, &post_process_set, 0, nullptr);
-        uint32_t tiles_x = (width + 15) / 16;
-        uint32_t tiles_y = (height + 15) / 16;
-        vkCmdDispatch(cmd, tiles_x, tiles_y, 1);
+        post_.dispatch(cmd, frame_in_flight, width, height);
     }
 
     // Transition this frame's processed image → SHADER_READ_ONLY for fragment sampling (blit)
@@ -4389,6 +4311,11 @@ void GsRenderer::load_world(const WorldManifest& manifest) {
 
 void GsRenderer::shutdown(VmaAllocator allocator) {
     if (!initialized_) return;
+
+    // Phase 5b: tear down owned subsystems before the renderer's gs_pool_
+    // (post_'s descriptor sets live in there) and before the device handle
+    // becomes invalid. shutdown() is idempotent.
+    post_.shutdown();
 
     // The async loader no longer spins up worker threads — reserve+submit
     // run synchronously on the main thread now. We still call
@@ -4495,7 +4422,7 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
 
     destroy_pipeline(preprocess_pipeline_);
     destroy_pipeline(sort_pipeline_);
-    destroy_pipeline(post_process_pipeline_);
+    // Phase 5b: post-process pipeline destroyed by GsPostProcessSystem::shutdown().
     destroy_pipeline(merge_pipeline_);
     destroy_pipeline(pbd_pipeline_);
     destroy_pipeline(tile_bin_pipeline_);
@@ -4511,7 +4438,7 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     destroy_layout(compose_pipeline_layout_);
     destroy_layout(preprocess_pipeline_layout_);
     destroy_layout(sort_pipeline_layout_);
-    destroy_layout(post_process_pipeline_layout_);
+    // Phase 5b: post-process pipeline layout destroyed by GsPostProcessSystem::shutdown().
     destroy_layout(merge_pipeline_layout_);
     destroy_layout(pbd_pipeline_layout_);
     destroy_layout(tile_bin_pipeline_layout_);
@@ -4525,7 +4452,7 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     destroy_set_layout(preprocess_layout_);
     destroy_set_layout(sort_layout_);
     destroy_set_layout(render_layout_);
-    destroy_set_layout(post_process_layout_);
+    // Phase 5b: post-process set layout destroyed by GsPostProcessSystem::shutdown().
     destroy_set_layout(merge_layout_);
     destroy_set_layout(pbd_layout_);
     destroy_set_layout(tile_bin_layout_);

--- a/src/engine/gs_renderer/post/gs_post_process_system.cpp
+++ b/src/engine/gs_renderer/post/gs_post_process_system.cpp
@@ -1,0 +1,203 @@
+#include "gseurat/engine/gs_renderer/post/gs_post_process_system.hpp"
+
+#include "gseurat/engine/gs_renderer/gs_resources.hpp"
+#include "gseurat/engine/pipeline.hpp"
+
+#include <glm/glm.hpp>
+
+#include <cassert>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+namespace gseurat {
+
+GsPostProcessSystem::~GsPostProcessSystem() {
+    shutdown();
+}
+
+void GsPostProcessSystem::init(VkDevice device, VkPipelineCache pipeline_cache,
+                                VkDescriptorPool pool, GsResourceManager* resources) {
+    assert(device != VK_NULL_HANDLE);
+    assert(pool != VK_NULL_HANDLE);
+    assert(resources != nullptr);
+    device_ = device;
+    resources_ = resources;
+
+    // Set layout: { input_image(readonly), depth_image(readonly), output_image(writeonly), ubo }
+    {
+        VkDescriptorSetLayoutBinding bindings[] = {
+            {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,  1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},  // input
+            {1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,  1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},  // depth
+            {2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,  1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},  // output
+            {3, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},  // UBO
+        };
+        VkDescriptorSetLayoutCreateInfo ci{};
+        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        ci.bindingCount = 4;
+        ci.pBindings = bindings;
+        if (vkCreateDescriptorSetLayout(device_, &ci, nullptr, &set_layout_) != VK_SUCCESS) {
+            throw std::runtime_error("GsPostProcessSystem: failed to create descriptor set layout");
+        }
+    }
+
+    // Pipeline: gs_post_process.comp, no push constants (dimensions in UBO).
+    {
+        auto module = load_shader_module(device_, "shaders/gs_post_process.comp.spv");
+
+        VkPipelineLayoutCreateInfo layout_info{};
+        layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+        layout_info.setLayoutCount = 1;
+        layout_info.pSetLayouts = &set_layout_;
+        if (vkCreatePipelineLayout(device_, &layout_info, nullptr, &pipeline_layout_) != VK_SUCCESS) {
+            vkDestroyShaderModule(device_, module, nullptr);
+            throw std::runtime_error("GsPostProcessSystem: failed to create pipeline layout");
+        }
+
+        VkComputePipelineCreateInfo pi{};
+        pi.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+        pi.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        pi.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+        pi.stage.module = module;
+        pi.stage.pName = "main";
+        pi.layout = pipeline_layout_;
+        VkResult res = vkCreateComputePipelines(device_, pipeline_cache, 1, &pi, nullptr, &pipeline_);
+        vkDestroyShaderModule(device_, module, nullptr);
+        if (res != VK_SUCCESS) {
+            throw std::runtime_error("GsPostProcessSystem: failed to create pipeline");
+        }
+    }
+
+    // Allocate two descriptor sets (one per frame in flight) from the shared
+    // gs_pool_. Pool capacity covers this — the central batch shrank by 2
+    // when this system took ownership of these sets.
+    {
+        VkDescriptorSetLayout layouts[kMaxFramesInFlight];
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) layouts[f] = set_layout_;
+
+        VkDescriptorSetAllocateInfo alloc{};
+        alloc.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+        alloc.descriptorPool = pool;
+        alloc.descriptorSetCount = kMaxFramesInFlight;
+        alloc.pSetLayouts = layouts;
+        if (vkAllocateDescriptorSets(device_, &alloc, sets_.data()) != VK_SUCCESS) {
+            throw std::runtime_error("GsPostProcessSystem: vkAllocateDescriptorSets failed");
+        }
+    }
+}
+
+void GsPostProcessSystem::write_descriptors() {
+    assert(device_ != VK_NULL_HANDLE);
+    assert(resources_ != nullptr);
+    // Per-frame: each sets_[i] binds frame i's output, depth, processed views.
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        VkDescriptorImageInfo input_info{VK_NULL_HANDLE, resources_->output_views[f],    VK_IMAGE_LAYOUT_GENERAL};
+        VkDescriptorImageInfo depth_info{VK_NULL_HANDLE, resources_->depth_views[f],     VK_IMAGE_LAYOUT_GENERAL};
+        VkDescriptorImageInfo proc_info {VK_NULL_HANDLE, resources_->processed_views[f], VK_IMAGE_LAYOUT_GENERAL};
+        VkDescriptorBufferInfo ubo_info{resources_->pp_ubo_buffer.buffer(), 0, sizeof(GsPostProcessUbo)};
+
+        VkDescriptorSet set = sets_[f];
+        VkWriteDescriptorSet writes[] = {
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,  &input_info, nullptr, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,  &depth_info, nullptr, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,  &proc_info,  nullptr, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
+             VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr,     &ubo_info, nullptr},
+        };
+        vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
+    }
+}
+
+void GsPostProcessSystem::dispatch(VkCommandBuffer cmd, uint32_t frame_in_flight,
+                                    uint32_t width, uint32_t height) {
+    assert(pipeline_ != VK_NULL_HANDLE && "init() must run first");
+    assert(frame_in_flight < kMaxFramesInFlight);
+
+    // Update post-process UBO.
+    GsPostProcessUbo pp_ubo{};
+    pp_ubo.fog_params = glm::vec4(params_.fog_density,
+                                   params_.fog_color_r,
+                                   params_.fog_color_g,
+                                   params_.fog_color_b);
+    pp_ubo.exposure_vignette = glm::vec4(params_.exposure,
+                                          params_.vignette_radius,
+                                          params_.vignette_softness,
+                                          params_.bloom_intensity);
+    pp_ubo.bloom_fade = glm::vec4(params_.bloom_threshold,
+                                   params_.fade_amount,
+                                   params_.flash_r,
+                                   params_.flash_g);
+    pp_ubo.effects = glm::vec4(params_.flash_b,
+                                params_.ca_intensity,
+                                params_.dof_focus_distance,
+                                params_.dof_focus_range);
+    pp_ubo.dimensions = glm::vec4(params_.dof_max_blur,
+                                   static_cast<float>(width),
+                                   static_cast<float>(height),
+                                   params_.far_plane);
+    pp_ubo.ground_sky = glm::vec4(params_.ground_color, params_.horizon_y);
+    pp_ubo.sky_enable = glm::vec4(params_.sky_color,
+                                   params_.background_enabled ? 1.0f : 0.0f);
+    pp_ubo.overlay = glm::vec4(params_.overlay_r,
+                                params_.overlay_g,
+                                params_.overlay_b,
+                                params_.overlay_alpha);
+    pp_ubo.overlay_effect_type = params_.overlay_effect_type;
+    pp_ubo._pad0 = pp_ubo._pad1 = pp_ubo._pad2 = 0;
+    std::memcpy(resources_->pp_ubo_buffer.mapped(), &pp_ubo, sizeof(pp_ubo));
+
+    // Transition this frame's processed image to GENERAL for compute write.
+    {
+        VkImageMemoryBarrier barrier{};
+        barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        barrier.srcAccessMask = 0;
+        barrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+        barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+        barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.image = resources_->processed_images[frame_in_flight];
+        barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+        vkCmdPipelineBarrier(cmd,
+            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            0, 0, nullptr, 0, nullptr, 1, &barrier);
+    }
+
+    // Dispatch (same tile grid as render).
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_);
+    VkDescriptorSet set = sets_[frame_in_flight];
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                            pipeline_layout_, 0, 1, &set, 0, nullptr);
+    uint32_t tiles_x = (width + 15) / 16;
+    uint32_t tiles_y = (height + 15) / 16;
+    vkCmdDispatch(cmd, tiles_x, tiles_y, 1);
+}
+
+void GsPostProcessSystem::shutdown() {
+    if (device_ == VK_NULL_HANDLE) return;
+
+    if (pipeline_) {
+        vkDestroyPipeline(device_, pipeline_, nullptr);
+        pipeline_ = VK_NULL_HANDLE;
+    }
+    if (pipeline_layout_) {
+        vkDestroyPipelineLayout(device_, pipeline_layout_, nullptr);
+        pipeline_layout_ = VK_NULL_HANDLE;
+    }
+    if (set_layout_) {
+        vkDestroyDescriptorSetLayout(device_, set_layout_, nullptr);
+        set_layout_ = VK_NULL_HANDLE;
+    }
+    // sets_ are owned by the descriptor pool; pool teardown reclaims them.
+    sets_.fill(VK_NULL_HANDLE);
+
+    device_ = VK_NULL_HANDLE;
+    resources_ = nullptr;
+}
+
+}  // namespace gseurat


### PR DESCRIPTION
## Summary

**First true renderer system extraction.** Lifts the `gs_post_process.comp` pipeline out of `GsRenderer` into a dedicated `GsPostProcessSystem` class. Establishes the architectural pattern that 5c (sort), 5d (tile-bin), and 5e (streaming) will follow: each system owns its descriptor layout + pipeline + per-frame descriptor sets + a runtime params struct, with `GsRenderer` becoming a thin orchestrator that calls `system_.dispatch(...)`.

## What moved into `GsPostProcessSystem`

- Descriptor set layout creation (`create_descriptor_resources`)
- Pipeline + pipeline layout creation (`create_compute_pipelines`)
- Per-frame descriptor set allocation — its own `vkAllocateDescriptorSets` against the shared `gs_pool_`
- Per-frame descriptor writes (`update_descriptors`)
- UBO upload + `processed_image` UNDEFINED→GENERAL barrier + `vkCmdDispatch` (the ~70-line block in `render()`)
- `GsPostProcessParams` runtime state (formerly `gs_pp_params_`)
- Pipeline / layout / set-layout destroys in `shutdown()`

## What stays in `GsRenderer`

- The downstream SHADER_READ_ONLY transition (inter-pass orchestration, not part of the post pass itself)
- `gs_pool_` ownership (system borrows it for its 2 set allocations)
- `set_post_process_params()` / `post_process_params()` — forward to `post_.params()` so external API stays source-stable

## Architectural decisions

- **By-value member** (not `unique_ptr`): lifetime is identical to the renderer; no heap allocation needed.
- **Params header extraction**: `GsPostProcessParams` and `GsPostProcessUbo` definitions moved to a new tiny header `gs_renderer/post/post_process_params.hpp` to avoid a circular include between `gs_renderer.hpp` and the system header. External callers continue to include `gs_renderer.hpp` (which re-exports both types) so the public surface is unchanged.
- **Central descriptor batch renumbered**: the two post_process layout slots ([3] and [31] in the pre-5b layout) are removed. Every subsequent index shifts down. `kSetCount: 58 → 56`. Pool capacity (`maxSets=236`) is unchanged; total live sets after 5a+5b is 58 (56 central + 2 in the system), well under cap.

## Test plan

- [x] `cmake --build --preset macos-debug` clean
- [x] `cmake --build --preset macos-release` clean
- [x] `cmake --build --preset macos-release-with-diag` clean
- [x] 8s `gseurat_demo` smoke: 1.7M splats loaded, post-process visibly active (fog/bloom/vignette in the rendered frame), async streaming completes, PBD/VFX/bones fire normally, clean `[ShutdownAuditor] No tracked objects alive`, `EXIT 0`, no Vulkan validation errors
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)