### PR TITLE
fix(demo): clear PlayerJump on landing + stop double-rotating PC covariances

### DIFF
--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1002,11 +1002,17 @@ void IslandDemoState::update(AppBase& app, float dt) {
 
     // Clear PlayerJump.active when KCC reports landing. Without this the flag
     // stays true forever after the first jump, muting footsteps (line 1051)
-    // and pinning the animation clip to "jump" (line 1580).
+    // and pinning the animation clip to "jump" (line 1580). The velocity.y<=0
+    // gate is required because KCC's ground probe (collision_system.cpp:408,
+    // 0.1m default) can re-flag grounded=true while the character is still
+    // ascending: at 144 FPS jump_velocity*dt is below the probe distance, so
+    // the post-jump probe still sees ground. Only treat it as a real landing
+    // once we're no longer rising.
     {
         auto* pj_land = app.world().try_get<PlayerJump>(player_entity_);
         auto* kb_land = app.world().try_get<KinematicBody>(player_entity_);
-        if (pj_land && pj_land->active && kb_land && kb_land->grounded) {
+        if (pj_land && pj_land->active && kb_land && kb_land->grounded
+            && kb_land->velocity.y <= 0.0f) {
             pj_land->active = false;
             pj_land->timer = 0.0f;
         }

--- a/src/demo/island_demo_state.cpp
+++ b/src/demo/island_demo_state.cpp
@@ -1000,6 +1000,18 @@ void IslandDemoState::update(AppBase& app, float dt) {
     // Run collision system (KCC processes velocity set by update_player)
     collision_system_.update(app.world(), dt);
 
+    // Clear PlayerJump.active when KCC reports landing. Without this the flag
+    // stays true forever after the first jump, muting footsteps (line 1051)
+    // and pinning the animation clip to "jump" (line 1580).
+    {
+        auto* pj_land = app.world().try_get<PlayerJump>(player_entity_);
+        auto* kb_land = app.world().try_get<KinematicBody>(player_entity_);
+        if (pj_land && pj_land->active && kb_land && kb_land->grounded) {
+            pj_land->active = false;
+            pj_land->timer = 0.0f;
+        }
+    }
+
     // Audio: update listener position + footstep SFX + audio zone crossfade
     if (auto* ae = app.audio()) {
         ae->set_listener_position(character_origin_.x, character_origin_.y, character_origin_.z);
@@ -1614,8 +1626,10 @@ void IslandDemoState::update_walk_animation(AppBase& app, float dt) {
         }
     }
 
-    // Actor rotation (for GS preprocess shader)
-    app.renderer().gs_renderer().set_actor_rotation(character_rotation_);
+    // Facing rotation is baked into the bone to_world matrix (see
+    // bone_animation_system.cpp), so the preprocess shader already rotates
+    // per-Gaussian orientations via bone_q. Leaving actor_rotation at identity
+    // avoids double-rotating the PC's covariances.
 }
 
 // ── Environment animation (terrain sway) ──


### PR DESCRIPTION
## Summary

Two regressions surfaced together in an `gseurat_demo` playtest report:

- **PC rotation looked offset / smeared when turning.** The bone `to_world`
  matrix already bakes `facing_angle` into bone transforms
  (`bone_animation_system.cpp:76`) and the preprocess shader rotates
  per-Gaussian orientations via `bone_q`
  (`gs_preprocess.comp:203`). The per-frame
  `set_actor_rotation(character_rotation_)` then multiplied `actor_q`
  onto `rot_q` again (`gs_preprocess.comp:209-213`), doubling the
  facing rotation on covariances while positions only rotated once.
  NPCs were unaffected — they never call `set_actor_rotation`, so the
  default-identity `actor_q` is skipped by the `abs(w)<0.999` guard.
  Dropped the call; the bone-matrix rotation is sufficient.

- **Footstep SFX went silent after the first jump and never recovered.**
  The composable PlayerJump refactor (#339) sets `pj->active = true` on
  Space (`island_demo_state.cpp:961`) but never cleared it — `pj->timer`
  was read for an unused arc and the active flag stayed true forever,
  so the footstep predicate `moving && !pj->active`
  (`island_demo_state.cpp:1051`) and the walk-clip gate
  (`island_demo_state.cpp:1580`) stayed locked in jump state. KCC owns
  the actual jump physics (`KinematicBody.velocity.y` / `.grounded`),
  so sync `pj->active` to `kb->grounded` right after
  `collision_system_.update()`.

## Investigation notes

A third playtest finding — dungeon map not rendering — was investigated
in parallel and deferred. Findings: the dungeon's 25,784 Gaussians DO
load into the GPU buffer (`static=25784 persistent_dyn=40308` partition,
`Async load complete — 25784 splats in 1 slabs`), but they render
invisibly dim compared to a May 1, 2026 reference screenshot.
`dungeon.ply` is unchanged since Apr 15, and PR #465's collision
migration didn't touch any visual config. Suspect window is Phase 4b–5e
refactors (RenderState, Lighting, PBD, Particles, Resource, PostProcess,
Sort, TileBin, Streaming, Render orchestrator) that landed between then
and now. To be tracked separately.

## Test plan

- [x] `cmake --build --preset macos-debug --target gseurat_demo` clean
- [x] gseurat_demo launches, scene transition into dungeon works,
  PC visible without obvious smearing (cursory observation — the
  visible rotation symptom is subjective and benefits from a re-check
  in the demo)
- [ ] Walk + jump + walk: footsteps should resume after landing
- [ ] PC turning while moving should look centered on the PC pivot,
  not offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)