### PR TITLE
fix(engine): plumb SimClock-aware dt through Renderer::draw_scene

### DIFF
--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -339,9 +339,14 @@ private:
 
     uint32_t current_frame_ = 0;
     uint32_t acquire_semaphore_index_ = 0;
-    // Phase 5.1 dt-plumbing: last_time_ + glfwGetTime() recomputation
-    // removed. dt now flows in from AppBase::main_loop() (SimClock-aware,
-    // already clamped) via draw_scene's new first parameter.
+    // Wall-clock timestamp of the previous `record_gs_prepass` call,
+    // scoped to the adaptive GS budget controller. The controller reads
+    // `1 / dt` as an instantaneous FPS measurement; it must see actual
+    // render time, NOT the gameplay dt that AppBase clamps to 0.1s and
+    // replaces with SimClock::fixed_dt() in deterministic mode (Codex P2
+    // on PR #447). Visual systems (camera, VFX, particles) continue to
+    // run on the SimClock-aware dt plumbed through draw_scene.
+    double last_render_wall_time_ = 0.0;
     bool font_initialized_ = false;
 
     // Gaussian splatting

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -59,7 +59,8 @@ public:
     void init_particles(ResourceManager& resources);
     void init_backgrounds(const std::vector<ResourceHandle<Texture>>& bg_textures);
     void init_shadows(ResourceManager& resources);
-    void draw_frame();
+    // Phase 5.1 dt-plumbing: legacy `draw_frame()` shim deleted as unused
+    // dead code (no callers in src/, examples/, tests/).
     void init_gs(const GaussianCloud& cloud, uint32_t width = 320, uint32_t height = 240);
 
     // Drop every GS chunk currently resident in VRAM. Allocates a transient
@@ -118,11 +119,22 @@ public:
     // BEFORE `init_gs` to take effect.
     void set_prewarm_at_startup(bool b) { prewarm_at_startup_ = b; }
 
+    // `dt` is the authoritative per-frame delta from AppBase's main loop —
+    // already clamped and SimClock-aware (fixed 1/60 s in deterministic
+    // mode). Previously the renderer recomputed its own dt from
+    // glfwGetTime(), which ran a parallel wall-clock against AppBase's
+    // SimClock-aware dt: camera, VFX, and particle systems advanced on a
+    // different clock than gameplay/physics. The frame-determinism harness
+    // already gated this with `determinism_test_state_.active` (dt forced
+    // to 0, vfx/particle updates skipped) but the parallel clock leaked
+    // through normal gameplay frames.
+    //
     // `dispatch_gpu_compute` gates GS-renderer compute pipelines (preprocess /
     // sort / merge / render / pbd_solver / tile_render / post_process). Set
     // false during EngineState::Loading to keep the GPU idle while the
     // loading screen draws; true during Warming and Playing.
