### PR TITLE
fix(vfx): cache decimated VfxInstance object PLYs, prefetch at scene init (#407)

### DIFF
--- a/include/gseurat/engine/gs_vfx.hpp
+++ b/include/gseurat/engine/gs_vfx.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include <glm/vec3.hpp>
 #include <gseurat/engine/gs_particle.hpp>
@@ -8,6 +9,8 @@
 #include <gseurat/engine/scene_loader.hpp>
 
 namespace gseurat {
+
+class VfxObjectCache;
 
 // ── VFX element data (parsed from .vfx.json) ──
 
@@ -56,12 +59,54 @@ struct VfxInstanceData {
 VfxPreset load_vfx_preset(const std::string& path);
 VfxPreset parse_vfx_preset(const nlohmann::json& j);
 
+// ── Decimated "object" PLY cache ──
+//
+// Issue #407: VfxInstance::init synchronously parses a PLY file for every
+// "object" element on the main render thread, which can stall gameplay when
+// a runtime trigger spawns a preset whose PLY hasn't been touched yet.
+//
+// VfxObjectCache holds already-decimated splats keyed by the (resolved)
+// PLY path. At scene init the demo + scene loader walk every VFX preset
+// that will be referenced and prefetch each "object" PLY into the cache.
+// `VfxInstance::init` then applies the per-instance scale/rotation/offset
+// transform on top of cached splats, skipping disk I/O entirely.
+//
+// On cache miss, `init` falls back to the legacy synchronous load with a
+// `[VFX] WARN: PLY '%s' not preloaded — main-thread stall` log line so
+// missing prefetches are visible in regression smokes.
+class VfxObjectCache {
+public:
+    struct Entry {
+        std::vector<Gaussian> decimated;   // post-decimation, no per-instance transform applied
+        std::size_t source_count = 0;      // raw splat count before decimation (for logging)
+        std::size_t stride = 1;
+    };
+
+    // Idempotent: re-calling preload() for an already-cached path is a no-op.
+    // Returns the resolved canonical path used as the cache key (so callers
+    // can log which file was actually parsed, including the fallback under
+    // assets/vfx/filename).
+    std::string preload(const std::string& ply_file);
+
+    // Returns nullptr on miss. Resolves the input path the same way as
+    // preload() so a preset element's raw `ply_file` string matches the
+    // prefetched entry.
+    const Entry* find(const std::string& ply_file) const;
+
+    void clear() noexcept { entries_.clear(); }
+    std::size_t size() const noexcept { return entries_.size(); }
+
+private:
+    std::unordered_map<std::string, Entry> entries_;
+};
+
 // ── Runtime VFX instance ──
 
 class VfxInstance {
 public:
     void init(const VfxPreset& preset, const glm::vec3& position, bool loop,
-              float rotation_y = 0.0f);
+              float rotation_y = 0.0f,
+              const VfxObjectCache* cache = nullptr);
 
     /// Append static object Gaussians to the buffer (call before animator runs).
     void append_objects(std::vector<Gaussian>& out_buffer);

--- a/include/gseurat/engine/systems/vfx_system.hpp
+++ b/include/gseurat/engine/systems/vfx_system.hpp
@@ -72,6 +72,18 @@ public:
     std::vector<VfxInstance>& instances_mutable() noexcept { return vfx_instances_; }
     const std::vector<VfxInstance>& instances() const noexcept { return vfx_instances_; }
 
+    // #407: prefetched "object" PLYs keyed by resolved path. Owned by the
+    // VFX system so it survives scene reloads (cleared in clear_instances)
+    // and is reachable from every site that calls VfxInstance::init.
+    VfxObjectCache& object_cache() noexcept { return object_cache_; }
+    const VfxObjectCache& object_cache() const noexcept { return object_cache_; }
+
+    // Parse `vfx_file` and preload every "object" element's PLY into the
+    // cache. Safe to call repeatedly for the same preset (preload itself
+    // is idempotent per resolved path). Logs and continues on malformed
+    // JSON so a single broken preset doesn't block scene init.
+    void prefetch_preset_objects(const std::string& vfx_file);
+
     // VFX-emitted lights — `out` is appended (caller may seed with statics).
     // Caps at `cap` total lights including pre-existing entries.
     void collect_active_lights(std::vector<PointLight>& out, std::size_t cap) const;
@@ -96,6 +108,7 @@ private:
     GaussianAnimator gs_animator_;
     // Scratch CPU buffer reused frame-to-frame to avoid per-frame allocs.
     std::vector<Gaussian> scratch_;
+    VfxObjectCache object_cache_;
 };
 
 }  // namespace systems

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -861,6 +861,27 @@ void IslandDemoState::on_enter(AppBase& app) {
     });
     app.debug_dump_registry().register_module(&*collision_dumper);
 
