### PR TITLE
docs(refactor): 2026-05-17 phase-status audit — phases 2/3 done, 4/5 residual

### DIFF
--- a/docs/superpowers/plans/2026-05-02-engine-refactor-phase1-plan.md
+++ b/docs/superpowers/plans/2026-05-02-engine-refactor-phase1-plan.md
@@ -12,6 +12,23 @@
 
 ---
 
+## Status update (2026-05-17)
+
+Audited against `main` at `9a7ede5f`. The strict-serial 17-PR cadence below did not survive contact with reality — most of the refactor landed organically alongside other work. PR-level task breakdowns in §Phase 1–5 are preserved as historical record; current status is tracked in the matrix below and in the spec doc's matching "Status update" section.
+
+| Phase | Status | Open work |
+|---|---|---|
+| 0 | ✅ DONE (#390, #391) | — |
+| 1 | ✅ DONE (closed via #455–458 on 2026-05-16) | — |
+| 2 | ✅ DONE | Legacy non-GS draw labels skipped on purpose (Phase 5e deletion candidates) |
+| 3 | ✅ DONE | — |
+| 4 | ⚠️ MOSTLY DONE | `VfxWriter` / `PbdWriter` / `ParticlesWriter` / `PointLightsWriter` declared but unused. Wire them so ECS systems push render data into `RenderState` instead of the renderer pulling from AppBase. Only `BonesWriter` has a caller today. |
+| 5 | ⚠️ MOSTLY DONE | `gs_renderer.cpp` is 2388 LOC (was 3919). `GsRenderer::render()` at line 1733+ still holds orchestration logic — not yet ~80 LOC. Phase 5e final extraction outstanding; blocked on Phase 4 writer wiring landing first. |
+
+**Next:** Close the Phase 4 writer gap (small, focused PRs per writer), then Phase 5e.
+
+---
+
 ## How to use this plan
 
 This plan covers 17 PRs across 5 phases plus pre-flight Phase 0. **Strict serial execution** — each PR merges green before the next begins. Per-phase detail level:

--- a/docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md
+++ b/docs/superpowers/specs/2026-05-02-engine-refactor-phase1-design.md
@@ -9,6 +9,23 @@
 
 ---
 
+## Status update (2026-05-17)
+
+Audited against `main` at `9a7ede5f`. The design below was authored 2026-05-02 with a strict-serial 17-PR cadence (§6 rollout table). In practice, most of the refactor landed organically alongside other work rather than in the planned `refactor/N{a,b,c}-*` branches. The architectural body of this design remains the source of truth; this section is the live status pointer.
+
+| Phase | Theme | Status | Notes |
+|---|---|---|---|
+| 0 | Pre-flight (`gs::dbg::`, golden-frame harness) | ✅ DONE | #390 (0a), #391 (0b). |
+| 1 | Deletion | ✅ DONE | All targets purged: `load_cloud_legacy`, `gs_chunk_grid_`, `update_static_gaussians`, `ensure_capacity` legacy, `render_pipeline_` (1c fired). PLY parser severed from `gseurat_core` via PRs #455–458 (2026-05-16). |
+| 2 | Instrumentation | ✅ DONE | 19 `GS_LABEL` sites with two-level hierarchy. 5 `GS_DBG_INVARIANT` sites. `GS_DIAG_STREAMING` migrated to `gs::dbg::Diag::StreamingState`. Legacy non-GS draws (`renderer.cpp` wireframe, `post_process.cpp` bloom) deliberately uninstrumented — Phase 5e deletion candidates. |
+| 3 | Infrastructure | ✅ DONE | `ecs/events.hpp` (228 LOC) uses a generation/epoch cursor model (more robust than the doc's `last_read_per_buffer[k]` sketch in §5.3). `World::events<T>()` type-erased registry. `RenderState` with all 5 typed writers (`BonesWriter`, `VfxWriter`, `PbdWriter`, `ParticlesWriter`, `PointLightsWriter`). Event types split into dedicated headers (`vfx_events.hpp`, `pbd_events.hpp`, `light_events.hpp`). |
+| 4 | Caller migration | ⚠️ MOSTLY DONE — residual gap | Events fully wired: `VfxSpawnEvent` (CommandDispatcher → VfxSystem), `PbdElementsLoadedEvent` (scene loader → PbdSystem), `PointLightsLoadedEvent` (scene loader + dev panels + CommandDispatcher → LightingSystem). State ownership migrated: `gs_animator_` + `vfx_instances_` now live inside `systems/vfx_system.cpp`; `gs_particle_emitters_` inside `ParticleSystem`. **Open gap:** `VfxWriter`/`PbdWriter`/`ParticlesWriter`/`PointLightsWriter` are declared but have ZERO callers. Only `BonesWriter` is used (single site at `gs_demo_state.cpp:835`). Renderer still pulls these payloads from AppBase rather than reading them from `RenderState`. |
+| 5 | Renderer system extraction | ⚠️ MOSTLY DONE — residual gap | All five subsystems exist per §5.5: `gs_resources`, `gs_post_process_system`, `gs_sort_system`, `gs_tile_bin_system`, `gs_streaming_system`. `gs_renderer.cpp` shrunk **3919 → 2388 LOC (~39%)**. **Open gap:** `GsRenderer::render()` (line 1733+) still contains orchestration logic and direct GPU dispatch — not yet the ~80-LOC orchestrator described in §5.1. Phase 5e final extraction outstanding. |
+
+**Next target:** Wire the four unused `RenderState` writers (close Phase 4), then attack Phase 5e (`render()` orchestrator). The two are coupled — `render()` can only become a pure orchestrator once data flows through `RenderState` rather than AppBase reach-throughs.
+
+---
+
 ## 1. Context & Motivation
 
 The streaming-strict ghost-debugging saga (PRs #385–#388) eliminated four ghost-rendering bugs over two weeks of intense investigation. The root causes were not individual bugs but **structural**:


### PR DESCRIPTION
## Summary

Audit of `main` at `9a7ede5f` against the engine-refactor design/plan docs (authored 2026-05-02) revealed the planned `refactor/N{a,b,c}-*` PR cadence didn't survive contact with reality — most of the refactor landed organically through other work. The docs still described phases 2–5 as pending; they aren't.

This PR adds a `Status update (2026-05-17)` section near the top of each doc so the next contributor doesn't waste audit time:

- **Phase 0** — DONE (#390, #391)
- **Phase 1** — DONE (PRs #455–#458 closed 2026-05-16)
- **Phase 2 (Instrumentation)** — DONE: 19 `GS_LABEL`, 5 `GS_DBG_INVARIANT`, `GS_DIAG_STREAMING` → `gs::dbg::Diag::StreamingState`. Legacy non-GS draws deliberately uninstrumented (Phase 5e deletion candidates).
- **Phase 3 (Infrastructure)** — DONE: `EventQueue<T>` with generation/epoch cursor model, all 5 `RenderState` writers declared, event types split into dedicated headers.
- **Phase 4 (Caller migration)** — MOSTLY DONE: events fully wired, state ownership migrated to ECS systems, but **`VfxWriter`/`PbdWriter`/`ParticlesWriter`/`PointLightsWriter` have zero callers**. Only `BonesWriter` is used. Renderer still pulls from AppBase.
- **Phase 5 (System extraction)** — MOSTLY DONE: all 5 subsystems exist, `gs_renderer.cpp` is 2388 LOC (was 3919), but `GsRenderer::render()` (line 1733+) still has orchestration logic — not the ~80-LOC orchestrator from §5.1.

Architectural body of both docs preserved as historical record.

## Test plan
- [x] Diff scoped to two docs only, +34/−0 lines
- [x] No code changes
- [x] Builds + tests are no-ops (markdown-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)