### PR TITLE
refactor(engine): extract GsTileBinSystem (Phase 5d)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,7 @@ target_sources(gseurat_core PRIVATE src/engine/systems/particle_system.cpp)
 target_sources(gseurat_core PRIVATE src/engine/gs_renderer/gs_resources.cpp)
 target_sources(gseurat_core PRIVATE src/engine/gs_renderer/post/gs_post_process_system.cpp)
 target_sources(gseurat_core PRIVATE src/engine/gs_renderer/sort/gs_sort_system.cpp)
+target_sources(gseurat_core PRIVATE src/engine/gs_renderer/tile_bin/gs_tile_bin_system.cpp)
 
 if(GSEURAT_SHARED_LIBS)
     target_compile_definitions(gseurat_core PUBLIC GSEURAT_ENGINE_BUILD_SHARED)

--- a/include/gseurat/engine/gs_renderer.hpp
+++ b/include/gseurat/engine/gs_renderer.hpp
@@ -6,6 +6,7 @@
 #include "gseurat/engine/gs_renderer/post/gs_post_process_system.hpp"
 #include "gseurat/engine/gs_renderer/post/post_process_params.hpp"
 #include "gseurat/engine/gs_renderer/sort/gs_sort_system.hpp"
+#include "gseurat/engine/gs_renderer/tile_bin/gs_tile_bin_system.hpp"
 #include "gseurat/engine/pbd_types.hpp"
 #include "gseurat/engine/render_state.hpp"  // FrameIndex
 #include "gseurat/engine/slab_allocator.hpp"
@@ -301,52 +302,16 @@ public:
     void set_post_process_params(const GsPostProcessParams& p) { post_.params() = p; }
     const GsPostProcessParams& post_process_params() const { return post_.params(); }
 
-    // Frame-determinism test harness (Mode 1): when active, copy the
-    // post-Onesweep tile_sort_a_ buffer into a host-mapped readback so the
-    // CPU can hash the live entry range and detect order-instability
-    // across frames with frozen inputs. Debug-only; no production cost.
-    void set_determinism_test_active(bool active) {
-        determinism_test_active_ = active;
-        if (!active) determinism_readback_emitted_ = false;
-    }
-    bool determinism_test_active() const { return determinism_test_active_; }
-
-    // True iff `dispatch_tile_sort` actually emitted a host-visible copy of
-    // tile_sort_a_ this frame. False during scene-transition / loading frames
-    // where the GS compute path was skipped (no cloud, !gs_rendering,
-    // !dispatch_gpu_compute, capacity == 0). The harness uses this to skip
-    // frames with stale readback contents — without it the test could report
-    // a false STABLE verdict from leftover bytes.
-    bool determinism_readback_emitted_this_frame() const {
-        return determinism_readback_emitted_;
-    }
-
-    // Raw VMA allocation handles + capacity exposed for the harness to call
-    // `vmaInvalidateAllocation` after the in-flight fence and clamp the hash
-    // range to actual buffer size. Both buffers are host-mapped; on
-    // platforms whose memory type is not `HOST_COHERENT`, omitting the
-    // invalidate would let stale CPU caches leak into the verdict.
-    VmaAllocation determinism_readback_allocation() const {
-        return resources_->determinism_readback.allocation();
-    }
-    VmaAllocation tile_sort_count_allocation() const {
-        // Phase 3.5: tile_sort_count is per-frame. Return the slot that
-        // dispatch_tile_sort most recently recorded into (matches the
-        // readback the harness reads after the in-flight fence).
-        return resources_->tile_sort_count_ssbos[determinism_last_emitted_frame_].allocation();
-    }
-    uint32_t tile_sort_capacity() const { return tile_sort_capacity_; }
-
-    const void* determinism_readback_data() const {
-        return resources_->determinism_readback.mapped();
-    }
-    uint32_t live_tile_sort_count() const {
-        // Phase 3.5: tile_sort_count is per-frame. Read the slot that
-        // dispatch_tile_sort most recently emitted (post-fence).
-        const auto& slot = resources_->tile_sort_count_ssbos[determinism_last_emitted_frame_];
-        if (slot.mapped() == nullptr) return 0;
-        return *static_cast<const uint32_t*>(slot.mapped());
-    }
+    // Frame-determinism test harness (Mode 1): forwarded to GsTileBinSystem,
+    // which owns the readback state since 5d. Public API stays identical.
+    void set_determinism_test_active(bool active) { tile_.set_determinism_test_active(active); }
+    bool determinism_test_active() const { return tile_.determinism_test_active(); }
+    bool determinism_readback_emitted_this_frame() const { return tile_.determinism_readback_emitted_this_frame(); }
+    VmaAllocation determinism_readback_allocation() const { return tile_.determinism_readback_allocation(); }
+    VmaAllocation tile_sort_count_allocation() const { return tile_.tile_sort_count_allocation(); }
+    uint32_t tile_sort_capacity() const { return tile_.tile_sort_capacity(); }
+    const void* determinism_readback_data() const { return tile_.determinism_readback_data(); }
+    uint32_t live_tile_sort_count() const { return tile_.live_tile_sort_count(); }
 
     // GPU timing averages (populated over kTimestampAvgFrames)
     float depth_sort_ms_avg() const { return depth_sort_ms_avg_; }
@@ -416,9 +381,7 @@ private:
     void create_descriptor_resources();
     void update_descriptors();
     // Phase 5c: dispatch_depth_onesweep moved to GsSortSystem (sort_.dispatch_depth_*).
-    // Phase 3: frame_in_flight selects tile_bin_sets_[f] so the per-frame
-    // racing projected/merged/counts slots are read correctly.
-    void dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_flight);
+    // Phase 5d: dispatch_tile_sort moved to GsTileBinSystem (tile_.dispatch_sort).
     // Drain pending_publications_ and record the metadata writes
     // (page_table, chunk_table) onto `cmd` via vkCmdUpdateBuffer + a
     // TRANSFER_WRITE -> SHADER_READ barrier. Called from poll_transfers
@@ -467,6 +430,13 @@ private:
     // pipeline, all depth-sort descriptor sets (3 paths × 4 sets × 2
     // frames + 2 merge = 26 sets), and the sort-size scalars.
     GsSortSystem sort_;
+
+    // Phase 5d: tile binning + tile sort + tile rasterization extraction.
+    // Owns 5 layouts + 6 pipelines + 18 descriptor sets (10 tile + 8 tile-
+    // onesweep). Borrows sort_'s onesweep pipelines via accessors. Holds
+    // the determinism readback harness state (forwarded by the getters
+    // above for ABI stability).
+    GsTileBinSystem tile_;
 
     // Phase 4b: bone transform storage moved to gseurat::RenderState
     // (per-frame-in-flight, persistent-mapped). Set via set_render_state
@@ -651,121 +621,16 @@ private:
     // Per-frame sort sets (Phase 2 plumbing; dispatch still binds [0]).
     std::array<VkDescriptorSet, kMaxFramesInFlight> sort_sets_{};
 
-    // ── Tile binning pipeline (deterministic count→scan→scatter) ──
-    // The combined `tile_bin_layout_` covers both the count and scatter
-    // shaders (gs_tile_count.comp / gs_tile_bin.comp). Bindings:
-    //   0 projected[]   1 merged_entries[]   2 counts (ro)
-    //   3 per_splat_tile_count[]  4 per_splat_tile_offset[]
-    //   5 tile_entries[]          6 uniforms
-    // Count shader uses 0,1,2,3,6. Scatter uses 0,1,2,4,5,6.
-    VkDescriptorSetLayout tile_bin_layout_ = VK_NULL_HANDLE;
-    VkPipelineLayout tile_bin_pipeline_layout_ = VK_NULL_HANDLE;
-    VkPipeline tile_bin_pipeline_ = VK_NULL_HANDLE;
-    // Per-frame (Phase 3): tile_bin_sets_[f] binds resources_->projected_ssbos[f],
-    // resources_->merged_sort_ssbos[f], resources_->counts_ssbos[f]. Other bindings (per_splat_*,
-    // tile_entries, uniforms) are single-instance.
-    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_bin_sets_{};
+    // Phase 5d: all tile-bin / tile-sort / tile-render layouts, pipelines,
+    // descriptor sets, sizing scalars, and determinism harness state moved
+    // into GsTileBinSystem (the `tile_` member declared earlier).
 
-    // Pre-scatter count pass (gs_tile_count.comp). Shares layout/set with
-    // tile_bin_pipeline_ — the binding set is a strict superset of what
-    // either shader reads.
-    VkPipeline tile_count_pipeline_ = VK_NULL_HANDLE;
-
-    // Three-dispatch exclusive prefix-sum (gs_tile_scan.comp). Bindings:
-    //   0 per_splat_tile_count[]  1 per_splat_tile_offset[]
-    //   2 scan_block_sums[]       3 tile_sort_count
-    // Per-frame (Phase 3.5): binds racing per_splat_*/scan_block_sums/
-    // tile_sort_count buffers, so the set itself is per-frame.
-    VkDescriptorSetLayout tile_scan_layout_ = VK_NULL_HANDLE;
-    VkPipelineLayout tile_scan_pipeline_layout_ = VK_NULL_HANDLE;
-    VkPipeline tile_scan_pipeline_ = VK_NULL_HANDLE;
-    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_scan_sets_{};
-
-    // Indirect dispatch preparation
-    // Per-frame (Phase 3.5): binds racing tile_sort_count + tile_indirect_args.
-    VkDescriptorSetLayout tile_indirect_layout_ = VK_NULL_HANDLE;
-    VkPipelineLayout tile_indirect_pipeline_layout_ = VK_NULL_HANDLE;
-    VkPipeline tile_indirect_pipeline_ = VK_NULL_HANDLE;
-    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_indirect_sets_{};
-
-    // Tile range detection pipeline
-    // Per-frame (Phase 3.5): binds racing tile_sort_a + tile_ranges + tile_sort_count.
-    VkDescriptorSetLayout tile_ranges_layout_ = VK_NULL_HANDLE;
-    VkPipelineLayout tile_ranges_pipeline_layout_ = VK_NULL_HANDLE;
-    VkPipeline tile_ranges_pipeline_ = VK_NULL_HANDLE;
-    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_ranges_sets_{};
-
-    // Tile render pipeline (8 bindings)
-    VkDescriptorSetLayout tile_render_layout_ = VK_NULL_HANDLE;
-    VkPipelineLayout tile_render_pipeline_layout_ = VK_NULL_HANDLE;
-    VkPipeline tile_render_pipeline_ = VK_NULL_HANDLE;
-    // tile_render binds output_image + depth_image — per-frame.
-    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_render_sets_{};
-
-    // Onesweep 2-dispatch sort (histogram+lookback → scatter) — per-frame
-    // (Phase 3.5). Binds racing tile_sort_a/b + tile_indirect_args.
-    // resources_->onesweep_statuses is also per-frame (final cross-frame race fix):
-    // frame N+1's vkCmdFillBuffer would otherwise stomp frame N's in-flight
-    // lookback state.
-    // Phase 5c: onesweep_hist pipeline + layout moved to GsSortSystem (shared with 5d tile-bin).
-    std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_hist_sets_a_{};  // read from A
-    std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_hist_sets_b_{};  // read from B
-
-    // Phase 5c: onesweep_scatter pipeline + layout moved to GsSortSystem (shared with 5d tile-bin).
-    std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_scatter_sets_ab_{};  // read A → write B
-    std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_scatter_sets_ba_{};  // read B → write A
-
-    // Per-digit lookback status buffer (tile sort, coherent). Per-frame:
-    // dispatch_tile_sort zeroes the slot at the start of every per-frame
-    // record and the onesweep compute reads/writes it; with kMaxFramesInFlight
-    // cmdbufs in flight a single-instance buffer would race itself.
-    uint32_t onesweep_max_wg_ = 0;
-
-    // Depth sort Onesweep (reuses same shaders as tile sort)
-    // Per-digit lookback status (depth sort, coherent). Per-frame for the
-    // same reason as resources_->onesweep_statuses.
-    // Phase 5c: depth_onesweep_max_wg_ kept here temporarily because
-    // init_streaming computes its size from sort sizes — pushed into
-    // GsSortSystem via set_sort_sizes() after the computation. Will be
-    // fully retired in a later cleanup.
+    // Phase 5c: depth_onesweep_max_wg_ — still computed in init_streaming
+    // (depends on max workgroups across static/dynamic/legacy depth paths)
+    // and pushed into GsSortSystem via set_sort_sizes(). Will be fully
+    // retired in a later cleanup.
     uint32_t depth_onesweep_max_wg_ = 0;
 
-    // Phase 5c: all depth-sort descriptor sets (legacy/static/dynamic
-    // × hist_a/hist_b/scatter_ab/scatter_ba × per-frame = 24 sets)
-    // moved into GsSortSystem.
-
-    // Tile sort buffers — per-frame (Phase 3.5).
-    // All seven buffers below are written every frame on the per-frame
-    // render path (dispatch_tile_sort). With kMaxFramesInFlight cmdbufs
-    // executing concurrently on the same VkQueue, single-instance
-    // buffers would race the same way the projected/sort_keys/visible_count
-    // buffers did pre-Phase-3. Each slot is sized identically (driven by
-    // tile_sort_capacity_ / scan_dispatch_size_).
-
-    // Deterministic tile-bin (Fix B) intermediate SSBOs. All sized to the
-    // visible-splat upper bound (static_sort_size_ + dynamic_sort_size_).
-    // Per-frame for the same race reason as the tile sort buffers above.
-    uint32_t scan_dispatch_size_ = 0;    // visible_upper rounded up to 256
-    uint32_t scan_num_blocks_ = 0;       // scan_dispatch_size_ / 256
-    // Frame-determinism harness: HOST_VISIBLE copy of the post-Onesweep
-    // tile_sort_a_ buffer. Sized to match tile_sort_a_; only populated when
-    // determinism_test_active_ is true.
-    bool determinism_test_active_ = false;
-    // Set true by `dispatch_tile_sort` once the host-visible copy has
-    // actually been recorded for the current command buffer. Cleared at
-    // the start of each `dispatch_tile_sort`. The harness consults this
-    // before counting a frame so that loading / transition frames where
-    // the GS compute path was gated off don't pollute the verdict.
-    bool determinism_readback_emitted_ = false;
-    // Phase 3.5: which per-frame slot of resources_->tile_sort_count_ssbos was the
-    // most recently emitted readback against. The harness uses this to
-    // select the right slot post-fence. Updated inside dispatch_tile_sort.
-    uint32_t determinism_last_emitted_frame_ = 0;
-
-    uint32_t tile_sort_capacity_ = 0;    // max entries in tile sort buffers
-    uint32_t tile_sort_size_ = 0;        // workgroup-aligned count for radix sort
-    uint32_t tile_sort_workgroups_ = 0;
-    static constexpr uint32_t kTileSortPasses = 4;  // 4 passes for 32-bit key
     bool initialized_ = false;
 
     // World manifest (Phase 3 streaming)

