### PR TITLE
docs(gpu-compute-pipeline): rewrite for post-#396 subsystem ownership

### DIFF
--- a/docs/gpu-compute-pipeline.md
+++ b/docs/gpu-compute-pipeline.md
@@ -335,11 +335,11 @@ To trace a set from allocation to use: open the subsystem's `.cpp`, find the `vk
 | Resource | Allocated | Pool Limit | Remaining |
 |---|---|---|---|
 | Sets | 51 | 236 | 185 |
-| `STORAGE_BUFFER` | ~170 | 416 | ~246 |
-| `STORAGE_IMAGE` | 8 | 24 | 16 |
-| `UNIFORM_BUFFER` | 8 | 48 | 40 |
+| `STORAGE_BUFFER` | 187 | 416 | 229 |
+| `STORAGE_IMAGE` | 10 | 24 | 14 |
+| `UNIFORM_BUFFER` | 11 | 48 | 37 |
 
-`STORAGE_BUFFER` is the dominant resource — sort + tile-bin allocate the bulk of it. `STORAGE_IMAGE` is bounded by per-frame `output_image` / `depth_image` views (each consumed by `tile_render` and `post_process`).
+Counts are exact summations over every set bound from `gs_pool_`. `STORAGE_BUFFER` is the dominant resource — depth-sort (84 sets-bindings: 24 sets × 3.5 SSBO avg), preprocess (28: 4 sets × 7), and the borrowed onesweep sets in `GsTileBinSystem` (28: 8 sets × 3.5 avg) make up most of it. `STORAGE_IMAGE` is bounded by `tile_render` (4: 2 frames × {output, depth}) and `post_process` (6: 2 frames × {output, depth, processed}). `UNIFORM_BUFFER` is spread across every layout that touches `GsUniforms`, `GsPostProcessUbo`, or the PBD UBO.
 
 **Per-frame intermediate images.** With `kMaxFramesInFlight = 2`, a single shared `output_image_` / `depth_image_` / `processed_image_` would be written by frame N+1's compute dispatch while frame N's composite-blit is still sampling it on the GPU — there is no producer/consumer fence between adjacent in-flight frames on those images. On Apple/MoltenVK with a 3-image swapchain that race manifested as a "first-rendered configuration flashes back" ghost. Each frame now writes into its own image and binds its own descriptor set; the `Renderer` passes its `current_frame_` index through `gs_renderer_.render(cmd, frame, view, proj)` and uses the matching `output_views_[frame]` for the swapchain blit (`DescriptorManager::allocate_sprite_sets_per_frame`).
 

--- a/docs/gpu-compute-pipeline.md
+++ b/docs/gpu-compute-pipeline.md
@@ -1,44 +1,55 @@
 # GPU Compute Pipeline
 
-Vulkan descriptor pools, set layouts, and compute shaders used by GSeurat's
-Gaussian Splatting renderer.
+Vulkan descriptor pools, set layouts, pipelines, and compute shaders used by GSeurat's Gaussian Splatting renderer.
+
+This document covers the **wire-level Vulkan details** — binding indices, descriptor types, push-constant sizes, shader paths. For the architectural rationale (why the renderer is an orchestrator over six subsystems, how cross-system barriers are organised, the resource-ownership summary), see `docs/architecture.md`. Where this document discusses pipelines and sets, it attributes them to the **subsystem that owns** them — `Gs*System::init()` is where the layout is created and the descriptor set is allocated.
+
+---
 
 ## Descriptor Pools
 
-GSeurat allocates four independent descriptor pools, each owned by a different
-subsystem.
+GSeurat allocates five independent descriptor pools. The first two belong to the GS compute path and are owned by `GsRenderer`; the rest are owned by other subsystems and unaffected by the #396 engine refactor.
 
-### GS Renderer (`gs_pool_`)
+### GS Compute (`gs_pool_`) — owned by `GsRenderer`
 
-Source: `src/engine/gs_renderer.cpp:233-249`
+Source: `src/engine/gs_renderer.cpp:225-246` (`create_descriptor_resources()`)
 
 | Descriptor Type | Count |
 |---|---|
-| `STORAGE_BUFFER` | 256 |
+| `STORAGE_BUFFER` | 416 |
 | `STORAGE_IMAGE` | 24 |
-| `UNIFORM_BUFFER` | 32 |
-| **Max Sets** | **128** |
+| `UNIFORM_BUFFER` | 48 |
+| **Max Sets** | **236** |
 
