### PR TITLE
fix(#467): specialize gs_preprocess with USE_PAGE_TABLE=1 for static path

### DIFF
--- a/include/gseurat/engine/gs_renderer/sort/gs_sort_system.hpp
+++ b/include/gseurat/engine/gs_renderer/sort/gs_sort_system.hpp
@@ -59,6 +59,14 @@ public:
                         uint32_t legacy_sort_size, uint32_t legacy_sort_workgroups,
                         uint32_t num_passes, uint32_t depth_onesweep_max_wg);
 
+    // Rebuild the static preprocess pipeline with `SPLATS_PER_SLAB` baked
+    // in. Called from GsStreamingSystem::init_streaming() once the runtime
+    // `streaming_config.slab_size_splats` is known. No-op when the value
+    // matches the pipeline already created by init() (the default 100000).
+    // Must run before any static preprocess dispatch when the runtime
+    // slab size diverges from that default.
+    void set_static_preprocess_slab_size(uint32_t slab_size_splats);
+
     // Store the RenderState pointer (for bones buffer in preprocess sets).
     // Must be called before write_descriptors() if bones are needed.
     // Mirrors the GsRenderer::set_render_state() pattern.
@@ -129,10 +137,19 @@ private:
     // indices to physical slab offsets in `static_gaussian_ssbo`; the
     // dynamic path uses `USE_PAGE_TABLE=0` (direct addressing) because
     // `dynamic_gaussian_ssbo` is densely packed.
+    //
+    // `static_preprocess_slab_size_` is the SPLATS_PER_SLAB value baked
+    // into the static pipeline's spec constants. It defaults to the
+    // shader/engine default (100000) so prewarm at startup uses a valid
+    // pipeline even before `init_streaming` runs; `init_streaming` calls
+    // `set_static_preprocess_slab_size()` with the runtime config value
+    // and rebuilds the pipeline if it differs.
+    VkPipelineCache                                    pipeline_cache_                 = VK_NULL_HANDLE;
     VkDescriptorSetLayout                              preprocess_layout_              = VK_NULL_HANDLE;
     VkPipelineLayout                                   preprocess_pipeline_layout_     = VK_NULL_HANDLE;
     VkPipeline                                         static_preprocess_pipeline_     = VK_NULL_HANDLE;
     VkPipeline                                         dynamic_preprocess_pipeline_    = VK_NULL_HANDLE;
+    uint32_t                                           static_preprocess_slab_size_    = 100000u;
     std::array<VkDescriptorSet, kMaxFramesInFlight>    static_preprocess_sets_{};
     std::array<VkDescriptorSet, kMaxFramesInFlight>    dynamic_preprocess_sets_{};
 

--- a/include/gseurat/engine/gs_renderer/sort/gs_sort_system.hpp
+++ b/include/gseurat/engine/gs_renderer/sort/gs_sort_system.hpp
@@ -99,7 +99,7 @@ public:
         VkPipelineLayout         pipeline_layout;
         VkDescriptorSetLayout    set_layout;
     };
-    std::array<PrewarmEntry, 4> prewarm_entries() const;
+    std::array<PrewarmEntry, 5> prewarm_entries() const;
 
     // Tear down. Idempotent.
     void shutdown();
@@ -123,10 +123,16 @@ private:
     VkPipeline              merge_pipeline_            = VK_NULL_HANDLE;
     std::array<VkDescriptorSet, kMaxFramesInFlight> merge_sets_{};
 
-    // Preprocess pipeline (Phase 5e — moved from GsRenderer)
+    // Preprocess pipelines (Phase 5e — moved from GsRenderer)
+    // Two specializations: the static path uses `USE_PAGE_TABLE=1` so that
+    // `gs_preprocess.comp` walks the page_table to translate logical chunk
+    // indices to physical slab offsets in `static_gaussian_ssbo`; the
+    // dynamic path uses `USE_PAGE_TABLE=0` (direct addressing) because
+    // `dynamic_gaussian_ssbo` is densely packed.
     VkDescriptorSetLayout                              preprocess_layout_              = VK_NULL_HANDLE;
     VkPipelineLayout                                   preprocess_pipeline_layout_     = VK_NULL_HANDLE;