--- a/include/gseurat/engine/gs_renderer/tile_bin/gs_tile_bin_system.hpp
+++ b/include/gseurat/engine/gs_renderer/tile_bin/gs_tile_bin_system.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+#include "gseurat/engine/types.hpp"  // kMaxFramesInFlight
+
+#include <vk_mem_alloc.h>
+#include <vulkan/vulkan.h>
+
+#include <array>
+#include <cstdint>
+
+namespace gseurat {
+
+struct GsResourceManager;
+class GsSortSystem;
+
+// Phase 5d: tile binning + tile sort + tile rasterization extraction. Owns:
+//  - 5 descriptor set layouts + 5 pipeline layouts + 6 pipelines (tile_count
+//    shares tile_bin layout): tile_bin (+ tile_count), tile_scan,
+//    tile_indirect, tile_ranges, tile_render
+//  - 10 tile descriptor sets (5 kinds × 2 frames) + 8 tile-onesweep sets
+//    (hist_a, hist_b, scatter_ab, scatter_ba × 2 frames) borrowing
+//    GsSortSystem's onesweep_*_set_layout()
+//  - Sizing scalars (tile_sort_capacity_, tile_sort_size_, …) pushed in
+//    via set_sort_sizes() from GsRenderer::init_streaming
+//  - Determinism harness state (active flag, emitted flag, last-emitted
+//    frame slot) — exposed via 1-line forwarders on GsRenderer for ABI
+//    stability
+//
+// Lifetime: by-value member of GsRenderer; same lifetime as the renderer.
+// init() runs in GsRenderer::create_descriptor_resources() after
+// gs_pool_ exists and after sort_.init() (we borrow sort_'s onesweep
+// set layouts).
+class GsTileBinSystem {
+public:
+    GsTileBinSystem() = default;
+    ~GsTileBinSystem();
+
+    GsTileBinSystem(const GsTileBinSystem&) = delete;
+    GsTileBinSystem& operator=(const GsTileBinSystem&) = delete;
+    GsTileBinSystem(GsTileBinSystem&&) = delete;
+    GsTileBinSystem& operator=(GsTileBinSystem&&) = delete;
+
+    // Create 5 set layouts, 5 pipeline layouts, 6 pipelines, and allocate
+    // 18 descriptor sets (10 tile + 8 tile-onesweep) from the shared
+    // gs_pool_. Borrows onesweep_*_set_layout() from `sort`.
+    void init(VkDevice device, VkPipelineCache pipeline_cache,
+              VkDescriptorPool pool, GsResourceManager* resources,
+              GsSortSystem* sort);
+
+    // Compute + cache tile-sort sizing for a given visible-splat upper
+    // bound (static_sort_size + dynamic_sort_size). Called from
+    // GsRenderer::init_streaming after the static/dynamic split is known.
+    // Writes back into `out_capacity_size_bytes` so init_streaming can
+    // size the tile_sort buffers it allocates inside GsResourceManager.
+    void set_sort_sizes(uint32_t static_sort_size, uint32_t dynamic_sort_size);
+
+    // Write/refresh all 18 descriptor sets. Called from
+    // GsRenderer::update_descriptors after buffer (re)creation.
+    void write_descriptors();
+
+    // 6-pass tile sort: tile_count → tile_scan ×3 → tile_bin (scatter) →
+    // tile_prepare_indirect → onesweep radix sort ×kPasses (via sort_'s
+    // pipelines) → tile_ranges. Also records the determinism readback
+    // copy when the harness is active.
+    void dispatch_sort(VkCommandBuffer cmd, uint32_t frame_in_flight);
+
+    // Final tile rasterization dispatch. Width/height come from the
+    // renderer (output size may have been resized since init_streaming).
+    void dispatch_render(VkCommandBuffer cmd, uint32_t frame_in_flight,
+                         uint32_t width, uint32_t height);
+
+    // Tear down. Idempotent.
+    void shutdown();
+
+    // ── Determinism harness controls (forwarded by GsRenderer) ────────
+    void set_determinism_test_active(bool active) {
+        determinism_test_active_ = active;
+        if (!active) determinism_readback_emitted_ = false;
+    }
+    bool determinism_test_active() const { return determinism_test_active_; }
+    bool determinism_readback_emitted_this_frame() const {
+        return determinism_readback_emitted_;
+    }
+    // Allocation of the host-visible readback buffer (single-instance —
+    // only one frame emits at a time, harness waits on in-flight fence).
+    VmaAllocation determinism_readback_allocation() const;
+    // Allocation of the per-frame tile_sort_count_ssbo slot that the
+    // last dispatch_sort recorded into.
+    VmaAllocation tile_sort_count_allocation() const;
+    const void*   determinism_readback_data() const;
+    // Post-fence: returns the live tile-sort entry count from the slot
+    // that the most-recent dispatch_sort recorded into.
+    uint32_t      live_tile_sort_count() const;
+
+    // ── Sizing access (used by GsRenderer::init_streaming to size the
+    //    per-frame tile_sort_* buffers in GsResourceManager) ───────────
+    uint32_t tile_sort_capacity()   const { return tile_sort_capacity_; }
+    uint32_t tile_sort_size()       const { return tile_sort_size_; }
+    uint32_t tile_sort_workgroups() const { return tile_sort_workgroups_; }
+    uint32_t scan_dispatch_size()   const { return scan_dispatch_size_; }
+    uint32_t scan_num_blocks()      const { return scan_num_blocks_; }
+    uint32_t onesweep_max_wg()      const { return onesweep_max_wg_; }
+
+    // ── Prewarm ───────────────────────────────────────────────────────
+    struct PrewarmEntry {
+        const char*              name;
+        VkPipeline               pipeline;
+        VkPipelineLayout         pipeline_layout;
+        VkDescriptorSetLayout    set_layout;
+        uint32_t                 push_size;
+    };
+    std::array<PrewarmEntry, 6> prewarm_entries() const;
+
+private:
+    static constexpr uint32_t kTileSortPasses = 4;  // 4 radix passes for 32-bit key
+
+    VkDevice           device_     = VK_NULL_HANDLE;
+    GsResourceManager* resources_  = nullptr;
+    GsSortSystem*      sort_       = nullptr;
+
+    // Layouts + pipelines
+    VkDescriptorSetLayout  tile_bin_layout_              = VK_NULL_HANDLE;  // shared by tile_count
+    VkPipelineLayout       tile_bin_pipeline_layout_     = VK_NULL_HANDLE;
+    VkPipeline             tile_bin_pipeline_            = VK_NULL_HANDLE;
+    VkPipeline             tile_count_pipeline_          = VK_NULL_HANDLE;
+
+    VkDescriptorSetLayout  tile_scan_layout_             = VK_NULL_HANDLE;
+    VkPipelineLayout       tile_scan_pipeline_layout_    = VK_NULL_HANDLE;
+    VkPipeline             tile_scan_pipeline_           = VK_NULL_HANDLE;
+
+    VkDescriptorSetLayout  tile_indirect_layout_         = VK_NULL_HANDLE;
+    VkPipelineLayout       tile_indirect_pipeline_layout_ = VK_NULL_HANDLE;
+    VkPipeline             tile_indirect_pipeline_       = VK_NULL_HANDLE;
+
+    VkDescriptorSetLayout  tile_ranges_layout_           = VK_NULL_HANDLE;
+    VkPipelineLayout       tile_ranges_pipeline_layout_  = VK_NULL_HANDLE;
+    VkPipeline             tile_ranges_pipeline_         = VK_NULL_HANDLE;
+
+    VkDescriptorSetLayout  tile_render_layout_           = VK_NULL_HANDLE;
+    VkPipelineLayout       tile_render_pipeline_layout_  = VK_NULL_HANDLE;
+    VkPipeline             tile_render_pipeline_         = VK_NULL_HANDLE;
+
+    // Per-frame descriptor sets
+    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_bin_sets_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_scan_sets_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_indirect_sets_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_ranges_sets_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> tile_render_sets_{};
+
+    // Tile-onesweep sets — borrow sort_'s onesweep_*_set_layout
+    std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_hist_sets_a_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_hist_sets_b_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_scatter_sets_ab_{};
+    std::array<VkDescriptorSet, kMaxFramesInFlight> onesweep_scatter_sets_ba_{};
+
+    // Sizing scalars (computed in set_sort_sizes)
+    uint32_t static_sort_size_       = 0;
+    uint32_t dynamic_sort_size_      = 0;
+    uint32_t tile_sort_capacity_     = 0;
+    uint32_t tile_sort_size_         = 0;
+    uint32_t tile_sort_workgroups_   = 0;
+    uint32_t scan_dispatch_size_     = 0;
+    uint32_t scan_num_blocks_        = 0;
+    uint32_t onesweep_max_wg_        = 0;
+
+    // Determinism harness state
+    bool     determinism_test_active_       = false;
+    bool     determinism_readback_emitted_  = false;
+    uint32_t determinism_last_emitted_frame_ = 0;
+};
+
+}  // namespace gseurat

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -250,11 +250,13 @@ void GsRenderer::create_descriptor_resources() {
     // sort_'s allocation isn't invalidated.
     vkResetDescriptorPool(device_, gs_pool_, 0);
 
-    // Phase 5c: GsSortSystem creates its own layouts/pipelines/sets here,
-    // BEFORE the central layouts[] array is built — that array borrows
-    // sort_.onesweep_*_set_layout() for the remaining tile-onesweep slots.
+    // Phase 5c: GsSortSystem creates its own layouts/pipelines/sets here.
+    // Phase 5d: GsTileBinSystem creates its own layouts/pipelines/sets
+    // here too, AFTER sort_ (it borrows sort_'s onesweep set layouts for
+    // the tile-onesweep descriptor sets).
     assert(resources_ != nullptr && "set_resources() must run before init()");
     sort_.init(device_, pipeline_cache_, gs_pool_, resources_);
+    tile_.init(device_, pipeline_cache_, gs_pool_, resources_, &sort_);
 
     // Preprocess layout: { gaussians, projected, sort_keys, uniforms, visible_count, bones, pbd_states }
     {
@@ -309,89 +311,10 @@ void GsRenderer::create_descriptor_resources() {
 
     // Phase 5c: merge descriptor set layout moved to GsSortSystem.
 
-    // Tile binning layout (deterministic count + scatter):
-    //   0 projected      1 merged_sort     2 counts (ro)
-    //   3 per_splat_tile_count    4 per_splat_tile_offset
-    //   5 tile_entries           6 uniforms
-    // Count shader uses 0,1,2,3,6. Scatter uses 0,1,2,4,5,6.
-    {
-        VkDescriptorSetLayoutBinding bindings[] = {
-            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {5, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {6, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-        };
-        VkDescriptorSetLayoutCreateInfo ci{};
-        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        ci.bindingCount = 7;
-        ci.pBindings = bindings;
-        vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_bin_layout_);
-    }
-
-    // Tile scan layout: per_splat_tile_count(0), per_splat_tile_offset(1),
-    //                   scan_block_sums(2), tile_sort_count(3)
-    {
-        VkDescriptorSetLayoutBinding bindings[] = {
-            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-        };
-        VkDescriptorSetLayoutCreateInfo ci{};
-        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        ci.bindingCount = 4;
-        ci.pBindings = bindings;
-        vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_scan_layout_);
-    }
-
     // Phase 5c: onesweep histogram + scatter descriptor set layouts moved to GsSortSystem.
-
-    // Tile indirect dispatch layout: { tile_sort_count(0), indirect_args(1) }
-    {
-        VkDescriptorSetLayoutBinding bindings[] = {
-            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-        };
-        VkDescriptorSetLayoutCreateInfo ci{};
-        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        ci.bindingCount = 2;
-        ci.pBindings = bindings;
-        vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_indirect_layout_);
-    }
-
-    // Tile render layout: { projected(0), tile_entries(1), uniforms(2), output_image(3), tile_ranges(4), depth_image(5) }
-    {
-        VkDescriptorSetLayoutBinding bindings[] = {
-            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {2, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {3, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {5, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-        };
-        VkDescriptorSetLayoutCreateInfo ci{};
-        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        ci.bindingCount = 6;
-        ci.pBindings = bindings;
-        vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_render_layout_);
-    }
-
-    // Tile range detection layout: { sorted_entries(0), tile_ranges(1), tile_count(2) }
-    {
-        VkDescriptorSetLayoutBinding bindings[] = {
-            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-            {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-        };
-        VkDescriptorSetLayoutCreateInfo ci{};
-        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        ci.bindingCount = 3;
-        ci.pBindings = bindings;
-        vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_ranges_layout_);
-    }
+    // Phase 5d: tile_bin / tile_scan / tile_indirect / tile_render / tile_ranges
+    // descriptor set layouts now live inside GsTileBinSystem (already created
+    // by tile_.init() above).
 
     // PBD solver layout: { pbd_states (rw), pbd_params (ro), pbd_constraints (ro), pbd_uniforms }
     {
@@ -424,44 +347,23 @@ void GsRenderer::create_descriptor_resources() {
                   "dynamic_preprocess/merge/depth_hist/depth_scatter/dynamic_depth_hist/"
                   "dynamic_depth_scatter) at the end of `layouts`.");
 
-    // Phase 5c: depth-sort + merge layout slots (26 entries) removed.
-    // GsSortSystem allocates its own 26 sets from the same gs_pool_.
-    // kSetCount: 56 → 30. The remaining onesweep_hist/scatter slots are
-    // for tile-sort only (will move to GsTileBinSystem in 5d) and
-    // reference layouts borrowed from GsSortSystem via sort_.onesweep_*().
-    const VkDescriptorSetLayout onesweep_hist_layout    = sort_.onesweep_hist_set_layout();
-    const VkDescriptorSetLayout onesweep_scatter_layout = sort_.onesweep_scatter_set_layout();
+    // Phase 5c: depth-sort + merge slots removed (26 sets owned by GsSortSystem).
+    // Phase 5d: tile-bin + tile-onesweep slots removed (18 sets owned by
+    // GsTileBinSystem). kSetCount: 56 → 30 (5c) → 12 (5d). Only the legacy
+    // preprocess/sort/render/pbd sets remain in the central batch.
     VkDescriptorSetLayout layouts[] = {
         preprocess_layout_, sort_layout_, render_layout_,   // 0-2: preprocess_sets_[0], sort_sets_[0], render_sets_[0]
         preprocess_layout_, preprocess_layout_,             // 3-4: static_preprocess_sets_[0], dynamic_preprocess_sets_[0]
-        render_layout_,                                     // 5: merged render
+        render_layout_,                                     // 5: merged render (legacy reservation, unused)
         pbd_layout_,                                        // 6: PBD solver
-        // Tile binning sets (per-frame slot [0])
-        tile_bin_layout_,                                   // 7: tile_bin_sets_[0]
-        tile_ranges_layout_,                                // 8: tile_ranges_sets_[0]
-        tile_indirect_layout_,                              // 9: tile_indirect_sets_[0]
-        tile_render_layout_,                                // 10: tile_render_sets_[0]
-        onesweep_hist_layout, onesweep_hist_layout,         // 11-12: tile onesweep hist A, B [0]
-        onesweep_scatter_layout, onesweep_scatter_layout,   // 13-14: tile onesweep scatter AB, BA [0]
-        tile_scan_layout_,                                  // 15: tile_scan_sets_[0]
-        // Per-frame [1] copies for sets that bind per-frame images:
-        render_layout_,                                     // 16: render_sets_[1]
-        tile_render_layout_,                                // 17: tile_render_sets_[1]
-        // Phase 2/3 per-frame [1] copies for compute sets that bind racing SSBOs.
-        preprocess_layout_,                                 // 18: preprocess_sets_[1]
-        sort_layout_,                                       // 19: sort_sets_[1]
-        preprocess_layout_,                                 // 20: static_preprocess_sets_[1]
-        preprocess_layout_,                                 // 21: dynamic_preprocess_sets_[1]
-        // tile_bin_set_ reads racing projected/merged/counts — must be per-frame.
-        tile_bin_layout_,                                   // 22: tile_bin_sets_[1]
-        // Phase 3.5 per-frame [1] copies for the racing tile-pipeline sets.
-        tile_scan_layout_,                                  // 23: tile_scan_sets_[1]
-        tile_indirect_layout_,                              // 24: tile_indirect_sets_[1]
-        tile_ranges_layout_,                                // 25: tile_ranges_sets_[1]
-        onesweep_hist_layout, onesweep_hist_layout,         // 26-27: tile onesweep hist A, B [1]
-        onesweep_scatter_layout, onesweep_scatter_layout,   // 28-29: tile onesweep scatter AB, BA [1]
+        // Per-frame [1] copies for sets that bind per-frame images / racing SSBOs:
+        render_layout_,                                     // 7: render_sets_[1]
+        preprocess_layout_,                                 // 8: preprocess_sets_[1]
+        sort_layout_,                                       // 9: sort_sets_[1]
+        preprocess_layout_,                                 // 10: static_preprocess_sets_[1]
+        preprocess_layout_,                                 // 11: dynamic_preprocess_sets_[1]
     };
-    constexpr uint32_t kSetCount = 30;
+    constexpr uint32_t kSetCount = 12;
     VkDescriptorSet sets[kSetCount];
     VkDescriptorSetAllocateInfo alloc_info{};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -478,41 +380,21 @@ void GsRenderer::create_descriptor_resources() {
 
     // Legacy sets (per-frame Phase 2)
     preprocess_sets_[0] = sets[0];
-    preprocess_sets_[1] = sets[18];
+    preprocess_sets_[1] = sets[8];
     sort_sets_[0] = sets[1];
-    sort_sets_[1] = sets[19];
+    sort_sets_[1] = sets[9];
     render_sets_[0] = sets[2];
-    render_sets_[1] = sets[16];
+    render_sets_[1] = sets[7];
     // Phase 5b: post_process_sets_ now lives in GsPostProcessSystem.
     // Phase 5c: merge_sets_ + all depth_*_sets_ now live in GsSortSystem.
+    // Phase 5d: all tile-bin / tile-onesweep sets now live in GsTileBinSystem.
     // Static/dynamic preprocess (per-frame Phase 2)
     static_preprocess_sets_[0] = sets[3];
-    static_preprocess_sets_[1] = sets[20];
+    static_preprocess_sets_[1] = sets[10];
     dynamic_preprocess_sets_[0] = sets[4];
-    dynamic_preprocess_sets_[1] = sets[21];
-    // sets[5] is the merged render set (render_layout_)
+    dynamic_preprocess_sets_[1] = sets[11];
+    // sets[5] is the merged render set (render_layout_) — legacy reservation.
     pbd_set_ = sets[6];
-    // Tile binning
-    tile_bin_sets_[0] = sets[7];
-    tile_bin_sets_[1] = sets[22];
-    // Phase 3.5: per-frame tile_ranges / tile_indirect / tile_scan + tile onesweep
-    tile_ranges_sets_[0] = sets[8];
-    tile_ranges_sets_[1] = sets[25];
-    tile_indirect_sets_[0] = sets[9];
-    tile_indirect_sets_[1] = sets[24];
-    tile_render_sets_[0] = sets[10];
-    tile_render_sets_[1] = sets[17];
-    onesweep_hist_sets_a_[0] = sets[11];
-    onesweep_hist_sets_b_[0] = sets[12];
-    onesweep_scatter_sets_ab_[0] = sets[13];
-    onesweep_scatter_sets_ba_[0] = sets[14];
-    onesweep_hist_sets_a_[1] = sets[26];
-    onesweep_hist_sets_b_[1] = sets[27];
-    onesweep_scatter_sets_ab_[1] = sets[28];
-    onesweep_scatter_sets_ba_[1] = sets[29];
-    // Deterministic tile-bin scan — per-frame (Phase 3.5)
-    tile_scan_sets_[0] = sets[15];
-    tile_scan_sets_[1] = sets[23];
 }
 
 void GsRenderer::create_compute_pipelines() {
@@ -568,51 +450,9 @@ void GsRenderer::create_compute_pipelines() {
                     pbd_pipeline_layout_, pbd_pipeline_);
 
     // Phase 5c: merge pipeline owned by GsSortSystem.
-
-    // Tile binning scatter (push: max_entries = 4 bytes). Builds the
-    // pipeline layout that the count pipeline below reuses — the count
-    // shader has no push constant but accepts a 4-byte range without
-    // touching it (Vulkan permits an unused push range to dangle).
-    create_pipeline("shaders/gs_tile_bin.comp.spv", tile_bin_layout_, 4,
-                    tile_bin_pipeline_layout_, tile_bin_pipeline_);
-
-    // Tile-bin count pass — reuses tile_bin_layout_ + push range.
-    {
-        auto module = load_shader_module(device_, "shaders/gs_tile_count.comp.spv");
-        VkPipelineShaderStageCreateInfo stage{};
-        stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        stage.module = module;
-        stage.pName = "main";
-
-        VkComputePipelineCreateInfo pipe_info{};
-        pipe_info.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-        pipe_info.stage = stage;
-        pipe_info.layout = tile_bin_pipeline_layout_;
-        if (vkCreateComputePipelines(device_, pipeline_cache_, 1, &pipe_info, nullptr,
-                                      &tile_count_pipeline_) != VK_SUCCESS) {
-            throw std::runtime_error("Failed to create tile_count pipeline");
-        }
-        vkDestroyShaderModule(device_, module, nullptr);
-    }
-
-    // Tile-bin scan (push: { pass, num_elements, num_blocks } = 12 bytes).
-    create_pipeline("shaders/gs_tile_scan.comp.spv", tile_scan_layout_, 12,
-                    tile_scan_pipeline_layout_, tile_scan_pipeline_);
-
-    // Tile range detection pipeline (push: num_tiles + max_entries = 8 bytes)
-    create_pipeline("shaders/gs_tile_ranges.comp.spv", tile_ranges_layout_, 8,
-                    tile_ranges_pipeline_layout_, tile_ranges_pipeline_);
-
-    // Indirect dispatch preparation (push: max_entries = 4 bytes)
-    create_pipeline("shaders/gs_tile_prepare_indirect.comp.spv", tile_indirect_layout_, 4,
-                    tile_indirect_pipeline_layout_, tile_indirect_pipeline_);
-
     // Phase 5c: onesweep histogram + scatter pipelines owned by GsSortSystem.
-
-    // Tile render pipeline (separate from render — uses tile_entries + tile_ranges)
-    create_pipeline("shaders/gs_tile_render.comp.spv", tile_render_layout_, 0,
-                    tile_render_pipeline_layout_, tile_render_pipeline_);
+    // Phase 5d: tile_bin, tile_count, tile_scan, tile_ranges, tile_prepare_indirect,
+    // tile_render pipelines owned by GsTileBinSystem (created by tile_.init()).
 
     // Phase 4c-vfx: compose pass (own descriptor pool to avoid disturbing
     // the central gs_pool_ slot indexing).
@@ -1092,21 +932,6 @@ void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool,
             add_entry("gs_merge", entries[2].pipeline, entries[2].pipeline_layout,
                       entries[2].set_layout, 0, {0,1,2,3}, {}, {});
         }
-        add_entry("gs_tile_bin", tile_bin_pipeline_, tile_bin_pipeline_layout_,
-                  tile_bin_layout_, 4,
-                  {0,1,2,3,4,5}, {6}, {});
-        add_entry("gs_tile_count", tile_count_pipeline_, tile_bin_pipeline_layout_,
-                  tile_bin_layout_, 4,
-                  {0,1,2,3,4,5}, {6}, {});
-        add_entry("gs_tile_scan", tile_scan_pipeline_, tile_scan_pipeline_layout_,
-                  tile_scan_layout_, 12,
-                  {0,1,2,3}, {}, {});
-        add_entry("gs_tile_ranges", tile_ranges_pipeline_, tile_ranges_pipeline_layout_,
-                  tile_ranges_layout_, 8,
-                  {0,1,2}, {}, {});
-        add_entry("gs_tile_prepare_indirect", tile_indirect_pipeline_,
-                  tile_indirect_pipeline_layout_, tile_indirect_layout_, 4,
-                  {0,1}, {}, {});
         // Phase 5c: onesweep histogram + scatter pipelines owned by GsSortSystem.
         {
             auto entries = sort_.prewarm_entries();
@@ -1117,10 +942,31 @@ void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool,
                       entries[1].pipeline_layout, entries[1].set_layout, 4,
                       {0,1,2,3}, {}, {});
         }
-        add_entry("gs_tile_render", tile_render_pipeline_, tile_render_pipeline_layout_,
-                  tile_render_layout_, 0,
-                  {0,1,4}, {2},
-                  {{3u, color_view}, {5u, depth_view}});
+        // Phase 5d: tile pipelines owned by GsTileBinSystem.
+        {
+            auto tile_entries = tile_.prewarm_entries();
+            // [0] gs_tile_bin, [1] gs_tile_count, [2] gs_tile_scan,
+            // [3] gs_tile_ranges, [4] gs_tile_prepare_indirect, [5] gs_tile_render
+            add_entry(tile_entries[0].name, tile_entries[0].pipeline,
+                      tile_entries[0].pipeline_layout, tile_entries[0].set_layout,
+                      tile_entries[0].push_size, {0,1,2,3,4,5}, {6}, {});
+            add_entry(tile_entries[1].name, tile_entries[1].pipeline,
+                      tile_entries[1].pipeline_layout, tile_entries[1].set_layout,
+                      tile_entries[1].push_size, {0,1,2,3,4,5}, {6}, {});
+            add_entry(tile_entries[2].name, tile_entries[2].pipeline,
+                      tile_entries[2].pipeline_layout, tile_entries[2].set_layout,
+                      tile_entries[2].push_size, {0,1,2,3}, {}, {});
+            add_entry(tile_entries[3].name, tile_entries[3].pipeline,
+                      tile_entries[3].pipeline_layout, tile_entries[3].set_layout,
+                      tile_entries[3].push_size, {0,1,2}, {}, {});
+            add_entry(tile_entries[4].name, tile_entries[4].pipeline,
+                      tile_entries[4].pipeline_layout, tile_entries[4].set_layout,
+                      tile_entries[4].push_size, {0,1}, {}, {});
+            add_entry(tile_entries[5].name, tile_entries[5].pipeline,
+                      tile_entries[5].pipeline_layout, tile_entries[5].set_layout,
+                      tile_entries[5].push_size, {0,1,4}, {2},
+                      {{3u, color_view}, {5u, depth_view}});
+        }
 
         // Allocate one descriptor set per entry.
         std::vector<VkDescriptorSetLayout> set_layouts;
@@ -1532,33 +1378,23 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
     resources_->pp_ubo_buffer = Buffer::create_uniform(allocator_, sizeof(GsPostProcessUbo));
 
     // ── Tile binning buffers ──
-    // Capacity: visible Gaussians × avg tile overlap. Cap at 1M entries (16MB per buffer).
+    // Phase 5d: tile-sort sizing now computed inside GsTileBinSystem.
+    // We push the static/dynamic split into the system, then read back
+    // the derived sizes via getters to size the per-frame tile_* SSBOs
+    // owned by GsResourceManager.
     {
-        uint32_t visible_upper = static_sort_size_ + dynamic_sort_size_;
-        tile_sort_capacity_ = std::min(visible_upper * 4, 1u << 21);  // cap at 2M (16MB per buffer)
-        // Align to 1024 (workgroup size for radix sort)
-        tile_sort_size_ = ((tile_sort_capacity_ + 2047) / 2048) * 2048;
-        tile_sort_workgroups_ = tile_sort_size_ / 2048;
-        if (tile_sort_workgroups_ == 0) tile_sort_workgroups_ = 1;
-        tile_sort_size_ = tile_sort_workgroups_ * 2048;
+        tile_.set_sort_sizes(static_sort_size_, dynamic_sort_size_);
 
-        VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_sort_size_) * 8;  // 8 bytes/entry
+        VkDeviceSize entry_buf_size = static_cast<VkDeviceSize>(tile_.tile_sort_size()) * 8;  // 8 bytes/entry
         // Allocate tile_ranges for max possible resolution (resources_->output_width may not
         // reflect final size at allocation time). Generous upper bound.
         static constexpr uint32_t kMaxTiles = 256 * 144;  // supports up to 4096×2304
         VkDeviceSize ranges_buf_size = static_cast<VkDeviceSize>(kMaxTiles) * 2 * sizeof(uint32_t);
 
-        // Deterministic tile-bin (Fix B) intermediate SSBOs. Sized to the
-        // visible-splat upper bound rounded up to a 256-thread workgroup —
-        // gs_tile_count.comp dispatches at this granularity, and the scan
-        // shader expects num_elements to match.
-        scan_dispatch_size_ = ((visible_upper + 255u) / 256u) * 256u;
-        if (scan_dispatch_size_ == 0) scan_dispatch_size_ = 256u;
-        scan_num_blocks_ = scan_dispatch_size_ / 256u;
         VkDeviceSize per_splat_buf_size =
-            static_cast<VkDeviceSize>(scan_dispatch_size_) * sizeof(uint32_t);
+            static_cast<VkDeviceSize>(tile_.scan_dispatch_size()) * sizeof(uint32_t);
         VkDeviceSize block_sums_buf_size =
-            static_cast<VkDeviceSize>(scan_num_blocks_) * sizeof(uint32_t);
+            static_cast<VkDeviceSize>(tile_.scan_num_blocks()) * sizeof(uint32_t);
 
         // Phase 3.5: per-frame — destroy + recreate every slot at the new
         // capacity. All seven buffers are racing across cmdbufs and must
@@ -1593,17 +1429,15 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
 
         std::fprintf(stderr, "GS: Tile sort -- capacity=%u entries (%u workgroups), "
                      "output=%ux%u, buf=%.1f MB; scan=%u elems / %u blocks\n",
-                     tile_sort_size_, tile_sort_workgroups_,
+                     tile_.tile_sort_size(), tile_.tile_sort_workgroups(),
                      resources_->output_width, resources_->output_height,
                      static_cast<float>(entry_buf_size * 2) / (1024.0f * 1024.0f),
-                     scan_dispatch_size_, scan_num_blocks_);
+                     tile_.scan_dispatch_size(), tile_.scan_num_blocks());
 
         // Onesweep status buffer: 4 passes × 256 digits × max_workgroups.
         // Per-frame so each in-flight cmdbuf clears + reads its own slot
         // without racing the other cmdbuf's in-progress onesweep lookback.
-        onesweep_max_wg_ = (tile_sort_capacity_ + 2047) / 2048;
-        if (onesweep_max_wg_ == 0) onesweep_max_wg_ = 1;
-        VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
+        VkDeviceSize status_size = 4ull * 256ull * tile_.onesweep_max_wg() * sizeof(uint32_t);
         for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
             resources_->onesweep_statuses[f].destroy(allocator_);
             resources_->onesweep_statuses[f] = Buffer::create_storage_gpu_only(allocator_, status_size);
@@ -2875,215 +2709,10 @@ void GsRenderer::update_descriptors() {
         vkUpdateDescriptorSets(device_, 6, writes, 0, nullptr);
     }
 
-    // ── Tile binning descriptor sets ──
-    if (resources_->tile_sort_as[0].buffer()) {
-        // Tile bin set (count + scatter share this layout):
-        //   0 projected  1 merged_sort  2 counts (ro)
-        //   3 per_splat_count (count writes here)
-        //   4 per_splat_offset (scatter reads here)
-        //   5 tile_entries (scatter writes here)
-        //   6 uniforms
-        //
-        // Per-frame (Phase 3): tile_bin_sets_[f] binds the per-frame
-        // projected/merged/counts slots so tile_bin in frame f reads the
-        // data frame f's preprocess+merge wrote earlier in the same
-        // command buffer. Frame N+1's tile_bin no longer reads frame N's
-        // slot.
-        // Phase 3.5: per_splat_count/offset, tile_entries are now per-frame
-        // too — bind frame f's slot.
-        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-            VkDescriptorBufferInfo projected_info{resources_->projected_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo merged_info{resources_->merged_sort_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo counts_info{resources_->counts_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo per_splat_count_info{resources_->per_splat_tile_count_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo per_splat_offset_info{resources_->per_splat_tile_offset_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo tile_entries_info{resources_->tile_sort_as[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo uniform_info{resources_->uniform_buffer.buffer(), 0, sizeof(GsUniforms)};
+    // ── Phase 5d: tile binning + tile sort + tile render descriptor sets
+    //    moved into GsTileBinSystem ─────────────────────────────────────
+    tile_.write_descriptors();
 
-            VkDescriptorSet tile_bin_set = tile_bin_sets_[f];
-            VkWriteDescriptorSet writes[] = {
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 0, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &projected_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 1, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &merged_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 2, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &counts_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 3, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &per_splat_count_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 4, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &per_splat_offset_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 5, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &tile_entries_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, tile_bin_set, 6, 0, 1,
-                 VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
-            };
-            vkUpdateDescriptorSets(device_, 7, writes, 0, nullptr);
-        }
-
-        // Tile scan set: per_splat_count(0), per_splat_offset(1),
-        //                scan_block_sums(2), tile_sort_count(3)
-        // Phase 3.5: per-frame.
-        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-            VkDescriptorBufferInfo count_info{resources_->per_splat_tile_count_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo offset_info{resources_->per_splat_tile_offset_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo block_sums_info{resources_->scan_block_sums_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo total_info{resources_->tile_sort_count_ssbos[f].buffer(), 0, sizeof(uint32_t)};
-            VkDescriptorSet scan_set = tile_scan_sets_[f];
-            VkWriteDescriptorSet writes[] = {
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scan_set, 0, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &count_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scan_set, 1, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &offset_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scan_set, 2, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &block_sums_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scan_set, 3, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &total_info, nullptr},
-            };
-            vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
-        }
-
-        // Tile range detection set: sorted_entries(0), tile_ranges(1), tile_count(2)
-        // Phase 3.5: per-frame.
-        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-            VkDescriptorBufferInfo sorted_info{resources_->tile_sort_as[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo ranges_info{resources_->tile_ranges_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo count_info{resources_->tile_sort_count_ssbos[f].buffer(), 0, sizeof(uint32_t)};
-            VkDescriptorSet ranges_set = tile_ranges_sets_[f];
-
-            VkWriteDescriptorSet writes[] = {
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, ranges_set, 0, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &sorted_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, ranges_set, 1, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &ranges_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, ranges_set, 2, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &count_info, nullptr},
-            };
-            vkUpdateDescriptorSets(device_, 3, writes, 0, nullptr);
-        }
-
-        // Tile indirect set: tile_sort_count(0), indirect_args(1)
-        // Phase 3.5: per-frame.
-        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-            VkDescriptorBufferInfo count_info{resources_->tile_sort_count_ssbos[f].buffer(), 0, sizeof(uint32_t)};
-            VkDescriptorBufferInfo args_info{resources_->tile_indirect_args[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorSet indirect_set = tile_indirect_sets_[f];
-            VkWriteDescriptorSet writes[] = {
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, indirect_set, 0, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &count_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, indirect_set, 1, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
-            };
-            vkUpdateDescriptorSets(device_, 2, writes, 0, nullptr);
-        }
-
-        // Onesweep histogram descriptor sets (read-only input + status + args)
-        // Phase 3.5 + onesweep status fix: every binding is per-frame, so
-        // each frame f's onesweep dispatch reads/writes only its own slot.
-        if (resources_->onesweep_statuses[0].buffer()) {
-            for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-                {
-                    VkDescriptorBufferInfo in_info{resources_->tile_sort_as[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo status_info{resources_->onesweep_statuses[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo args_info{resources_->tile_indirect_args[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorSet hist_a = onesweep_hist_sets_a_[f];
-                    VkWriteDescriptorSet writes[] = {
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, hist_a, 0, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, hist_a, 1, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, hist_a, 2, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
-                    };
-                    vkUpdateDescriptorSets(device_, 3, writes, 0, nullptr);
-                }
-                {
-                    VkDescriptorBufferInfo in_info{resources_->tile_sort_bs[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo status_info{resources_->onesweep_statuses[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo args_info{resources_->tile_indirect_args[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorSet hist_b = onesweep_hist_sets_b_[f];
-                    VkWriteDescriptorSet writes[] = {
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, hist_b, 0, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, hist_b, 1, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, hist_b, 2, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
-                    };
-                    vkUpdateDescriptorSets(device_, 3, writes, 0, nullptr);
-                }
-                // Onesweep scatter descriptor sets (input + output + status + args)
-                {
-                    VkDescriptorBufferInfo in_info{resources_->tile_sort_as[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo out_info{resources_->tile_sort_bs[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo status_info{resources_->onesweep_statuses[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo args_info{resources_->tile_indirect_args[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorSet scatter_ab = onesweep_scatter_sets_ab_[f];
-                    VkWriteDescriptorSet writes[] = {
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ab, 0, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ab, 1, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &out_info, nullptr},
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ab, 2, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ab, 3, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
-                    };
-                    vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
-                }
-                {
-                    VkDescriptorBufferInfo in_info{resources_->tile_sort_bs[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo out_info{resources_->tile_sort_as[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo status_info{resources_->onesweep_statuses[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorBufferInfo args_info{resources_->tile_indirect_args[f].buffer(), 0, VK_WHOLE_SIZE};
-                    VkDescriptorSet scatter_ba = onesweep_scatter_sets_ba_[f];
-                    VkWriteDescriptorSet writes[] = {
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ba, 0, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &in_info, nullptr},
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ba, 1, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &out_info, nullptr},
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ba, 2, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
-                        {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, scatter_ba, 3, 0, 1,
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
-                    };
-                    vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
-                }
-            }
-        }
-
-        // Tile render set: projected(0), tile_entries(1), uniforms(2), output_image(3), tile_ranges(4), depth_image(5)
-        // Per-frame (Phase 3): each tile_render_sets_[f] binds frame f's
-        // output/depth views AND frame f's resources_->projected_ssbos[f]. The tile_render
-        // dispatch runs in frame f's command buffer and reads projected data
-        // that frame f's preprocess wrote earlier in the same command buffer.
-        // Phase 3.5: tile_entries (tile_sort_a) and tile_ranges are also
-        // per-frame — bind frame f's slot.
-        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
-            VkDescriptorBufferInfo projected_info{resources_->projected_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo tile_entries_info{resources_->tile_sort_as[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorBufferInfo uniform_info{resources_->uniform_buffer.buffer(), 0, sizeof(GsUniforms)};
-            VkDescriptorImageInfo image_info{VK_NULL_HANDLE, resources_->output_views[f], VK_IMAGE_LAYOUT_GENERAL};
-            VkDescriptorBufferInfo tile_ranges_info{resources_->tile_ranges_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
-            VkDescriptorImageInfo depth_img_info{VK_NULL_HANDLE, resources_->depth_views[f], VK_IMAGE_LAYOUT_GENERAL};
-
-            VkDescriptorSet set = tile_render_sets_[f];
-            VkWriteDescriptorSet writes[] = {
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &projected_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &tile_entries_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
-                 VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &image_info, nullptr, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 4, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &tile_ranges_info, nullptr},
-                {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 5, 0, 1,
-                 VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &depth_img_info, nullptr, nullptr},
-            };
-            vkUpdateDescriptorSets(device_, 6, writes, 0, nullptr);
-        }
-    }
 }
 
 void GsRenderer::resize_output(uint32_t width, uint32_t height) {
@@ -3209,269 +2838,6 @@ void GsRenderer::init_output_layouts(VkCommandBuffer cmd) {
 }
 
 
-void GsRenderer::dispatch_tile_sort(VkCommandBuffer cmd, uint32_t frame_in_flight) {
-    GS_LABEL(cmd, "TileSort");
-    // Reset the per-frame "did we record a readback?" flag at the start of
-    // every dispatch attempt. The harness in Renderer::draw_scene reads
-    // this flag after the in-flight fence to decide whether the captured
-    // frame represents a real measurement.
-    determinism_readback_emitted_ = false;
-    GS_DBG_INVARIANT(resources_->tile_sort_as[frame_in_flight].buffer() && tile_sort_capacity_ > 0,
-                     "dispatch_tile_sort: tile sort buffers must be allocated before first dispatch");
-
-    uint32_t width = resources_->output_width;
-    uint32_t height = resources_->output_height;
-    uint32_t tiles_x = (width + 15) / 16;
-    uint32_t tiles_y = (height + 15) / 16;
-
-    // === Phase 0: zero counters and pre-fill tile_sort_a_ with sentinels.
-    // Sentinels still matter: the radix sort processes
-    // tile_sort_workgroups_ * 2048 entries, but the deterministic count
-    // pass only writes [0, total). Slots in [total, tile_sort_size_)
-    // need 0xFFFFFFFF keys so the sort routes them to the tail and
-    // keeps real entries contiguous at [0, total).
-    // Phase 3.5: per-frame — fills target frame f's slot, not the shared
-    // singleton, so cmdbuf f and cmdbuf f+1 don't stomp on each other.
-    vkCmdFillBuffer(cmd, resources_->tile_sort_count_ssbos[frame_in_flight].buffer(), 0, sizeof(uint32_t), 0);
-    vkCmdFillBuffer(cmd, resources_->tile_sort_as[frame_in_flight].buffer(), 0,
-                    static_cast<VkDeviceSize>(tile_sort_size_) * 8, 0xFFFFFFFF);
-    // per_splat_tile_count_ must be zeroed before the count dispatch so the
-    // tail (gid >= visible) reads 0 in the scan; the count shader doesn't
-    // touch those slots.
-    vkCmdFillBuffer(cmd, resources_->per_splat_tile_count_ssbos[frame_in_flight].buffer(), 0,
-                    static_cast<VkDeviceSize>(scan_dispatch_size_) * sizeof(uint32_t), 0);
-
-    {
-        VkMemoryBarrier fill_barrier{};
-        fill_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-        fill_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-        fill_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
-        vkCmdPipelineBarrier(cmd,
-            VK_PIPELINE_STAGE_TRANSFER_BIT,
-            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-            0, 1, &fill_barrier, 0, nullptr, 0, nullptr);
-    }
-
-    uint32_t visible_upper = static_sort_size_ + dynamic_sort_size_;
-    uint32_t count_workgroups = scan_num_blocks_;  // (visible_upper + 255) / 256, rounded
-
-    // === Phase 1: Count pass — per-splat tile-overlap count ===
-    {
-        GS_LABEL(cmd, "Count");
-        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_count_pipeline_);
-        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                tile_bin_pipeline_layout_, 0, 1, &tile_bin_sets_[frame_in_flight], 0, nullptr);
-        // Push range allocated for the scatter; count shader has no push,
-        // but Vulkan permits leaving the range untouched.
-        uint32_t push_data[1] = {tile_sort_capacity_};
-        vkCmdPushConstants(cmd, tile_bin_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
-                           0, 4, push_data);
-        vkCmdDispatch(cmd, count_workgroups, 1, 1);
-    }
-    insert_compute_barrier(cmd);
-
-    // === Phase 2: Three-pass exclusive scan ===
-    {
-        GS_LABEL(cmd, "Scan");
-        struct ScanPush { uint32_t pass; uint32_t num_elements; uint32_t num_blocks; };
-        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_scan_pipeline_);
-        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                tile_scan_pipeline_layout_, 0, 1, &tile_scan_sets_[frame_in_flight], 0, nullptr);
-
-        // Pass 0: per-block local exclusive scan + write block sums.
-        ScanPush p0{0u, scan_dispatch_size_, scan_num_blocks_};
-        vkCmdPushConstants(cmd, tile_scan_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
-                           0, sizeof(ScanPush), &p0);
-        vkCmdDispatch(cmd, scan_num_blocks_, 1, 1);
-        insert_compute_barrier(cmd);
-
-        // Pass 1: single-workgroup scan over scan_block_sums_, writes total.
-        ScanPush p1{1u, scan_dispatch_size_, scan_num_blocks_};
-        vkCmdPushConstants(cmd, tile_scan_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
-                           0, sizeof(ScanPush), &p1);
-        vkCmdDispatch(cmd, 1u, 1, 1);
-        insert_compute_barrier(cmd);
-
-        // Pass 2: add scanned base to per_splat_tile_offset_.
-        ScanPush p2{2u, scan_dispatch_size_, scan_num_blocks_};
-        vkCmdPushConstants(cmd, tile_scan_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
-                           0, sizeof(ScanPush), &p2);
-        vkCmdDispatch(cmd, scan_num_blocks_, 1, 1);
-    }
-    insert_compute_barrier(cmd);
-
-    // === Phase 3: Deterministic scatter ===
-    {
-        GS_LABEL(cmd, "Bin");
-        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_bin_pipeline_);
-        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                tile_bin_pipeline_layout_, 0, 1, &tile_bin_sets_[frame_in_flight], 0, nullptr);
-        uint32_t push_data[1] = {tile_sort_capacity_};
-        vkCmdPushConstants(cmd, tile_bin_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
-                           0, 4, push_data);
-        vkCmdDispatch(cmd, count_workgroups, 1, 1);
-    }
-
-    insert_compute_barrier(cmd);
-
-    // === Prepare indirect dispatch args from tile_sort_count ===
-    {
-        GS_LABEL(cmd, "IndirectArgs");
-        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_indirect_pipeline_);
-        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                tile_indirect_pipeline_layout_, 0, 1, &tile_indirect_sets_[frame_in_flight], 0, nullptr);
-        vkCmdPushConstants(cmd, tile_indirect_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
-                           0, 4, &tile_sort_capacity_);
-        vkCmdDispatch(cmd, 1, 1, 1);
-    }
-
-    // Barrier: indirect args must be written before DispatchIndirect reads them
-    {
-        VkMemoryBarrier barrier{};
-        barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-        barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-        barrier.dstAccessMask = VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_SHADER_READ_BIT;
-        vkCmdPipelineBarrier(cmd,
-            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-            VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-            0, 1, &barrier, 0, nullptr, 0, nullptr);
-    }
-
-    // === Onesweep 2-dispatch: clear status buffer once ===
-    // Per-frame: fill frame f's slot so cmdbuf f+1's clear doesn't stomp
-    // cmdbuf f's still-in-progress onesweep lookback state.
-    {
-        GS_LABEL(cmd, "Onesweep");
-        VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
-        vkCmdFillBuffer(cmd, resources_->onesweep_statuses[frame_in_flight].buffer(), 0, status_size, 0);
-        {
-            VkMemoryBarrier sb{};
-            sb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-            sb.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            sb.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
-            vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
-                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &sb, 0, nullptr, 0, nullptr);
-        }
-
-        // === Onesweep: 4 radix passes × 2 dispatches each ===
-        for (uint32_t pass = 0; pass < kTileSortPasses; pass++) {
-            uint32_t push_data[1] = {pass};
-            bool read_from_a = (pass % 2 == 0);
-
-            // Dispatch 1: histogram + decoupled lookback
-            // Phase 3.5: per-frame onesweep sets bind racing tile_sort_a/b + indirect_args.
-            // Phase 5c: onesweep pipelines + layouts borrowed from GsSortSystem.
-            {
-                VkDescriptorSet hist_set = read_from_a ? onesweep_hist_sets_a_[frame_in_flight]
-                                                       : onesweep_hist_sets_b_[frame_in_flight];
-                vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, sort_.onesweep_hist_pipeline());
-                vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                        sort_.onesweep_hist_pipeline_layout(), 0, 1, &hist_set, 0, nullptr);
-                vkCmdPushConstants(cmd, sort_.onesweep_hist_pipeline_layout(), VK_SHADER_STAGE_COMPUTE_BIT,
-                                   0, 4, push_data);
-                vkCmdDispatchIndirect(cmd, resources_->tile_indirect_args[frame_in_flight].buffer(), 0);
-            }
-
-            insert_compute_barrier(cmd);
-
-            // Dispatch 2: read status buffer, compute prefix, scatter
-            {
-                VkDescriptorSet scatter_set = read_from_a ? onesweep_scatter_sets_ab_[frame_in_flight]
-                                                          : onesweep_scatter_sets_ba_[frame_in_flight];
-                vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, sort_.onesweep_scatter_pipeline());
-                vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                        sort_.onesweep_scatter_pipeline_layout(), 0, 1, &scatter_set, 0, nullptr);
-                vkCmdPushConstants(cmd, sort_.onesweep_scatter_pipeline_layout(), VK_SHADER_STAGE_COMPUTE_BIT,
-                                   0, 4, push_data);
-                vkCmdDispatchIndirect(cmd, resources_->tile_indirect_args[frame_in_flight].buffer(), 0);
-            }
-
-            insert_compute_barrier(cmd);
-        }
-        // After 4 passes (even count), sorted result is in tile_sort_a_
-    }
-
-    // === Frame-determinism readback (Mode 1) ===
-    // When the harness is active, copy tile_sort_a_ into a host-visible
-    // readback buffer so the CPU can hash the live entry range and detect
-    // order-instability across frames with frozen inputs.
-    // Phase 3.5: tile_sort_a is per-frame; source from frame f's slot.
-    // resources_->determinism_readback stays single-instance — only one frame emits at
-    // a time, and the harness waits on the in-flight fence before reading.
-    if (determinism_test_active_ && resources_->determinism_readback.buffer() != VK_NULL_HANDLE
-        && resources_->determinism_readback_size > 0) {
-        VkBufferMemoryBarrier src_barrier{};
-        src_barrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
-        src_barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-        src_barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-        src_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        src_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        src_barrier.buffer = resources_->tile_sort_as[frame_in_flight].buffer();
-        src_barrier.offset = 0;
-        src_barrier.size = resources_->determinism_readback_size;
-        vkCmdPipelineBarrier(cmd,
-            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-            VK_PIPELINE_STAGE_TRANSFER_BIT,
-            0, 0, nullptr, 1, &src_barrier, 0, nullptr);
-
-        VkBufferCopy region{};
-        region.srcOffset = 0;
-        region.dstOffset = 0;
-        region.size = resources_->determinism_readback_size;
-        vkCmdCopyBuffer(cmd, resources_->tile_sort_as[frame_in_flight].buffer(),
-                        resources_->determinism_readback.buffer(), 1, &region);
-
-        VkBufferMemoryBarrier dst_barrier{};
-        dst_barrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
-        dst_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-        dst_barrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
-        dst_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        dst_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        dst_barrier.buffer = resources_->determinism_readback.buffer();
-        dst_barrier.offset = 0;
-        dst_barrier.size = resources_->determinism_readback_size;
-        vkCmdPipelineBarrier(cmd,
-            VK_PIPELINE_STAGE_TRANSFER_BIT,
-            VK_PIPELINE_STAGE_HOST_BIT,
-            0, 0, nullptr, 1, &dst_barrier, 0, nullptr);
-        determinism_readback_emitted_ = true;
-        // Phase 3.5: remember which per-frame slot of resources_->tile_sort_count_ssbos
-        // the harness should sample post-fence.
-        determinism_last_emitted_frame_ = frame_in_flight;
-    }
-
-    // === Tile range detection ===
-    // Phase 3.5: tile_ranges per-frame — fill frame f's slot.
-    {
-        uint32_t num_tiles = tiles_x * tiles_y;
-        vkCmdFillBuffer(cmd, resources_->tile_ranges_ssbos[frame_in_flight].buffer(), 0,
-                        static_cast<VkDeviceSize>(num_tiles) * 2 * sizeof(uint32_t), 0);
-
-        VkMemoryBarrier fill_barrier{};
-        fill_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-        fill_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-        fill_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
-        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
-            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-            0, 1, &fill_barrier, 0, nullptr, 0, nullptr);
-    }
-
-    // Dispatch tile range detection (indirect from args[3..5])
-    {
-        GS_LABEL(cmd, "Ranges");
-        uint32_t num_tiles = tiles_x * tiles_y;
-        uint32_t push_data[2] = {num_tiles, tile_sort_capacity_};
-        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_ranges_pipeline_);
-        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                tile_ranges_pipeline_layout_, 0, 1, &tile_ranges_sets_[frame_in_flight], 0, nullptr);
-        vkCmdPushConstants(cmd, tile_ranges_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
-                           0, 8, push_data);
-        vkCmdDispatchIndirect(cmd, resources_->tile_indirect_args[frame_in_flight].buffer(), 3 * sizeof(uint32_t));
-    }
-
-    insert_compute_barrier(cmd);
-}
-
 void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
                         const glm::mat4& view, const glm::mat4& proj) {
     if (gaussian_count_ == 0 && static_count_ == 0 && dynamic_count_ == 0) return;
@@ -3486,7 +2852,7 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
     const VkImage processed_img = resources_->processed_images[frame_in_flight];
     // Phase 5b: post-process descriptor set now lives in GsPostProcessSystem;
     // post_.dispatch() resolves the per-frame set internally.
-    VkDescriptorSet tile_render_set  = tile_render_sets_[frame_in_flight];
+    // Phase 5d: tile_render_set now lives in GsTileBinSystem; tile_.dispatch_render() resolves it internally.
 
     uint32_t width = resources_->output_width;
     uint32_t height = resources_->output_height;
@@ -3702,7 +3068,7 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
         // shift the depth-sort key for tagged splats. Skip the dispatch
         // entirely while a Mode-1 test is active so the GPU's pbd_state
         // SSBO retains its pre-test contents.
-        if (pbd_count_ > 0 && !determinism_test_active_) {
+        if (pbd_count_ > 0 && !tile_.determinism_test_active()) {
             GS_LABEL(cmd, "PBD");
             struct {
                 float time;
@@ -3871,33 +3237,22 @@ void GsRenderer::render(VkCommandBuffer cmd, uint32_t frame_in_flight,
                 vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
                                    timestamp_pool_, ts_slot_offset + 2);  // tile_sort_begin
             }
-            dispatch_tile_sort(cmd, frame_in_flight);
+            tile_.dispatch_sort(cmd, frame_in_flight);
             if (timestamp_pool_) {
                 vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
                                    timestamp_pool_, ts_slot_offset + 3);  // tile_sort_end
             }
 
-            // === Phase 4: Tile-based rasterization ===
-            {
-                GS_LABEL(cmd, "Rasterize");
-                GS_DBG_INVARIANT(resources_->tile_sort_as[frame_in_flight].buffer() && tile_sort_capacity_ > 0,
-                                 "tile render: tile sort buffers must be allocated post-init");
-                vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_render_pipeline_);
-                vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
-                                        tile_render_pipeline_layout_, 0, 1, &tile_render_set, 0, nullptr);
-                uint32_t tiles_x = (width + 15) / 16;
-                uint32_t tiles_y = (height + 15) / 16;
-
-                if (timestamp_pool_) {
-                    vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                                       timestamp_pool_, ts_slot_offset + 4);  // raster_begin
-                }
-                vkCmdDispatch(cmd, tiles_x, tiles_y, 1);
-                if (timestamp_pool_) {
-                    vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                                       timestamp_pool_, ts_slot_offset + 5);  // raster_end
-                    timestamps_written_per_slot_[frame_in_flight] = true;
-                }
+            // === Phase 4: Tile-based rasterization (Phase 5d: into GsTileBinSystem) ===
+            if (timestamp_pool_) {
+                vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                   timestamp_pool_, ts_slot_offset + 4);  // raster_begin
+            }
+            tile_.dispatch_render(cmd, frame_in_flight, width, height);
+            if (timestamp_pool_) {
+                vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                   timestamp_pool_, ts_slot_offset + 5);  // raster_end
+                timestamps_written_per_slot_[frame_in_flight] = true;
             }
         }
 
@@ -4010,6 +3365,7 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     // becomes invalid. Both shutdown() calls are idempotent.
     post_.shutdown();
     sort_.shutdown();
+    tile_.shutdown();
 
     // The async loader no longer spins up worker threads — reserve+submit
     // run synchronously on the main thread now. We still call
@@ -4118,13 +3474,8 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     destroy_pipeline(sort_pipeline_);
     // Phase 5b: post-process pipeline destroyed by GsPostProcessSystem::shutdown().
     // Phase 5c: merge pipeline destroyed by GsSortSystem::shutdown().
+    // Phase 5d: all tile pipelines destroyed by GsTileBinSystem::shutdown().
     destroy_pipeline(pbd_pipeline_);
-    destroy_pipeline(tile_bin_pipeline_);
-    destroy_pipeline(tile_count_pipeline_);
-    destroy_pipeline(tile_scan_pipeline_);
-    destroy_pipeline(tile_ranges_pipeline_);
-    destroy_pipeline(tile_indirect_pipeline_);
-    destroy_pipeline(tile_render_pipeline_);
     // Phase 5c: onesweep hist + scatter pipelines destroyed by GsSortSystem::shutdown().
     destroy_pipeline(compose_pipeline_);
 
@@ -4133,12 +3484,8 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     destroy_layout(sort_pipeline_layout_);
     // Phase 5b: post-process pipeline layout destroyed by GsPostProcessSystem::shutdown().
     // Phase 5c: merge pipeline layout destroyed by GsSortSystem::shutdown().
+    // Phase 5d: all tile pipeline layouts destroyed by GsTileBinSystem::shutdown().
     destroy_layout(pbd_pipeline_layout_);
-    destroy_layout(tile_bin_pipeline_layout_);
-    destroy_layout(tile_scan_pipeline_layout_);
-    destroy_layout(tile_ranges_pipeline_layout_);
-    destroy_layout(tile_indirect_pipeline_layout_);
-    destroy_layout(tile_render_pipeline_layout_);
     // Phase 5c: onesweep hist + scatter pipeline layouts destroyed by GsSortSystem::shutdown().
 
     destroy_set_layout(preprocess_layout_);
@@ -4146,12 +3493,8 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     destroy_set_layout(render_layout_);
     // Phase 5b: post-process set layout destroyed by GsPostProcessSystem::shutdown().
     // Phase 5c: merge descriptor set layout destroyed by GsSortSystem::shutdown().
+    // Phase 5d: all tile descriptor set layouts destroyed by GsTileBinSystem::shutdown().
     destroy_set_layout(pbd_layout_);
-    destroy_set_layout(tile_bin_layout_);
-    destroy_set_layout(tile_scan_layout_);
-    destroy_set_layout(tile_ranges_layout_);
-    destroy_set_layout(tile_indirect_layout_);
-    destroy_set_layout(tile_render_layout_);
     // Phase 5c: onesweep hist + scatter descriptor set layouts destroyed by GsSortSystem::shutdown().
     destroy_set_layout(compose_layout_);
 

--- a/src/engine/gs_renderer/tile_bin/gs_tile_bin_system.cpp
+++ b/src/engine/gs_renderer/tile_bin/gs_tile_bin_system.cpp
@@ -1,0 +1,784 @@
+#include "gseurat/engine/gs_renderer/tile_bin/gs_tile_bin_system.hpp"
+
+#include "gseurat/engine/debug.hpp"
+#include "gseurat/engine/gs_renderer/gs_resources.hpp"
+#include "gseurat/engine/gs_renderer/sort/gs_sort_system.hpp"
+#include "gseurat/engine/pipeline.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+namespace gseurat {
+
+namespace {
+
+void insert_compute_barrier(VkCommandBuffer cmd) {
+    VkMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        0, 1, &barrier, 0, nullptr, 0, nullptr);
+}
+
+}  // namespace
+
+GsTileBinSystem::~GsTileBinSystem() {
+    shutdown();
+}
+
+void GsTileBinSystem::init(VkDevice device, VkPipelineCache pipeline_cache,
+                            VkDescriptorPool pool, GsResourceManager* resources,
+                            GsSortSystem* sort) {
+    assert(device != VK_NULL_HANDLE);
+    assert(pool != VK_NULL_HANDLE);
+    assert(resources != nullptr);
+    assert(sort != nullptr);
+    device_    = device;
+    resources_ = resources;
+    sort_      = sort;
+
+    // ── Set layouts ───────────────────────────────────────────────────
+    // Tile binning layout (count + scatter share):
+    //   0 projected  1 merged_sort  2 counts (ro)
+    //   3 per_splat_tile_count    4 per_splat_tile_offset
+    //   5 tile_entries           6 uniforms
+    {
+        VkDescriptorSetLayoutBinding bindings[] = {
+            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {5, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {6, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        };
+        VkDescriptorSetLayoutCreateInfo ci{};
+        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        ci.bindingCount = 7;
+        ci.pBindings = bindings;
+        if (vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_bin_layout_) != VK_SUCCESS) {
+            throw std::runtime_error("GsTileBinSystem: tile_bin descriptor set layout");
+        }
+    }
+    // Tile scan: per_splat_count(0), per_splat_offset(1), scan_block_sums(2), tile_sort_count(3)
+    {
+        VkDescriptorSetLayoutBinding bindings[] = {
+            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        };
+        VkDescriptorSetLayoutCreateInfo ci{};
+        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        ci.bindingCount = 4;
+        ci.pBindings = bindings;
+        if (vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_scan_layout_) != VK_SUCCESS) {
+            throw std::runtime_error("GsTileBinSystem: tile_scan descriptor set layout");
+        }
+    }
+    // Tile indirect: tile_sort_count(0), indirect_args(1)
+    {
+        VkDescriptorSetLayoutBinding bindings[] = {
+            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        };
+        VkDescriptorSetLayoutCreateInfo ci{};
+        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        ci.bindingCount = 2;
+        ci.pBindings = bindings;
+        if (vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_indirect_layout_) != VK_SUCCESS) {
+            throw std::runtime_error("GsTileBinSystem: tile_indirect descriptor set layout");
+        }
+    }
+    // Tile ranges: sorted_entries(0), tile_ranges(1), tile_count(2)
+    {
+        VkDescriptorSetLayoutBinding bindings[] = {
+            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        };
+        VkDescriptorSetLayoutCreateInfo ci{};
+        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        ci.bindingCount = 3;
+        ci.pBindings = bindings;
+        if (vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_ranges_layout_) != VK_SUCCESS) {
+            throw std::runtime_error("GsTileBinSystem: tile_ranges descriptor set layout");
+        }
+    }
+    // Tile render: projected(0), tile_entries(1), uniforms(2), output_image(3), tile_ranges(4), depth_image(5)
+    {
+        VkDescriptorSetLayoutBinding bindings[] = {
+            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {2, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {3, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,  1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+            {5, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,  1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        };
+        VkDescriptorSetLayoutCreateInfo ci{};
+        ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        ci.bindingCount = 6;
+        ci.pBindings = bindings;
+        if (vkCreateDescriptorSetLayout(device_, &ci, nullptr, &tile_render_layout_) != VK_SUCCESS) {
+            throw std::runtime_error("GsTileBinSystem: tile_render descriptor set layout");
+        }
+    }
+
+    // ── Pipelines ─────────────────────────────────────────────────────
+    auto create_pipeline = [&](const char* spv_path, VkDescriptorSetLayout layout,
+                                uint32_t push_size,
+                                VkPipelineLayout& out_layout, VkPipeline& out_pipeline) {
+        auto module = load_shader_module(device_, spv_path);
+
+        VkPipelineLayoutCreateInfo layout_info{};
+        layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+        layout_info.setLayoutCount = 1;
+        layout_info.pSetLayouts = &layout;
+
+        VkPushConstantRange push_range{};
+        if (push_size > 0) {
+            push_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+            push_range.size = push_size;
+            layout_info.pushConstantRangeCount = 1;
+            layout_info.pPushConstantRanges = &push_range;
+        }
+        if (vkCreatePipelineLayout(device_, &layout_info, nullptr, &out_layout) != VK_SUCCESS) {
+            vkDestroyShaderModule(device_, module, nullptr);
+            throw std::runtime_error(std::string("GsTileBinSystem: pipeline layout: ") + spv_path);
+        }
+
+        VkComputePipelineCreateInfo pi{};
+        pi.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+        pi.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        pi.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+        pi.stage.module = module;
+        pi.stage.pName = "main";
+        pi.layout = out_layout;
+        VkResult res = vkCreateComputePipelines(device_, pipeline_cache, 1, &pi, nullptr, &out_pipeline);
+        vkDestroyShaderModule(device_, module, nullptr);
+        if (res != VK_SUCCESS) {
+            throw std::runtime_error(std::string("GsTileBinSystem: pipeline create: ") + spv_path);
+        }
+    };
+
+    // Tile-bin scatter (push: max_entries = 4 bytes). Builds the pipeline
+    // layout the count pipeline below reuses; count has no push but accepts
+    // a 4-byte range without touching it.
+    create_pipeline("shaders/gs_tile_bin.comp.spv", tile_bin_layout_, 4,
+                    tile_bin_pipeline_layout_, tile_bin_pipeline_);
+
+    // Tile-count pass — reuses tile_bin_pipeline_layout_.
+    {
+        auto module = load_shader_module(device_, "shaders/gs_tile_count.comp.spv");
+        VkPipelineShaderStageCreateInfo stage{};
+        stage.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stage.stage  = VK_SHADER_STAGE_COMPUTE_BIT;
+        stage.module = module;
+        stage.pName  = "main";
+
+        VkComputePipelineCreateInfo pi{};
+        pi.sType  = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+        pi.stage  = stage;
+        pi.layout = tile_bin_pipeline_layout_;
+        VkResult res = vkCreateComputePipelines(device_, pipeline_cache, 1, &pi, nullptr,
+                                                 &tile_count_pipeline_);
+        vkDestroyShaderModule(device_, module, nullptr);
+        if (res != VK_SUCCESS) {
+            throw std::runtime_error("GsTileBinSystem: tile_count pipeline create");
+        }
+    }
+
+    create_pipeline("shaders/gs_tile_scan.comp.spv", tile_scan_layout_, 12,
+                    tile_scan_pipeline_layout_, tile_scan_pipeline_);
+    create_pipeline("shaders/gs_tile_ranges.comp.spv", tile_ranges_layout_, 8,
+                    tile_ranges_pipeline_layout_, tile_ranges_pipeline_);
+    create_pipeline("shaders/gs_tile_prepare_indirect.comp.spv", tile_indirect_layout_, 4,
+                    tile_indirect_pipeline_layout_, tile_indirect_pipeline_);
+    create_pipeline("shaders/gs_tile_render.comp.spv", tile_render_layout_, 0,
+                    tile_render_pipeline_layout_, tile_render_pipeline_);
+
+    // ── Descriptor set allocation ─────────────────────────────────────
+    // 18 sets total: 10 tile (5 kinds × 2 frames) + 8 tile-onesweep
+    // (hist_a, hist_b, scatter_ab, scatter_ba × 2 frames).
+    constexpr uint32_t kTilePerFrame = 5;  // tile_bin, tile_scan, tile_indirect, tile_ranges, tile_render
+    constexpr uint32_t kOnesweepPerFrame = 4;  // hist_a, hist_b, scatter_ab, scatter_ba
+    constexpr uint32_t kTotal =
+        (kTilePerFrame + kOnesweepPerFrame) * kMaxFramesInFlight;
+
+    const VkDescriptorSetLayout onesweep_hist_layout    = sort_->onesweep_hist_set_layout();
+    const VkDescriptorSetLayout onesweep_scatter_layout = sort_->onesweep_scatter_set_layout();
+
+    VkDescriptorSetLayout layouts[kTotal];
+    uint32_t i = 0;
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        layouts[i++] = tile_bin_layout_;
+        layouts[i++] = tile_scan_layout_;
+        layouts[i++] = tile_indirect_layout_;
+        layouts[i++] = tile_ranges_layout_;
+        layouts[i++] = tile_render_layout_;
+    }
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        layouts[i++] = onesweep_hist_layout;
+        layouts[i++] = onesweep_hist_layout;
+        layouts[i++] = onesweep_scatter_layout;
+        layouts[i++] = onesweep_scatter_layout;
+    }
+    assert(i == kTotal);
+
+    VkDescriptorSet sets[kTotal];
+    VkDescriptorSetAllocateInfo alloc{};
+    alloc.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    alloc.descriptorPool = pool;
+    alloc.descriptorSetCount = kTotal;
+    alloc.pSetLayouts = layouts;
+    if (vkAllocateDescriptorSets(device_, &alloc, sets) != VK_SUCCESS) {
+        throw std::runtime_error("GsTileBinSystem: vkAllocateDescriptorSets failed");
+    }
+
+    i = 0;
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        tile_bin_sets_[f]      = sets[i++];
+        tile_scan_sets_[f]     = sets[i++];
+        tile_indirect_sets_[f] = sets[i++];
+        tile_ranges_sets_[f]   = sets[i++];
+        tile_render_sets_[f]   = sets[i++];
+    }
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        onesweep_hist_sets_a_[f]     = sets[i++];
+        onesweep_hist_sets_b_[f]     = sets[i++];
+        onesweep_scatter_sets_ab_[f] = sets[i++];
+        onesweep_scatter_sets_ba_[f] = sets[i++];
+    }
+    assert(i == kTotal);
+}
+
+void GsTileBinSystem::set_sort_sizes(uint32_t static_sort_size, uint32_t dynamic_sort_size) {
+    static_sort_size_  = static_sort_size;
+    dynamic_sort_size_ = dynamic_sort_size;
+
+    // Capacity: visible Gaussians × avg tile overlap. Cap at 2M entries (16MB per buffer).
+    uint32_t visible_upper = static_sort_size_ + dynamic_sort_size_;
+    tile_sort_capacity_ = std::min(visible_upper * 4, 1u << 21);
+    // Align to 2048 (workgroup size for radix sort)
+    tile_sort_size_       = ((tile_sort_capacity_ + 2047) / 2048) * 2048;
+    tile_sort_workgroups_ = tile_sort_size_ / 2048;
+    if (tile_sort_workgroups_ == 0) tile_sort_workgroups_ = 1;
+    tile_sort_size_ = tile_sort_workgroups_ * 2048;
+
+    // Scan sizing — visible_upper rounded up to 256-thread workgroup
+    scan_dispatch_size_ = ((visible_upper + 255u) / 256u) * 256u;
+    if (scan_dispatch_size_ == 0) scan_dispatch_size_ = 256u;
+    scan_num_blocks_ = scan_dispatch_size_ / 256u;
+
+    // Onesweep max workgroups for tile-sort status buffer sizing
+    onesweep_max_wg_ = (tile_sort_capacity_ + 2047) / 2048;
+    if (onesweep_max_wg_ == 0) onesweep_max_wg_ = 1;
+}
+
+void GsTileBinSystem::write_descriptors() {
+    if (!resources_->tile_sort_as[0].buffer()) return;
+
+    // ── tile_bin sets ────────────────────────────────────────────────
+    // 0 projected  1 merged_sort  2 counts  3 per_splat_count
+    // 4 per_splat_offset  5 tile_entries  6 uniforms
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        VkDescriptorBufferInfo projected_info{resources_->projected_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo merged_info{resources_->merged_sort_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo counts_info{resources_->counts_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo per_splat_count_info{resources_->per_splat_tile_count_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo per_splat_offset_info{resources_->per_splat_tile_offset_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo tile_entries_info{resources_->tile_sort_as[f].buffer(), 0, VK_WHOLE_SIZE};
+        // GsUniforms is an internal struct in gs_renderer.cpp; using WHOLE_SIZE
+// matches the buffer's actual size (allocated as sizeof(GsUniforms) in
+// init_streaming).
+VkDescriptorBufferInfo uniform_info{resources_->uniform_buffer.buffer(), 0, VK_WHOLE_SIZE};
+
+        VkDescriptorSet set = tile_bin_sets_[f];
+        VkWriteDescriptorSet writes[] = {
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &projected_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &merged_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &counts_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &per_splat_count_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 4, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &per_splat_offset_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 5, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &tile_entries_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 6, 0, 1,
+             VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
+        };
+        vkUpdateDescriptorSets(device_, 7, writes, 0, nullptr);
+    }
+
+    // ── tile_scan sets ───────────────────────────────────────────────
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        VkDescriptorBufferInfo count_info{resources_->per_splat_tile_count_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo offset_info{resources_->per_splat_tile_offset_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo block_sums_info{resources_->scan_block_sums_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo total_info{resources_->tile_sort_count_ssbos[f].buffer(), 0, sizeof(uint32_t)};
+
+        VkDescriptorSet set = tile_scan_sets_[f];
+        VkWriteDescriptorSet writes[] = {
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &count_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &offset_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &block_sums_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &total_info, nullptr},
+        };
+        vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
+    }
+
+    // ── tile_ranges sets ─────────────────────────────────────────────
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        VkDescriptorBufferInfo sorted_info{resources_->tile_sort_as[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo ranges_info{resources_->tile_ranges_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo count_info{resources_->tile_sort_count_ssbos[f].buffer(), 0, sizeof(uint32_t)};
+
+        VkDescriptorSet set = tile_ranges_sets_[f];
+        VkWriteDescriptorSet writes[] = {
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &sorted_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &ranges_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &count_info, nullptr},
+        };
+        vkUpdateDescriptorSets(device_, 3, writes, 0, nullptr);
+    }
+
+    // ── tile_indirect sets ───────────────────────────────────────────
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        VkDescriptorBufferInfo count_info{resources_->tile_sort_count_ssbos[f].buffer(), 0, sizeof(uint32_t)};
+        VkDescriptorBufferInfo args_info{resources_->tile_indirect_args[f].buffer(), 0, VK_WHOLE_SIZE};
+
+        VkDescriptorSet set = tile_indirect_sets_[f];
+        VkWriteDescriptorSet writes[] = {
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &count_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
+        };
+        vkUpdateDescriptorSets(device_, 2, writes, 0, nullptr);
+    }
+
+    // ── tile-onesweep sets ───────────────────────────────────────────
+    if (resources_->onesweep_statuses[0].buffer()) {
+        for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+            VkDescriptorBufferInfo a_info{resources_->tile_sort_as[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo b_info{resources_->tile_sort_bs[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo status_info{resources_->onesweep_statuses[f].buffer(), 0, VK_WHOLE_SIZE};
+            VkDescriptorBufferInfo args_info{resources_->tile_indirect_args[f].buffer(), 0, VK_WHOLE_SIZE};
+
+            // hist_a: input = tile_sort_a
+            {
+                VkDescriptorSet set = onesweep_hist_sets_a_[f];
+                VkWriteDescriptorSet writes[] = {
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &a_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
+                };
+                vkUpdateDescriptorSets(device_, 3, writes, 0, nullptr);
+            }
+            // hist_b: input = tile_sort_b
+            {
+                VkDescriptorSet set = onesweep_hist_sets_b_[f];
+                VkWriteDescriptorSet writes[] = {
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &b_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
+                };
+                vkUpdateDescriptorSets(device_, 3, writes, 0, nullptr);
+            }
+            // scatter_ab: in = a, out = b
+            {
+                VkDescriptorSet set = onesweep_scatter_sets_ab_[f];
+                VkWriteDescriptorSet writes[] = {
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &a_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &b_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
+                };
+                vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
+            }
+            // scatter_ba: in = b, out = a
+            {
+                VkDescriptorSet set = onesweep_scatter_sets_ba_[f];
+                VkWriteDescriptorSet writes[] = {
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &b_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &a_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &status_info, nullptr},
+                    {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
+                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &args_info, nullptr},
+                };
+                vkUpdateDescriptorSets(device_, 4, writes, 0, nullptr);
+            }
+        }
+    }
+
+    // ── tile_render sets ─────────────────────────────────────────────
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        VkDescriptorBufferInfo projected_info{resources_->projected_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorBufferInfo tile_entries_info{resources_->tile_sort_as[f].buffer(), 0, VK_WHOLE_SIZE};
+        // GsUniforms is an internal struct in gs_renderer.cpp; using WHOLE_SIZE
+// matches the buffer's actual size (allocated as sizeof(GsUniforms) in
+// init_streaming).
+VkDescriptorBufferInfo uniform_info{resources_->uniform_buffer.buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorImageInfo  image_info{VK_NULL_HANDLE, resources_->output_views[f], VK_IMAGE_LAYOUT_GENERAL};
+        VkDescriptorBufferInfo tile_ranges_info{resources_->tile_ranges_ssbos[f].buffer(), 0, VK_WHOLE_SIZE};
+        VkDescriptorImageInfo  depth_img_info{VK_NULL_HANDLE, resources_->depth_views[f], VK_IMAGE_LAYOUT_GENERAL};
+
+        VkDescriptorSet set = tile_render_sets_[f];
+        VkWriteDescriptorSet writes[] = {
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 0, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &projected_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 1, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &tile_entries_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 2, 0, 1,
+             VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, nullptr, &uniform_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 3, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &image_info, nullptr, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 4, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, nullptr, &tile_ranges_info, nullptr},
+            {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr, set, 5, 0, 1,
+             VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, &depth_img_info, nullptr, nullptr},
+        };
+        vkUpdateDescriptorSets(device_, 6, writes, 0, nullptr);
+    }
+}
+
+void GsTileBinSystem::dispatch_sort(VkCommandBuffer cmd, uint32_t frame_in_flight) {
+    GS_LABEL(cmd, "TileSort");
+    determinism_readback_emitted_ = false;
+    GS_DBG_INVARIANT(resources_->tile_sort_as[frame_in_flight].buffer() && tile_sort_capacity_ > 0,
+                     "dispatch_sort: tile sort buffers must be allocated before first dispatch");
+
+    uint32_t width  = resources_->output_width;
+    uint32_t height = resources_->output_height;
+    uint32_t tiles_x = (width + 15) / 16;
+    uint32_t tiles_y = (height + 15) / 16;
+
+    // === Phase 0: zero counters + sentinel-fill tile_sort_a ===========
+    vkCmdFillBuffer(cmd, resources_->tile_sort_count_ssbos[frame_in_flight].buffer(), 0,
+                    sizeof(uint32_t), 0);
+    vkCmdFillBuffer(cmd, resources_->tile_sort_as[frame_in_flight].buffer(), 0,
+                    static_cast<VkDeviceSize>(tile_sort_size_) * 8, 0xFFFFFFFF);
+    vkCmdFillBuffer(cmd, resources_->per_splat_tile_count_ssbos[frame_in_flight].buffer(), 0,
+                    static_cast<VkDeviceSize>(scan_dispatch_size_) * sizeof(uint32_t), 0);
+
+    {
+        VkMemoryBarrier fill_barrier{};
+        fill_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+        fill_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        fill_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            0, 1, &fill_barrier, 0, nullptr, 0, nullptr);
+    }
+
+    uint32_t visible_upper = static_sort_size_ + dynamic_sort_size_;
+    uint32_t count_workgroups = scan_num_blocks_;
+    (void)visible_upper;  // suppress unused warning when invariant compiled out
+
+    // === Phase 1: Count pass ==========================================
+    {
+        GS_LABEL(cmd, "Count");
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_count_pipeline_);
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                tile_bin_pipeline_layout_, 0, 1, &tile_bin_sets_[frame_in_flight], 0, nullptr);
+        uint32_t push_data[1] = {tile_sort_capacity_};
+        vkCmdPushConstants(cmd, tile_bin_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                           0, 4, push_data);
+        vkCmdDispatch(cmd, count_workgroups, 1, 1);
+    }
+    insert_compute_barrier(cmd);
+
+    // === Phase 2: Three-pass exclusive scan ==========================
+    {
+        GS_LABEL(cmd, "Scan");
+        struct ScanPush { uint32_t pass; uint32_t num_elements; uint32_t num_blocks; };
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_scan_pipeline_);
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                tile_scan_pipeline_layout_, 0, 1, &tile_scan_sets_[frame_in_flight], 0, nullptr);
+
+        ScanPush p0{0u, scan_dispatch_size_, scan_num_blocks_};
+        vkCmdPushConstants(cmd, tile_scan_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                           0, sizeof(ScanPush), &p0);
+        vkCmdDispatch(cmd, scan_num_blocks_, 1, 1);
+        insert_compute_barrier(cmd);
+
+        ScanPush p1{1u, scan_dispatch_size_, scan_num_blocks_};
+        vkCmdPushConstants(cmd, tile_scan_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                           0, sizeof(ScanPush), &p1);
+        vkCmdDispatch(cmd, 1u, 1, 1);
+        insert_compute_barrier(cmd);
+
+        ScanPush p2{2u, scan_dispatch_size_, scan_num_blocks_};
+        vkCmdPushConstants(cmd, tile_scan_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                           0, sizeof(ScanPush), &p2);
+        vkCmdDispatch(cmd, scan_num_blocks_, 1, 1);
+    }
+    insert_compute_barrier(cmd);
+
+    // === Phase 3: Deterministic scatter ==============================
+    {
+        GS_LABEL(cmd, "Bin");
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_bin_pipeline_);
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                tile_bin_pipeline_layout_, 0, 1, &tile_bin_sets_[frame_in_flight], 0, nullptr);
+        uint32_t push_data[1] = {tile_sort_capacity_};
+        vkCmdPushConstants(cmd, tile_bin_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                           0, 4, push_data);
+        vkCmdDispatch(cmd, count_workgroups, 1, 1);
+    }
+    insert_compute_barrier(cmd);
+
+    // === Phase 4: Prepare indirect args ==============================
+    {
+        GS_LABEL(cmd, "IndirectArgs");
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_indirect_pipeline_);
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                tile_indirect_pipeline_layout_, 0, 1, &tile_indirect_sets_[frame_in_flight], 0, nullptr);
+        vkCmdPushConstants(cmd, tile_indirect_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                           0, 4, &tile_sort_capacity_);
+        vkCmdDispatch(cmd, 1, 1, 1);
+    }
+
+    // Indirect args must be visible before DispatchIndirect reads them.
+    {
+        VkMemoryBarrier barrier{};
+        barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+        barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+        barrier.dstAccessMask = VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_SHADER_READ_BIT;
+        vkCmdPipelineBarrier(cmd,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            0, 1, &barrier, 0, nullptr, 0, nullptr);
+    }
+
+    // === Phase 5: Onesweep radix sort (kTileSortPasses passes) =======
+    {
+        GS_LABEL(cmd, "Onesweep");
+        VkDeviceSize status_size = 4ull * 256ull * onesweep_max_wg_ * sizeof(uint32_t);
+        vkCmdFillBuffer(cmd, resources_->onesweep_statuses[frame_in_flight].buffer(), 0,
+                        status_size, 0);
+        {
+            VkMemoryBarrier sb{};
+            sb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+            sb.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            sb.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+            vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &sb, 0, nullptr, 0, nullptr);
+        }
+
+        for (uint32_t pass = 0; pass < kTileSortPasses; pass++) {
+            uint32_t push_data[1] = {pass};
+            bool read_from_a = (pass % 2 == 0);
+
+            // Histogram + decoupled lookback
+            {
+                VkDescriptorSet hist_set = read_from_a ? onesweep_hist_sets_a_[frame_in_flight]
+                                                       : onesweep_hist_sets_b_[frame_in_flight];
+                vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, sort_->onesweep_hist_pipeline());
+                vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                        sort_->onesweep_hist_pipeline_layout(), 0, 1, &hist_set, 0, nullptr);
+                vkCmdPushConstants(cmd, sort_->onesweep_hist_pipeline_layout(), VK_SHADER_STAGE_COMPUTE_BIT,
+                                   0, 4, push_data);
+                vkCmdDispatchIndirect(cmd, resources_->tile_indirect_args[frame_in_flight].buffer(), 0);
+            }
+            insert_compute_barrier(cmd);
+
+            // Scatter
+            {
+                VkDescriptorSet scatter_set = read_from_a ? onesweep_scatter_sets_ab_[frame_in_flight]
+                                                          : onesweep_scatter_sets_ba_[frame_in_flight];
+                vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, sort_->onesweep_scatter_pipeline());
+                vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                        sort_->onesweep_scatter_pipeline_layout(), 0, 1, &scatter_set, 0, nullptr);
+                vkCmdPushConstants(cmd, sort_->onesweep_scatter_pipeline_layout(), VK_SHADER_STAGE_COMPUTE_BIT,
+                                   0, 4, push_data);
+                vkCmdDispatchIndirect(cmd, resources_->tile_indirect_args[frame_in_flight].buffer(), 0);
+            }
+            insert_compute_barrier(cmd);
+        }
+        // After kTileSortPasses (even count = 4), sorted result is in tile_sort_a.
+    }
+
+    // === Frame-determinism readback (when harness is active) ==========
+    // resources_->determinism_readback stays single-instance: only one
+    // frame emits at a time, and the harness waits on the in-flight
+    // fence before reading.
+    if (determinism_test_active_ && resources_->determinism_readback.buffer() != VK_NULL_HANDLE
+        && resources_->determinism_readback_size > 0) {
+        VkBufferMemoryBarrier src_barrier{};
+        src_barrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+        src_barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+        src_barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        src_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        src_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        src_barrier.buffer = resources_->tile_sort_as[frame_in_flight].buffer();
+        src_barrier.offset = 0;
+        src_barrier.size = resources_->determinism_readback_size;
+        vkCmdPipelineBarrier(cmd,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            0, 0, nullptr, 1, &src_barrier, 0, nullptr);
+
+        VkBufferCopy region{};
+        region.srcOffset = 0;
+        region.dstOffset = 0;
+        region.size = resources_->determinism_readback_size;
+        vkCmdCopyBuffer(cmd, resources_->tile_sort_as[frame_in_flight].buffer(),
+                        resources_->determinism_readback.buffer(), 1, &region);
+
+        VkBufferMemoryBarrier dst_barrier{};
+        dst_barrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+        dst_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        dst_barrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
+        dst_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        dst_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        dst_barrier.buffer = resources_->determinism_readback.buffer();
+        dst_barrier.offset = 0;
+        dst_barrier.size = resources_->determinism_readback_size;
+        vkCmdPipelineBarrier(cmd,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_HOST_BIT,
+            0, 0, nullptr, 1, &dst_barrier, 0, nullptr);
+        determinism_readback_emitted_  = true;
+        determinism_last_emitted_frame_ = frame_in_flight;
+    }
+
+    // === Phase 6: Tile range detection ===============================
+    {
+        uint32_t num_tiles = tiles_x * tiles_y;
+        vkCmdFillBuffer(cmd, resources_->tile_ranges_ssbos[frame_in_flight].buffer(), 0,
+                        static_cast<VkDeviceSize>(num_tiles) * 2 * sizeof(uint32_t), 0);
+
+        VkMemoryBarrier fill_barrier{};
+        fill_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+        fill_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        fill_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            0, 1, &fill_barrier, 0, nullptr, 0, nullptr);
+    }
+
+    {
+        GS_LABEL(cmd, "Ranges");
+        uint32_t num_tiles = tiles_x * tiles_y;
+        uint32_t push_data[2] = {num_tiles, tile_sort_capacity_};
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_ranges_pipeline_);
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                tile_ranges_pipeline_layout_, 0, 1, &tile_ranges_sets_[frame_in_flight], 0, nullptr);
+        vkCmdPushConstants(cmd, tile_ranges_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT,
+                           0, 8, push_data);
+        vkCmdDispatchIndirect(cmd, resources_->tile_indirect_args[frame_in_flight].buffer(),
+                              3 * sizeof(uint32_t));
+    }
+    insert_compute_barrier(cmd);
+}
+
+void GsTileBinSystem::dispatch_render(VkCommandBuffer cmd, uint32_t frame_in_flight,
+                                       uint32_t width, uint32_t height) {
+    GS_LABEL(cmd, "Rasterize");
+    GS_DBG_INVARIANT(resources_->tile_sort_as[frame_in_flight].buffer() && tile_sort_capacity_ > 0,
+                     "dispatch_render: tile sort buffers must be allocated post-init");
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, tile_render_pipeline_);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                            tile_render_pipeline_layout_, 0, 1, &tile_render_sets_[frame_in_flight], 0, nullptr);
+    uint32_t tiles_x = (width + 15) / 16;
+    uint32_t tiles_y = (height + 15) / 16;
+    vkCmdDispatch(cmd, tiles_x, tiles_y, 1);
+}
+
+std::array<GsTileBinSystem::PrewarmEntry, 6> GsTileBinSystem::prewarm_entries() const {
+    return {{
+        {"gs_tile_bin",              tile_bin_pipeline_,      tile_bin_pipeline_layout_,      tile_bin_layout_,      4},
+        {"gs_tile_count",            tile_count_pipeline_,    tile_bin_pipeline_layout_,      tile_bin_layout_,      4},
+        {"gs_tile_scan",             tile_scan_pipeline_,     tile_scan_pipeline_layout_,     tile_scan_layout_,     12},
+        {"gs_tile_ranges",           tile_ranges_pipeline_,   tile_ranges_pipeline_layout_,   tile_ranges_layout_,   8},
+        {"gs_tile_prepare_indirect", tile_indirect_pipeline_, tile_indirect_pipeline_layout_, tile_indirect_layout_, 4},
+        {"gs_tile_render",           tile_render_pipeline_,   tile_render_pipeline_layout_,   tile_render_layout_,   0},
+    }};
+}
+
+VmaAllocation GsTileBinSystem::determinism_readback_allocation() const {
+    return resources_->determinism_readback.allocation();
+}
+
+VmaAllocation GsTileBinSystem::tile_sort_count_allocation() const {
+    return resources_->tile_sort_count_ssbos[determinism_last_emitted_frame_].allocation();
+}
+
+const void* GsTileBinSystem::determinism_readback_data() const {
+    return resources_->determinism_readback.mapped();
+}
+
+uint32_t GsTileBinSystem::live_tile_sort_count() const {
+    const auto& slot = resources_->tile_sort_count_ssbos[determinism_last_emitted_frame_];
+    if (slot.mapped() == nullptr) return 0;
+    return *static_cast<const uint32_t*>(slot.mapped());
+}
+
+void GsTileBinSystem::shutdown() {
+    if (device_ == VK_NULL_HANDLE) return;
+
+    auto destroy_pipeline = [&](VkPipeline& p) {
+        if (p) { vkDestroyPipeline(device_, p, nullptr); p = VK_NULL_HANDLE; }
+    };
+    auto destroy_layout = [&](VkPipelineLayout& l) {
+        if (l) { vkDestroyPipelineLayout(device_, l, nullptr); l = VK_NULL_HANDLE; }
+    };
+    auto destroy_set_layout = [&](VkDescriptorSetLayout& l) {
+        if (l) { vkDestroyDescriptorSetLayout(device_, l, nullptr); l = VK_NULL_HANDLE; }
+    };
+
+    destroy_pipeline(tile_bin_pipeline_);
+    destroy_pipeline(tile_count_pipeline_);
+    destroy_pipeline(tile_scan_pipeline_);
+    destroy_pipeline(tile_ranges_pipeline_);
+    destroy_pipeline(tile_indirect_pipeline_);
+    destroy_pipeline(tile_render_pipeline_);
+
+    destroy_layout(tile_bin_pipeline_layout_);
+    destroy_layout(tile_scan_pipeline_layout_);
+    destroy_layout(tile_ranges_pipeline_layout_);
+    destroy_layout(tile_indirect_pipeline_layout_);
+    destroy_layout(tile_render_pipeline_layout_);
+
+    destroy_set_layout(tile_bin_layout_);
+    destroy_set_layout(tile_scan_layout_);
+    destroy_set_layout(tile_ranges_layout_);
+    destroy_set_layout(tile_indirect_layout_);
+    destroy_set_layout(tile_render_layout_);
+
+    device_ = VK_NULL_HANDLE;
+}
+
+}  // namespace gseurat


