### PR TITLE
chore(engine): retire orphan gaussian_ssbo buffer (post-#397 follow-up)

### DIFF
--- a/include/gseurat/engine/gs_renderer/gs_resources.hpp
+++ b/include/gseurat/engine/gs_renderer/gs_resources.hpp
@@ -54,8 +54,7 @@ struct GsResourceManager {
     std::array<VmaAllocation,  kMaxFramesInFlight> processed_allocations{};
     std::array<VkImageView,    kMaxFramesInFlight> processed_views{};
 
-    // ── Splat buffers (legacy + split) ────────────────────────────────
-    Buffer gaussian_ssbo;
+    // ── Splat buffers (static/dynamic split) ──────────────────────────
     Buffer uniform_buffer;
     Buffer static_gaussian_ssbo;
     Buffer dynamic_gaussian_ssbo;

--- a/include/gseurat/engine/gs_renderer/streaming/gs_streaming_system.hpp
+++ b/include/gseurat/engine/gs_renderer/streaming/gs_streaming_system.hpp
@@ -71,8 +71,8 @@ public:
     // compute and store the sort sizing scalars, and push them into
     // GsSortSystem/GsTileBinSystem. The renderer's own init_streaming
     // continues to allocate the non-streaming GPU buffers (pbd_*,
-    // gaussian_ssbo, projected, sort A/B, merged_sort, uniform, etc.)
-    // and reads the sizing scalars back via the getters below.
+    // projected, sort A/B, merged_sort, uniform, etc.) and reads the
+    // sizing scalars back via the getters below.
     //
     // `num_sort_passes` is owned by GsRenderer (render config) and
     // passed in so the depth-onesweep sizing matches the dispatch.

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1161,7 +1161,6 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
 
     // Destroy all renderer-owned GPU buffers (streaming-owned page_table
     // and chunk_table are destroyed/recreated inside streaming_.init_streaming).
-    resources_->gaussian_ssbo.destroy(allocator_);
     resources_->uniform_buffer.destroy(allocator_);
     resources_->pbd_state_ssbo.destroy(allocator_);
     resources_->pbd_params_ssbo.destroy(allocator_);
@@ -1204,7 +1203,6 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
     // Read back sizing for renderer-owned buffer allocation.
     const uint32_t max_static          = streaming_.max_static_count();
     const uint32_t max_dynamic         = streaming_.max_dynamic_count();
-    const uint32_t max_gaussian        = streaming_.max_gaussian_count();
     const uint32_t s_sort_size         = streaming_.static_sort_size();
     const uint32_t d_sort_size         = streaming_.dynamic_sort_size();
     const uint32_t s_sort_workgroups   = streaming_.static_sort_workgroups();
@@ -1273,10 +1271,6 @@ void GsRenderer::init_streaming(const StreamingConfig& config) {
                             * sizeof(SortEntry));
         }
     }
-
-    // Legacy buffers (same sizes as static counterparts for backward compat).
-    resources_->gaussian_ssbo = Buffer::create_storage(allocator_,
-        static_cast<VkDeviceSize>(max_gaussian) * sizeof(GpuGaussian));
 
     // PBD buffers
     resources_->pbd_state_ssbo = Buffer::create_storage(allocator_,
@@ -2273,8 +2267,6 @@ void GsRenderer::shutdown(VmaAllocator allocator) {
     resources_->page_table_ssbo.destroy(allocator);
     resources_->chunk_table_ssbo.destroy(allocator);
 
-    // Legacy buffers
-    resources_->gaussian_ssbo.destroy(allocator);
     resources_->uniform_buffer.destroy(allocator);
     resources_->pbd_state_ssbo.destroy(allocator);
     resources_->pbd_params_ssbo.destroy(allocator);

--- a/src/engine/gs_renderer/gs_resources.cpp
+++ b/src/engine/gs_renderer/gs_resources.cpp
@@ -52,7 +52,6 @@ void GsResourceManager::destroy_output_views_and_images() {
 
 void GsResourceManager::destroy_streaming_buffers() {
     if (allocator == VK_NULL_HANDLE) return;
-    gaussian_ssbo.destroy(allocator);
     uniform_buffer.destroy(allocator);
     pbd_state_ssbo.destroy(allocator);
     pbd_params_ssbo.destroy(allocator);


### PR DESCRIPTION
## Summary

Tight follow-up to #451 (now merged on `main`). `gaussian_ssbo` (the non-split per-source Gaussian buffer) was the **last consumer-less buffer** in the renderer-owned set. #451 deleted its only descriptor binding (the dead `preprocess_sets_` write block) but left the buffer's allocation/destruction in place to keep that PR scope-tight. This change removes them.

Confirmed dead by exhaustive grep — no remaining `gaussian_ssbo` references in `.cpp` / `.hpp` / `.comp` / `.glsl` sources after #451.

## Deletions

- `Buffer gaussian_ssbo` field on `GsResourceManager`
- `Buffer::create_storage` call in `GsRenderer::init_streaming` (under the now-misleading "Legacy buffers (same sizes as static counterparts for backward compat)" comment)
- The unused `max_gaussian` local that fed the allocation
- Three `gaussian_ssbo.destroy(allocator)` calls (renderer init, renderer shutdown, and `GsResourceManager::destroy_streaming_buffers`)
- Stale `gaussian_ssbo` mention in `GsStreamingSystem::init_streaming` doc comment

## Retained

Public getter `GsRenderer::max_gaussian_count()` — UI / debug surfaces (`dev_panels`, island_demo HUD, `command_dispatcher`, `app_base` snapshot) still report capacity via that path. Not a buffer field, no backing storage to delete.

## Validation

- [x] All 3 macOS configs build clean (`macos-debug`, `macos-release`, `macos-release-with-diag`)
- [x] 8s `gseurat_demo` smoke (release): no Vulkan validation errors, no descriptor-pool issues, runtime `[VfxTrigger] SPAWN 'chimney_smoke.vfx.json'` works, `[ShutdownAuditor] No tracked objects alive.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)