-    void draw_scene(Scene& scene,
+    void draw_scene(float dt,
+                    Scene& scene,
                     const std::vector<SpriteDrawInfo>& entity_sprites = {},
                     const std::vector<SpriteDrawInfo>& outline_sprites = {},
                     const std::vector<SpriteDrawInfo>& reflection_sprites = {},
@@ -327,7 +339,9 @@ private:
 
     uint32_t current_frame_ = 0;
     uint32_t acquire_semaphore_index_ = 0;
-    float last_time_ = 0.0f;
+    // Phase 5.1 dt-plumbing: last_time_ + glfwGetTime() recomputation
+    // removed. dt now flows in from AppBase::main_loop() (SimClock-aware,
+    // already clamped) via draw_scene's new first parameter.
     bool font_initialized_ = false;
 
     // Gaussian splatting

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -502,7 +502,10 @@ void AppBase::main_loop() {
         const bool dispatch_gpu_compute = loading_monitor_.should_dispatch_gpu_work();
         GS_LOG_FRAME("[loop/wd] before_draw_scene tick={} dispatch={}",
                      tick_, dispatch_gpu_compute ? 1 : 0);
-        renderer_.draw_scene(scene_, draw_lists_.entity, draw_lists_.outline, draw_lists_.reflection,
+        // Phase 5.1 dt-plumbing: pass the SimClock-aware dt (computed at
+        // line 310-312) through to the renderer so its camera / VFX /
+        // particle advance is driven by the same clock as gameplay/physics.
+        renderer_.draw_scene(dt, scene_, draw_lists_.entity, draw_lists_.outline, draw_lists_.reflection,
                              draw_lists_.shadow, particle_sprites, draw_lists_.overlay, ui_batches,
                              draw_lists_.debug_colliders, feature_flags_, dispatch_gpu_compute);
 #if GSEURAT_DEBUG_BUILD

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -1221,9 +1221,21 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
     const auto t_prepass_start = std::chrono::steady_clock::now();
     uint32_t dbg_dyn_count = 0;
 #endif
-    // Adaptive GS budget: converge to target FPS then lock
-    if (flags.gs_adaptive_budget && gs_adaptive_budget_ && gs_gaussian_budget_ > 0 && dt > 0.0f) {
-        float fps = 1.0f / dt;
+    // Adaptive GS budget: converge to target FPS then lock.
+    //
+    // Measure render-side wall-clock dt locally, NOT the gameplay dt
+    // parameter. The gameplay dt is SimClock-aware (fixed 1/60 in
+    // deterministic mode) and clamped to 0.1s by AppBase — both make it
+    // wrong for FPS feedback: deterministic runs would always see
+    // 60 FPS, and a real 5 FPS stall would underestimate as 10 FPS
+    // (Codex P2 on PR #447).
+    const double render_now = glfwGetTime();
+    const double render_dt = (last_render_wall_time_ > 0.0)
+        ? render_now - last_render_wall_time_
+        : 0.0;
+    last_render_wall_time_ = render_now;
+    if (flags.gs_adaptive_budget && gs_adaptive_budget_ && gs_gaussian_budget_ > 0 && render_dt > 0.0) {
+        float fps = static_cast<float>(1.0 / render_dt);
         gs_smoothed_fps_ = gs_smoothed_fps_ * 0.9f + fps * 0.1f;
 
         if (!gs_budget_locked_) {

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -101,8 +101,6 @@ void Renderer::init(GLFWwindow* window, ResourceManager& resources,
 
     float aspect = static_cast<float>(kWindowWidth) / static_cast<float>(kWindowHeight);
     camera_.configure_hd2d(aspect);
-
-    last_time_ = static_cast<float>(glfwGetTime());
 }
 
 void Renderer::init_font(const FontAtlas& atlas, ResourceManager& resources) {
@@ -398,7 +396,8 @@ void Renderer::set_gs_background(const ResourceHandle<Texture>& texture) {
     gs_bg_initialized_ = true;
 }
 
-void Renderer::draw_scene(Scene& scene,
+void Renderer::draw_scene(float dt,
+                           Scene& scene,
                            const std::vector<SpriteDrawInfo>& entity_sprites,
                            const std::vector<SpriteDrawInfo>& outline_sprites,
                            const std::vector<SpriteDrawInfo>& reflection_sprites,
@@ -416,10 +415,14 @@ void Renderer::draw_scene(Scene& scene,
     auto device = context_.device();
     const auto& frame_sync = sync_.frame(current_frame_);
 
-    // Delta time
-    float now = static_cast<float>(glfwGetTime());
-    float dt = now - last_time_;
-    last_time_ = now;
+    // Phase 5.1 dt-plumbing: dt is passed in from AppBase::main_loop, which
+    // computes it via gs::SimClock::fixed_dt() in deterministic mode and a
+    // wall-clock delta otherwise. The renderer previously recomputed its
+    // own dt from glfwGetTime() — a parallel clock that drifted from
+    // AppBase's authoritative one and accumulated into VFX / particle /
+    // camera state. The frame-determinism harness already forced dt to 0
+    // inside its gate, but the recomputation leaked through normal
+    // gameplay frames.
 
     // Frame-determinism harness: when active, freeze every CPU-side input
     // that feeds the GS pipeline. Goal is to render N frames against
@@ -987,15 +990,6 @@ void Renderer::draw_scene(Scene& scene,
     current_frame_ = (current_frame_ + 1) % kMaxFramesInFlight;
 }
 
-void Renderer::draw_frame() {
-    // Legacy shim: render a single white quad
-    Scene test_scene;
-    SpriteDrawInfo info{};
-    info.position = {0.0f, 0.0f, 0.0f};
-    info.size = {1.0f, 1.0f};
-    info.color = {1.0f, 1.0f, 1.0f, 1.0f};
-    draw_scene(test_scene, {info}, {}, {}, {}, {}, {}, {});
-}
 
 void Renderer::shutdown() {
     // Persist the pipeline cache to disk BEFORE vkDeviceWaitIdle and any


### PR DESCRIPTION
## Summary

`Renderer::draw_scene` recomputed its own `dt` from `glfwGetTime()` at the top of every frame, running a wall-clock against `AppBase::main_loop`'s authoritative SimClock-aware `dt` (`app_base.cpp:310-312`, which uses `gs::SimClock::fixed_dt()` in deterministic mode).

**Effect:** camera, VFX, and particle `update_per_frame()` advanced on a different clock than gameplay/physics. The frame-determinism harness already gated this via `determinism_test_state_.active` (forcing `dt=0` and skipping vfx/particle updates), but the parallel clock leaked through every normal gameplay frame and accumulated drift between runs.

**Documented symptom** (`scripts/regression/island_demo_canonical.py:131`):
> *"adding `step 1` after EVERY screenshot regressed early-frame SSIMs — likely wall-clock-dependent visual code paths whose drift accumulates with each extra step."*

## What's in the diff

- `Renderer::draw_scene` gains `float dt` as its first parameter.
- `app_base.cpp:505` (the only call site) passes the SimClock-aware `dt` it already computed at line 310-312.
- `Renderer::record_gs_prepass` was already declared with a `float dt` parameter — it now receives the plumbed-through value instead of the locally-recomputed one.
- Deletes the `last_time_` field, the constructor's `last_time_ = glfwGetTime()`, and the per-frame `glfwGetTime()`/`dt` recomputation in `draw_scene`.
- Deletes `Renderer::draw_frame()` — "legacy shim" with zero callers in `src/`, `examples/`, or `tests/` (same dead-code pattern as the `update_active_gaussians` removal in 5e-2).

## Wall-clock uses left untouched (intentional)

All non-visual diagnostic/telemetry uses of `std::chrono::steady_clock` and `glfwGetTime()` are preserved:
- Frame profiling timers (`scoped_timer.hpp`, `ScopedStallTimer`, all `t_ds_*` measurements)
- `save_system.cpp` save-file timestamps
- `random.cpp:25` RNG seed entropy
- `gs_chunk_streamer.cpp` load-time telemetry
- `app_base.cpp`'s loading-monitor min-duration gate (per its own comment, needs true wall-clock for the 1.5s loading-screen min-duration)

## What this fix does NOT do

It does not restore `SSIM=1.0` on Apple Silicon. Per `project_harness_apple_silicon_methodology.md`, TBDR tile scheduling order, MoltenVK Metal command translation, async-compute dispatch ordering, and PBD wind RNG parallel-reduction order are platform-level non-determinism sources unrelated to wall-clock and remain the dominant SSIM noise floor on M-series.

This PR closes one identified contributing factor (the parallel clock) and aligns the renderer's clock with the gameplay clock. Restoring SSIM=1.0 reliably requires a Linux/Mesa CI lane (methodology memo Path D) or region-masked SSIM (Path C).

## Test plan
- [x] `cmake --build --preset macos-debug` — clean
- [x] `cmake --build --preset macos-release` — clean
- [x] `cmake --build --preset macos-release-with-diag` — clean
- [x] 8s demo smoke: clean shutdown, `[ShutdownAuditor] No tracked objects alive.`, `[PipelineCache] saved 207848 bytes`, `EXIT 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)