### PR TITLE
fix(engine): widen transition_outputs_for_compute barrier to cover TRANSFER clear

### DIFF
--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -1730,7 +1730,7 @@ void GsRenderer::transition_outputs_for_compute(VkCommandBuffer cmd, uint32_t fr
     VkImageMemoryBarrier barriers[2]{};
     barriers[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
     barriers[0].srcAccessMask = 0;
-    barriers[0].dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    barriers[0].dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT | VK_ACCESS_SHADER_WRITE_BIT;
     barriers[0].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     barriers[0].newLayout = VK_IMAGE_LAYOUT_GENERAL;
     barriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -1743,7 +1743,7 @@ void GsRenderer::transition_outputs_for_compute(VkCommandBuffer cmd, uint32_t fr
 
     vkCmdPipelineBarrier(cmd,
         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_PIPELINE_STAGE_TRANSFER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
         0, 0, nullptr, 0, nullptr, 2, barriers);
 }
 


### PR DESCRIPTION
## Summary

Widens the `transition_outputs_for_compute()` barrier in `src/engine/gs_renderer.cpp` so its UNDEFINED → GENERAL layout transition is visible to both the TRANSFER-stage clear and the COMPUTE-stage rasterize that immediately follow it.

Before:
- `dstStageMask  = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT`
- `dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT`

After:
- `dstStageMask  = VK_PIPELINE_STAGE_TRANSFER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT`
- `dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT | VK_ACCESS_SHADER_WRITE_BIT`

The very next operation after this barrier is `clear_outputs()` which issues two `vkCmdClearColorImage` calls — TRANSFER-stage, TRANSFER_WRITE access. Strict Vulkan validation (NV / AMD) would flag the missing TRANSFER coverage on both dst masks.

## Background

This is a pre-existing latent issue carried verbatim from before the Phase 5e refactor and was deliberately deferred as a non-blocker in PR #461's cumulative review. macOS / MoltenVK's permissive TBDR scheduling has masked the gap on the dev machine (no validation messages on the 5s smoke). No runtime behavior change expected — strictly a correctness fix for stricter validation paths.

## Test Plan

- [x] `cmake --build --preset macos-debug --target gseurat_demo` succeeds
- [x] `cmake --build --preset macos-release --target gseurat_demo` succeeds
- [x] 5s `./gseurat_demo` smoke (release): `[ShutdownAuditor] No tracked objects alive.`, zero new `VUID-`, zero `validation layer`, zero `wait_current_frame_fence TIMEOUT`
- [ ] (Optional, not done) `VK_LAYER_LUNARG_api_dump` diff vs main — would show one hunk: the changed dst stage/access masks on this single barrier