+    // #407: prefetch every VfxTrigger's preset "object" PLY before
+    // gameplay starts. The scene loader already prefetched auto-trigger
+    // presets from scene_data.vfx_instances; this pass covers the
+    // runtime-spawned VFX referenced by proximity-triggered components.
+    // Without this, the first time a player triggers a VfxTrigger whose
+    // preset uses an "object" element, VfxInstance::init would block on
+    // a synchronous PLY load on the main thread (mid-gameplay stall).
+    if (app.vfx_system()) {
+        std::size_t prefetched = 0;
+        app.world().view<VfxTrigger>().each(
+            [&](ecs::Entity, VfxTrigger& vt) {
+                if (vt.vfx_path[0] != '\0') {
+                    app.vfx_system()->prefetch_preset_objects(vt.vfx_path);
+                    ++prefetched;
+                }
+            });
+        std::fprintf(stderr,
+            "[IslandDemo] VfxTrigger prefetch: %zu trigger(s), %zu PLY cache entries\n",
+            prefetched, app.vfx_system()->object_cache().size());
+    }
+
     // Scene loaded — ready for play
 }
 
@@ -1486,7 +1507,9 @@ void IslandDemoState::update_effects(AppBase& app, float dt) {
                     try {
                         auto preset = load_vfx_preset(path);
                         VfxInstance inst;
-                        inst.init(preset, t.position.vec(), true);
+                        const VfxObjectCache* cache = app.vfx_system()
+                            ? &app.vfx_system()->object_cache() : nullptr;
+                        inst.init(preset, t.position.vec(), true, 0.0f, cache);
                         if (app.vfx_system()) {
                             app.vfx_system()->add_instance(std::move(inst));
                         } else {

--- a/src/engine/gs_scene_loader.cpp
+++ b/src/engine/gs_scene_loader.cpp
@@ -439,6 +439,17 @@ void GsSceneLoader::finalize_on_main(SceneLoadContext& ctx, const SceneData& sce
             proj[1][1] *= -1.0f;
             ctx.renderer.set_gs_camera(view, proj);
         }
+        // #407: prefetch all auto-trigger preset "object" PLYs before we
+        // start initialising instances, so the inst.init loop below never
+        // blocks on disk I/O. Runtime triggers (VfxTrigger components,
+        // VfxSpawnEvent) are prefetched separately by the demo/game state
+        // since they aren't in scene_data.vfx_instances.
+        if (ctx.vfx_system) {
+            for (const auto& vi : scene_data.vfx_instances) {
+                if (vi.trigger != "auto") continue;
+                ctx.vfx_system->prefetch_preset_objects(vi.vfx_file);
+            }
+        }
         for (const auto& vi : scene_data.vfx_instances) {
             if (vi.trigger != "auto") continue;
             auto preset = load_vfx_preset(vi.vfx_file);
@@ -454,7 +465,8 @@ void GsSceneLoader::finalize_on_main(SceneLoadContext& ctx, const SceneData& sce
             }
             VfxInstance inst;
             auto world_pos = coord::to_world(vi.position, ctx.terrain.terrain_aabb);
-            inst.init(preset, world_pos.vec(), vi.loop, vi.rotation_y);
+            const VfxObjectCache* cache = ctx.vfx_system ? &ctx.vfx_system->object_cache() : nullptr;
+            inst.init(preset, world_pos.vec(), vi.loop, vi.rotation_y, cache);
             if (ctx.vfx_system) {
                 ctx.vfx_system->add_instance(std::move(inst));
             } else {

--- a/src/engine/gs_vfx.cpp
+++ b/src/engine/gs_vfx.cpp
@@ -110,8 +110,69 @@ static glm::vec3 rotate_y(const glm::vec3& v, float angle_rad) {
     return {v.x * c + v.z * s, v.y, -v.x * s + v.z * c};
 }
 
+// Cap each VFX object's splat count to keep the dynamic SSBO budget
+// reasonable. Authored asset sizes (e.g. torch.ply at 50k splats) target
+// showcase rendering, not 20× instancing in one scene. See the long
+// comment in VfxInstance::init below for the full rationale — this
+// constant is shared between the legacy sync-load path and the
+// VfxObjectCache::preload path so both decimate identically.
+namespace { constexpr std::size_t kMaxVfxObjectSplats = 2048; }
+
+// Resolve a preset's `ply_file` string to a path on disk. Tries the exact
+// path first (so absolute paths and project-relative paths both work),
+// then falls back to `assets/vfx/<filename>` exactly as the legacy
+// `VfxInstance::init` path did. Returns the empty string if neither
+// candidate exists.
+static std::string resolve_vfx_ply_path(const std::string& ply_file) {
+    if (std::filesystem::exists(ply_file)) {
+        return ply_file;
+    }
+    auto filename = std::filesystem::path(ply_file).filename().string();
+    auto alt = resolve_asset_path("assets/vfx/" + filename).string();
+    if (std::filesystem::exists(alt)) {
+        return alt;
+    }
+    return {};
+}
+
+std::string VfxObjectCache::preload(const std::string& ply_file) {
+    std::string resolved = resolve_vfx_ply_path(ply_file);
+    if (resolved.empty()) {
+        std::fprintf(stderr, "[VFX] preload failed — PLY not found: %s\n", ply_file.c_str());
+        return resolved;
+    }
+    if (entries_.count(resolved)) return resolved;  // idempotent
+
+    auto cloud = GaussianCloud::load_with_gsvx_first(resolved);
+    const auto& gs = cloud.gaussians();
+    const std::size_t total = gs.size();
+    const std::size_t stride = (total > kMaxVfxObjectSplats)
+        ? (total + kMaxVfxObjectSplats - 1) / kMaxVfxObjectSplats
+        : 1;
+
+    Entry entry;
+    entry.source_count = total;
+    entry.stride = stride;
+    entry.decimated.reserve((total + stride - 1) / stride);
+    for (std::size_t i = 0; i < total; i += stride) {
+        entry.decimated.push_back(gs[i]);  // raw, no per-instance transform
+    }
+    std::fprintf(stderr,
+        "[VFX] preload '%s' -> %zu/%zu Gaussians (stride=%zu)\n",
+        resolved.c_str(), entry.decimated.size(), total, stride);
+    entries_.emplace(resolved, std::move(entry));
+    return resolved;
+}
+
+const VfxObjectCache::Entry* VfxObjectCache::find(const std::string& ply_file) const {
+    std::string resolved = resolve_vfx_ply_path(ply_file);
+    if (resolved.empty()) return nullptr;
+    auto it = entries_.find(resolved);
+    return (it == entries_.end()) ? nullptr : &it->second;
+}
+
 void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool loop,
-                       float rotation_y) {
+                       float rotation_y, const VfxObjectCache* cache) {
     preset_ = preset;
     position_ = position;
     rotation_y_ = rotation_y;
@@ -145,49 +206,57 @@ void VfxInstance::init(const VfxPreset& preset, const glm::vec3& position, bool 
             as.activated = false;
             anim_states_.push_back(std::move(as));
         } else if (el.type == "object" && !el.ply_file.empty()) {
-            // Load PLY file — try exact path, then assets/vfx/filename
-            std::string ply_path = el.ply_file;
-            if (!std::filesystem::exists(ply_path)) {
-                auto filename = std::filesystem::path(el.ply_file).filename().string();
-                ply_path = resolve_asset_path("assets/vfx/" + filename).string();
-            }
-            if (std::filesystem::exists(ply_path)) {
-                auto cloud = GaussianCloud::load_with_gsvx_first(ply_path);
-                const auto& gs = cloud.gaussians();
-                // VFX object decimation: cap each VFX object's splat count to
-                // keep the dynamic SSBO budget reasonable. Reusable assets
-                // (e.g. torch.ply at 50k splats) are designed for showcase
-                // rendering, not for being instantiated 20+ times in a single
-                // scene. The dungeon spawns 23 torch instances; at 50k each
-                // they would alone exceed the dynamic budget. The dynamic
-                // depth-sort cost is dominated by sort_size (fixed at init
-                // based on max_dynamic_count_), so reducing actual splat
-                // counts only partially mitigates GPU work — but it does cut
-                // CPU upload bandwidth, projection cost, and overdraw. Cap at
-                // 2k per instance (23 × 2k = 46k for the dungeon). Stride-
-                // sampling preserves spatial distribution; the visual
-                // difference for a small mesh viewed at distance is minimal.
-                // Authoring fix track (see spec §11.2): reduce dungeon torch
-                // instance count, or replace torch.ply with a smaller asset
-                // (~2k splats) authored for the showcase rendering scale.
-                constexpr size_t kMaxVfxObjectSplats = 2048;
-                const size_t total = gs.size();
-                const size_t stride = (total > kMaxVfxObjectSplats)
-                    ? (total + kMaxVfxObjectSplats - 1) / kMaxVfxObjectSplats
-                    : 1;
-                size_t taken = 0;
-                for (size_t i = 0; i < total; i += stride) {
-                    Gaussian g = gs[i];
-                    // Rotate Gaussian position around prefab origin, then offset
+            // #407: prefer the prefetched cache so spawning a runtime VFX
+            // doesn't block on disk I/O. The cache stores already-decimated
+            // raw splats; we only apply the per-instance scale/rotate/offset
+            // transform here. On miss, fall back to a sync load with a
+            // visible warning so the missing prefetch is loud in smoke tests.
+            //
+            // VFX object decimation (rationale preserved from the legacy
+            // inline path): cap each instance's splat count to keep the
+            // dynamic SSBO budget reasonable. Reusable assets like torch.ply
+            // (~50k splats) are authored for showcase rendering, not for 20×
+            // instancing in one scene; the dungeon spawns 23 torches and at
+            // 50k each would alone exceed the dynamic budget. Stride sampling
+            // preserves spatial distribution; the visual difference for a
+            // small mesh viewed at distance is minimal. Sort cost is
+            // dominated by `max_dynamic_count_` so this mainly cuts CPU
+            // upload bandwidth, projection cost, and overdraw. Authoring fix
+            // track (spec §11.2): reduce dungeon torch count or author a
+            // smaller torch asset.
+            const VfxObjectCache::Entry* entry = cache ? cache->find(el.ply_file) : nullptr;
+            if (entry) {
+                object_gaussians_.reserve(object_gaussians_.size() + entry->decimated.size());
+                for (Gaussian g : entry->decimated) {
                     g.position = rotate_y(g.position * el.scale, rot_rad) + position_ + rotated_pos;
                     object_gaussians_.push_back(g);
-                    ++taken;
                 }
-                std::fprintf(stderr,
-                    "VFX: Object '%s' loaded %zu/%zu Gaussians from %s (stride=%zu)\n",
-                    el.name.c_str(), taken, total, el.ply_file.c_str(), stride);
             } else {
-                std::fprintf(stderr, "VFX: Object PLY not found: %s\n", el.ply_file.c_str());
+                // Sync fallback — same shape as the pre-#407 inline path.
+                std::string ply_path = resolve_vfx_ply_path(el.ply_file);
+                if (!ply_path.empty()) {
+                    std::fprintf(stderr,
+                        "[VFX] WARN: PLY '%s' not preloaded — main-thread stall\n",
+                        el.ply_file.c_str());
+                    auto cloud = GaussianCloud::load_with_gsvx_first(ply_path);
+                    const auto& gs = cloud.gaussians();
+                    const std::size_t total = gs.size();
+                    const std::size_t stride = (total > kMaxVfxObjectSplats)
+                        ? (total + kMaxVfxObjectSplats - 1) / kMaxVfxObjectSplats
+                        : 1;
+                    std::size_t taken = 0;
+                    for (std::size_t k = 0; k < total; k += stride) {
+                        Gaussian g = gs[k];
+                        g.position = rotate_y(g.position * el.scale, rot_rad) + position_ + rotated_pos;
+                        object_gaussians_.push_back(g);
+                        ++taken;
+                    }
+                    std::fprintf(stderr,
+                        "VFX: Object '%s' (fallback) loaded %zu/%zu Gaussians from %s (stride=%zu)\n",
+                        el.name.c_str(), taken, total, el.ply_file.c_str(), stride);
+                } else {
+                    std::fprintf(stderr, "VFX: Object PLY not found: %s\n", el.ply_file.c_str());
+                }
             }
         } else if (el.type == "light") {
             LightState ls;

--- a/src/engine/systems/vfx_system.cpp
+++ b/src/engine/systems/vfx_system.cpp
@@ -19,7 +19,7 @@ void VfxSystem::run(ecs::World& world, float /*dt*/) {
             auto preset = load_vfx_preset(evt.vfx_file);
             if (preset.elements.empty()) continue;
             VfxInstance inst;
-            inst.init(preset, evt.position, evt.loop, evt.rotation_y);
+            inst.init(preset, evt.position, evt.loop, evt.rotation_y, &object_cache_);
             vfx_instances_.push_back(std::move(inst));
         } catch (const std::exception& e) {
             std::fprintf(stderr,
@@ -29,10 +29,29 @@ void VfxSystem::run(ecs::World& world, float /*dt*/) {
     }
 }
 
+void VfxSystem::prefetch_preset_objects(const std::string& vfx_file) {
+    try {
+        auto preset = load_vfx_preset(vfx_file);
+        for (const auto& el : preset.elements) {
+            if (el.type == "object" && !el.ply_file.empty()) {
+                object_cache_.preload(el.ply_file);
+            }
+        }
+    } catch (const std::exception& e) {
+        std::fprintf(stderr,
+            "[VfxSystem] prefetch_preset_objects '%s' skipped: %s\n",
+            vfx_file.c_str(), e.what());
+    }
+}
+
 void VfxSystem::clear_instances() {
     vfx_instances_.clear();
     gs_animator_.reset();
     scratch_.clear();
+    // Drop the cache too — a new scene may reference different PLYs and
+    // we want stale entries garbage-collected. Scene-init prefetch
+    // repopulates whatever the next scene needs.
+    object_cache_.clear();
 }
 
 void VfxSystem::collect_active_lights(std::vector<PointLight>& out, std::size_t cap) const {


### PR DESCRIPTION
## Summary

Resolves #407 — `VfxInstance::init` synchronously parses a PLY for every `"object"` element on the main render thread. Today this only fires at scene init (torch is the sole referenced PLY in the canonical scenario and is pre-loaded) but is latent for any runtime-spawned VFX preset whose preset includes an `"object"` element: a future authoring choice would introduce a multi-hundred-millisecond stall mid-gameplay when a `VfxTrigger` fires.

## Approach (Option 2 from the issue body)

Introduce **`VfxObjectCache`** keyed by resolved canonical PLY path holding already-decimated splats. `VfxInstance::init` takes an optional cache pointer; on hit it applies only the per-instance scale/rotation/offset transform, skipping disk I/O. On miss the legacy synchronous load runs with a `[VFX] WARN: PLY '%s' not preloaded — main-thread stall` log line so missing prefetches are visible in regression smokes. The cache is owned by `VfxSystem` and cleared in `clear_instances()` so scene reloads drop stale entries.

Prefetched from two sites that together cover the demo's VFX surface:

- **`GsSceneLoader::finalize_on_main`** — walks `scene_data.vfx_instances` and prefetches every auto-trigger preset before the inst.init loop.
- **`IslandDemoState::on_enter`** — walks `world.view<VfxTrigger>()` after game objects are constructed and prefetches each trigger's preset path. Kept demo-side per CLAUDE.md's subrepo rules (engine code stays game-agnostic).

`VfxSpawnEvent`-driven spawns in `VfxSystem::run` also take the cache; an event referencing a never-prefetched preset still works (sync fallback) but logs the stall as the "you forgot to prefetch" signal.

## Why Option 2 over async

- Cache is tiny: only 1 PLY (`torch.ply`) referenced by `"object"` elements in the entire `examples/island_demo/assets/vfx/` set today.
- Matches the existing scene-init preload pattern for torch.
- Sync fallback in the miss path already covers runtime-discovered presets without async-future plumbing into `VfxSystem`.
- Reduces redundant parsing: pre-#407 the dungeon's 23 torch instances each re-parsed `torch.ply`; post-#407 the file is parsed once, then all instances are cache hits.

## Test plan

- [x] All 3 macOS configs build clean (`macos-debug`, `macos-release`, `macos-release-with-diag`)
- [x] `test_vfx_lights_rotation` + `test_vfx_system` pass
- [x] 12s `gseurat_demo` smoke (release):
  - `[VFX] preload 'assets/vfx/torch.ply' -> 2000/50000 Gaussians (stride=25)`
  - `[IslandDemo] VfxTrigger prefetch: 3 trigger(s), 1 PLY cache entries`
  - No `[VFX] WARN: ... main-thread stall` lines
  - `[ShutdownAuditor] No tracked objects alive.`, EXIT 0
- [ ] Follow-up: add unit test exercising `VfxObjectCache::preload`/`find`/`clear` against an on-disk fixture (existing `test_vfx_system.cpp` is event-bus-only; this would need a small synthetic PLY in `tests/data/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)