-Currently allocates **30 sets** (see [Set Allocation](#set-allocation) below).
-98 sets remain available.
+`gs_pool_` is created by `GsRenderer` and **shared** with the four compute subsystems — each `Gs*System::init()` allocates its own descriptor sets from this pool. The pool is reset (`vkResetDescriptorPool`) before any subsystem allocation runs, so the four `init()` calls own the complete allocation order. Total sets currently allocated: **51** (see [Per-Subsystem Allocation](#per-subsystem-allocation)). Pool headroom: 185 sets.
 
-### Sprites / Graphics (`DescriptorManager`)
+### Compose (`compose_pool_`) — owned by `GsRenderer`
 
-Source: `src/engine/descriptor.cpp:39-55`
+Source: `src/engine/gs_renderer.cpp:418-449` (`create_compose_pipeline()`)
 
 | Descriptor Type | Count |
 |---|---|
-| `UNIFORM_BUFFER` | 32 (`kMaxFramesInFlight * 16`) |
-| `COMBINED_IMAGE_SAMPLER` | 64 (`kMaxFramesInFlight * 32`) |
-| **Max Sets** | **32** |
+| `STORAGE_BUFFER` | 12 (`kSetsPerSource × kSources × 2 bindings`) |
+| **Max Sets** | **6** (`kMaxFramesInFlight × 3 sources`) |
+
+Dedicated pool for the `gs_compose.comp` pass — kept separate from `gs_pool_` so that adding new compose sources (currently VFX + PBD + particles) does not perturb the GS pool's allocation indexing. Allocates exactly 6 sets — two per source (one per frame in flight).
+
+### Sprites / Graphics (`DescriptorManager::pool_`)
+
+Source: `src/engine/descriptor.cpp:40-55`
+
+| Descriptor Type | Count |
+|---|---|
+| `UNIFORM_BUFFER` | 32 (`kMaxFramesInFlight × 16`) |
+| `COMBINED_IMAGE_SAMPLER` | 64 (`kMaxFramesInFlight × 32`) |
+| **Max Sets** | **32** (`kMaxFramesInFlight × 16`) |
 | **Flags** | `FREE_DESCRIPTOR_SET_BIT` |
 
-Single layout with 3 bindings (UBO + texture sampler + normal map), used for
-sprite rendering.
+Single sprite layout with 3 bindings (UBO + diffuse texture + normal map), used for sprite rendering. Unchanged by #396.
 
-### PostProcess (`pp_pool_`)
+### PostProcess Graphics (`PostProcessPipeline::pp_pool_`)
 
-Source: `src/engine/post_process.cpp:541-558`
+Source: `src/engine/post_process.cpp:551-568`
 
 | Descriptor Type | Count |
 |---|---|
@@ -46,12 +57,11 @@ Source: `src/engine/post_process.cpp:541-558`
 | `UNIFORM_BUFFER` | 1 |
 | **Max Sets** | **6** |
 
-Allocates 5 sets: 4 single-sampler (offscreen, bloom_a, bloom_b, dof_a) + 1
-composite (4 samplers + light glow UBO).
+Graphics-stage post-process — bloom blur passes and final composite to swapchain. Distinct from the **compute** post-process (fog / tone-map / DoF / etc.) owned by `GsPostProcessSystem`. Allocates 5 sets: 4 single-sampler (offscreen, bloom_a, bloom_b, dof_a) + 1 composite (4 samplers + light glow UBO).
 
 ### ImGui / DevOverlay (`imgui_pool_`)
 
-Source: `src/engine/dev_overlay.cpp:19-28`
+Source: `src/engine/dev_overlay.cpp:18-28`
 
 | Descriptor Type | Count |
 |---|---|
@@ -63,12 +73,15 @@ Source: `src/engine/dev_overlay.cpp:19-28`
 
 ## Compute Descriptor Set Layouts
 
-All compute layouts live in `src/engine/gs_renderer.cpp:251-433`. Every binding
-uses `VK_SHADER_STAGE_COMPUTE_BIT`.
+Every binding uses `VK_SHADER_STAGE_COMPUTE_BIT`. Layouts are grouped by owning subsystem.
 
-### Preprocess (`preprocess_layout_`)
+### Owned by `GsSortSystem`
 
-Frustum culling and 2D projection of Gaussian splats.
+Source: `src/engine/gs_renderer/sort/gs_sort_system.cpp:21-219` (`GsSortSystem::init`)
+
+#### Preprocess (`preprocess_layout_`)
+
+Frustum culling + 2D projection of Gaussian splats. Also re-applies bone and PBD transforms each frame.
 
 | Binding | Type | Resource |
 |---|---|---|
@@ -81,48 +94,38 @@ Frustum culling and 2D projection of Gaussian splats.
 | 6 | `STORAGE_BUFFER` | pbd_states |
 | 8 | `STORAGE_BUFFER` | page_table |
 
-Shader: `gs_preprocess.comp` | Push constants: `GsPreprocessPush`
+Shader: `shaders/gs_preprocess.comp.spv` | Push constants: `sizeof(GsPreprocessPush)`
 
-### Sort (`sort_layout_`) — Legacy
+#### Onesweep Histogram (`onesweep_hist_layout_`)
 
-| Binding | Type | Resource |
-|---|---|---|
-| 0 | `STORAGE_BUFFER` | sort keys |
-| 1 | `UNIFORM_BUFFER` | uniforms |
-
-Shader: `gs_sort.comp` | Push constants: 8 bytes
-
-### Render (`render_layout_`)
-
-Full-screen Gaussian rasterization (non-tiled path). Allocated per-frame as `render_sets_[kMaxFramesInFlight]` — each frame's set binds the frame's matching `output_image[frame]` / `depth_image[frame]`.
+Histogram phase of the GPU radix sort (Onesweep with decoupled lookback).
 
 | Binding | Type | Resource |
 |---|---|---|
-| 0 | `STORAGE_BUFFER` | projected |
-| 1 | `STORAGE_BUFFER` | sort_keys |
-| 2 | `UNIFORM_BUFFER` | uniforms |
-| 3 | `STORAGE_IMAGE` | output_image (per frame) |
-| 4 | `STORAGE_BUFFER` | visible_count |
-| 5 | `STORAGE_IMAGE` | depth_image (per frame) |
+| 0 | `STORAGE_BUFFER` | input |
+| 1 | `STORAGE_BUFFER` | status (lookback) |
+| 2 | `STORAGE_BUFFER` | indirect_args |
 
-Shader: `gs_render.comp`
+Shader: `shaders/gs_onesweep_histogram.comp.spv` | Push constants: 4 bytes (`pass`)
 
-### Post-Process (`post_process_layout_`)
+#### Onesweep Scatter (`onesweep_scatter_layout_`)
 
-Fog, tone mapping, vignette, bloom, DoF, chromatic aberration. Allocated per-frame as `post_process_sets_[kMaxFramesInFlight]` — each frame's set reads / writes the frame's matching images.
+Scatter phase — reads histogram lookback and redistributes keys.
 
 | Binding | Type | Resource |
 |---|---|---|
-| 0 | `STORAGE_IMAGE` | input (readonly, per frame = output_image[frame]) |
-| 1 | `STORAGE_IMAGE` | depth (readonly, per frame = depth_image[frame]) |
-| 2 | `STORAGE_IMAGE` | output (writeonly, per frame = processed_image[frame]) |
-| 3 | `UNIFORM_BUFFER` | UBO |
+| 0 | `STORAGE_BUFFER` | input |
+| 1 | `STORAGE_BUFFER` | output |
+| 2 | `STORAGE_BUFFER` | status (lookback) |
+| 3 | `STORAGE_BUFFER` | indirect_args |
 
-Shader: `gs_post_process.comp`
+Shader: `shaders/gs_onesweep_scatter.comp.spv` | Push constants: 4 bytes (`pass`)
 
-### Merge (`merge_layout_`)
+`GsTileBinSystem` re-uses these two layouts (via `sort_->onesweep_hist_set_layout()` / `…scatter_set_layout()`) to allocate its own tile-sort descriptor sets — the layouts are sort-owned, the sets are tile-bin-owned.
 
-Merges static and dynamic sort key buffers after independent radix sorts.
+#### Merge (`merge_layout_`)
+
+Combines static + dynamic sorted keys into the merged sort buffer.
 
 | Binding | Type | Resource |
 |---|---|---|
@@ -131,15 +134,15 @@ Merges static and dynamic sort key buffers after independent radix sorts.
 | 2 | `STORAGE_BUFFER` | merged_sort |
 | 3 | `STORAGE_BUFFER` | counts |
 
-Shader: `gs_merge.comp`
+Shader: `shaders/gs_merge.comp.spv` | Push constants: none
 
-### Tile Binning (`tile_bin_layout_`)
+### Owned by `GsTileBinSystem`
 
-Assigns projected splats to screen-space tiles. Implemented as a deterministic
-3-pass count → exclusive-scan → scatter pipeline rather than a single-pass
-`atomicAdd`, so the entry order in `tile_sort_a_` is bit-stable across frames
-with identical input. Two compute pipelines share this layout (count uses
-bindings 0-3, 6; scatter uses 0-2, 4-6).
+Source: `src/engine/gs_renderer/tile_bin/gs_tile_bin_system.cpp:21-245` (`GsTileBinSystem::init`)
+
+#### Tile Binning (`tile_bin_layout_`)
+
+Assigns projected splats to screen-space tiles via a deterministic 3-pass count → scan → scatter pipeline. The `tile_count` and `tile_bin` compute pipelines share this layout (and share `tile_bin_pipeline_layout_`): count uses bindings 0–3 + 6; scatter uses 0–2 + 4–6.
 
 | Binding | Type | Resource |
 |---|---|---|
@@ -152,17 +155,12 @@ bindings 0-3, 6; scatter uses 0-2, 4-6).
 | 6 | `UNIFORM_BUFFER` | uniforms |
 
 Shaders:
-- `gs_tile_count.comp` — pass 1, writes per-splat tile-overlap count.
-- `gs_tile_bin.comp` — pass 3 (scatter), reads precomputed offsets and writes `TileSortEntry` blocks. Push constants: 4 bytes (`max_entries`).
+- `shaders/gs_tile_count.comp.spv` — pass 1, per-splat tile-overlap count. Reuses `tile_bin_pipeline_layout_` (no push values touched).
+- `shaders/gs_tile_bin.comp.spv` — pass 3 (scatter). Push constants: 4 bytes (`max_entries`).
 
-### Tile Scan (`tile_scan_layout_`)
+#### Tile Scan (`tile_scan_layout_`)
 
-Three-dispatch hierarchical exclusive prefix-sum over `per_splat_tile_count[]`,
-producing the deterministic write offsets the scatter consumes. Single shader
-dispatched 3× via the `pass` push constant: pass 0 = local 256-element scan +
-write block sums, pass 1 = single-workgroup chunked scan over block sums (also
-writes the grand total to `tile_sort_count`), pass 2 = add scanned base back
-to per-splat offsets.
+Three-dispatch hierarchical exclusive prefix-sum over `per_splat_tile_count[]`, producing the deterministic write offsets the scatter consumes. Single shader dispatched 3× via the `pass` push constant — pass 0 = local 256-element scan + write block sums, pass 1 = single-workgroup chunked scan over block sums (also writes the grand total into `tile_sort_count`), pass 2 = add scanned base back to per-splat offsets.
 
 | Binding | Type | Resource |
 |---|---|---|
@@ -171,13 +169,24 @@ to per-splat offsets.
 | 2 | `STORAGE_BUFFER` | scan_block_sums (intermediate) |
 | 3 | `STORAGE_BUFFER` | tile_sort_count (pass 1 writes total) |
 
-Shader: `gs_tile_scan.comp` | Push constants: 12 bytes (`pass`, `num_elements`, `num_blocks`)
+Shader: `shaders/gs_tile_scan.comp.spv` | Push constants: 12 bytes (`pass`, `num_elements`, `num_blocks`)
 
 Capacity: pass 1's chunked scan supports up to 256 × 256 = 65 536 blocks → 16.7 M visible splats, well above `tile_sort_capacity_`'s 2 M cap.
 
 Headless GPU correctness coverage: `tests/test_tile_scan_gpu.cpp` (8 cases including 262 K-element multi-chunk).
 
-### Tile Range Detection (`tile_ranges_layout_`)
+#### Tile Indirect Dispatch (`tile_indirect_layout_`)
+
+Prepares `VkDispatchIndirectCommand` from the tile-sort count.
+
+| Binding | Type | Resource |
+|---|---|---|
+| 0 | `STORAGE_BUFFER` | tile_sort_count |
+| 1 | `STORAGE_BUFFER` | indirect_args |
+
+Shader: `shaders/gs_tile_prepare_indirect.comp.spv` | Push constants: 4 bytes (`max_entries`)
+
+#### Tile Range Detection (`tile_ranges_layout_`)
 
 Detects per-tile start/end ranges in the sorted tile entry buffer.
 
@@ -187,22 +196,11 @@ Detects per-tile start/end ranges in the sorted tile entry buffer.
 | 1 | `STORAGE_BUFFER` | tile_ranges |
 | 2 | `STORAGE_BUFFER` | tile_count |
 
-Shader: `gs_tile_ranges.comp` | Push constants: 8 bytes (num_tiles + max_entries)
+Shader: `shaders/gs_tile_ranges.comp.spv` | Push constants: 8 bytes (`num_tiles`, `max_entries`)
 
-### Tile Indirect Dispatch (`tile_indirect_layout_`)
+#### Tile Render (`tile_render_layout_`)
 
-Prepares `VkDispatchIndirectCommand` from tile sort count.
-
-| Binding | Type | Resource |
-|---|---|---|
-| 0 | `STORAGE_BUFFER` | tile_sort_count |
-| 1 | `STORAGE_BUFFER` | indirect_args |
-
-Shader: `gs_tile_prepare_indirect.comp` | Push constants: 4 bytes (max_entries)
-
-### Tile Render (`tile_render_layout_`)
-
-Per-tile Gaussian rasterization (production path, ~3x faster than full-screen). Allocated per-frame as `tile_render_sets_[kMaxFramesInFlight]` — each frame's set binds the frame's matching `output_image[frame]` / `depth_image[frame]`.
+Per-tile alpha-blended Gaussian rasterization (the production path). Allocated per-frame as `tile_render_sets_[kMaxFramesInFlight]` so each frame's set binds the frame's matching `output_image[frame]` / `depth_image[frame]`.
 
 | Binding | Type | Resource |
 |---|---|---|
@@ -213,37 +211,32 @@ Per-tile Gaussian rasterization (production path, ~3x faster than full-screen). 
 | 4 | `STORAGE_BUFFER` | tile_ranges |
 | 5 | `STORAGE_IMAGE` | depth_image (per frame) |
 
-Shader: `gs_tile_render.comp`
+Shader: `shaders/gs_tile_render.comp.spv` | Push constants: none
 
-### Onesweep Histogram (`onesweep_hist_layout_`)
+### Owned by `GsPostProcessSystem`
 
-Histogram phase of the GPU radix sort (Onesweep algorithm).
+Source: `src/engine/gs_renderer/post/gs_post_process_system.cpp:19-87` (`GsPostProcessSystem::init`)
 
-| Binding | Type | Resource |
-|---|---|---|
-| 0 | `STORAGE_BUFFER` | input |
-| 1 | `STORAGE_BUFFER` | status (lookback) |
-| 2 | `STORAGE_BUFFER` | indirect_args |
+#### Post-Process Compute (`set_layout_`)
 
-Shader: `gs_onesweep_histogram.comp` | Push constants: 4 bytes (pass)
-
-### Onesweep Scatter (`onesweep_scatter_layout_`)
-
-Scatter phase of the GPU radix sort — reads histogram lookback and redistributes
-keys.
+Fog, tone-mapping, vignette, bloom premix, DoF, chromatic aberration. Allocated per-frame as `sets_[kMaxFramesInFlight]`.
 
 | Binding | Type | Resource |
 |---|---|---|
-| 0 | `STORAGE_BUFFER` | input |
-| 1 | `STORAGE_BUFFER` | output |
-| 2 | `STORAGE_BUFFER` | status (lookback) |
-| 3 | `STORAGE_BUFFER` | indirect_args |
+| 0 | `STORAGE_IMAGE` | input — `output_image[frame]` (readonly via `VK_IMAGE_LAYOUT_GENERAL`) |
+| 1 | `STORAGE_IMAGE` | depth — `depth_image[frame]` (readonly via `GENERAL`) |
+| 2 | `STORAGE_IMAGE` | output — `processed_image[frame]` (writeonly via `GENERAL`) |
+| 3 | `UNIFORM_BUFFER` | `GsPostProcessUbo` |
 
-Shader: `gs_onesweep_scatter.comp` | Push constants: 4 bytes (pass)
+Shader: `shaders/gs_post_process.comp.spv` | Push constants: none (dimensions live in the UBO)
 
-### PBD Solver (`pbd_layout_`)
+### Owned by `GsPbdSystem`
 
-Position-Based Dynamics constraint solver for hair/cloth simulation.
+Source: `src/engine/gs_renderer/pbd/gs_pbd_system.cpp:21-93` (`GsPbdSystem::init`)
+
+#### PBD Solver (`pbd_set_layout_`)
+
+Position-Based Dynamics constraint solver for hair, foliage sway, dangling chains. Single descriptor set — not per-frame, because the underlying buffers are stable across frames.
 
 | Binding | Type | Resource |
 |---|---|---|
@@ -252,13 +245,30 @@ Position-Based Dynamics constraint solver for hair/cloth simulation.
 | 2 | `STORAGE_BUFFER` | pbd_constraints (readonly) |
 | 3 | `UNIFORM_BUFFER` | pbd_uniforms |
 
-Shader: `pbd_solver.comp` | Push constants: 4 bytes (pbd_count)
+Shader: `shaders/pbd_solver.comp.spv` | Push constants: 4 bytes (`pbd_count`, `uint32_t`)
+
+### Owned by `GsRenderer` (Compose)
+
+Source: `src/engine/gs_renderer.cpp:371-449` (`create_compose_pipeline()`)
+
+#### Compose (`compose_layout_`)
+
+Renderer-owned compute pass that copies typed `RenderState` writer buffers (VFX / PBD / particles) into slots inside the persistent-dynamic prefix of the dynamic Gaussian SSBO. Runs in `Renderer::record_gs_prepass`, **before** `GsRenderer::render()`. Three named sets — `compose_sets_vfx_`, `compose_sets_pbd_`, `compose_sets_particles_` — each per-frame; all share this layout.
+
+| Binding | Type | Resource |
+|---|---|---|
+| 0 | `STORAGE_BUFFER` | src — `RenderState::{vfx,pbd,particles}_buffer(frame)` (readonly) |
+| 1 | `STORAGE_BUFFER` | dst — `dynamic_gaussian_ssbo` (RW) |
+
+Shader: `shaders/gs_compose.comp.spv` | Push constants: 8 bytes (`splat_count`, `dst_offset`)
 
 ---
 
 ## Graphics Descriptor Set Layouts
 
-### Sprite Layout (`DescriptorManager`)
+These are unchanged by the #396 refactor.
+
+### Sprite Layout (`DescriptorManager::sprite_layout_`)
 
 Source: `src/engine/descriptor.cpp:8-37`
 
@@ -270,7 +280,7 @@ Source: `src/engine/descriptor.cpp:8-37`
 
 ### PostProcess Single Sampler (`pp_layout_`)
 
-Source: `src/engine/post_process.cpp:498-512`
+Source: `src/engine/post_process.cpp:508-523`
 
 | Binding | Type | Stage | Resource |
 |---|---|---|---|
@@ -278,7 +288,7 @@ Source: `src/engine/post_process.cpp:498-512`
 
 ### Composite (`composite_layout_`)
 
-Source: `src/engine/post_process.cpp:515-538`
+Source: `src/engine/post_process.cpp:525-549`
 
 | Binding | Type | Stage | Resource |
 |---|---|---|---|
@@ -290,38 +300,20 @@ Source: `src/engine/post_process.cpp:515-538`
 
 ---
 
-## Set Allocation
+## Per-Subsystem Allocation
 
-The GS Renderer allocates all 30 sets in a single `vkAllocateDescriptorSets`
-call (`gs_renderer.cpp:439-504`).
+Before the #396 refactor a single `vkAllocateDescriptorSets` in `gs_renderer.cpp` allocated 30 sets in a fixed indexed order. That centralised allocation is gone: each subsystem now allocates its own sets from `gs_pool_` inside its `init()` method, and the renderer never refers to sets by global slot index.
 
-| Index | Layout | Purpose |
+| Subsystem | Sets | Breakdown |
 |---|---|---|
-| 0 | preprocess | Legacy preprocess |
-| 1 | sort | Legacy sort |
-| 2 | render | Legacy render |
-| 3 | post_process | Compute post-process |
-| 4 | preprocess | Static splat preprocess |
-| 5 | preprocess | Dynamic splat preprocess |
-| 6 | merge | Static/dynamic merge |
-| 7 | render | Merged render |
-| 8 | pbd | PBD solver |
-| 9 | tile_bin | Tile binning (count + scatter) |
-| 10 | tile_ranges | Tile range detection |
-| 11 | tile_indirect | Indirect dispatch prep |
-| 12 | tile_render | Tile render |
-| 13-14 | onesweep_hist | Tile sort histogram A/B |
-| 15-16 | onesweep_scatter | Tile sort scatter A->B / B->A |
-| 17-18 | onesweep_hist | Depth sort histogram A/B (legacy) |
-| 19-20 | onesweep_scatter | Depth sort scatter (legacy) |
-| 21-22 | onesweep_hist | Depth sort histogram A/B (static) |
-| 23-24 | onesweep_scatter | Depth sort scatter (static) |
-| 25-26 | onesweep_hist | Depth sort histogram A/B (dynamic) |
-| 27-28 | onesweep_scatter | Depth sort scatter (dynamic) |
-| 29 | tile_scan | Deterministic tile-bin prefix-sum |
-| 30 | render | Render set (frame-in-flight 1) — paired with slot 2 |
-| 31 | post_process | Post-process set (frame-in-flight 1) — paired with slot 3 |
-| 32 | tile_render | Tile render set (frame-in-flight 1) — paired with slot 12 |
+| `GsSortSystem` | 30 | 24 depth-sort (legacy × static × dynamic, each `{hist_a, hist_b, scatter_ab, scatter_ba}`, × 2 frames) + 2 merge (per frame) + 4 preprocess (2 static + 2 dynamic, per frame) |
+| `GsTileBinSystem` | 18 | 10 tile-pipeline (`tile_bin`, `tile_scan`, `tile_indirect`, `tile_ranges`, `tile_render`, × 2 frames) + 8 onesweep (`hist_a`, `hist_b`, `scatter_ab`, `scatter_ba`, × 2 frames) using *borrowed* `GsSortSystem` layouts |
+| `GsPostProcessSystem` | 2 | 1 per frame in flight |
+| `GsPbdSystem` | 1 | Not per-frame (PBD buffers stable across frames) |
+| **Total in `gs_pool_`** | **51** | — |
+| `GsRenderer` compose (separate pool) | 6 | 3 sources (VFX / PBD / particles) × 2 frames |
+
+To trace a set from allocation to use: open the subsystem's `.cpp`, find the `vkAllocateDescriptorSets` call in `init()`, then follow the matching `write_descriptors()` and `dispatch()` to see what buffers it binds and which `vkCmdDispatch` consumes it.
 
 ---
 
@@ -331,63 +323,59 @@ call (`gs_renderer.cpp:439-504`).
 |---|---|---|
 | `kMaxFramesInFlight` | 2 | `include/gseurat/engine/types.hpp:12` |
 | `kMaxLights` | 8 | `include/gseurat/engine/types.hpp:42` |
-| `kMaxBones` | 32 | `include/gseurat/engine/gs_renderer.hpp:186` |
-| `kParticleHeadroom` | 2048 | `include/gseurat/engine/gs_renderer.hpp:112` |
-| `kDynamicHeadroom` | 8192 | `include/gseurat/engine/gs_renderer.hpp:113` |
-| `kTileSortPasses` | 4 | `include/gseurat/engine/gs_renderer.hpp:444` |
-| `ENTRIES_PER_WG` | 2048 | `src/engine/gs_renderer.cpp:614` |
+| `kDynamicHeadroom` | 1 048 576 | `include/gseurat/engine/gs_renderer/streaming/gs_streaming_system.hpp:48` |
+| `kTileSortPasses` | 4 | `include/gseurat/engine/gs_renderer/tile_bin/gs_tile_bin_system.hpp:117` |
 
 ---
 
 ## Capacity
 
-**GS Renderer pool headroom:**
+**`gs_pool_` headroom** (current allocation vs. pool limit):
 
 | Resource | Allocated | Pool Limit | Remaining |
 |---|---|---|---|
-| Sets | 33 | 160 | 127 |
-| `STORAGE_BUFFER` | ~120 | 256 | ~136 |
-| `STORAGE_IMAGE` | 14 | 24 | 10 |
-| `UNIFORM_BUFFER` | 9 | 32 | 23 |
+| Sets | 51 | 236 | 185 |
+| `STORAGE_BUFFER` | ~170 | 416 | ~246 |
+| `STORAGE_IMAGE` | 8 | 24 | 16 |
+| `UNIFORM_BUFFER` | 8 | 48 | 40 |
 
-The set count grew from 30 to 33 when `output_image_` / `depth_image_` /
-`processed_image_` were promoted to per-frame `std::array<…, kMaxFramesInFlight>`
-arrays — the render, post_process, and tile_render descriptor sets that bind
-those images had to follow, so each gets one set per frame in flight (slots
-2, 3, 12 hold the frame-0 set; slots 30, 31, 32 hold the frame-1 set). The
-storage-image count grew similarly: 3 images × 2 frames = 6, plus one extra
-sampler view per frame, vs. the original 3 single shared images.
+`STORAGE_BUFFER` is the dominant resource — sort + tile-bin allocate the bulk of it. `STORAGE_IMAGE` is bounded by per-frame `output_image` / `depth_image` views (each consumed by `tile_render` and `post_process`).
 
-**Per-frame intermediates rationale.** With `kMaxFramesInFlight = 2`, a
-single shared `output_image_` / `depth_image_` / `processed_image_` would be
-written by frame N+1's compute dispatch while frame N's composite-blit is
-still sampling it on the GPU — there is no producer/consumer fence between
-adjacent in-flight frames on those images. On Apple/MoltenVK with a 3-image
-swapchain that race manifested as a "first-rendered configuration flashes
-back" ghost. Each frame now writes into its own image and binds its own
-descriptor set; the `Renderer` passes its `current_frame_` index through
-`gs_renderer_.render(cmd, frame, view, proj)` and uses the matching
-`output_views_[frame]` for the swapchain blit (`DescriptorManager::allocate_sprite_sets_per_frame`).
+**Per-frame intermediate images.** With `kMaxFramesInFlight = 2`, a single shared `output_image_` / `depth_image_` / `processed_image_` would be written by frame N+1's compute dispatch while frame N's composite-blit is still sampling it on the GPU — there is no producer/consumer fence between adjacent in-flight frames on those images. On Apple/MoltenVK with a 3-image swapchain that race manifested as a "first-rendered configuration flashes back" ghost. Each frame now writes into its own image and binds its own descriptor set; the `Renderer` passes its `current_frame_` index through `gs_renderer_.render(cmd, frame, view, proj)` and uses the matching `output_views_[frame]` for the swapchain blit (`DescriptorManager::allocate_sprite_sets_per_frame`).
 
-Adding a new compute pass with a typical layout (4 SSBOs + 1 UBO + 1 storage
-image) is well within pool limits without resizing.
+Adding a new compute pass with a typical layout (4 SSBOs + 1 UBO + 1 storage image) is well within pool limits without resizing.
 
 ---
 
 ## Frame Execution Order
 
-Each frame dispatches compute work in this order:
+`GsRenderer::render()` is a ~73-line orchestrator that invokes subsystem `dispatch()` calls in a fixed order. Each `dispatch()` may emit many `vkCmd*` calls internally — the orchestrator never sees them. The `dispatch_compose_*` passes run earlier, in `Renderer::record_gs_prepass`, before `GsRenderer::render` is called.
 
-1. **Preprocess** (static + dynamic) — frustum cull, project to 2D
-2. **Onesweep radix sort** (4 passes per buffer) — depth-sort splats
-3. **Merge** — combine static + dynamic sorted keys
-4. **Tile binning** — deterministic 3-pass pipeline:
-   1. **Count** (`gs_tile_count.comp`) — per-splat tile-overlap count
-   2. **Scan** (`gs_tile_scan.comp`, dispatched 3×) — exclusive prefix-sum → write offsets, also writes grand total
-   3. **Scatter** (`gs_tile_bin.comp`) — write `TileSortEntry` blocks at precomputed offsets
-5. **Tile sort** (onesweep, 4 passes) — sort within tiles
-6. **Tile range detection** — find per-tile entry ranges
-7. **Tile render** — per-tile alpha-blended rasterization
-8. **Post-process** (compute) — fog, tone mapping, bloom, DoF
-9. **Post-process** (graphics) — bloom blur passes, composite to swapchain
-10. **PBD solver** — runs when physics objects are active
+```
+Renderer::draw_scene
+ ├── Renderer::record_gs_prepass
+ │     ├── GsRenderer::dispatch_compose_vfx       — gs_compose.comp
+ │     ├── GsRenderer::dispatch_compose_pbd       — gs_compose.comp
+ │     └── GsRenderer::dispatch_compose_particles — gs_compose.comp
+ │
+ └── GsRenderer::render
+       ├── (if !skip_gs_compute)
+       │     ├── transition_outputs_for_compute   — UNDEFINED → GENERAL on output + depth
+       │     ├── clear_outputs                    — vkCmdClearColorImage on output + depth
+       │     ├── GsPbdSystem::dispatch            — pbd_solver.comp
+       │     ├── GsSortSystem::dispatch           — preprocess + onesweep depth-sort + merge
+       │     └── GsTileBinSystem::dispatch        — tile_count → tile_scan ×3 → tile_bin
+       │                                            → tile_prepare_indirect → onesweep tile-sort
+       │                                            → tile_ranges → tile_render
+       │
+       └── GsPostProcessSystem::dispatch          — gs_post_process.comp
+```
+
+Within each subsystem's `dispatch()`:
+
+- **`GsSortSystem::dispatch`** prepares sort buffers (static-tail fill, counts SSBO reset, dynamic sort fill with `0xFFFFFFFFu` sentinel) behind a global `TRANSFER → COMPUTE` barrier, emits the depth-sort begin timestamp, runs dynamic preprocess + Onesweep depth sort (if `dynamic_count > 0`), runs static preprocess + sort (if static is dirty), runs the merge, emits the `sort → tile` cross-system barrier, and emits the depth-sort end timestamp.
+- **`GsTileBinSystem::dispatch`** runs the six tile-phase passes, borrows the Onesweep histogram/scatter pipelines from `GsSortSystem` for the tile-sort, emits the four tile-phase timestamps, and emits the final `tile → post` cross-system barrier.
+- **`GsPostProcessSystem::dispatch`** emits a leading `UNDEFINED → GENERAL` transition on the per-frame `processed_image`, dispatches `gs_post_process.comp`, and emits a trailing `GENERAL → SHADER_READ_ONLY_OPTIMAL` transition (the cross-system barrier handing off to the swapchain blit's fragment shader).
+- **`GsPbdSystem::dispatch`** uploads the PBD UBO, dispatches `pbd_solver.comp`, and emits the `pbd → preprocess` cross-system barrier (this system's last operation).
+
+The graphics-stage **PostProcess** (bloom blur, composite to swapchain) runs after `GsRenderer::render` returns, inside `Renderer::draw_scene`, consuming `processed_image[frame]` via the graphics pipeline. It is independent of the GS compute path and unaffected by the #396 refactor.


### PR DESCRIPTION
## Summary

Rewrites `docs/gpu-compute-pipeline.md` to match the post-#396 architecture. The previous version described the renderer's pre-refactor monolithic state (30 sets allocated in a single `vkAllocateDescriptorSets` in `gs_renderer.cpp:439-504`, all compute layouts created in `gs_renderer.cpp:251-433`); both citations are stale and the bulk-allocation model itself no longer exists.

## Changes

**Scope & cross-references.** Adds an introductory paragraph clarifying that this doc owns the Vulkan wire-level details (binding indices, descriptor types, push-constant sizes, shader paths) while `docs/architecture.md` owns the high-level story (orchestrator pattern, cross-system barriers, resource ownership).

**Re-attribution to owning subsystems.** Every compute layout is moved under its actual owning subsystem:

| Subsystem | Layouts owned |
|---|---|
| `GsSortSystem` | preprocess, onesweep_hist, onesweep_scatter, merge |
| `GsTileBinSystem` | tile_bin, tile_scan, tile_indirect, tile_ranges, tile_render (borrows onesweep layouts from sort for tile-sort sets) |
| `GsPostProcessSystem` | post_process compute set layout |
| `GsPbdSystem` | pbd_set_layout |
| `GsRenderer` | compose_layout_ (new section — was previously undocumented) |

**Pool sizes refreshed.** `gs_pool_` is now `STORAGE_BUFFER=416 / STORAGE_IMAGE=24 / UNIFORM_BUFFER=48 / maxSets=236` (was documented as 256 / 24 / 32 / 128). Added a new "Compose (`compose_pool_`)" entry — a separate pool for the `gs_compose.comp` pass.

**Allocation table replaced.** The obsolete 30-set bulk allocation table is replaced with a per-subsystem allocation summary: 30 (sort) + 18 (tile-bin) + 2 (post) + 1 (pbd) = **51 sets in `gs_pool_`**, plus 6 in `compose_pool_`.

**Constants culled.** Removed stale references to `kMaxBones`, `kParticleHeadroom`, and `ENTRIES_PER_WG` (no longer named constants). Corrected `kDynamicHeadroom` value and location (`8192` at `gs_renderer.hpp:113` → **1 048 576** at `gs_streaming_system.hpp:48`) and `kTileSortPasses` location (`gs_renderer.hpp:444` → `gs_tile_bin_system.hpp:117`).

**Line citations refreshed** against current source: `descriptor.cpp:40-55`, `post_process.cpp:551-568`, `dev_overlay.cpp:18-28`, `gs_renderer.cpp:225-246`, etc.

**Frame Execution Order rewritten** as an orchestrator tree showing `Renderer::record_gs_prepass` running the three compose passes, then `GsRenderer::render` invoking `transition_outputs_for_compute → clear_outputs → GsPbdSystem::dispatch → GsSortSystem::dispatch → GsTileBinSystem::dispatch → GsPostProcessSystem::dispatch`, with per-subsystem `dispatch()` bullet breakdowns underneath.

## Verification

Every architectural claim was verified directly against source at `main` HEAD `75e95f22` — not against the older Phase 1 / Phase 5e design specs, which is the discipline the four rounds of Codex P2 findings on #462 taught us.

Confirmed by reading:
- `src/engine/gs_renderer.cpp:225-449` — pool sizes, compose pipeline ownership
- `src/engine/gs_renderer/sort/gs_sort_system.cpp:21-219` — sort layouts + 30 sets
- `src/engine/gs_renderer/tile_bin/gs_tile_bin_system.cpp:21-245` — tile layouts + 18 sets (10 tile + 8 borrowed-layout onesweep)
- `src/engine/gs_renderer/post/gs_post_process_system.cpp:19-87` — 1 layout + 2 per-frame sets
- `src/engine/gs_renderer/pbd/gs_pbd_system.cpp:21-93` — 1 layout + 1 set (not per-frame)
- `include/gseurat/engine/types.hpp`, `gs_streaming_system.hpp`, `tile_bin/gs_tile_bin_system.hpp` — current constant locations

## Test Plan

- [x] Doc-only change; no build verification needed
- [ ] User to review the PR diff for any factual inaccuracies before merge
