### PR TITLE
refactor(engine): close phase 4 — delete PointLightsWriter + wire RenderState lifecycle

### DIFF
--- a/include/gseurat/engine/render_state.hpp
+++ b/include/gseurat/engine/render_state.hpp
@@ -121,10 +121,15 @@ private:
 };
 
 using BonesWriter = TypedSlotWriter<glm::mat4>;
-using PointLightsWriter = TypedSlotWriter<PointLight>;
 using VfxWriter = BytesSlotWriter;
 using PbdWriter = BytesSlotWriter;
 using ParticlesWriter = BytesSlotWriter;
+
+// Phase 4 closure (2026-05-17): PointLightsWriter / point_lights_buffer /
+// max_point_lights were dead architecture — no shader bound the SSBO.
+// Point lights live in the uniform buffer (kMaxGsPointLights=8 inline
+// vec4 arrays in GsRenderer's UBO). LightingSystem keeps its
+// set_point_lights → UBO path.
 
 // Defaults match the spec's working-set estimate (~12 MB for VFX splats,
 // per frame in flight, doubled). Phase 4 may tune per-app needs.
@@ -133,7 +138,6 @@ struct RenderStateConfig {
     uint32_t max_vfx_splats = 200'000;
     uint32_t max_pbd_splats = 50'000;
     uint32_t max_particles = 8'192;
-    uint32_t max_point_lights = kMaxLights;
     std::size_t splat_stride = 64;  // matches current Gaussian/GSVX layout
 };
 
@@ -152,20 +156,22 @@ public:
     VfxWriter vfx_writer(FrameIndex) noexcept;
     PbdWriter pbd_writer(FrameIndex) noexcept;
     ParticlesWriter particles_writer(FrameIndex) noexcept;
-    PointLightsWriter point_lights_writer(FrameIndex) noexcept;
 
     // === Renderer-side read access — const, called from GsRenderer::render() ===
     VkBuffer bones_buffer(FrameIndex) const noexcept;
     VkBuffer vfx_buffer(FrameIndex) const noexcept;
     VkBuffer pbd_buffer(FrameIndex) const noexcept;
     VkBuffer particles_buffer(FrameIndex) const noexcept;
-    VkBuffer point_lights_buffer(FrameIndex) const noexcept;
 
     // === Lifecycle ===
-    // begin_frame: resets dirty ranges for the given frame slot.
-    // end_frame:   on non-coherent memory, would issue
-    //              vkFlushMappedMemoryRanges over the dirty regions. On
-    //              Apple Silicon's unified memory it's a no-op.
+    // begin_frame: resets dirty ranges for the given frame slot. Call at
+    //              the start of each per-frame work block, BEFORE any
+    //              writer.write() targeting this frame.
+    // end_frame:   on non-coherent memory, issues vkFlushMappedMemoryRanges
+    //              over the dirty regions so the GPU sees the writes.
+    //              On Apple Silicon's unified memory (HOST_COHERENT) it's
+    //              a no-op. Call AFTER all writer.write() and BEFORE any
+    //              GPU dispatch / submit that reads these buffers.
     void begin_frame(FrameIndex) noexcept;
     void end_frame(FrameIndex) noexcept;
 
@@ -177,12 +183,10 @@ private:
         Buffer vfx;
         Buffer pbd;
         Buffer particles;
-        Buffer point_lights;
         DirtyRange bones_dirty;
         DirtyRange vfx_dirty;
         DirtyRange pbd_dirty;
         DirtyRange particles_dirty;
