### PR TITLE
refactor(assets): #396 PR-B2 — migrate scene/manifest/vfx JSON paths .ply → .gsvx

### DIFF
--- a/examples/island_demo/assets/characters/knight/knight.manifest.json
+++ b/examples/island_demo/assets/characters/knight/knight.manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "knight",
-  "ply_file": "knight.ply",
+  "ply_file": "knight.gsvx",
   "scale": 1,
   "bones": [
     {

--- a/examples/island_demo/assets/characters/slime/slime.manifest.json
+++ b/examples/island_demo/assets/characters/slime/slime.manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "slime",
-  "ply_file": "slime.ply",
+  "ply_file": "slime.gsvx",
   "scale": 1.0,
   "bones": [
     {

--- a/examples/island_demo/assets/characters/snes_hero/snes_hero.manifest.json
+++ b/examples/island_demo/assets/characters/snes_hero/snes_hero.manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "snes_hero",
-  "ply_file": "snes_hero.ply",
+  "ply_file": "snes_hero.gsvx",
   "scale": 1.0,
   "bones": [
     {

--- a/examples/island_demo/assets/characters/warm_robot/warm_robot.manifest.json
+++ b/examples/island_demo/assets/characters/warm_robot/warm_robot.manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "warm_robot",
-  "ply_file": "warm_robot.ply",
+  "ply_file": "warm_robot.gsvx",
   "scale": 0.5,
   "bones": [
     { "id": "torso", "parent": null, "joint": [16, 3, 16] },

--- a/examples/island_demo/assets/props/island_manifest.json
+++ b/examples/island_demo/assets/props/island_manifest.json
@@ -2,7 +2,7 @@
   {
     "id": "tree_1",
     "name": "Tree",
-    "ply_file": "assets/props/island_tree_1.ply",
+    "ply_file": "assets/props/island_tree_1.gsvx",
     "position": [
       120,
       0,
@@ -18,7 +18,7 @@
   {
     "id": "tree_2",
     "name": "Tree",
-    "ply_file": "assets/props/island_tree_2.ply",
+    "ply_file": "assets/props/island_tree_2.gsvx",
     "position": [
       200,
       0,
@@ -34,7 +34,7 @@
   {
     "id": "tree_3",
     "name": "Tree",
-    "ply_file": "assets/props/island_tree_3.ply",
+    "ply_file": "assets/props/island_tree_3.gsvx",
     "position": [
       160,
       0,
@@ -50,7 +50,7 @@
   {
     "id": "tree_4",
     "name": "Tree",
-    "ply_file": "assets/props/island_tree_4.ply",
+    "ply_file": "assets/props/island_tree_4.gsvx",
     "position": [
       220,
       0,
@@ -66,7 +66,7 @@
   {
     "id": "tree_5",
     "name": "Tree",
-    "ply_file": "assets/props/island_tree_5.ply",
+    "ply_file": "assets/props/island_tree_5.gsvx",
     "position": [
       140,
       0,
@@ -82,7 +82,7 @@
   {
     "id": "tree_6",
     "name": "Tree",
-    "ply_file": "assets/props/island_tree_6.ply",
+    "ply_file": "assets/props/island_tree_6.gsvx",
     "position": [
       250,
       0,
@@ -98,7 +98,7 @@
   {
     "id": "tree_7",
     "name": "Tree",
-    "ply_file": "assets/props/island_tree_7.ply",
+    "ply_file": "assets/props/island_tree_7.gsvx",
     "position": [
       180,
       0,
@@ -114,7 +114,7 @@
   {
     "id": "tree_8",
     "name": "Tree",
-    "ply_file": "assets/props/island_tree_8.ply",
+    "ply_file": "assets/props/island_tree_8.gsvx",
     "position": [
       130,
       0,
@@ -130,7 +130,7 @@
   {
     "id": "tree_9",
     "name": "Tree",
-    "ply_file": "assets/props/island_tree_9.ply",
+    "ply_file": "assets/props/island_tree_9.gsvx",
     "position": [
       210,
       0,
@@ -146,7 +146,7 @@
   {
     "id": "tree_10",
     "name": "Tree",
-    "ply_file": "assets/props/island_tree_10.ply",
+    "ply_file": "assets/props/island_tree_10.gsvx",
     "position": [
       170,
       0,
@@ -162,7 +162,7 @@
   {
     "id": "tree_11",
     "name": "Tree",
-    "ply_file": "assets/props/island_tree_11.ply",
+    "ply_file": "assets/props/island_tree_11.gsvx",
     "position": [
       240,
       0,
@@ -178,7 +178,7 @@
   {
     "id": "tree_12",
     "name": "Tree",
-    "ply_file": "assets/props/island_tree_12.ply",
+    "ply_file": "assets/props/island_tree_12.gsvx",
     "position": [
       150,
       0,
@@ -194,7 +194,7 @@
   {
     "id": "rock_1",
     "name": "Rock",
-    "ply_file": "assets/props/island_rock_1.ply",
+    "ply_file": "assets/props/island_rock_1.gsvx",
     "position": [
       150,
       4.38,
@@ -210,7 +210,7 @@
   {
     "id": "rock_2",
     "name": "Rock",
-    "ply_file": "assets/props/island_rock_2.ply",
+    "ply_file": "assets/props/island_rock_2.gsvx",
     "position": [
       230,
       11.124,
@@ -226,7 +226,7 @@
   {
     "id": "rock_3",
     "name": "Rock",
-    "ply_file": "assets/props/island_rock_3.ply",
+    "ply_file": "assets/props/island_rock_3.gsvx",
     "position": [
       130,
       5.212199999999999,
@@ -242,7 +242,7 @@
   {
     "id": "rock_4",
     "name": "Rock",
-    "ply_file": "assets/props/island_rock_4.ply",
+    "ply_file": "assets/props/island_rock_4.gsvx",
     "position": [
       200,
       8.100000000000001,
@@ -258,7 +258,7 @@
   {
     "id": "rock_5",
     "name": "Rock",
-    "ply_file": "assets/props/island_rock_5.ply",
+    "ply_file": "assets/props/island_rock_5.gsvx",
     "position": [
       170,
       4.4018999999999995,
@@ -274,7 +274,7 @@
   {
     "id": "rock_6",
     "name": "Rock",
-    "ply_file": "assets/props/island_rock_6.ply",
+    "ply_file": "assets/props/island_rock_6.gsvx",
     "position": [
       260,
       8.370000000000001,
@@ -290,7 +290,7 @@
   {
     "id": "house",
     "name": "House",
-    "ply_file": "assets/props/island_house1.ply",
+    "ply_file": "assets/props/island_house1.gsvx",
     "position": [
       192,
       0,
@@ -306,7 +306,7 @@
   {
     "id": "flower_1",
     "name": "Flower",
-    "ply_file": "assets/props/island_flower1.ply",
+    "ply_file": "assets/props/island_flower1.gsvx",
     "position": [
       160,
       0.5474000000000001,
@@ -322,7 +322,7 @@
   {
     "id": "flower_2",
     "name": "Flower",
-    "ply_file": "assets/props/island_flower1.ply",
+    "ply_file": "assets/props/island_flower1.gsvx",
     "position": [
       200,
       0.5152,
@@ -338,7 +338,7 @@
   {
     "id": "flower_3",
     "name": "Flower",
-    "ply_file": "assets/props/island_flower1.ply",
+    "ply_file": "assets/props/island_flower1.gsvx",
     "position": [
       180,
       0.6118,
@@ -354,7 +354,7 @@
   {
     "id": "flower_4",
     "name": "Flower",
-    "ply_file": "assets/props/island_flower1.ply",
+    "ply_file": "assets/props/island_flower1.gsvx",
     "position": [
       220,
       0.6118,
@@ -370,7 +370,7 @@
   {
     "id": "flower_5",
     "name": "Flower",
-    "ply_file": "assets/props/island_flower1.ply",
+    "ply_file": "assets/props/island_flower1.gsvx",
     "position": [
       140,
       0.3864,
@@ -386,7 +386,7 @@
   {
     "id": "flower_6",
     "name": "Flower",
-    "ply_file": "assets/props/island_flower1.ply",
+    "ply_file": "assets/props/island_flower1.gsvx",
     "position": [
       190,
       0.6118,
@@ -402,7 +402,7 @@
   {
     "id": "flower_7",
     "name": "Flower",
-    "ply_file": "assets/props/island_flower1.ply",
+    "ply_file": "assets/props/island_flower1.gsvx",
     "position": [
       170,
       0.5796,
@@ -418,7 +418,7 @@
   {
     "id": "flower_8",
     "name": "Flower",
-    "ply_file": "assets/props/island_flower1.ply",
+    "ply_file": "assets/props/island_flower1.gsvx",
     "position": [
       210,
       0.3542,
@@ -434,7 +434,7 @@
   {
     "id": "crystal_1",
     "name": "Crystal",
-    "ply_file": "assets/props/island_crystal1.ply",
+    "ply_file": "assets/props/island_crystal1.gsvx",
     "position": [
       155,
       0,
@@ -450,7 +450,7 @@
   {
     "id": "crystal_2",
     "name": "Crystal",
-    "ply_file": "assets/props/island_crystal1.ply",
+    "ply_file": "assets/props/island_crystal1.gsvx",
     "position": [
       225,
       0,
@@ -466,7 +466,7 @@
   {
     "id": "crystal_3",
     "name": "Crystal",
-    "ply_file": "assets/props/island_crystal1.ply",
+    "ply_file": "assets/props/island_crystal1.gsvx",
     "position": [
       175,
       0,
@@ -482,7 +482,7 @@
   {
     "id": "crystal_4",
     "name": "Crystal",
-    "ply_file": "assets/props/island_crystal1.ply",
+    "ply_file": "assets/props/island_crystal1.gsvx",
     "position": [
       195,
       0,

--- a/examples/island_demo/assets/scenes/camera_test.json
+++ b/examples/island_demo/assets/scenes/camera_test.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "gaussian_splat": {
-    "ply_file": "assets/maps/test_terrain.ply",
+    "ply_file": "assets/maps/test_terrain.gsvx",
     "camera": { "position": [32, 30, 80], "target": [32, 0, 32], "fov": 45 },
     "render_width": 320, "render_height": 240
   },

--- a/examples/island_demo/assets/scenes/dungeon.json
+++ b/examples/island_demo/assets/scenes/dungeon.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "gaussian_splat": {
-    "ply_file": "assets/maps/dungeon.ply",
+    "ply_file": "assets/maps/dungeon.gsvx",
     "camera": {
       "position": [
         25,
@@ -3564,7 +3564,7 @@
         0
       ],
       "scale": 0.5,
-      "ply_file": "assets/characters/slime/slime.ply",
+      "ply_file": "assets/characters/slime/slime.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/slime/slime.manifest.json",
@@ -3591,7 +3591,7 @@
         0
       ],
       "scale": 0.6,
-      "ply_file": "assets/characters/slime/slime.ply",
+      "ply_file": "assets/characters/slime/slime.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/slime/slime.manifest.json",
@@ -3618,7 +3618,7 @@
         0
       ],
       "scale": 0.4,
-      "ply_file": "assets/characters/slime/slime.ply",
+      "ply_file": "assets/characters/slime/slime.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/slime/slime.manifest.json",

--- a/examples/island_demo/assets/scenes/emissive_test.json
+++ b/examples/island_demo/assets/scenes/emissive_test.json
@@ -69,7 +69,7 @@
     }
   ],
   "gaussian_splat": {
-    "ply_file": "assets/maps/emissive_test.ply",
+    "ply_file": "assets/maps/emissive_test.gsvx",
     "camera": {
       "position": [
         32,

--- a/examples/island_demo/assets/scenes/island_demo.json
+++ b/examples/island_demo/assets/scenes/island_demo.json
@@ -87,7 +87,7 @@
         0
       ],
       "scale": 1.56,
-      "ply_file": "assets/props/island_tree_1.ply",
+      "ply_file": "assets/props/island_tree_1.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -115,7 +115,7 @@
         0
       ],
       "scale": 2.36,
-      "ply_file": "assets/props/island_tree_2.ply",
+      "ply_file": "assets/props/island_tree_2.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -143,7 +143,7 @@
         0
       ],
       "scale": 2.4,
-      "ply_file": "assets/props/island_tree_3.ply",
+      "ply_file": "assets/props/island_tree_3.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -171,7 +171,7 @@
         0
       ],
       "scale": 1.91,
-      "ply_file": "assets/props/island_tree_4.ply",
+      "ply_file": "assets/props/island_tree_4.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -199,7 +199,7 @@
         0
       ],
       "scale": 2.15,
-      "ply_file": "assets/props/island_tree_5.ply",
+      "ply_file": "assets/props/island_tree_5.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -227,7 +227,7 @@
         0
       ],
       "scale": 2.07,
-      "ply_file": "assets/props/island_tree_6.ply",
+      "ply_file": "assets/props/island_tree_6.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -255,7 +255,7 @@
         0
       ],
       "scale": 1.55,
-      "ply_file": "assets/props/island_tree_7.ply",
+      "ply_file": "assets/props/island_tree_7.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -283,7 +283,7 @@
         0
       ],
       "scale": 2.21,
-      "ply_file": "assets/props/island_tree_8.ply",
+      "ply_file": "assets/props/island_tree_8.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -311,7 +311,7 @@
         0
       ],
       "scale": 2.21,
-      "ply_file": "assets/props/island_tree_9.ply",
+      "ply_file": "assets/props/island_tree_9.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -339,7 +339,7 @@
         0
       ],
       "scale": 2.24,
-      "ply_file": "assets/props/island_tree_10.ply",
+      "ply_file": "assets/props/island_tree_10.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -367,7 +367,7 @@
         0
       ],
       "scale": 2,
-      "ply_file": "assets/props/island_tree_11.ply",
+      "ply_file": "assets/props/island_tree_11.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -395,7 +395,7 @@
         0
       ],
       "scale": 2.43,
-      "ply_file": "assets/props/island_tree_12.ply",
+      "ply_file": "assets/props/island_tree_12.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -423,7 +423,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/island_rock_1.ply",
+      "ply_file": "assets/props/island_rock_1.gsvx",
       "components": {}
     },
     {
@@ -440,7 +440,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/island_rock_2.ply",
+      "ply_file": "assets/props/island_rock_2.gsvx",
       "components": {}
     },
     {
@@ -457,7 +457,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/island_rock_3.ply",
+      "ply_file": "assets/props/island_rock_3.gsvx",
       "components": {}
     },
     {
@@ -474,7 +474,7 @@
         0
       ],
       "scale": 0.98,
-      "ply_file": "assets/props/island_rock_4.ply",
+      "ply_file": "assets/props/island_rock_4.gsvx",
       "components": {}
     },
     {
@@ -491,7 +491,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/island_rock_5.ply",
+      "ply_file": "assets/props/island_rock_5.gsvx",
       "components": {}
     },
     {
@@ -508,7 +508,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/island_rock_6.ply",
+      "ply_file": "assets/props/island_rock_6.gsvx",
       "components": {}
     },
     {
@@ -525,7 +525,7 @@
         0
       ],
       "scale": 0.8,
-      "ply_file": "assets/props/island_house.ply",
+      "ply_file": "assets/props/island_house.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 30
@@ -549,7 +549,7 @@
         0
       ],
       "scale": 0.65,
-      "ply_file": "assets/props/island_fountain.ply",
+      "ply_file": "assets/props/island_fountain.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 10
@@ -573,7 +573,7 @@
         0
       ],
       "scale": 0.8,
-      "ply_file": "assets/props/treasure_chest.ply",
+      "ply_file": "assets/props/treasure_chest.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 8,
@@ -601,7 +601,7 @@
         0
       ],
       "scale": 0.5,
-      "ply_file": "assets/props/glow_mushrooms.ply",
+      "ply_file": "assets/props/glow_mushrooms.gsvx",
       "components": {}
     },
     {
@@ -618,7 +618,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/props/lantern_post.ply",
+      "ply_file": "assets/props/lantern_post.gsvx",
       "components": {}
     },
     {
@@ -635,7 +635,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/props/lantern_post.ply",
+      "ply_file": "assets/props/lantern_post.gsvx",
       "components": {}
     },
     {
@@ -652,7 +652,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/props/lantern_post.ply",
+      "ply_file": "assets/props/lantern_post.gsvx",
       "components": {}
     },
     {
@@ -669,7 +669,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/props/lantern_post.ply",
+      "ply_file": "assets/props/lantern_post.gsvx",
       "components": {}
     },
     {
@@ -686,7 +686,7 @@
         0
       ],
       "scale": 0.1,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -703,7 +703,7 @@
         0
       ],
       "scale": 0.1,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -720,7 +720,7 @@
         0
       ],
       "scale": 0.11,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -737,7 +737,7 @@
         0
       ],
       "scale": 0.11,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -754,7 +754,7 @@
         0
       ],
       "scale": 0.07,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -771,7 +771,7 @@
         0
       ],
       "scale": 0.11,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -788,7 +788,7 @@
         0
       ],
       "scale": 0.11,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -805,7 +805,7 @@
         0
       ],
       "scale": 0.07,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -822,7 +822,7 @@
         0
       ],
       "scale": 1.28,
-      "ply_file": "assets/props/island_crystal1.ply",
+      "ply_file": "assets/props/island_crystal1.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 14
@@ -849,7 +849,7 @@
         0
       ],
       "scale": 1.63,
-      "ply_file": "assets/props/island_crystal1.ply",
+      "ply_file": "assets/props/island_crystal1.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 14
@@ -876,7 +876,7 @@
         0
       ],
       "scale": 1.36,
-      "ply_file": "assets/props/island_crystal1.ply",
+      "ply_file": "assets/props/island_crystal1.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 14
@@ -903,7 +903,7 @@
         0
       ],
       "scale": 1.53,
-      "ply_file": "assets/props/island_crystal1.ply",
+      "ply_file": "assets/props/island_crystal1.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 14
@@ -1276,7 +1276,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/characters/knight/knight.ply",
+      "ply_file": "assets/characters/knight/knight.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/knight/knight.manifest.json",
@@ -1303,7 +1303,7 @@
         0
       ],
       "scale": 0.5,
-      "ply_file": "assets/characters/slime/slime.ply",
+      "ply_file": "assets/characters/slime/slime.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/slime/slime.manifest.json",
@@ -1339,7 +1339,7 @@
         0
       ],
       "scale": 0.5,
-      "ply_file": "assets/characters/slime/slime.ply",
+      "ply_file": "assets/characters/slime/slime.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/slime/slime.manifest.json",
@@ -1375,7 +1375,7 @@
         0
       ],
       "scale": 0.5,
-      "ply_file": "assets/characters/slime/slime.ply",
+      "ply_file": "assets/characters/slime/slime.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/slime/slime.manifest.json",
@@ -1411,7 +1411,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/characters/snes_hero/snes_hero.ply",
+      "ply_file": "assets/characters/snes_hero/snes_hero.gsvx",
       "components": {
         "PlayerController": {
           "speed": 20,
@@ -1454,7 +1454,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_stone_wall.ply",
+      "ply_file": "assets/props/kcc_stone_wall.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1496,7 +1496,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_stone_wall.ply",
+      "ply_file": "assets/props/kcc_stone_wall.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1538,7 +1538,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_boulder_1_2.ply",
+      "ply_file": "assets/props/kcc_boulder_1_2.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1569,7 +1569,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_boulder_1_0.ply",
+      "ply_file": "assets/props/kcc_boulder_1_0.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1607,7 +1607,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_boulder_1_5.ply",
+      "ply_file": "assets/props/kcc_boulder_1_5.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1645,7 +1645,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_stone_pillar.ply",
+      "ply_file": "assets/props/kcc_stone_pillar.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1684,7 +1684,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_stone_pillar.ply",
+      "ply_file": "assets/props/kcc_stone_pillar.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1723,7 +1723,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_stone_ramp.ply",
+      "ply_file": "assets/props/kcc_stone_ramp.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1934,7 +1934,7 @@
     ]
   },
   "gaussian_splat": {
-    "ply_file": "assets/maps/seurat_island.ply",
+    "ply_file": "assets/maps/seurat_island.gsvx",
     "camera": {
       "position": [
         192,

--- a/examples/island_demo/assets/scenes/northern_forest.json
+++ b/examples/island_demo/assets/scenes/northern_forest.json
@@ -149,7 +149,7 @@
           "speed": 1.5
         }
       },
-      "ply_file": "assets/characters/deer/deer.ply"
+      "ply_file": "assets/characters/deer/deer.gsvx"
     },
     {
       "id": "forest_deer_2",
@@ -171,7 +171,7 @@
           "speed": 1.5
         }
       },
-      "ply_file": "assets/characters/deer/deer.ply"
+      "ply_file": "assets/characters/deer/deer.gsvx"
     },
     {
       "id": "forest_wolf",
@@ -193,7 +193,7 @@
           "speed": 1.5
         }
       },
-      "ply_file": "assets/characters/wolf/wolf.ply"
+      "ply_file": "assets/characters/wolf/wolf.gsvx"
     },
     {
       "id": "forest_mushroom_1",
@@ -221,7 +221,7 @@
           "effect_radius": 6
         }
       },
-      "ply_file": "assets/props/glow_mushrooms.ply"
+      "ply_file": "assets/props/glow_mushrooms.gsvx"
     },
     {
       "id": "forest_mushroom_2",
@@ -249,7 +249,7 @@
           "effect_radius": 6
         }
       },
-      "ply_file": "assets/props/glow_mushrooms.ply"
+      "ply_file": "assets/props/glow_mushrooms.gsvx"
     },
     {
       "id": "forest_mushroom_3",
@@ -277,7 +277,7 @@
           "effect_radius": 6
         }
       },
-      "ply_file": "assets/props/glow_mushrooms.ply"
+      "ply_file": "assets/props/glow_mushrooms.gsvx"
     },
     {
       "id": "forest_mushroom_4",
@@ -305,7 +305,7 @@
           "effect_radius": 6
         }
       },
-      "ply_file": "assets/props/glow_mushrooms.ply"
+      "ply_file": "assets/props/glow_mushrooms.gsvx"
     },
     {
       "id": "forest_guardian",
@@ -321,7 +321,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/characters/warm_robot/warm_robot.ply",
+      "ply_file": "assets/characters/warm_robot/warm_robot.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/warm_robot/warm_robot.manifest.json",
@@ -348,7 +348,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/characters/knight/knight.ply",
+      "ply_file": "assets/characters/knight/knight.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/knight/knight.manifest.json",
@@ -375,7 +375,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/firefly.ply",
+      "ply_file": "assets/props/firefly.gsvx",
       "components": {
         "EmissiveToggle": {
           "emission_base": 5.0,
@@ -398,7 +398,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/firefly.ply",
+      "ply_file": "assets/props/firefly.gsvx",
       "components": {
         "EmissiveToggle": {
           "emission_base": 5.0,
@@ -421,7 +421,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/firefly.ply",
+      "ply_file": "assets/props/firefly.gsvx",
       "components": {
         "EmissiveToggle": {
           "emission_base": 5.0,
@@ -444,7 +444,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/firefly.ply",
+      "ply_file": "assets/props/firefly.gsvx",
       "components": {
         "EmissiveToggle": {
           "emission_base": 5.0,
@@ -467,7 +467,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/firefly.ply",
+      "ply_file": "assets/props/firefly.gsvx",
       "components": {
         "EmissiveToggle": {
           "emission_base": 5.0,
@@ -637,7 +637,7 @@
     ]
   },
   "gaussian_splat": {
-    "ply_file": "assets/maps/northern_forest.ply",
+    "ply_file": "assets/maps/northern_forest.gsvx",
     "camera": {
       "position": [
         192,

--- a/examples/island_demo/assets/scenes/seurat_island.json
+++ b/examples/island_demo/assets/scenes/seurat_island.json
@@ -87,7 +87,7 @@
         0
       ],
       "scale": 1.56,
-      "ply_file": "assets/props/island_tree_1.ply",
+      "ply_file": "assets/props/island_tree_1.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -115,7 +115,7 @@
         0
       ],
       "scale": 2.36,
-      "ply_file": "assets/props/island_tree_2.ply",
+      "ply_file": "assets/props/island_tree_2.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -143,7 +143,7 @@
         0
       ],
       "scale": 2.4,
-      "ply_file": "assets/props/island_tree_3.ply",
+      "ply_file": "assets/props/island_tree_3.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -171,7 +171,7 @@
         0
       ],
       "scale": 1.91,
-      "ply_file": "assets/props/island_tree_4.ply",
+      "ply_file": "assets/props/island_tree_4.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -199,7 +199,7 @@
         0
       ],
       "scale": 2.15,
-      "ply_file": "assets/props/island_tree_5.ply",
+      "ply_file": "assets/props/island_tree_5.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -227,7 +227,7 @@
         0
       ],
       "scale": 2.07,
-      "ply_file": "assets/props/island_tree_6.ply",
+      "ply_file": "assets/props/island_tree_6.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -255,7 +255,7 @@
         0
       ],
       "scale": 1.55,
-      "ply_file": "assets/props/island_tree_7.ply",
+      "ply_file": "assets/props/island_tree_7.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -283,7 +283,7 @@
         0
       ],
       "scale": 2.21,
-      "ply_file": "assets/props/island_tree_8.ply",
+      "ply_file": "assets/props/island_tree_8.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -311,7 +311,7 @@
         0
       ],
       "scale": 2.21,
-      "ply_file": "assets/props/island_tree_9.ply",
+      "ply_file": "assets/props/island_tree_9.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -339,7 +339,7 @@
         0
       ],
       "scale": 2.24,
-      "ply_file": "assets/props/island_tree_10.ply",
+      "ply_file": "assets/props/island_tree_10.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -367,7 +367,7 @@
         0
       ],
       "scale": 2,
-      "ply_file": "assets/props/island_tree_11.ply",
+      "ply_file": "assets/props/island_tree_11.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -395,7 +395,7 @@
         0
       ],
       "scale": 2.43,
-      "ply_file": "assets/props/island_tree_12.ply",
+      "ply_file": "assets/props/island_tree_12.gsvx",
       "pbd": {
         "mode": "wind_sway",
         "sway_threshold": 0.7,
@@ -423,7 +423,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/island_rock_1.ply",
+      "ply_file": "assets/props/island_rock_1.gsvx",
       "components": {}
     },
     {
@@ -440,7 +440,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/island_rock_2.ply",
+      "ply_file": "assets/props/island_rock_2.gsvx",
       "components": {}
     },
     {
@@ -457,7 +457,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/island_rock_3.ply",
+      "ply_file": "assets/props/island_rock_3.gsvx",
       "components": {}
     },
     {
@@ -474,7 +474,7 @@
         0
       ],
       "scale": 0.98,
-      "ply_file": "assets/props/island_rock_4.ply",
+      "ply_file": "assets/props/island_rock_4.gsvx",
       "components": {}
     },
     {
@@ -491,7 +491,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/island_rock_5.ply",
+      "ply_file": "assets/props/island_rock_5.gsvx",
       "components": {}
     },
     {
@@ -508,7 +508,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/island_rock_6.ply",
+      "ply_file": "assets/props/island_rock_6.gsvx",
       "components": {}
     },
     {
@@ -525,7 +525,7 @@
         0
       ],
       "scale": 0.8,
-      "ply_file": "assets/props/island_house.ply",
+      "ply_file": "assets/props/island_house.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 30
@@ -549,7 +549,7 @@
         0
       ],
       "scale": 0.65,
-      "ply_file": "assets/props/island_fountain.ply",
+      "ply_file": "assets/props/island_fountain.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 10
@@ -573,7 +573,7 @@
         0
       ],
       "scale": 0.8,
-      "ply_file": "assets/props/treasure_chest.ply",
+      "ply_file": "assets/props/treasure_chest.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 8,
@@ -601,7 +601,7 @@
         0
       ],
       "scale": 0.5,
-      "ply_file": "assets/props/glow_mushrooms.ply",
+      "ply_file": "assets/props/glow_mushrooms.gsvx",
       "components": {}
     },
     {
@@ -618,7 +618,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/props/lantern_post.ply",
+      "ply_file": "assets/props/lantern_post.gsvx",
       "components": {}
     },
     {
@@ -635,7 +635,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/props/lantern_post.ply",
+      "ply_file": "assets/props/lantern_post.gsvx",
       "components": {}
     },
     {
@@ -652,7 +652,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/props/lantern_post.ply",
+      "ply_file": "assets/props/lantern_post.gsvx",
       "components": {}
     },
     {
@@ -669,7 +669,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/props/lantern_post.ply",
+      "ply_file": "assets/props/lantern_post.gsvx",
       "components": {}
     },
     {
@@ -686,7 +686,7 @@
         0
       ],
       "scale": 0.1,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -703,7 +703,7 @@
         0
       ],
       "scale": 0.1,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -720,7 +720,7 @@
         0
       ],
       "scale": 0.11,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -737,7 +737,7 @@
         0
       ],
       "scale": 0.11,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -754,7 +754,7 @@
         0
       ],
       "scale": 0.07,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -771,7 +771,7 @@
         0
       ],
       "scale": 0.11,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -788,7 +788,7 @@
         0
       ],
       "scale": 0.11,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -805,7 +805,7 @@
         0
       ],
       "scale": 0.07,
-      "ply_file": "assets/props/island_flower1.ply",
+      "ply_file": "assets/props/island_flower1.gsvx",
       "components": {}
     },
     {
@@ -822,7 +822,7 @@
         0
       ],
       "scale": 1.28,
-      "ply_file": "assets/props/island_crystal1.ply",
+      "ply_file": "assets/props/island_crystal1.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 14
@@ -849,7 +849,7 @@
         0
       ],
       "scale": 1.63,
-      "ply_file": "assets/props/island_crystal1.ply",
+      "ply_file": "assets/props/island_crystal1.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 14
@@ -876,7 +876,7 @@
         0
       ],
       "scale": 1.36,
-      "ply_file": "assets/props/island_crystal1.ply",
+      "ply_file": "assets/props/island_crystal1.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 14
@@ -903,7 +903,7 @@
         0
       ],
       "scale": 1.53,
-      "ply_file": "assets/props/island_crystal1.ply",
+      "ply_file": "assets/props/island_crystal1.gsvx",
       "components": {
         "ProximityTrigger": {
           "radius": 14
@@ -1276,7 +1276,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/characters/knight/knight.ply",
+      "ply_file": "assets/characters/knight/knight.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/knight/knight.manifest.json",
@@ -1303,7 +1303,7 @@
         0
       ],
       "scale": 0.5,
-      "ply_file": "assets/characters/slime/slime.ply",
+      "ply_file": "assets/characters/slime/slime.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/slime/slime.manifest.json",
@@ -1339,7 +1339,7 @@
         0
       ],
       "scale": 0.5,
-      "ply_file": "assets/characters/slime/slime.ply",
+      "ply_file": "assets/characters/slime/slime.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/slime/slime.manifest.json",
@@ -1375,7 +1375,7 @@
         0
       ],
       "scale": 0.5,
-      "ply_file": "assets/characters/slime/slime.ply",
+      "ply_file": "assets/characters/slime/slime.gsvx",
       "components": {
         "BoneAnimated": {
           "manifest": "assets/characters/slime/slime.manifest.json",
@@ -1411,7 +1411,7 @@
         0
       ],
       "scale": 0.45,
-      "ply_file": "assets/characters/snes_hero/snes_hero.ply",
+      "ply_file": "assets/characters/snes_hero/snes_hero.gsvx",
       "components": {
         "PlayerController": {
           "speed": 20,
@@ -1454,7 +1454,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_stone_wall.ply",
+      "ply_file": "assets/props/kcc_stone_wall.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1496,7 +1496,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_stone_wall.ply",
+      "ply_file": "assets/props/kcc_stone_wall.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1538,7 +1538,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_boulder_1_2.ply",
+      "ply_file": "assets/props/kcc_boulder_1_2.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1569,7 +1569,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_boulder_1_0.ply",
+      "ply_file": "assets/props/kcc_boulder_1_0.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1607,7 +1607,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_boulder_1_5.ply",
+      "ply_file": "assets/props/kcc_boulder_1_5.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1645,7 +1645,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_stone_pillar.ply",
+      "ply_file": "assets/props/kcc_stone_pillar.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1684,7 +1684,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_stone_pillar.ply",
+      "ply_file": "assets/props/kcc_stone_pillar.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1723,7 +1723,7 @@
         0
       ],
       "scale": 1,
-      "ply_file": "assets/props/kcc_stone_ramp.ply",
+      "ply_file": "assets/props/kcc_stone_ramp.gsvx",
       "components": {
         "ColliderComponent": {
           "shape": {
@@ -1934,7 +1934,7 @@
     ]
   },
   "gaussian_splat": {
-    "ply_file": "assets/maps/seurat_island.ply",
+    "ply_file": "assets/maps/seurat_island.gsvx",
     "camera": {
       "position": [
         192,

--- a/examples/island_demo/assets/scenes/test_bricklayer.json
+++ b/examples/island_demo/assets/scenes/test_bricklayer.json
@@ -147,7 +147,7 @@
     ]
   },
   "gaussian_splat": {
-    "ply_file": "assets/maps/test_bricklayer.ply",
+    "ply_file": "assets/maps/test_bricklayer.gsvx",
     "camera": {
       "position": [
         128,

--- a/examples/island_demo/assets/scenes/test_scene.json
+++ b/examples/island_demo/assets/scenes/test_scene.json
@@ -21,7 +21,7 @@
     "facing": "down"
   },
   "gaussian_splat": {
-    "ply_file": "maps/map.ply",
+    "ply_file": "maps/map.gsvx",
     "camera": {
       "position": [
         0,

--- a/examples/island_demo/assets/vfx/presets/torch_1.vfx.json
+++ b/examples/island_demo/assets/vfx/presets/torch_1.vfx.json
@@ -10,7 +10,7 @@
         -10
       ],
       "duration": 0,
-      "ply_file": "scene/torch.ply",
+      "ply_file": "scene/torch.gsvx",
       "scale": 10
     },
     {

--- a/examples/island_demo/assets/vfx/presets/torch_2.vfx.json
+++ b/examples/island_demo/assets/vfx/presets/torch_2.vfx.json
@@ -10,7 +10,7 @@
         -10
       ],
       "duration": 0,
-      "ply_file": "scene/torch.ply",
+      "ply_file": "scene/torch.gsvx",
       "scale": 10
     },
     {

--- a/examples/island_demo/assets/vfx/presets/torch_3.vfx.json
+++ b/examples/island_demo/assets/vfx/presets/torch_3.vfx.json
@@ -10,7 +10,7 @@
         -10
       ],
       "duration": 0,
-      "ply_file": "scene/torch.ply",
+      "ply_file": "scene/torch.gsvx",
       "scale": 10
     },
     {

--- a/examples/island_demo/assets/vfx/presets/torch_4.vfx.json
+++ b/examples/island_demo/assets/vfx/presets/torch_4.vfx.json
@@ -10,7 +10,7 @@
         -10
       ],
       "duration": 0,
-      "ply_file": "scene/torch.ply",
+      "ply_file": "scene/torch.gsvx",
       "scale": 10
     },
     {

--- a/examples/island_demo/assets/vfx/torch.vfx.json
+++ b/examples/island_demo/assets/vfx/torch.vfx.json
@@ -10,7 +10,7 @@
         -10
       ],
       "duration": 0,
-      "ply_file": "scene/torch.ply",
+      "ply_file": "scene/torch.gsvx",
       "scale": 10
     },
     {


### PR DESCRIPTION
## Summary

Second of three PRs that close out #396 ("no runtime PLY parser link in the engine"). Following PR-B1 (#455) which committed `.gsvx` siblings for every `.ply`, this PR retargets every engine-consumed JSON path string from the `.ply` source to the `.gsvx` artifact.

After this lands, the runtime engine's `load_with_gsvx_first` path resolves directly to the baked file — the PLY-fallback branch becomes unreachable on the demo path. PR-B3 will then delete `GaussianCloud::load_ply()` + the PLY parser namespace and rename `load_with_gsvx_first` → `load_gsvx`.

## What changed

**167 path-value strings across 18 JSON files:**
- 4 character `manifest.json` files (knight, slime, snes_hero, warm_robot)
- 1 `props/island_manifest.json` (31 path values)
- 9 scenes: `island_demo.json`, `seurat_island.json`, `northern_forest.json`, `dungeon.json`, `emissive_test.json`, `camera_test.json`, `test_bricklayer.json`, `test_scene.json`, and `tavern.json` was unchanged
- 5 VFX presets: `torch.vfx.json` + 4 `torch_N.vfx.json`

JSON keys remain `"ply_file"` per the design spec — renaming cascades through Bricklayer schemas, TS types, and bridge protocol. Tracked as separate tech debt.

## Explicitly out of scope (per `docs/superpowers/specs/2026-05-16-396-prb-no-runtime-ply-parser-design.md`)

- **`examples/island_demo/assets/gsvx_sync_manifest.json`** — its `.ply` strings are object keys keyed by source path, not paths-to-load. Untouched.
- **`examples/island_demo/tools_data/bricklayer/*.bricklayer`** — Bricklayer (TS scene editor) keeps loading `.ply` for viewport preview because `.ply` still exists. `validate_bricklayer_sync.py` only compares entity counts, not paths, so engine JSON pointing at `.gsvx` while `.bricklayer` points at `.ply` is intentionally fine. Untouched.
- **Engine code** — zero `src/`, `include/`, or `tests/` changes.

## Verification done locally

- [x] `python3 scripts/validate_gsvx_in_sync.py` — `OK (56 .ply files in sync)`
- [x] `python3 scripts/validate_bricklayer_sync.py` — `All bricklayer files in sync.`
- [x] All 57 JSON files under `examples/island_demo/assets/` re-parse cleanly (json.loads on each)
- [x] `grep -rE '"ply_file"\s*:\s*"[^"]+\.ply"' examples/island_demo/assets` — 0 matches
- [x] Diff is perfectly line-for-line: 18 files, 167 insertions, 167 deletions

## Test plan

- [ ] CI build/check matrix passes on Linux / macOS / Windows
- [ ] CI `Validate (Demo Data)` job passes (both bricklayer-sync and gsvx-in-sync)
- [ ] **Manual runtime smoke (please verify locally):** build the demo, launch it; island scene must render pixel-identical to PR-B1's HEAD. `load_with_gsvx_first` now resolves directly because the JSON path already says `.gsvx`; the PLY-fallback branch should never fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