### PR DESCRIPTION
## Summary
- Third renderer system extraction. Lifts the 6-pass tile-bin chain (`tile_count` → `tile_scan` ×3 → `tile_bin` scatter → `tile_prepare_indirect` → onesweep radix sort ×4 → `tile_ranges`) and the tile rasterization dispatch out of `GsRenderer` into `GsTileBinSystem`.
- Reuses `GsSortSystem`'s onesweep histogram + scatter pipelines via the accessor pattern established in 5c — `tile_.init()` takes a `GsSortSystem*` and reads `sort_->onesweep_*()` at dispatch time, no duplicate pipeline creation.
- Central descriptor batch shrinks again: `kSetCount` 30 → 12. The 18 tile-related sets (10 tile + 8 tile-onesweep) now live inside `GsTileBinSystem`.

## What moved
- 5 descriptor set layouts (`tile_bin`, `tile_scan`, `tile_indirect`, `tile_ranges`, `tile_render`) + 5 pipeline layouts
- 6 compute pipelines (`tile_count` shares `tile_bin` pipeline layout)
- 18 per-frame descriptor sets allocated against the shared `gs_pool_`
- `dispatch_tile_sort` body (~260 LOC) → `tile_.dispatch_sort(cmd, frame_in_flight)`
- Inline tile rasterization dispatch in `render()` → `tile_.dispatch_render(cmd, frame_in_flight, w, h)`
- Tile sizing scalars (`tile_sort_capacity_`, `tile_sort_size_`, `scan_dispatch_size_`, `scan_num_blocks_`, `onesweep_max_wg_`, `kTileSortPasses`)
- Determinism harness state (`determinism_test_active_`, `determinism_readback_emitted_`, `determinism_last_emitted_frame_`). `GsRenderer` keeps thin forwarders for ABI stability.