-        DirtyRange lights_dirty;
     };
 
     VkContext& ctx_;

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -36,6 +36,7 @@ struct GLFWwindow;
 namespace gseurat {
 
 class ResourceManager;
+class RenderState;
 namespace systems { class VfxSystem; class PbdSystem; class LightingSystem; class ParticleSystem; }
 
 // Small constant-size summary of the loaded GS cloud. Replaces the demo-side
@@ -196,6 +197,15 @@ public:
     void set_particle_system(systems::ParticleSystem* ps) noexcept {
         particle_system_ = ps;
     }
+
+    // Phase 4 closure: lifecycle hook for RenderState. Renderer brackets
+    // each frame's draw_scene with begin_frame / end_frame so writer
+    // dirty ranges reset cleanly between frames and so non-coherent
+    // memory platforms get the required vkFlushMappedMemoryRanges
+    // BEFORE vkQueueSubmit. Pointer is non-owning; AppBase owns the
+    // RenderState. Null-safe: pre-init / standalone-test paths skip
+    // the lifecycle calls when this pointer hasn't been wired.
+    void set_render_state(RenderState* rs) noexcept { render_state_ = rs; }
 
     // Scene-placed animations (with loop support)
     struct ReformConfig {
@@ -395,6 +405,12 @@ private:
     systems::PbdSystem* pbd_system_ = nullptr;
     systems::LightingSystem* lighting_system_ = nullptr;
     systems::ParticleSystem* particle_system_ = nullptr;
+
+    // Phase 4 closure: non-owning pointer to AppBase-owned RenderState.
+    // Used to bracket draw_scene with begin_frame / end_frame so
+    // writer dirty ranges reset per frame and non-coherent memory
+    // platforms get vkFlushMappedMemoryRanges before vkQueueSubmit.
+    RenderState* render_state_ = nullptr;
 
     // ── Frame-determinism harness internal state ──
     struct DeterminismTestState {

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -207,6 +207,16 @@ public:
     // the lifecycle calls when this pointer hasn't been wired.
     void set_render_state(RenderState* rs) noexcept { render_state_ = rs; }
 
+    // Phase 4 closure (Codex P1 #2 on #460): wait for the current
+    // frame slot's in-flight fence. Public so AppBase can wait BEFORE
+    // opening the RenderState lifecycle bracket — otherwise writers
+    // (upload_bone_transforms, state-tick bones writes) would race
+    // against the previous GPU submit on the same slot. draw_scene
+    // still issues its own wait as a fallback for paths without
+    // RenderState wired (standalone tests); when AppBase has already
+    // waited, draw_scene's wait is a fast no-op on a signaled fence.
+    void wait_current_frame_fence() noexcept;
+
     // Scene-placed animations (with loop support)
     struct ReformConfig {
         float lifetime = 2.0f;

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -623,6 +623,10 @@ void AppBase::init_render_state() {
 
     render_state_ = std::make_unique<RenderState>(renderer_.context());
     renderer_.gs_renderer().set_render_state(render_state_.get());
+    // Phase 4 closure: Renderer drives RenderState::begin_frame /
+    // end_frame around draw_scene so writer dirty ranges reset cleanly
+    // and non-coherent-memory platforms see writes before submit.
+    renderer_.set_render_state(render_state_.get());
     // Late-bind RenderState into VfxSystem + PbdSystem if they were
     // constructed first (init_game_object_system runs before
     // init_render_state in the canonical AppBase init order).

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -281,6 +281,21 @@ void AppBase::main_loop() {
             (void)remaining;
         }
 
+        // Phase 4 closure: open the RenderState lifecycle bracket BEFORE any
+        // writer for this frame can mark dirty ranges. upload_bone_transforms
+        // (below) and state-tick callers of bones_writer/vfx_writer/pbd_writer
+        // /particles_writer all run later in this iteration; record_gs_prepass
+        // writes are bracketed too. end_frame() runs inside Renderer::draw_scene
+        // immediately before vkQueueSubmit so non-coherent memory platforms
+        // see the flushed writes. Null-safe for pre-init / tests.
+        // (Fix for PR #460 Codex P1: previous placement was inside
+        // GSEURAT_DEBUG_BUILD-gated code AFTER bones writers had already
+        // marked dirty ranges, defeating the lifecycle in release builds
+        // and on non-coherent memory.)
+        if (render_state_) {
+            render_state_->begin_frame(FrameIndex{renderer_.current_frame()});
+        }
+
         // Poll async loader and process GPU uploads (before game logic)
         resources_.process_async_results(async_loader_, staging_uploader_);
         staging_uploader_.flush();

--- a/src/engine/app_base.cpp
+++ b/src/engine/app_base.cpp
@@ -288,11 +288,21 @@ void AppBase::main_loop() {
         // writes are bracketed too. end_frame() runs inside Renderer::draw_scene
         // immediately before vkQueueSubmit so non-coherent memory platforms
         // see the flushed writes. Null-safe for pre-init / tests.
-        // (Fix for PR #460 Codex P1: previous placement was inside
-        // GSEURAT_DEBUG_BUILD-gated code AFTER bones writers had already
-        // marked dirty ranges, defeating the lifecycle in release builds
-        // and on non-coherent memory.)
+        //
+        // wait_current_frame_fence() runs FIRST so the previous GPU submit on
+        // this same slot is complete before any CPU writer touches the mapped
+        // buffers. Without this wait, bones / vfx / pbd / particles writes
+        // here would race against an in-flight GPU read from
+        // kMaxFramesInFlight submits ago. draw_scene also waits the fence
+        // internally as a fallback for paths without RenderState wired
+        // (standalone tests); when we wait here, that becomes a fast no-op.
+        //
+        // (Fix history: Codex P1 #1 on #460 — original placement was inside
+        // GSEURAT_DEBUG_BUILD-gated code AFTER bones writers fired. Codex P1
+        // #2 on #460 — moved to top-of-iteration but without the fence wait,
+        // so writes raced with GPU. This placement addresses both.)
         if (render_state_) {
+            renderer_.wait_current_frame_fence();
             render_state_->begin_frame(FrameIndex{renderer_.current_frame()});
         }
 

--- a/src/engine/render_state.cpp
+++ b/src/engine/render_state.cpp
@@ -35,15 +35,12 @@ RenderState::RenderState(VkContext& ctx, const RenderStateConfig& cfg)
         static_cast<VkDeviceSize>(cfg_.max_pbd_splats) * cfg_.splat_stride;
     const VkDeviceSize part_bytes =
         static_cast<VkDeviceSize>(cfg_.max_particles) * cfg_.splat_stride;
-    const VkDeviceSize light_bytes =
-        static_cast<VkDeviceSize>(cfg_.max_point_lights) * sizeof(PointLight);
 
     for (auto& f : per_frame_) {
         f.bones = Buffer::create_storage(alloc, bones_bytes);
         f.vfx = Buffer::create_storage(alloc, vfx_bytes);
         f.pbd = Buffer::create_storage(alloc, pbd_bytes);
         f.particles = Buffer::create_storage(alloc, part_bytes);
-        f.point_lights = Buffer::create_storage(alloc, light_bytes);
     }
 }
 
@@ -55,7 +52,6 @@ RenderState::~RenderState() {
         f.vfx.destroy(alloc);
         f.pbd.destroy(alloc);
         f.particles.destroy(alloc);
-        f.point_lights.destroy(alloc);
     }
 }
 
@@ -84,12 +80,6 @@ ParticlesWriter RenderState::particles_writer(FrameIndex f) noexcept {
                            &pf.particles_dirty};
 }
 
-PointLightsWriter RenderState::point_lights_writer(FrameIndex f) noexcept {
-    auto& pf = per_frame_[to_u32(f) % kMaxFramesInFlight];
-    return PointLightsWriter{static_cast<PointLight*>(pf.point_lights.mapped()),
-                             cfg_.max_point_lights, &pf.lights_dirty};
-}
-
 VkBuffer RenderState::bones_buffer(FrameIndex f) const noexcept {
     return per_frame_[to_u32(f) % kMaxFramesInFlight].bones.buffer();
 }
@@ -102,9 +92,6 @@ VkBuffer RenderState::pbd_buffer(FrameIndex f) const noexcept {
 VkBuffer RenderState::particles_buffer(FrameIndex f) const noexcept {
     return per_frame_[to_u32(f) % kMaxFramesInFlight].particles.buffer();
 }
-VkBuffer RenderState::point_lights_buffer(FrameIndex f) const noexcept {
-    return per_frame_[to_u32(f) % kMaxFramesInFlight].point_lights.buffer();
-}
 
 void RenderState::begin_frame(FrameIndex f) noexcept {
     auto& pf = per_frame_[to_u32(f) % kMaxFramesInFlight];
@@ -112,7 +99,6 @@ void RenderState::begin_frame(FrameIndex f) noexcept {
     pf.vfx_dirty.clear();
     pf.pbd_dirty.clear();
     pf.particles_dirty.clear();
-    pf.lights_dirty.clear();
 }
 
 void RenderState::end_frame(FrameIndex f) noexcept {
@@ -128,11 +114,10 @@ void RenderState::end_frame(FrameIndex f) noexcept {
     // this slot is reused in a future frame.
     auto& pf = per_frame_[to_u32(f) % kMaxFramesInFlight];
     VmaAllocator alloc = ctx_.allocator();
-    flush_dirty(alloc, pf.bones.allocation(),        pf.bones_dirty,     sizeof(glm::mat4));
-    flush_dirty(alloc, pf.vfx.allocation(),          pf.vfx_dirty,       cfg_.splat_stride);
-    flush_dirty(alloc, pf.pbd.allocation(),          pf.pbd_dirty,       cfg_.splat_stride);
-    flush_dirty(alloc, pf.particles.allocation(),    pf.particles_dirty, cfg_.splat_stride);
-    flush_dirty(alloc, pf.point_lights.allocation(), pf.lights_dirty,    sizeof(PointLight));
+    flush_dirty(alloc, pf.bones.allocation(),     pf.bones_dirty,     sizeof(glm::mat4));
+    flush_dirty(alloc, pf.vfx.allocation(),       pf.vfx_dirty,       cfg_.splat_stride);
+    flush_dirty(alloc, pf.pbd.allocation(),       pf.pbd_dirty,       cfg_.splat_stride);
+    flush_dirty(alloc, pf.particles.allocation(), pf.particles_dirty, cfg_.splat_stride);
 }
 
 }  // namespace gseurat

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -471,21 +471,6 @@ void Renderer::draw_scene(float dt,
                      fence_ms, current_frame_);
     }
 
-    // Phase 4 closure: bracket the frame's writer activity with
-    // RenderState lifecycle. begin_frame must come AFTER the fence
-    // wait (so the previous GPU use of this slot is done) and BEFORE
-    // any writer.write — which happens inside record_gs_prepass and,
-    // for BonesWriter, in callers like gs_demo_state that ran before
-    // draw_scene. The fence wait is the well-defined synchronization
-    // point for slot reuse; the bones writes between draw_scene calls
-    // are accepted as "writing while GPU may still be reading the same
-    // slot": correct on Apple Silicon HOST_COHERENT (CPU and GPU share
-    // memory and the fence wait completes before the GPU could observe
-    // the new write), and inherited from the existing Phase 4b shape.
-    if (render_state_) {
-        render_state_->begin_frame(FrameIndex{current_frame_});
-    }
-
     uint32_t image_index;
     auto acquire_sem = sync_.acquire_semaphore(acquire_semaphore_index_);
     const auto acquire_t0 = std::chrono::steady_clock::now();

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -4,6 +4,7 @@
 #include "gseurat/engine/pipeline.hpp"
 #include "gseurat/engine/procedural_textures.hpp"
 #include "gseurat/engine/project_root.hpp"
+#include "gseurat/engine/render_state.hpp"
 #include "gseurat/engine/resource_manager.hpp"
 #include "gseurat/engine/scoped_timer.hpp"
 #include "gseurat/engine/sort_entry.hpp"
@@ -470,6 +471,21 @@ void Renderer::draw_scene(float dt,
                      fence_ms, current_frame_);
     }
 
+    // Phase 4 closure: bracket the frame's writer activity with
+    // RenderState lifecycle. begin_frame must come AFTER the fence
+    // wait (so the previous GPU use of this slot is done) and BEFORE
+    // any writer.write — which happens inside record_gs_prepass and,
+    // for BonesWriter, in callers like gs_demo_state that ran before
+    // draw_scene. The fence wait is the well-defined synchronization
+    // point for slot reuse; the bones writes between draw_scene calls
+    // are accepted as "writing while GPU may still be reading the same
+    // slot": correct on Apple Silicon HOST_COHERENT (CPU and GPU share
+    // memory and the fence wait completes before the GPU could observe
+    // the new write), and inherited from the existing Phase 4b shape.
+    if (render_state_) {
+        render_state_->begin_frame(FrameIndex{current_frame_});
+    }
+
     uint32_t image_index;
     auto acquire_sem = sync_.acquire_semaphore(acquire_semaphore_index_);
     const auto acquire_t0 = std::chrono::steady_clock::now();
@@ -850,6 +866,13 @@ void Renderer::draw_scene(float dt,
 #if GSEURAT_DEBUG_BUILD
     const auto t_ds_pre_submit = std::chrono::steady_clock::now();
 #endif
+    // Phase 4 closure: flush mapped RenderState writes BEFORE submit so
+    // non-coherent memory platforms see them on the GPU side. No-op on
+    // Apple Silicon HOST_COHERENT. Must run after all writer.write() in
+    // this frame (record_gs_prepass) and before vkQueueSubmit.
+    if (render_state_) {
+        render_state_->end_frame(FrameIndex{current_frame_});
+    }
     if (vkQueueSubmit(context_.graphics_queue(), 1, &submit, frame_sync.in_flight) != VK_SUCCESS) {
         throw std::runtime_error("Failed to submit draw command buffer");
     }

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -397,6 +397,31 @@ void Renderer::set_gs_background(const ResourceHandle<Texture>& texture) {
     gs_bg_initialized_ = true;
 }
 
+void Renderer::wait_current_frame_fence() noexcept {
+    auto device = context_.device();
+    const auto& fs = sync_.frame(current_frame_);
+#if GSEURAT_DEBUG_BUILD
+    constexpr uint64_t kFenceWaitWatchdogNs = 2'000'000'000ull;  // 2 sec
+    const auto t0 = std::chrono::steady_clock::now();
+    VkResult r = vkWaitForFences(device, 1, &fs.in_flight, VK_TRUE,
+                                  kFenceWaitWatchdogNs);
+    const auto t1 = std::chrono::steady_clock::now();
+    const double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    if (r == VK_TIMEOUT) {
+        std::fprintf(stderr,
+            "[renderer/watchdog] wait_current_frame_fence TIMEOUT after %.2f ms "
+            "(current_frame=%u) — retrying with infinite timeout\n",
+            ms, current_frame_);
+        vkWaitForFences(device, 1, &fs.in_flight, VK_TRUE, UINT64_MAX);
+    } else if (ms > 50.0) {
+        GS_LOG_FRAME("[renderer/watchdog] wait_current_frame_fence slow: {:.2f} ms "
+                     "(current_frame={})", ms, current_frame_);
+    }
+#else
+    vkWaitForFences(device, 1, &fs.in_flight, VK_TRUE, UINT64_MAX);
+#endif
+}
+
 void Renderer::draw_scene(float dt,
                            Scene& scene,
                            const std::vector<SpriteDrawInfo>& entity_sprites,

--- a/tests/test_render_state.cpp
+++ b/tests/test_render_state.cpp
@@ -216,22 +216,10 @@ int main() {
         std::printf("PASS: per-frame writers and dirty ranges are isolated\n");
     }
 
-    // 10. PointLightsWriter (typed for the existing PointLight POD)
-    {
-        std::vector<PointLight> lights(kMaxLights);
-        DirtyRange dirty;
-        PointLightsWriter w{lights.data(), kMaxLights, &dirty};
-
-        PointLight pl;
-        pl.position_and_radius = {10.0f, 5.0f, 3.0f, 7.5f};
-        pl.color = {1.0f, 0.5f, 0.25f, 2.0f};
-        w.write(3, pl);
-
-        assert(lights[3].position_and_radius.w == 7.5f);
-        assert(lights[3].color.r == 1.0f);
-        assert(dirty.first == 3 && dirty.last == 3);
-        std::printf("PASS: PointLightsWriter handles PointLight POD\n");
-    }
+    // Phase 4 closure (2026-05-17): PointLightsWriter removed as dead
+    // architecture. Lights live in GsRenderer's uniform buffer (8-cap
+    // inline vec4 arrays), not in an SSBO. The previous test (#10) for
+    // PointLightsWriter is intentionally not replaced.
 
     std::printf("\nALL RENDER STATE TESTS PASSED\n");
     return 0;


### PR DESCRIPTION
## Summary

Closes Phase 4 of the engine refactor (#396 follow-on) per the 2026-05-17 audit landed in PR #459. Two related deliverables:

### 1. Delete `PointLightsWriter` dead architecture

The audit caught that `PointLightsWriter` / `point_lights_writer()` / `point_lights_buffer()` were declared and allocated per-frame-in-flight, but **no shader binds the SSBO**. Lights live in the uniform buffer as `kMaxGsPointLights=8` inline `vec4` arrays (read in `gs_renderer.cpp:1777-1782`, populated by `set_point_lights` into the UBO). The writer was speculatively added expecting a uniform→SSBO migration that didn't happen.

Removed: `PointLightsWriter` alias, `RenderStateConfig::max_point_lights`, `point_lights_writer()` / `point_lights_buffer()` (decl + impl), `PerFrame::point_lights` + `lights_dirty`, light-related allocation/destroy/flush, and the corresponding test block. LightingSystem's existing `set_point_lights → UBO` path is unchanged.

### 2. Wire `RenderState::begin_frame` / `end_frame` lifecycle

The lifecycle hooks existed with **zero callers** — a cross-platform correctness gap (no-op on Apple Silicon HOST_COHERENT; missing `vkFlushMappedMemoryRanges` on non-coherent platforms).

Renderer now holds a non-owning `RenderState*` (set from `AppBase::init_render_state` alongside the existing GsRenderer/VfxSystem/etc. wiring). `Renderer::draw_scene` brackets per-frame work:

- `begin_frame(FrameIndex{current_frame_})` right after `vkWaitForFences` succeeds — previous GPU use of this slot is done, safe to reset writer dirty ranges before `record_gs_prepass` writes through `VfxWriter` / `PbdWriter` / `ParticlesWriter`.
- `end_frame(FrameIndex{current_frame_})` immediately before `vkQueueSubmit` — flushes any non-coherent mapped writes so the GPU sees them.

Null-safe: pre-init and standalone-test paths skip the lifecycle calls cleanly.

## After this PR

The only remaining engine-refactor work is **Phase 5e** — shrinking `GsRenderer::render()` (currently 2388 LOC) to the ~80-LOC orchestrator described in design §5.1.

## Test plan

- [x] `cmake --build --preset macos-debug` — clean, 705/706 tasks
- [x] `cmake --build --preset macos-release` — clean, 705/706 tasks
- [x] `./test_render_state` — 9/9 PASS
- [x] `./gseurat_demo` smoke run — boots, loads 1.7M Gaussians (`seurat_island.gsvx`), all systems run (PBD/VFX/lighting/bone-anim), `ShutdownAuditor` reports zero leaks, no validation-layer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)