### PR TITLE
fix(#379): migrate dungeon collision grid to kcc_wall/floor entities

### DIFF
--- a/examples/island_demo/assets/scenes/dungeon.json
+++ b/examples/island_demo/assets/scenes/dungeon.json
@@ -3649,6 +3649,528 @@
           "max_height": 0.0
         }
       }
+    },
+    {
+      "id": "kcc_wall_001",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        25.0,
+        0.0,
+        1.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              25.0,
+              2.0,
+              1.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_002",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        1.0,
+        0.0,
+        26.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              1.0,
+              2.0,
+              24.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_003",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        15.0,
+        0.0,
+        3.5
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              3.0,
+              2.0,
+              1.5
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_004",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        34.0,
+        0.0,
+        3.5
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              2.0,
+              2.0,
+              1.5
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_005",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        49.0,
+        0.0,
+        26.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              1.0,
+              2.0,
+              24.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_006",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        15.0,
+        0.0,
+        18.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              3.0,
+              2.0,
+              9.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_007",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        34.0,
+        0.0,
+        19.5
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              2.0,
+              2.0,
+              10.5
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_008",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        7.0,
+        0.0,
+        17.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              5.0,
+              2.0,
+              5.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_009",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        42.0,
+        0.0,
+        21.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              6.0,
+              2.0,
+              7.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_010",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        21.0,
+        0.0,
+        19.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              3.0,
+              2.0,
+              3.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_011",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        30.0,
+        0.0,
+        19.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              2.0,
+              2.0,
+              3.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_012",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        15.0,
+        0.0,
+        40.5
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              3.0,
+              2.0,
+              9.5
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_013",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        34.0,
+        0.0,
+        36.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              2.0,
+              2.0,
+              2.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_014",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        7.0,
+        0.0,
+        43.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              5.0,
+              2.0,
+              7.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_015",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        27.0,
+        0.0,
+        37.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              5.0,
+              2.0,
+              1.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_016",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        27.0,
+        0.0,
+        46.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              9.0,
+              2.0,
+              4.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_wall_017",
+      "name": "Dungeon Wall (migrated)",
+      "position": [
+        42.0,
+        0.0,
+        49.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              6.0,
+              2.0,
+              1.0
+            ]
+          },
+          "offset": [
+            0.0,
+            2.0,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
+    },
+    {
+      "id": "kcc_floor_main",
+      "name": "Dungeon Floor (migrated)",
+      "position": [
+        25.0,
+        0.0,
+        25.0
+      ],
+      "components": {
+        "ColliderComponent": {
+          "shape": {
+            "type": "box",
+            "half_extents": [
+              25.0,
+              0.25,
+              25.0
+            ]
+          },
+          "offset": [
+            0.0,
+            -0.25,
+            0.0
+          ],
+          "collision_mask": 1,
+          "is_trigger": false,
+          "is_dynamic": false
+        }
+      }
     }
   ],
   "particle_emitters": [

--- a/examples/island_demo/tools_data/bricklayer/dungeon.bricklayer
+++ b/examples/island_demo/tools_data/bricklayer/dungeon.bricklayer
@@ -1367,6 +1367,528 @@
             "max_height": 0.0
           }
         }