## Init order (critical lesson from 5c)
In `create_descriptor_resources`:
1. Create `gs_pool_`
2. `vkResetDescriptorPool` — must run BEFORE any subsystem's `init()` allocates from the pool
3. `sort_.init(...)`
4. `tile_.init(..., &sort_)` — borrows `sort_`'s onesweep set layouts
5. Central layouts/sets allocation (now 12 slots)

## Note on Q3 (retire `static_sort_size_` / `dynamic_sort_size_`)
The plan called for retiring these GsRenderer fields in 5d. Audit found they're not exclusively tile-only state — they're used by static/dynamic SSBO allocation, sentinel fills, bounds checks in `update_active_gaussians`, and depth-sort sizing too. 5c's commit message overstated the cleanup opportunity. Kept them in `GsRenderer` and pass into `tile_.set_sort_sizes()` from `init_streaming`.

## Validation
- 3 macOS configs clean (`macos-debug`, `macos-release`, `macos-release-with-diag`)
- 8s smoke: 1.7M splats render, tile sort capacity 2,097,152 entries / 1024 workgroups, clean shutdown
- `[ShutdownAuditor] No tracked objects alive.`
- `[PipelineCache] saved 207848 bytes`
- `EXIT 0`

## Phase 5 ladder
- 5a `GsResourceManager` ✅ (#441)
- 5b `GsPostProcessSystem` ✅ (#442)
- 5c `GsSortSystem` ✅ (#443)
- **5d `GsTileBinSystem` ← this PR**
- 5e `GsStreamingSystem` — remaining

## Test plan
- [ ] CI green on all platforms
- [ ] Codex review pass
- [ ] Spot-check rendered frame matches main (mechanical lift, no shader changes — expect SSIM = 1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)