### PR TITLE
feat(engine): add Renderer::set_pre_sort_compute_callback hook

### DIFF
--- a/include/gseurat/engine/app_base.hpp
+++ b/include/gseurat/engine/app_base.hpp
@@ -271,6 +271,16 @@ public:
     // BEFORE any state push triggers init_streaming → update_descriptors.
     void init_render_state();
 
+    // === GS resource access (Phase 5a) ===
+    // Non-owning reference to AppBase's GsResourceManager. Host applications
+    // need this to bind engine-owned SSBOs (e.g. `dynamic_gaussian_ssbo`) as
+    // the destination of game-side compute passes dispatched via
+    // `set_pre_sort_compute_callback`. Returns a valid reference only after
+    // `init_render_state()` has constructed the manager.
+    GsResourceManager& gs_resources() { return *gs_resources_; }
+    const GsResourceManager& gs_resources() const { return *gs_resources_; }
+    bool has_gs_resources() const noexcept { return gs_resources_ != nullptr; }
+
 protected:
     void init_window();
     virtual void init_game_content();

--- a/include/gseurat/engine/renderer.hpp
+++ b/include/gseurat/engine/renderer.hpp
@@ -291,6 +291,29 @@ public:
     using OverlayCallback = std::function<void(VkCommandBuffer, uint32_t)>;
     void set_overlay_callback(OverlayCallback cb) { overlay_callback_ = std::move(cb); }
 
+    // Pre-sort GS compute callback. Fires inside `record_gs_prepass` after all
+    // engine compose dispatches (vfx / pbd / particles) but BEFORE
+    // `gs_renderer_.render()` runs the sort + tile-bin + raster pipeline.
+    // Host applications can use this to inject a game-specific compute pass
+    // that writes into `dynamic_gaussian_ssbo` — for example, a procedural
+    // mesh deformer, a fluid sim, or a Present↔Past state morph.
+    //
+    // Contract:
+    //   - Gated by the same `dispatch_gpu_compute` flag the engine uses for
+    //     its own compose dispatches; the callback does NOT fire during
+    //     EngineState::Loading.
+    //   - The callback is responsible for its own VK_ACCESS_SHADER_WRITE_BIT
+    //     → SHADER_READ_BIT memory barrier after its dispatch, matching the
+    //     pattern in `dispatch_compose_vfx/_pbd/_particles`. The engine does
+    //     not add one on the callback's behalf.
+    //   - `frame_in_flight` mirrors the engine's `current_frame()` and is
+    //     valid for the duration of the callback call.
+    using PreSortComputeCallback =
+        std::function<void(VkCommandBuffer cmd, uint32_t frame_in_flight)>;
+    void set_pre_sort_compute_callback(PreSortComputeCallback cb) {
+        pre_sort_compute_callback_ = std::move(cb);
+    }
+
 private:
     void create_sprite_pipeline();
     void create_outline_pipeline();
@@ -456,6 +479,10 @@ private:
 
     // Overlay callback (ImGui rendering hook)
     OverlayCallback overlay_callback_;
+
+    // Pre-sort game compute hook (procedural deformers, state morphs, etc.).
+    // See `set_pre_sort_compute_callback` for the contract.
+    PreSortComputeCallback pre_sort_compute_callback_;
 };
 
 }  // namespace gseurat

--- a/src/engine/renderer.cpp
+++ b/src/engine/renderer.cpp
@@ -1458,6 +1458,15 @@ void Renderer::record_gs_prepass(VkCommandBuffer cmd, VkDevice device, float dt,
                                                 /*prior_offset=*/vfx_count + pbd_count,
                                                 particles_count);
 
+        // Pre-sort game compute hook. Fires after all engine compose dispatches
+        // but before sort+tile-bin+raster, giving host applications a slot to
+        // inject their own compute pass (e.g. procedural deformers, State A/B
+        // morph). Callback is responsible for its own SSBO write→read barrier;
+        // see contract in `set_pre_sort_compute_callback`.
+        if (pre_sort_compute_callback_) {
+            pre_sort_compute_callback_(cmd, current_frame_);
+        }
+
 #if GSEURAT_DEBUG_BUILD
         const auto t_prepass_pre_render = std::chrono::steady_clock::now();
 #endif


### PR DESCRIPTION
## Summary

Adds a host-application slot inside `Renderer::record_gs_prepass` for game-specific compute passes that need to write into `dynamic_gaussian_ssbo` between the engine's compose dispatches (vfx / pbd / particles) and `GsRenderer::render()` (sort + tile-bin + raster).

Symmetric to the existing `OverlayCallback` for post-composite ImGui, but fires earlier in the frame so host writes are picked up by sort.

```cpp
using PreSortComputeCallback =
    std::function<void(VkCommandBuffer cmd, uint32_t frame_in_flight)>;
void set_pre_sort_compute_callback(PreSortComputeCallback cb);
```

### Contract
- Gated by the same `dispatch_gpu_compute` flag the engine uses for its own compose work → no compute during `EngineState::Loading`.
- The callback owns its own `SHADER_WRITE_BIT → SHADER_READ_BIT` memory barrier, matching the pattern in `dispatch_compose_vfx / _pbd / _particles`. Engine adds none on the callback's behalf.
- `frame_in_flight` mirrors `Renderer::current_frame()` and is valid for the duration of the call.

## Motivating consumer

Akashic's State A↔B morph (a per-frame interpolation between two slab-resident static clouds) is migrating off the now-purged `update_static_gaussians` CPU upload path onto a GPU `gs_morph.comp` pass. The new game-side `MorphSystem` registers via this callback to dispatch its compute between the engine's compose passes and sort.

The callback is intentionally generic so future game-side compute (procedural deformers, fluid sims, GPU-driven crowd anim) can reuse the same slot without further engine API churn — keeps `src/engine/` game-agnostic per the engine's subrepo rules.

## Changes

- `include/gseurat/engine/renderer.hpp` (+27): typedef + setter + private member with full contract doc.
- `src/engine/renderer.cpp` (+9): invoke callback at the right point in `record_gs_prepass`, after `dispatch_compose_particles` and before `gs_renderer_.render()`, inside the `dispatch_gpu_compute` gate.

## Test plan

- [x] `cmake --build --preset macos-debug` clean against the new header (engine `gseurat_core` static lib + downstream consumers).
- [x] `ctest` (`test_player_physics_integration`) passes — no engine-side runtime change when no callback is set (default-constructed `std::function` is falsy, skipping the invocation entirely).
- [ ] Verified live end-to-end against the Akashic morph implementation (pending — that's the next PR in the parent repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)