-    VkPipeline                                         preprocess_pipeline_            = VK_NULL_HANDLE;
+    VkPipeline                                         static_preprocess_pipeline_     = VK_NULL_HANDLE;
+    VkPipeline                                         dynamic_preprocess_pipeline_    = VK_NULL_HANDLE;
     std::array<VkDescriptorSet, kMaxFramesInFlight>    static_preprocess_sets_{};
     std::array<VkDescriptorSet, kMaxFramesInFlight>    dynamic_preprocess_sets_{};
 

--- a/src/engine/gs_renderer.cpp
+++ b/src/engine/gs_renderer.cpp
@@ -819,13 +819,21 @@ void GsRenderer::prewarm_pipelines(VkQueue queue, VkCommandPool cmd_pool,
         };
 
         // Phase 5e step 2: gs_preprocess pipeline now owned by GsSortSystem.
+        // Issue #467: split into two specializations (USE_PAGE_TABLE 1/0)
+        // for the static / dynamic paths — prewarm both so neither cold-starts.
         {
             auto sort_entries = sort_.prewarm_entries();
-            // sort_entries[3] is the preprocess pipeline.
-            add_entry("gs_preprocess",
+            // sort_entries[3] = static preprocess, [4] = dynamic preprocess.
+            add_entry("gs_preprocess.static",
                       sort_entries[3].pipeline,
                       sort_entries[3].pipeline_layout,
                       sort_entries[3].set_layout,
+                      sizeof(GsPreprocessPush),
+                      {0,1,2,4,5,6,8}, {3}, {});
+            add_entry("gs_preprocess.dynamic",
+                      sort_entries[4].pipeline,
+                      sort_entries[4].pipeline_layout,
+                      sort_entries[4].set_layout,
                       sizeof(GsPreprocessPush),
                       {0,1,2,4,5,6,8}, {3}, {});
         }

--- a/src/engine/gs_renderer/sort/gs_sort_system.cpp
+++ b/src/engine/gs_renderer/sort/gs_sort_system.cpp
@@ -214,9 +214,80 @@ void GsSortSystem::init(VkDevice device, VkPipelineCache pipeline_cache,
         }
     }
 