+      },
+      {
+        "id": "kcc_wall_001",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          25.0,
+          0.0,
+          1.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                25.0,
+                2.0,
+                1.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_002",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          1.0,
+          0.0,
+          26.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                1.0,
+                2.0,
+                24.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_003",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          15.0,
+          0.0,
+          3.5
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                3.0,
+                2.0,
+                1.5
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_004",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          34.0,
+          0.0,
+          3.5
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                2.0,
+                2.0,
+                1.5
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_005",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          49.0,
+          0.0,
+          26.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                1.0,
+                2.0,
+                24.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_006",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          15.0,
+          0.0,
+          18.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                3.0,
+                2.0,
+                9.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_007",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          34.0,
+          0.0,
+          19.5
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                2.0,
+                2.0,
+                10.5
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_008",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          7.0,
+          0.0,
+          17.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                5.0,
+                2.0,
+                5.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_009",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          42.0,
+          0.0,
+          21.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                6.0,
+                2.0,
+                7.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_010",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          21.0,
+          0.0,
+          19.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                3.0,
+                2.0,
+                3.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_011",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          30.0,
+          0.0,
+          19.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                2.0,
+                2.0,
+                3.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_012",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          15.0,
+          0.0,
+          40.5
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                3.0,
+                2.0,
+                9.5
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_013",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          34.0,
+          0.0,
+          36.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                2.0,
+                2.0,
+                2.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_014",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          7.0,
+          0.0,
+          43.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                5.0,
+                2.0,
+                7.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_015",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          27.0,
+          0.0,
+          37.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                5.0,
+                2.0,
+                1.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_016",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          27.0,
+          0.0,
+          46.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                9.0,
+                2.0,
+                4.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_wall_017",
+        "name": "Dungeon Wall (migrated)",
+        "position": [
+          42.0,
+          0.0,
+          49.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                6.0,
+                2.0,
+                1.0
+              ]
+            },
+            "offset": [
+              0.0,
+              2.0,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
+      },
+      {
+        "id": "kcc_floor_main",
+        "name": "Dungeon Floor (migrated)",
+        "position": [
+          25.0,
+          0.0,
+          25.0
+        ],
+        "components": {
+          "ColliderComponent": {
+            "shape": {
+              "type": "box",
+              "half_extents": [
+                25.0,
+                0.25,
+                25.0
+              ]
+            },
+            "offset": [
+              0.0,
+              -0.25,
+              0.0
+            ],
+            "collision_mask": 1,
+            "is_trigger": false,
+            "is_dynamic": false
+          }
+        }
       }
     ],
     "player": {

--- a/scripts/migrate_collision_grid.py
+++ b/scripts/migrate_collision_grid.py
@@ -149,6 +149,88 @@ def migrate_solid_cells(collision, cell_size):
     return game_objects
 
 
+def migrate_solid_cells_as_walls(collision, cell_size, wall_height=4.0):
+    """Convert solid cells to tall Box wall colliders (dungeon mode).
+
+    Solid cells represent impassable walls (e.g. inside a dungeon), not floor.
+    Greedy-merges adjacent solid cells into rectangles, then emits each as a
+    box wall whose bottom sits at y=0 and top at y=wall_height.
+    """
+    width = collision['width']
+    height = collision['height']
+    solid = collision.get('solid', [])
+
+    if not solid:
+        return []
+
+    def predicate(x, z):
+        idx = z * width + x
+        return idx < len(solid) and solid[idx]
+
+    rects = greedy_merge(width, height, predicate)
+    half_h = wall_height / 2.0
+
+    game_objects = []
+    for i, (rx, rz, rw, rh) in enumerate(rects, start=1):
+        cx = (rx + rw / 2.0) * cell_size
+        cz = (rz + rh / 2.0) * cell_size
+        hex_ = (rw * cell_size) / 2.0
+        hez = (rh * cell_size) / 2.0
+
+        game_objects.append({
+            'id': f'kcc_wall_{i:03d}',
+            'name': 'Dungeon Wall (migrated)',
+            'position': [round(cx, 4), 0.0, round(cz, 4)],
+            'components': {
+                'ColliderComponent': {
+                    'shape': {
+                        'type': 'box',
+                        'half_extents': [round(hex_, 4), half_h, round(hez, 4)],
+                    },
+                    'offset': [0.0, half_h, 0.0],
+                    'collision_mask': 1,
+                    'is_trigger': False,
+                    'is_dynamic': False,
+                }
+            }
+        })
+
+    return game_objects
+
+
+def make_floor_slab(collision, cell_size, slab_thickness=0.5):
+    """Emit one large Box collider covering the full grid as a floor.
+
+    Top face sits at y=0 (matching the convention used by the kcc_wall_*
+    showcase entities in seurat_island.json). Player capsule rests on it.
+    """
+    width = collision['width']
+    height = collision['height']
+    half_h = slab_thickness / 2.0
+    cx = (width * cell_size) / 2.0
+    cz = (height * cell_size) / 2.0
+    hex_ = (width * cell_size) / 2.0
+    hez = (height * cell_size) / 2.0
+
+    return [{
+        'id': 'kcc_floor_main',
+        'name': 'Dungeon Floor (migrated)',
+        'position': [round(cx, 4), 0.0, round(cz, 4)],
+        'components': {
+            'ColliderComponent': {
+                'shape': {
+                    'type': 'box',
+                    'half_extents': [round(hex_, 4), half_h, round(hez, 4)],
+                },
+                'offset': [0.0, -half_h, 0.0],
+                'collision_mask': 1,
+                'is_trigger': False,
+                'is_dynamic': False,
+            }
+        }
+    }]
+
+
 def migrate_nav_zones(collision, cell_size):
     """Convert nav_zone[] to NavZoneVolume trigger boxes."""
     width = collision['width']
@@ -273,6 +355,14 @@ def main():
     parser.add_argument('--skip-light-probes', action='store_true')
     parser.add_argument('--probe-block-size', type=int, default=4)
     parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument(
+        '--mode', choices=['floors', 'walls'], default='floors',
+        help='floors (default): emit thin box per solid cell as floor tile. '
+             'walls: emit tall box per solid cell as wall + one floor slab. '
+             "Use 'walls' for dungeon-interior scenes where solid means impassable wall.")
+    parser.add_argument(
+        '--wall-height', type=float, default=4.0,
+        help='Wall height in world units when --mode=walls (default 4.0).')
     args = parser.parse_args()
 
     scene_path = Path(args.scene)
@@ -287,14 +377,23 @@ def main():
     cell_size = collision.get('cell_size', 1.0)
 
     # Migrate
-    floor_objects = migrate_solid_cells(collision, cell_size)
+    if args.mode == 'walls':
+        wall_objects = migrate_solid_cells_as_walls(collision, cell_size, args.wall_height)
+        floor_objects = make_floor_slab(collision, cell_size)
+    else:
+        wall_objects = []
+        floor_objects = migrate_solid_cells(collision, cell_size)
     nav_objects = [] if args.skip_nav_zones else migrate_nav_zones(collision, cell_size)
     probe_objects = [] if args.skip_light_probes else migrate_light_probes(collision, cell_size, args.probe_block_size)
 
-    total = len(floor_objects) + len(nav_objects) + len(probe_objects)
+    total = len(wall_objects) + len(floor_objects) + len(nav_objects) + len(probe_objects)
 
-    print(f'Migration results:')
-    print(f'  Floor colliders: {len(floor_objects)}')
+    print(f'Migration results (mode={args.mode}):')
+    if args.mode == 'walls':
+        print(f'  Wall colliders: {len(wall_objects)}')
+        print(f'  Floor slab:     {len(floor_objects)}')
+    else:
+        print(f'  Floor colliders: {len(floor_objects)}')
     print(f'  Nav zone volumes: {len(nav_objects)}')
     print(f'  Light probes: {len(probe_objects)}')
     print(f'  Total entities: {total}')
@@ -306,6 +405,7 @@ def main():
     # Append to game_objects
     if 'game_objects' not in scene:
         scene['game_objects'] = []
+    scene['game_objects'].extend(wall_objects)
     scene['game_objects'].extend(floor_objects)
     scene['game_objects'].extend(nav_objects)
     scene['game_objects'].extend(probe_objects)


### PR DESCRIPTION
## Summary

Migrate `examples/island_demo/assets/scenes/dungeon.json` from the legacy 2D `collision.solid` grid (50×50 bool mask) to the new KCC primitive colliders (`ColliderComponent` game objects), fixing the open follow-up tracked in `project_demo_followups.md` — *"Dungeon falls through walls / off floor edge"*.

PR #354 migrated KCC to read its world from `ColliderComponent`-bearing game objects via `CollisionSystem`'s BVH. `c65170cd` added showcase `kcc_wall_*` entities to `seurat_island.json` but never authored equivalent colliders for `dungeon.json`. The dungeon's `collision.solid` grid still sat in the JSON, *unused by the new movement system* — so the player walked through dungeon walls and off the floor edge.

## Approach

Pure JSON/tooling change. Zero engine code touched.

- **17 `kcc_wall_*` entities** generated by greedy-merging the 1300 solid cells into axis-aligned rectangles. Each becomes a tall box (`half_extents.y = 2.0`, `offset.y = 2.0`) — bottom on the ground, top at y=4. Same convention as `kcc_wall_a` in `seurat_island.json`.
- **1 `kcc_floor_main` entity** — single 50×50 floor slab (`half_extents = [25, 0.25, 25]`, `offset.y = -0.25`) so the top face is at y=0 and the player capsule has a solid surface to stand on.
- **Collision grid retained** — `Pathfinder::find_path_grid` (`src/engine/pathfinder.cpp:127`) still consumes `collision.solid` for NPC pathfinding, so the grid stays. The new colliders coexist with it; KCC reads the BVH path, pathfinding reads the grid.

## Tooling

Extended `scripts/migrate_collision_grid.py` with a `--mode walls` flag:
- `floors` (default, unchanged): emits flat box per solid cell, treating solid as floor tile (original outdoor-scene behaviour).
- `walls`: emits tall box per merged solid-cell rectangle as a wall, plus one floor slab covering the grid extent. Intended for dungeon-interior scenes.
- `--wall-height` knob (default 4.0).

## Verification

- ASCII reconstruction of merged rectangles back from the generated entities exactly matches the original `collision.solid` grid — no gaps, no overlap with walkable cells.
- `build/macos-release-with-diag/gseurat_demo` 12s smoke loads the scene cleanly. No collider-parsing errors, no Vulkan validation warnings, audio zone `dungeon_music_zone` still loads.
- ColliderComponent structure matches `schemas/scene.schema.json:288-317` and the working `kcc_wall_a` pattern in `seurat_island.json:1443-1484`.

## Test plan

- [ ] Smoke-test the demo: walk to `portal_dungeon_exit`, enter the dungeon, attempt to walk through each interior wall — player capsule should be blocked at every wall, including the corner pillars in rows 2-11 and 22-26.
- [ ] Walk over the entire dungeon floor — no falling through.
- [ ] Verify NPC pathfinding still works inside the dungeon (the collision grid is intact).

## Related

- Memory: `project_demo_followups.md` (item 1 — Dungeon falls through walls)
- Original KCC migration: PR #354, commits `09bfbcbe`, `27b998be`, `c65170cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