-    create_pipeline("shaders/gs_preprocess.comp.spv", preprocess_layout_,
-                    static_cast<uint32_t>(sizeof(GsPreprocessPush)),
-                    preprocess_pipeline_layout_, preprocess_pipeline_);
+    // The preprocess shader exposes two specialization constants:
+    //   id=0: SPLATS_PER_SLAB (default 100000) — divisor used by
+    //         resolve_physical_index() to split a logical chunk index
+    //         into {slab_logical, offset_in_slab}.
+    //   id=1: USE_PAGE_TABLE     (default 0)   — when 1, the shader
+    //         resolves through `page_table[]` to translate logical
+    //         slab indices to physical slab offsets.
+    //
+    // The static path must use USE_PAGE_TABLE=1: clear_chunks releases
+    // overworld slabs back to a LIFO free-list, so the next chunk gets
+    // assigned a non-zero slab index (e.g. dungeon = slab 16) and the
+    // direct-addressed read would land in the zeroed region. The
+    // dynamic path leaves USE_PAGE_TABLE=0 — dynamic_gaussian_ssbo is
+    // densely packed without slabs.
+    //
+    // SPLATS_PER_SLAB must match streaming_config.slab_size_splats; the
+    // engine default (100000, see streaming_config.hpp) matches the
+    // shader default, so we keep it constant here. If we ever want to
+    // make slab size configurable per scene, this site needs to plumb
+    // the runtime value through.
+    struct PreprocessSpec {
+        uint32_t splats_per_slab;
+        uint32_t use_page_table;
+    };
+    PreprocessSpec static_spec{100000u, 1u};
+    PreprocessSpec dynamic_spec{100000u, 0u};
+    VkSpecializationMapEntry spec_map[2] = {
+        {0, offsetof(PreprocessSpec, splats_per_slab), sizeof(uint32_t)},
+        {1, offsetof(PreprocessSpec, use_page_table),  sizeof(uint32_t)},
+    };
+    VkSpecializationInfo static_spec_info{
+        2, spec_map, sizeof(PreprocessSpec), &static_spec};
+    VkSpecializationInfo dynamic_spec_info{
+        2, spec_map, sizeof(PreprocessSpec), &dynamic_spec};
+
+    // Create the shared pipeline layout (one push-constant range, one
+    // descriptor set layout — same for both specializations).
+    {
+        VkPushConstantRange push_range{};
+        push_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        push_range.size = static_cast<uint32_t>(sizeof(GsPreprocessPush));
+
+        VkPipelineLayoutCreateInfo layout_info{};
+        layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+        layout_info.setLayoutCount = 1;
+        layout_info.pSetLayouts = &preprocess_layout_;
+        layout_info.pushConstantRangeCount = 1;
+        layout_info.pPushConstantRanges = &push_range;
+        if (vkCreatePipelineLayout(device_, &layout_info, nullptr,
+                                    &preprocess_pipeline_layout_) != VK_SUCCESS) {
+            throw std::runtime_error("GsSortSystem: preprocess pipeline layout");
+        }
+    }
+
+    auto create_preprocess_pipeline = [&](const VkSpecializationInfo* spec_info,
+                                           VkPipeline& out_pipeline) {
+        auto module = load_shader_module(device_, "shaders/gs_preprocess.comp.spv");
+        VkComputePipelineCreateInfo pi{};
+        pi.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+        pi.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        pi.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+        pi.stage.module = module;
+        pi.stage.pName = "main";
+        pi.stage.pSpecializationInfo = spec_info;
+        pi.layout = preprocess_pipeline_layout_;
+        VkResult res = vkCreateComputePipelines(device_, pipeline_cache, 1, &pi,
+                                                 nullptr, &out_pipeline);
+        vkDestroyShaderModule(device_, module, nullptr);
+        if (res != VK_SUCCESS) {
+            throw std::runtime_error("GsSortSystem: preprocess pipeline create failed");
+        }
+    };
+    create_preprocess_pipeline(&static_spec_info,  static_preprocess_pipeline_);
+    create_preprocess_pipeline(&dynamic_spec_info, dynamic_preprocess_pipeline_);
 
     // Allocate 4 preprocess descriptor sets (2 static + 2 dynamic, per frame).
     {
@@ -511,12 +582,13 @@ void GsSortSystem::dispatch_merge(VkCommandBuffer cmd, uint32_t frame_in_flight,
     vkCmdDispatch(cmd, (total_upper + 255) / 256, 1, 1);
 }
 
-std::array<GsSortSystem::PrewarmEntry, 4> GsSortSystem::prewarm_entries() const {
+std::array<GsSortSystem::PrewarmEntry, 5> GsSortSystem::prewarm_entries() const {
     return {{
-        {onesweep_hist_pipeline_,    onesweep_hist_pipeline_layout_,    onesweep_hist_layout_},
-        {onesweep_scatter_pipeline_, onesweep_scatter_pipeline_layout_, onesweep_scatter_layout_},
-        {merge_pipeline_,            merge_pipeline_layout_,            merge_layout_},
-        {preprocess_pipeline_,       preprocess_pipeline_layout_,       preprocess_layout_},
+        {onesweep_hist_pipeline_,     onesweep_hist_pipeline_layout_,    onesweep_hist_layout_},
+        {onesweep_scatter_pipeline_,  onesweep_scatter_pipeline_layout_, onesweep_scatter_layout_},
+        {merge_pipeline_,             merge_pipeline_layout_,            merge_layout_},
+        {static_preprocess_pipeline_,  preprocess_pipeline_layout_,      preprocess_layout_},
+        {dynamic_preprocess_pipeline_, preprocess_pipeline_layout_,      preprocess_layout_},
     }};
 }
 
@@ -526,7 +598,9 @@ void GsSortSystem::dispatch_preprocess(VkCommandBuffer cmd, uint32_t frame_in_fl
     if (count == 0) return;
     GS_LABEL(cmd, is_static ? "Preprocess.Static" : "Preprocess.Dynamic");
 
-    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, preprocess_pipeline_);
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                      is_static ? static_preprocess_pipeline_
+                                : dynamic_preprocess_pipeline_);
     VkDescriptorSet set = is_static
         ? static_preprocess_sets_[frame_in_flight]
         : dynamic_preprocess_sets_[frame_in_flight];
@@ -553,10 +627,12 @@ void GsSortSystem::shutdown() {
     if (onesweep_scatter_layout_) { vkDestroyDescriptorSetLayout(device_, onesweep_scatter_layout_, nullptr); onesweep_scatter_layout_ = VK_NULL_HANDLE; }
     if (merge_layout_)            { vkDestroyDescriptorSetLayout(device_, merge_layout_,            nullptr); merge_layout_ = VK_NULL_HANDLE; }
 
-    // Preprocess pipeline (Phase 5e — moved from GsRenderer)
-    if (preprocess_pipeline_)        { vkDestroyPipeline(device_, preprocess_pipeline_, nullptr);             preprocess_pipeline_        = VK_NULL_HANDLE; }
-    if (preprocess_pipeline_layout_) { vkDestroyPipelineLayout(device_, preprocess_pipeline_layout_, nullptr); preprocess_pipeline_layout_ = VK_NULL_HANDLE; }
-    if (preprocess_layout_)          { vkDestroyDescriptorSetLayout(device_, preprocess_layout_, nullptr);     preprocess_layout_          = VK_NULL_HANDLE; }
+    // Preprocess pipelines (Phase 5e — moved from GsRenderer). Two
+    // specializations of the same shader, see init() for rationale.
+    if (static_preprocess_pipeline_)  { vkDestroyPipeline(device_, static_preprocess_pipeline_,  nullptr); static_preprocess_pipeline_  = VK_NULL_HANDLE; }
+    if (dynamic_preprocess_pipeline_) { vkDestroyPipeline(device_, dynamic_preprocess_pipeline_, nullptr); dynamic_preprocess_pipeline_ = VK_NULL_HANDLE; }
+    if (preprocess_pipeline_layout_)  { vkDestroyPipelineLayout(device_, preprocess_pipeline_layout_, nullptr); preprocess_pipeline_layout_ = VK_NULL_HANDLE; }
+    if (preprocess_layout_)           { vkDestroyDescriptorSetLayout(device_, preprocess_layout_, nullptr);     preprocess_layout_          = VK_NULL_HANDLE; }
 
     // Sets are pool-owned; pool teardown reclaims them.
     merge_sets_.fill(VK_NULL_HANDLE);

--- a/src/engine/gs_renderer/sort/gs_sort_system.cpp
+++ b/src/engine/gs_renderer/sort/gs_sort_system.cpp
@@ -229,25 +229,12 @@ void GsSortSystem::init(VkDevice device, VkPipelineCache pipeline_cache,
     // dynamic path leaves USE_PAGE_TABLE=0 — dynamic_gaussian_ssbo is
     // densely packed without slabs.
     //
-    // SPLATS_PER_SLAB must match streaming_config.slab_size_splats; the
-    // engine default (100000, see streaming_config.hpp) matches the
-    // shader default, so we keep it constant here. If we ever want to
-    // make slab size configurable per scene, this site needs to plumb
-    // the runtime value through.
-    struct PreprocessSpec {
-        uint32_t splats_per_slab;
-        uint32_t use_page_table;
-    };
-    PreprocessSpec static_spec{100000u, 1u};
-    PreprocessSpec dynamic_spec{100000u, 0u};
-    VkSpecializationMapEntry spec_map[2] = {
-        {0, offsetof(PreprocessSpec, splats_per_slab), sizeof(uint32_t)},
-        {1, offsetof(PreprocessSpec, use_page_table),  sizeof(uint32_t)},
-    };
-    VkSpecializationInfo static_spec_info{
-        2, spec_map, sizeof(PreprocessSpec), &static_spec};
-    VkSpecializationInfo dynamic_spec_info{
-        2, spec_map, sizeof(PreprocessSpec), &dynamic_spec};
+    // SPLATS_PER_SLAB must match streaming_config.slab_size_splats. We
+    // bake the engine default (100000) here so prewarm at startup has
+    // a valid pipeline; GsStreamingSystem::init_streaming() later calls
+    // set_static_preprocess_slab_size() with the runtime config value
+    // and rebuilds the static pipeline if it differs.
+    pipeline_cache_ = pipeline_cache;
 
     // Create the shared pipeline layout (one push-constant range, one
     // descriptor set layout — same for both specializations).
@@ -268,8 +255,18 @@ void GsSortSystem::init(VkDevice device, VkPipelineCache pipeline_cache,
         }
     }
 
-    auto create_preprocess_pipeline = [&](const VkSpecializationInfo* spec_info,
-                                           VkPipeline& out_pipeline) {
+    // Dynamic pipeline is invariant: USE_PAGE_TABLE=0 short-circuits the
+    // SPLATS_PER_SLAB divisor in resolve_physical_index(), so the value
+    // is irrelevant for the dynamic path.
+    set_static_preprocess_slab_size(static_preprocess_slab_size_);
+    {
+        struct DynamicSpec { uint32_t splats_per_slab; uint32_t use_page_table; };
+        DynamicSpec dyn{100000u, 0u};
+        VkSpecializationMapEntry map[2] = {
+            {0, offsetof(DynamicSpec, splats_per_slab), sizeof(uint32_t)},
+            {1, offsetof(DynamicSpec, use_page_table),  sizeof(uint32_t)},
+        };
+        VkSpecializationInfo info{2, map, sizeof(DynamicSpec), &dyn};
         auto module = load_shader_module(device_, "shaders/gs_preprocess.comp.spv");
         VkComputePipelineCreateInfo pi{};
         pi.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
@@ -277,17 +274,15 @@ void GsSortSystem::init(VkDevice device, VkPipelineCache pipeline_cache,
         pi.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
         pi.stage.module = module;
         pi.stage.pName = "main";
-        pi.stage.pSpecializationInfo = spec_info;
+        pi.stage.pSpecializationInfo = &info;
         pi.layout = preprocess_pipeline_layout_;
         VkResult res = vkCreateComputePipelines(device_, pipeline_cache, 1, &pi,
-                                                 nullptr, &out_pipeline);
+                                                 nullptr, &dynamic_preprocess_pipeline_);
         vkDestroyShaderModule(device_, module, nullptr);
         if (res != VK_SUCCESS) {
-            throw std::runtime_error("GsSortSystem: preprocess pipeline create failed");
+            throw std::runtime_error("GsSortSystem: dynamic preprocess pipeline create failed");
         }
-    };
-    create_preprocess_pipeline(&static_spec_info,  static_preprocess_pipeline_);
-    create_preprocess_pipeline(&dynamic_spec_info, dynamic_preprocess_pipeline_);
+    }
 
     // Allocate 4 preprocess descriptor sets (2 static + 2 dynamic, per frame).
     {
@@ -324,6 +319,52 @@ void GsSortSystem::set_sort_sizes(uint32_t static_sort_size, uint32_t static_sor
     legacy_sort_workgroups_   = legacy_sort_workgroups;
     num_passes_               = num_passes;
     depth_onesweep_max_wg_    = depth_onesweep_max_wg;
+}
+
+void GsSortSystem::set_static_preprocess_slab_size(uint32_t slab_size_splats) {
+    // No-op if the existing pipeline already bakes this value AND was
+    // built (init() invokes this once with the default to construct the
+    // initial pipeline). The early-out keeps init_streaming() cheap when
+    // the runtime config matches the engine default.
+    if (static_preprocess_pipeline_ != VK_NULL_HANDLE &&
+        static_preprocess_slab_size_ == slab_size_splats) {
+        return;
+    }
+    if (device_ == VK_NULL_HANDLE) return;
+
+    // Stale pipeline, if any, must outlive any in-flight dispatches; we
+    // only get here from init() (no in-flight work) and from
+    // init_streaming() which runs on the main thread before
+    // create_transfer_queue / first frame.
+    if (static_preprocess_pipeline_ != VK_NULL_HANDLE) {
+        vkDestroyPipeline(device_, static_preprocess_pipeline_, nullptr);
+        static_preprocess_pipeline_ = VK_NULL_HANDLE;
+    }
+
+    struct StaticSpec { uint32_t splats_per_slab; uint32_t use_page_table; };
+    StaticSpec spec{slab_size_splats, 1u};
+    VkSpecializationMapEntry map[2] = {
+        {0, offsetof(StaticSpec, splats_per_slab), sizeof(uint32_t)},
+        {1, offsetof(StaticSpec, use_page_table),  sizeof(uint32_t)},
+    };
+    VkSpecializationInfo info{2, map, sizeof(StaticSpec), &spec};
+
+    auto module = load_shader_module(device_, "shaders/gs_preprocess.comp.spv");
+    VkComputePipelineCreateInfo pi{};
+    pi.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+    pi.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    pi.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+    pi.stage.module = module;
+    pi.stage.pName = "main";
+    pi.stage.pSpecializationInfo = &info;
+    pi.layout = preprocess_pipeline_layout_;
+    VkResult res = vkCreateComputePipelines(device_, pipeline_cache_, 1, &pi,
+                                             nullptr, &static_preprocess_pipeline_);
+    vkDestroyShaderModule(device_, module, nullptr);
+    if (res != VK_SUCCESS) {
+        throw std::runtime_error("GsSortSystem: static preprocess pipeline create failed");
+    }
+    static_preprocess_slab_size_ = slab_size_splats;
 }
 
 void GsSortSystem::write_depth_set_quad(VkDescriptorSet hist_a, VkDescriptorSet hist_b,

--- a/src/engine/gs_renderer/streaming/gs_streaming_system.cpp
+++ b/src/engine/gs_renderer/streaming/gs_streaming_system.cpp
@@ -157,6 +157,14 @@ void GsStreamingSystem::init_streaming(const StreamingConfig& config, uint32_t n
                           num_sort_passes, depth_onesweep_max_wg_);
     tile_->set_sort_sizes(static_sort_size_, dynamic_sort_size_);
 
+    // Issue #467 P1 follow-up: bake the runtime slab size into the static
+    // preprocess pipeline's `SPLATS_PER_SLAB` spec constant. The pipeline
+    // initially created by GsSortSystem::init() uses the engine default
+    // (100000) so prewarm has something to warm; this call rebuilds it
+    // here if a custom `streaming.slab_size_splats` was loaded from disk
+    // — `resolve_physical_index()` in the shader depends on it.
+    sort_->set_static_preprocess_slab_size(config.slab_size_splats);
+
     // Page table: one uint32 per slab, initialized to 0xFFFFFFFF (invalid).
     // host_dst variant: reads happen on the GPU every frame; updates from
     // chunk-load completions are recorded as vkCmdUpdateBuffer onto the


### PR DESCRIPTION
## Summary

Fixes #467 — dungeon static gaussians fail to render after portal transition.

The preprocess shader's `USE_PAGE_TABLE` specialization constant was never set from C++ and defaulted to 0, so `resolve_physical_index()` was a no-op — `gaussians[idx]` was read directly from physical offset `idx`. This silently worked for the initial overworld load (slab allocator hands out slabs [0..16] contiguously) but broke for any subsequent scene whose chunk got assigned a non-zero starting slab. The dungeon's chunk lands on slab 16 after `clear_chunks` releases the overworld slabs to the LIFO free-list, so its data lives at physical offset 1,600,000 while the shader kept reading from physical offset 0..25784 (the cleared region).

Net visible effect: dungeon static gaussians projected to valid screen coords with zero color and zero opacity → invisible to the rasterizer. Dynamic gaussians (PC, NPCs, torches) rendered fine because they use a densely-packed buffer without slab indirection.

The shader already had all the page-table infrastructure ready (`resolve_physical_index()`, `page_table[]` SSBO at binding 8, populated chunk_table). Only the C++-side spec const was missing.

## Fix

- Create two specializations of `gs_preprocess.comp.spv` via `VkSpecializationInfo`:
  - **Static**: `USE_PAGE_TABLE=1` → walks `page_table[]` to translate logical chunk indices to physical slab offsets.
  - **Dynamic**: `USE_PAGE_TABLE=0` → direct addressing (dynamic_gaussian_ssbo is densely packed).
- Both pipelines share the descriptor set layout and pipeline layout.
- `dispatch_preprocess` selects the right pipeline based on `is_static`.
- Both pipelines are prewarmed at startup so neither cold-starts.

`SPLATS_PER_SLAB` is set to 100000, matching `streaming_config_`'s default and the shader default. If slab size ever becomes runtime-configurable, the spec const wiring needs to plumb the value through.

## Test Plan

- [x] Build clean (`cmake --build --preset macos-debug --target gseurat_demo`)
- [x] Overworld renders identically (no regression on the initial scene)
- [x] Walk into dungeon portal at (203, 175) → dungeon static walls, floor, and corridor render correctly
- [x] Yellow torches and PC remain visible (dynamic path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)